### PR TITLE
fix: respect mask_port for local masking and ignore .vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ config.toml
 .env
 .ruff_cache/
 *.session
+.vscode/

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -184,6 +184,31 @@ bash "$TMPBUILD/deploy/setup_nfqws.sh" || warn "nfqws setup failed"
 systemctl restart "$SERVICE_NAME"
 ok "Advanced OS-Level DPI Evasion and Masking successfully configured!"
 
+# Validate masking configuration after restart
+MASK_PORT="$(awk '
+    BEGIN { in_censorship = 0 }
+    /^[[:space:]]*\[[^]]+\][[:space:]]*$/ {
+        in_censorship = ($0 ~ /^[[:space:]]*\[censorship\][[:space:]]*$/)
+        next
+    }
+    in_censorship && /^[[:space:]]*mask_port[[:space:]]*=/ {
+        line = $0
+        sub(/#.*/, "", line)
+        split(line, parts, "=")
+        value = parts[2]
+        gsub(/[[:space:]]/, "", value)
+        print value
+    }
+' "$INSTALL_DIR/config.toml" | tail -1)"
+
+if [[ -z "$MASK_PORT" ]]; then
+    warn "mask_port is not set in [censorship] — masking may fall back to remote tls_domain:443"
+elif curl -sk --max-time 5 "https://127.0.0.1:${MASK_PORT}/" >/dev/null 2>&1; then
+    ok "Masking validation passed (127.0.0.1:${MASK_PORT} responds over TLS)"
+else
+    warn "Masking validation failed: https://127.0.0.1:${MASK_PORT}/ is not responding"
+fi
+
 # ── Cleanup ─────────────────────────────────────────────────
 rm -rf "$TMPBUILD"
 

--- a/deploy/setup_masking.sh
+++ b/deploy/setup_masking.sh
@@ -152,13 +152,59 @@ fi
 # ── Update mtproto config ──────────────────────────────────
 CONFIG_FILE="${INSTALL_DIR}/config.toml"
 if [[ -f "$CONFIG_FILE" ]]; then
-    # Check if mask_port is already set
-    if grep -q "mask_port" "$CONFIG_FILE"; then
-        sed -i "s/^mask_port.*/mask_port = ${NGINX_PORT}/" "$CONFIG_FILE"
+    TMP_CONFIG="$(mktemp)"
+    if awk -v mask_port="${NGINX_PORT}" '
+        BEGIN {
+            in_censorship = 0;
+            saw_censorship = 0;
+            wrote_mask_port = 0;
+        }
+
+        function emit_mask_port() {
+            if (!wrote_mask_port) {
+                print "mask_port = " mask_port;
+                wrote_mask_port = 1;
+            }
+        }
+
+        /^[[:space:]]*\[[^]]+\][[:space:]]*$/ {
+            if (in_censorship) {
+                emit_mask_port();
+            }
+            in_censorship = ($0 ~ /^[[:space:]]*\[censorship\][[:space:]]*$/);
+            if (in_censorship) {
+                saw_censorship = 1;
+                wrote_mask_port = 0;
+            }
+            print;
+            next;
+        }
+
+        {
+            if (in_censorship && $0 ~ /^[[:space:]]*mask_port[[:space:]]*=/) {
+                emit_mask_port();
+                next;
+            }
+            print;
+        }
+
+        END {
+            if (in_censorship) {
+                emit_mask_port();
+            }
+            if (!saw_censorship) {
+                print "";
+                print "[censorship]";
+                print "mask_port = " mask_port;
+            }
+        }
+    ' "$CONFIG_FILE" > "$TMP_CONFIG"; then
+        mv "$TMP_CONFIG" "$CONFIG_FILE"
     else
-        # Add mask_port after the mask line in [censorship] section
-        sed -i "/^mask\s*=\s*true/a mask_port = ${NGINX_PORT}" "$CONFIG_FILE"
+        rm -f "$TMP_CONFIG"
+        fail "Failed to update ${CONFIG_FILE} with mask_port=${NGINX_PORT}"
     fi
+
     ok "Updated ${CONFIG_FILE} with mask_port = ${NGINX_PORT}"
     info "Restart the proxy to apply: systemctl restart mtproto-proxy"
 else

--- a/src/config.zig
+++ b/src/config.zig
@@ -113,6 +113,8 @@ pub const Config = struct {
                         cfg.tls_domain = try allocator.dupe(u8, value);
                     } else if (std.mem.eql(u8, key, "mask")) {
                         cfg.mask = std.mem.eql(u8, value, "true");
+                    } else if (std.mem.eql(u8, key, "mask_port")) {
+                        cfg.mask_port = std.fmt.parseInt(u16, value, 10) catch 443;
                     } else if (std.mem.eql(u8, key, "desync")) {
                         cfg.desync = std.mem.eql(u8, value, "true");
                     } else if (std.mem.eql(u8, key, "fast_mode")) {

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -171,15 +171,16 @@ pub const ProxyState = struct {
         // Resolve mask domain DNS at startup (avoids getaddrinfo on small-stack threads)
         var resolved_addr: ?net.Address = null;
         if (cfg.mask) {
-            const list = net.getAddressList(allocator, cfg.tls_domain, cfg.mask_port) catch |err| blk: {
-                log.err("Failed to resolve mask domain '{s}': {any}", .{ cfg.tls_domain, err });
+            const mask_target = if (cfg.mask_port != 443) "127.0.0.1" else cfg.tls_domain;
+            const list = net.getAddressList(allocator, mask_target, cfg.mask_port) catch |err| blk: {
+                log.err("Failed to resolve mask target '{s}': {any}", .{ mask_target, err });
                 break :blk null;
             };
             if (list) |al| {
                 defer al.deinit();
                 if (al.addrs.len > 0) {
                     resolved_addr = al.addrs[0];
-                    log.info("Mask domain '{s}' resolved at startup", .{cfg.tls_domain});
+                    log.info("Mask target '{s}' resolved at startup", .{mask_target});
                 }
             }
         }


### PR DESCRIPTION
## Summary
- parse and apply `mask_port` end-to-end so masking on non-443 ports uses local loopback targeting as intended
- stop repeated outbound connects to public `tls_domain:443` in masking flow and restore local Nginx masking behavior from issue #20
- include `.gitignore` update to ignore local `.vscode/` workspace settings

Fixes #20.