### PR TITLE
feat(deploy): add safe in-place server update flow

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -42,6 +42,7 @@ src/
 │   └── crypto.zig        # AES-256-CTR, SHA-256, HMAC wrappers
 deploy/
 ├── install.sh            # One-line VPS bootstrap (Zig + build + systemd + TCPMSS + IPv6)
+├── update.sh             # In-place server updater from GitHub Release artifacts
 ├── ipv6-hop.sh           # IPv6 address rotation (Cloudflare API)
 ├── mtproto-proxy.service # systemd unit file
 ├── update_dns.sh         # Cloudflare DNS A-record updater
@@ -86,7 +87,19 @@ make release                                           # Release build (native)
 make release_linux                                     # Cross-compile for Linux
 make test                                              # Run unit tests
 make deploy                                            # Cross-compile + stop + scp + start
+make update-server SERVER=<ip> [VERSION=vX.Y.Z]       # Update VPS from GitHub Release
 ```
+
+### Release Workflow (GitHub)
+
+- Release automation is handled by `release-please` in `.github/workflows/release-please.yml`.
+- It updates/opens one release PR, not one release per commit.
+- A real GitHub release is created only when the release PR is merged.
+- Bump policy follows Conventional Commits:
+  - `fix:` -> patch
+  - `feat:` -> minor
+  - `BREAKING CHANGE:` / `!` -> major
+- To keep required checks compatible with release PRs, repository secret `RELEASE_PLEASE_TOKEN` must be set (PAT with `Contents`, `Pull requests`, `Issues` read/write for this repo).
 
 > [!NOTE]
 > On macOS 26 (Tahoe), `zig build` is broken due to Zig 0.15.2's linker not supporting the new TBD format.
@@ -102,6 +115,38 @@ make deploy                                            # Cross-compile + stop + 
 
 > [!IMPORTANT]
 > You must stop the service before using `scp` because the systemd unit has `ReadOnlyPaths=/opt/mtproto-proxy`, which prevents overwriting the binary while it is running.
+
+### Server Update Path (Recommended for Operators)
+
+For routine production upgrades, users should update from GitHub Releases instead of rebuilding on the VPS.
+
+#### Local orchestrated update
+```bash
+make update-server SERVER=<SERVER_IP>
+make update-server SERVER=<SERVER_IP> VERSION=v0.1.0
+```
+
+This runs `deploy/update.sh` remotely over SSH.
+
+#### Direct update on the VPS
+```bash
+curl -fsSL https://raw.githubusercontent.com/sleep3r/mtproto.zig/main/deploy/update.sh | sudo bash
+curl -fsSL https://raw.githubusercontent.com/sleep3r/mtproto.zig/main/deploy/update.sh | sudo bash -s -- v0.1.0
+```
+
+#### Update safety guarantees
+- Detects server architecture (`x86_64`/`aarch64`) and downloads matching release artifact.
+- Stops `mtproto-proxy`, installs new binary, updates deploy helper scripts and service unit.
+- Preserves runtime state (`/opt/mtproto-proxy/config.toml`, `/opt/mtproto-proxy/env.sh`).
+- Creates timestamped backup of current binary before replacement.
+- Automatically rolls back to previous binary if restart fails.
+
+#### Operator rollback
+If needed, restore the backup binary printed by `update.sh` and restart:
+```bash
+sudo cp /opt/mtproto-proxy/mtproto-proxy.backup.<timestamp> /opt/mtproto-proxy/mtproto-proxy
+sudo systemctl restart mtproto-proxy
+```
 
 ### Configuration (`config.toml.example`)
 Users can copy `config.toml.example` to `config.toml`. The structure natively supports the new anti-DPI routing fields:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build release run test clean fmt deploy migrate update-dns release-manual
+.PHONY: build release run test clean fmt deploy update-server migrate update-dns release-manual
 
 SERVER ?= 185.125.46.60
 CONFIG ?= config.toml
@@ -50,6 +50,14 @@ deploy:
 		rm .env.tmp_deploy; \
 	fi
 	ssh root@$(SERVER) 'systemctl start mtproto-proxy && systemctl status mtproto-proxy --no-pager'
+
+update-server:
+	@if [ -z "$(SERVER)" ]; then echo "Usage: make update-server SERVER=<ip> [VERSION=vX.Y.Z]"; exit 1; fi
+	@if [ -n "$(VERSION)" ]; then \
+		ssh root@$(SERVER) 'bash -s -- $(VERSION)' < deploy/update.sh; \
+	else \
+		ssh root@$(SERVER) 'bash -s' < deploy/update.sh; \
+	fi
 
 migrate:
 	@if [ -z "$(SERVER)" ]; then echo "Usage: make migrate SERVER=<ip> [PASSWORD=<pass>]"; exit 1; fi

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Disguises Telegram traffic as standard TLS 1.3 HTTPS to bypass network censorshi
 
 [Features](#-features) &nbsp;&bull;&nbsp;
 [Quick Start](#-quick-start) &nbsp;&bull;&nbsp;
-[Releases](#-releases) &nbsp;&bull;&nbsp;
+[Update](#-update-existing-server) &nbsp;&bull;&nbsp;
 [Deploy](#-deploy-to-server) &nbsp;&bull;&nbsp;
 [Configuration](#-configuration) &nbsp;&bull;&nbsp;
 [Troubleshooting](#-troubleshooting-updating)
@@ -92,37 +92,43 @@ make test
 | `make fmt` | Format all Zig source files |
 | `make deploy` | Cross-compile, upload binary/scripts/config to VPS, restart service |
 | `make deploy SERVER=<ip>` | Deploy to a specific server |
-| `make release-manual VERSION=vX.Y.Z` | Manual fallback: tag HEAD and publish GitHub Release |
+| `make update-server SERVER=<ip> [VERSION=vX.Y.Z]` | Update server binary from GitHub Release artifacts |
 
 </details>
 
-## &nbsp; Releases
+## &nbsp; Update existing server
 
-Automated releases are managed by GitHub Actions and `release-please`.
+The easiest way to upgrade an already installed proxy is to pull a prebuilt binary from GitHub Releases and restart the service.
 
-Before enabling required status checks on release PRs, create repository secret `RELEASE_PLEASE_TOKEN` (PAT with access to this repo). This allows CI to run on release-please PRs.
-
-### Recommended flow (automatic)
-
-1. Merge commits into `main` using Conventional Commit prefixes.
-2. `Release Please` opens or updates a release PR when a version bump is needed.
-3. Merge that release PR to create tag `vX.Y.Z`, update `CHANGELOG.md`, and publish a GitHub release.
-4. The same `Release Please` workflow builds Linux binaries and attaches `.tar.gz` artifacts when a release is created.
-
-Version bump rules:
-- `fix:` -> patch (`v1.2.3` -> `v1.2.4`)
-- `feat:` -> minor (`v1.2.3` -> `v1.3.0`)
-- `feat!:` or `BREAKING CHANGE:` -> major (`v1.2.3` -> `v2.0.0`)
-
-### Manual fallback from CLI
-
-If GitHub automation is unavailable, you can publish a release directly from your terminal:
+From your local machine:
 
 ```bash
