### PR TITLE
fix(proxy): increase max_connections to 65535

### DIFF
--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -156,7 +156,7 @@ pub const ProxyState = struct {
 
     /// Maximum concurrent connections before rejecting new ones.
     /// Prevents thread exhaustion under load.
-    const max_connections: u32 = 8192;
+    const max_connections: u32 = 65535;
 
     pub fn init(allocator: std.mem.Allocator, cfg: Config) ProxyState {
         var secrets: std.ArrayList(obfuscation.UserSecret) = .empty;


### PR DESCRIPTION
Fixes #26. Increased `max_connections` from 8192 to 65535 to prevent thread exhaustion limits from being reached prematurely, matching the 65535 limits set in the systemd service `TasksMax`.