### PR TITLE
ci(release): use PAT token for release PR checks

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,7 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN != '' && secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ make test
 
 Automated releases are managed by GitHub Actions and `release-please`.
 
+Before enabling required status checks on release PRs, create repository secret `RELEASE_PLEASE_TOKEN` (PAT with access to this repo). This allows CI to run on release-please PRs.
+
 ### Recommended flow (automatic)
 
 1. Merge commits into `main` using Conventional Commit prefixes.


### PR DESCRIPTION
## Summary
- switch `release-please` to use `RELEASE_PLEASE_TOKEN` so release PR commits trigger `CI`
- document the required secret in release setup notes
- keep branch protection (`required checks`) compatible with automated release PRs