-make release-manual VERSION=v1.2.3
+make update-server SERVER=<SERVER_IP>
 ```
 
-This tags current `HEAD`, pushes the tag, and creates a GitHub release with generated notes.
+Pin to a specific version:
+
+```bash
+make update-server SERVER=<SERVER_IP> VERSION=v0.1.0
+```
+
+What `update-server` does on the VPS:
+1. Downloads the latest (or pinned) release artifact for server architecture.
+2. Stops `mtproto-proxy`, replaces binary, and keeps `config.toml`/`env.sh` untouched.
+3. Refreshes helper scripts and service unit from the same release tag.
+4. Restarts service and rolls back binary automatically if restart fails.
+
+If you are already on the server:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sleep3r/mtproto.zig/main/deploy/update.sh | sudo bash
+```
+
+Or pinned version:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sleep3r/mtproto.zig/main/deploy/update.sh | sudo bash -s -- v0.1.0
+```
 
 ## &nbsp; Deploy to Server
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -83,6 +83,11 @@ fi
 cp zig-out/bin/mtproto-proxy "$INSTALL_DIR/mtproto-proxy"
 chmod +x "$INSTALL_DIR/mtproto-proxy"
 
+# Keep helper scripts locally for future maintenance/update operations
+cp "$TMPBUILD/deploy"/*.sh "$INSTALL_DIR/"
+cp "$TMPBUILD/deploy/capture_template.py" "$INSTALL_DIR/"
+chmod +x "$INSTALL_DIR"/*.sh
+
 # ── Generate config (if not exists) ─────────────────────────
 if [[ ! -f "$INSTALL_DIR/config.toml" ]]; then
     SECRET=$(openssl rand -hex 16)

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# update.sh — update mtproto-proxy from GitHub Release artifacts.
+#
+# Usage:
+#   sudo bash update.sh
+#   sudo bash update.sh v0.1.0
+
+set -euo pipefail
+
+REPO_OWNER="${REPO_OWNER:-sleep3r}"
+REPO_NAME="${REPO_NAME:-mtproto.zig}"
+INSTALL_DIR="/opt/mtproto-proxy"
+SERVICE_NAME="mtproto-proxy"
+VERSION="${1:-}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+DIM='\033[2m'
+RESET='\033[0m'
+
+info()  { echo -e "${CYAN}▸${RESET} $*"; }
+ok()    { echo -e "${GREEN}✓${RESET} $*"; }
+warn()  { echo -e "${RED}⚠${RESET} $*"; }
+fail()  { echo -e "${RED}✗${RESET} $*" >&2; exit 1; }
+
+[[ $EUID -eq 0 ]] || fail "Run as root: sudo bash update.sh"
+
+for cmd in curl tar systemctl uname mktemp; do
+    command -v "$cmd" >/dev/null 2>&1 || fail "Missing required command: $cmd"
+done
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+    x86_64|amd64)
+        ASSET_ARCH="x86_64"
+        ;;
+    aarch64|arm64)
+        ASSET_ARCH="aarch64"
+        ;;
+    *)
+        fail "Unsupported architecture: $ARCH"
+        ;;
+esac
+
+if [[ -z "$VERSION" ]]; then
+    info "Resolving latest release tag..."
+    TAG="$(curl -fsSL "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest" | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"[^"]+"' | head -1 | cut -d '"' -f4 || true)"
+    [[ -n "$TAG" ]] || fail "Could not determine latest release tag"
+else
+    TAG="$VERSION"
+fi
+
+if [[ "$TAG" != v* ]]; then
+    TAG="v${TAG}"
+fi
+
+ASSET_BASENAME="mtproto-proxy-linux-${ASSET_ARCH}"
+ASSET_FILE="${ASSET_BASENAME}.tar.gz"
+ASSET_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${TAG}/${ASSET_FILE}"
+RAW_BASE="https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${TAG}/deploy"
+
+TMP_DIR="$(mktemp -d)"
+BACKUP_BINARY=""
+
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+info "Downloading ${TAG} artifact for ${ASSET_ARCH}..."
+curl -fsSL "$ASSET_URL" -o "${TMP_DIR}/${ASSET_FILE}" || fail "Release artifact not found: ${ASSET_URL}"
+
+tar -xzf "${TMP_DIR}/${ASSET_FILE}" -C "$TMP_DIR"
+NEW_BINARY="${TMP_DIR}/${ASSET_BASENAME}"
+[[ -f "$NEW_BINARY" ]] || fail "Extracted binary not found in artifact"
+chmod +x "$NEW_BINARY"
+
+info "Downloading deploy scripts and service from ${TAG}..."
+for file in install.sh update.sh update_dns.sh ipv6-hop.sh setup_masking.sh setup_nfqws.sh capture_template.py mtproto-proxy.service; do
+    curl -fsSL "${RAW_BASE}/${file}" -o "${TMP_DIR}/${file}" || fail "Failed to download ${file}"
+done
+
+[[ -d "$INSTALL_DIR" ]] || fail "Install directory not found: $INSTALL_DIR"
+
+if [[ -f "${INSTALL_DIR}/mtproto-proxy" ]]; then
+    BACKUP_BINARY="${INSTALL_DIR}/mtproto-proxy.backup.$(date +%Y%m%d%H%M%S)"
+    cp "${INSTALL_DIR}/mtproto-proxy" "$BACKUP_BINARY"
+    ok "Current binary backed up to ${BACKUP_BINARY}"
+else
+    warn "Existing binary not found, proceeding with fresh install"
+fi
+
+info "Stopping ${SERVICE_NAME}..."
+systemctl stop "$SERVICE_NAME" 2>/dev/null || true
+
+install -m 0755 "$NEW_BINARY" "${INSTALL_DIR}/mtproto-proxy"
+
+install -m 0755 "${TMP_DIR}/install.sh" "${INSTALL_DIR}/install.sh"
+install -m 0755 "${TMP_DIR}/update.sh" "${INSTALL_DIR}/update.sh"
+install -m 0755 "${TMP_DIR}/update_dns.sh" "${INSTALL_DIR}/update_dns.sh"
+install -m 0755 "${TMP_DIR}/ipv6-hop.sh" "${INSTALL_DIR}/ipv6-hop.sh"
+install -m 0755 "${TMP_DIR}/setup_masking.sh" "${INSTALL_DIR}/setup_masking.sh"
+install -m 0755 "${TMP_DIR}/setup_nfqws.sh" "${INSTALL_DIR}/setup_nfqws.sh"
+install -m 0644 "${TMP_DIR}/capture_template.py" "${INSTALL_DIR}/capture_template.py"
+
+install -m 0644 "${TMP_DIR}/mtproto-proxy.service" "/etc/systemd/system/mtproto-proxy.service"
+systemctl daemon-reload
+
+info "Starting ${SERVICE_NAME}..."
+if ! systemctl restart "$SERVICE_NAME"; then
+    warn "Service failed to start after update"
+    if [[ -n "$BACKUP_BINARY" && -f "$BACKUP_BINARY" ]]; then
+        warn "Rolling back to previous binary..."
+        cp "$BACKUP_BINARY" "${INSTALL_DIR}/mtproto-proxy"
+        systemctl restart "$SERVICE_NAME" || fail "Rollback failed. Check: journalctl -u ${SERVICE_NAME} --no-pager"
+        fail "Update rolled back because new binary failed to start"
+    fi
+    fail "Service failed and no backup binary was available"
+fi
+
+if systemctl is-active --quiet "$SERVICE_NAME"; then
+    ok "Update complete: ${SERVICE_NAME} is active"
+else
+    fail "Service is not active after restart"
+fi
+
+echo ""
+echo -e "${BOLD}${CYAN}══════════════════════════════════════════════════${RESET}"
+echo -e "${BOLD}  Update completed${RESET}"
+echo -e "${CYAN}══════════════════════════════════════════════════${RESET}"
+echo ""
+echo -e "  ${DIM}Version:${RESET}   ${TAG}"
+echo -e "  ${DIM}Arch:${RESET}      ${ASSET_ARCH}"
+echo -e "  ${DIM}Status:${RESET}    systemctl status ${SERVICE_NAME} --no-pager"
+echo -e "  ${DIM}Logs:${RESET}      journalctl -u ${SERVICE_NAME} -f"
+if [[ -n "$BACKUP_BINARY" ]]; then
+    echo -e "  ${DIM}Backup:${RESET}    ${BACKUP_BINARY}"
+fi
+echo ""


### PR DESCRIPTION
## Summary
- add `deploy/update.sh` for in-place server updates from GitHub release artifacts with automatic rollback
- add `make update-server` target to run remote updates over SSH with optional pinned version
- move release-process notes out of README and document operator-friendly update workflow in README + GEMINI