### PR TITLE
fix middleproxy C2S overflow and add bench/soak tooling

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -30,6 +30,7 @@ High-performance MTProto proxy that mimics TLS 1.3 handshakes (domain fronting) 
 ```text
 src/
 ├── main.zig              # Entry point, banner, public IP detection, custom logger
+├── bench.zig             # Performance microbench + multithreaded soak runner
 ├── config.zig            # TOML config parser
 ├── proxy/
 │   └── proxy.zig         # Core: accept loop, client handler, relay, DRS, Split-TLS desync
@@ -86,6 +87,8 @@ make build                                             # Debug build (native)
 make release                                           # Release build (native)
 make release_linux                                     # Cross-compile for Linux
 make test                                              # Run unit tests
+make bench                                             # ReleaseFast encapsulation microbench
+make soak                                              # ReleaseFast 30s multithreaded soak stress
 make deploy                                            # Cross-compile + stop + scp + start
 make update-server SERVER=<ip> [VERSION=vX.Y.Z]       # Update VPS from GitHub Release
 ```
@@ -290,6 +293,12 @@ All relay sockets use these settings:
 - Runtime updates are protected by `std.Thread.RwLock` and applied per new connection.
 - If fetching fails, bundled defaults remain active.
 
+### MiddleProxy C2S Frame Safety
+- `encapsulateSingleMessageC2S` previously built RPC payload in a fixed 64KiB stack buffer.
+- Under large client packets, this could overflow the local buffer and crash with `SIGSEGV`.
+- Fixed by writing RPC payload directly into `out_buf` with precomputed frame size and explicit bounds checks (`error.OutBufOverflow`).
+- Added regression test for payloads larger than 64KiB.
+
 ---
 
 ## Chronological Bug Fixes
@@ -317,6 +326,8 @@ All relay sockets use these settings:
 22. **Telemt promo parity**: Added `[general].use_middle_proxy` support for regular DC1..5 and `[general].ad_tag` alias; ME path now injects ad tag into `RPC_PROXY_REQ` when configured.
 23. **Deploy config parity**: `make deploy` now uploads runtime `config.toml` (via `CONFIG`) to `/opt/mtproto-proxy/config.toml` to avoid stale server config after binary-only deploys.
 24. **Production log normalization**: reverted temporary relay diagnostics (`DIAG C2S/S2C`, `Relay ended`, common reset/EOF errors) back to debug level to reduce log I/O noise and keep warning/error logs actionable under high mobile churn.
+25. **MiddleProxy C2S overflow fix**: removed fixed 64KiB stack RPC buffer in `encapsulateSingleMessageC2S`, switched to direct write into output buffer with explicit bounds checks.
+26. **Bench/Soak tooling**: added built-in `bench` and multithreaded `soak` runners (`src/bench.zig`, `zig build bench`, `zig build soak`, `make bench`, `make soak`) for repeatable local performance and stability validation.
 
 ---
 
@@ -329,6 +340,12 @@ Implemented a 100% loopback test capability:
 
 ### Re-enabling DRS
 Once iPhone connectivity is stable, test with the `DRS` ramp enabled (shifting to 16384-byte records after a threshold).
+
+### Soak Gate in CI
+Current soak runner is local-first (`make soak`) and already useful for manual release checks. Future work:
+- add CI profile for short/medium soak tiers (e.g., 10s on PR, 60s on main)
+- keep host-specific throughput baselines and fail on statistically significant regressions
+- publish bench/soak artifacts per run to track perf drift over time
 
 ### Advanced Anti-DPI Research
 Based on continuous updates from DPI developers (e.g., VAS Experts/EcoSnat), bypass development remains a cat-and-mouse game. Notably, they actively maintain a detailed public changelog tracking new blocking capabilities: [VAS Experts DPI Changelog](https://wiki.vasexperts.ru/doku.php?id=dpi:changelog:versions:beta).

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build release run test clean fmt deploy update-server migrate update-dns release-manual
+.PHONY: build release run test bench soak clean fmt deploy update-server migrate update-dns release-manual
 
 SERVER ?= 185.125.46.60
 CONFIG ?= config.toml
@@ -27,6 +27,12 @@ run:
 
 test:
 	zig build test
+
+bench:
+	zig build -Doptimize=ReleaseFast bench
+
+soak:
+	zig build -Doptimize=ReleaseFast soak -- --seconds=30
 
 fmt:
 	zig fmt src/

--- a/README.md
+++ b/README.md
@@ -79,6 +79,22 @@ make run
 make test
 ```
 
+### Performance & Stability Checks
+
+```bash
+# Fast microbenchmark for C2S encapsulation
+make bench
+
+# 30-second multithreaded soak (crash/stability guard)
+make soak
+
+# Custom soak shape
+zig build -Doptimize=ReleaseFast soak -- --seconds=120 --threads=8 --max-payload=131072
+```
+
+`bench` prints per-payload throughput (`in_mib_per_s`, `out_mib_per_s`) and `ns_per_op`.
+`soak` prints aggregate `ops/s`, throughput, and `errors`; non-zero errors fail the step.
+
 <details>
 <summary>All Make targets</summary>
 
@@ -88,6 +104,8 @@ make test
 | `make release` | Optimized build (`ReleaseFast`) |
 | `make run CONFIG=<path>` | Run proxy (default: `config.toml`) |
 | `make test` | Run unit tests |
+| `make bench` | Run ReleaseFast encapsulation microbenchmarks |
+| `make soak` | Run ReleaseFast multithreaded soak stress test (30s default) |
 | `make clean` | Remove build artifacts |
 | `make fmt` | Format all Zig source files |
 | `make deploy` | Cross-compile, upload binary/scripts/config to VPS, restart service |

--- a/build.zig
+++ b/build.zig
@@ -26,6 +26,36 @@ pub fn build(b: *std.Build) void {
     const run_step = b.step("run", "Run the proxy");
     run_step.dependOn(&run_cmd.step);
 
+    const bench_mod = b.createModule(.{
+        .root_source_file = b.path("src/bench.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const bench_exe = b.addExecutable(.{
+        .name = "mtproto-bench",
+        .root_module = bench_mod,
+    });
+
+    b.installArtifact(bench_exe);
+
+    const run_bench_cmd = b.addRunArtifact(bench_exe);
+    if (b.args) |args| {
+        run_bench_cmd.addArgs(args);
+    }
+
+    const bench_step = b.step("bench", "Run encapsulation microbenchmarks");
+    bench_step.dependOn(&run_bench_cmd.step);
+
+    const run_soak_cmd = b.addRunArtifact(bench_exe);
+    run_soak_cmd.addArg("soak");
+    if (b.args) |args| {
+        run_soak_cmd.addArgs(args);
+    }
+
+    const soak_step = b.step("soak", "Run multithreaded soak stress test");
+    soak_step.dependOn(&run_soak_cmd.step);
+
     // Tests
     const test_mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -1,0 +1,344 @@
+const std = @import("std");
+const net = std.net;
+const crypto = @import("crypto/crypto.zig");
+const middleproxy = @import("protocol/middleproxy.zig");
+const constants = @import("protocol/constants.zig");
+
+const Mode = enum {
+    bench,
+    soak,
+};
+
+const Options = struct {
+    mode: Mode = .bench,
+    seconds: u32 = 30,
+    threads: usize = 0,
+    max_payload: usize = 128 * 1024,
+};
+
+const SoakShared = struct {
+    deadline_ms: i64,
+    total_ops: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    total_in_bytes: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    total_out_bytes: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    errors: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+};
+
+const WorkerArgs = struct {
+    worker_id: usize,
+    max_payload: usize,
+    shared: *SoakShared,
+};
+
+pub fn main() !void {
+    const allocator = std.heap.page_allocator;
+
+    const opts = parseArgs(allocator) catch |err| {
+        if (err != error.ShowHelp) {
+            std.debug.print("error: {any}\n\n", .{err});
+        }
+        printUsage();
+        if (err == error.ShowHelp) return;
+        return err;
+    };
+
+    switch (opts.mode) {
+        .bench => try runBench(allocator),
+        .soak => try runSoak(allocator, opts),
+    }
+}
+
+fn runBench(allocator: std.mem.Allocator) !void {
+    const sizes = [_]usize{ 64, 256, 1024, 4096, 16384, 65536, 131072 };
+    const target_bytes = 128 * 1024 * 1024;
+
+    std.debug.print("benchmark: encapsulateSingleMessageC2S (proto={s})\n", .{@tagName(constants.ProtoTag.intermediate)});
+    std.debug.print("payload_bytes iterations ns_per_op in_mib_per_s out_mib_per_s\n", .{});
+
+    for (sizes) |payload_size| {
+        var ctx = try initContext(allocator, .intermediate);
+        defer ctx.deinit(allocator);
+
+        const payload = try allocator.alloc(u8, payload_size);
+        defer allocator.free(payload);
+        fillPayload(payload);
+
+        const out_buf = try allocator.alloc(u8, payload_size + 256);
+        defer allocator.free(out_buf);
+
+        var iters = target_bytes / payload_size;
+        if (iters < 1_000) iters = 1_000;
+        if (iters > 300_000) iters = 300_000;
+
+        const warmup_iters = @min(iters, 256);
+        var w: usize = 0;
+        while (w < warmup_iters) : (w += 1) {
+            payload[0] +%= 1;
+            _ = try ctx.encapsulateSingleMessageC2S(payload, (w & 1) == 1, out_buf);
+        }
+
+        var timer = try std.time.Timer.start();
+
+        var produced_out_bytes: u64 = 0;
+        var i: usize = 0;
+        while (i < iters) : (i += 1) {
+            payload[0] +%= 1;
+            const written = try ctx.encapsulateSingleMessageC2S(payload, (i & 1) == 1, out_buf);
+            produced_out_bytes += @as(u64, @intCast(written));
+        }
+
+        const elapsed_ns = timer.read();
+        const total_in_bytes = @as(u64, @intCast(payload_size)) * @as(u64, @intCast(iters));
+        const ns_per_op = elapsedNsPerOp(elapsed_ns, iters);
+
+        std.debug.print("{d} {d} {d} {d} {d}\n", .{
+            payload_size,
+            iters,
+            ns_per_op,
+            bytesPerSecToMiB(total_in_bytes, elapsed_ns),
+            bytesPerSecToMiB(produced_out_bytes, elapsed_ns),
+        });
+    }
+}
+
+fn runSoak(allocator: std.mem.Allocator, opts: Options) !void {
+    const start_ms = std.time.milliTimestamp();
+    const duration_ms = @as(i64, @intCast(opts.seconds)) * 1000;
+
+    var shared = SoakShared{
+        .deadline_ms = start_ms + duration_ms,
+    };
+
+    std.debug.print("soak: workers={d} duration={d}s max_payload={d}\n", .{
+        opts.threads,
+        opts.seconds,
+        opts.max_payload,
+    });
+
+    var threads: std.ArrayList(std.Thread) = .empty;
+    defer threads.deinit(allocator);
+
+    for (0..opts.threads) |worker_id| {
+        const worker = WorkerArgs{
+            .worker_id = worker_id,
+            .max_payload = opts.max_payload,
+            .shared = &shared,
+        };
+        const thread = try std.Thread.spawn(.{}, soakWorker, .{worker});
+        try threads.append(allocator, thread);
+    }
+
+    for (threads.items) |thread| {
+        thread.join();
+    }
+
+    const end_ms = std.time.milliTimestamp();
+    const elapsed_ms_i64 = @max(@as(i64, 1), end_ms - start_ms);
+    const elapsed_ms: u64 = @intCast(elapsed_ms_i64);
+
+    const ops = shared.total_ops.load(.monotonic);
+    const in_bytes = shared.total_in_bytes.load(.monotonic);
+    const out_bytes = shared.total_out_bytes.load(.monotonic);
+    const errors = shared.errors.load(.monotonic);
+
+    std.debug.print("result: ops={d} ops/s={d} in_mib/s={d} out_mib/s={d} errors={d}\n", .{
+        ops,
+        perSec(ops, elapsed_ms),
+        bytesPerSecToMiBMs(in_bytes, elapsed_ms),
+        bytesPerSecToMiBMs(out_bytes, elapsed_ms),
+        errors,
+    });
+
+    if (errors != 0 or ops == 0) {
+        return error.SoakFailed;
+    }
+}
+
+fn soakWorker(args: WorkerArgs) void {
+    const allocator = std.heap.page_allocator;
+
+    var ctx = initContext(allocator, .intermediate) catch {
+        _ = args.shared.errors.fetchAdd(1, .monotonic);
+        return;
+    };
+    defer ctx.deinit(allocator);
+
+    const payload_buf = allocator.alloc(u8, args.max_payload) catch {
+        _ = args.shared.errors.fetchAdd(1, .monotonic);
+        return;
+    };
+    defer allocator.free(payload_buf);
+    fillPayload(payload_buf);
+
+    const out_buf = allocator.alloc(u8, args.max_payload + 256) catch {
+        _ = args.shared.errors.fetchAdd(1, .monotonic);
+        return;
+    };
+    defer allocator.free(out_buf);
+
+    var rng_state = makeSeed(args.worker_id);
+
+    while (std.time.milliTimestamp() < args.shared.deadline_ms) {
+        const payload_len = nextPayloadLen(&rng_state, args.max_payload);
+        payload_buf[0] +%= 1;
+        const quickack = (nextRand(&rng_state) & 1) == 1;
+
+        const written = ctx.encapsulateSingleMessageC2S(payload_buf[0..payload_len], quickack, out_buf) catch {
+            _ = args.shared.errors.fetchAdd(1, .monotonic);
+            return;
+        };
+
+        _ = args.shared.total_ops.fetchAdd(1, .monotonic);
+        _ = args.shared.total_in_bytes.fetchAdd(@as(u64, @intCast(payload_len)), .monotonic);
+        _ = args.shared.total_out_bytes.fetchAdd(@as(u64, @intCast(written)), .monotonic);
+    }
+}
+
+fn initContext(allocator: std.mem.Allocator, proto_tag: constants.ProtoTag) !middleproxy.MiddleProxyContext {
+    const key = [_]u8{0} ** 32;
+    const iv = [_]u8{0} ** 16;
+
+    return middleproxy.MiddleProxyContext.init(
+        allocator,
+        crypto.AesCbc.init(&key, &iv),
+        crypto.AesCbc.init(&key, &iv),
+        [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 },
+        -2,
+        net.Address.initIp4(.{ 10, 20, 30, 40 }, 12345),
+        net.Address.initIp4(.{ 91, 105, 192, 110 }, 443),
+        proto_tag,
+        null,
+    );
+}
+
+fn fillPayload(buf: []u8) void {
+    for (buf, 0..) |*byte, idx| {
+        byte.* = @truncate((idx * 17 + 11) % 251);
+    }
+}
+
+fn parseArgs(allocator: std.mem.Allocator) !Options {
+    var opts = Options{};
+
+    var args = try std.process.argsWithAllocator(allocator);
+    defer args.deinit();
+
+    _ = args.next();
+    while (args.next()) |arg| {
+        if (std.mem.eql(u8, arg, "bench")) {
+            opts.mode = .bench;
+            continue;
+        }
+        if (std.mem.eql(u8, arg, "soak")) {
+            opts.mode = .soak;
+            continue;
+        }
+        if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
+            return error.ShowHelp;
+        }
+        if (std.mem.startsWith(u8, arg, "--seconds=")) {
+            opts.seconds = try parsePositiveU32(arg["--seconds=".len..]);
+            continue;
+        }
+        if (std.mem.startsWith(u8, arg, "--threads=")) {
+            opts.threads = try parsePositiveUsize(arg["--threads=".len..]);
+            continue;
+        }
+        if (std.mem.startsWith(u8, arg, "--max-payload=")) {
+            opts.max_payload = try parsePositiveUsize(arg["--max-payload=".len..]);
+            continue;
+        }
+
+        return error.InvalidArgument;
+    }
+
+    if (opts.threads == 0) {
+        const cpu_count = std.Thread.getCpuCount() catch 4;
+        opts.threads = @max(@as(usize, 1), cpu_count);
+    }
+
+    if (opts.max_payload < 64) return error.InvalidArgument;
+
+    return opts;
+}
+
+fn parsePositiveU32(text: []const u8) !u32 {
+    const value = try std.fmt.parseInt(u32, text, 10);
+    if (value == 0) return error.InvalidArgument;
+    return value;
+}
+
+fn parsePositiveUsize(text: []const u8) !usize {
+    const value = try std.fmt.parseInt(usize, text, 10);
+    if (value == 0) return error.InvalidArgument;
+    return value;
+}
+
+fn printUsage() void {
+    std.debug.print(
+        \\Usage:
+        \\  zig build bench
+        \\  zig build bench -- --help
+        \\  zig build soak -- --seconds=30 --threads=8 --max-payload=131072
+        \\
+        \\Modes:
+        \\  bench (default): microbenchmark for C2S encapsulation
+        \\  soak: multithreaded crash/stability stress test
+        \\
+    , .{});
+}
+
+fn elapsedNsPerOp(elapsed_ns: u64, iters: usize) u64 {
+    if (iters == 0) return 0;
+    return elapsed_ns / @as(u64, @intCast(iters));
+}
+
+fn bytesPerSecToMiB(bytes: u64, elapsed_ns: u64) u64 {
+    if (elapsed_ns == 0) return 0;
+    const numerator = @as(u128, bytes) * std.time.ns_per_s;
+    const denominator = @as(u128, elapsed_ns) * 1024 * 1024;
+    return @intCast(numerator / denominator);
+}
+
+fn perSec(value: u64, elapsed_ms: u64) u64 {
+    if (elapsed_ms == 0) return 0;
+    const numerator = @as(u128, value) * 1000;
+    return @intCast(numerator / elapsed_ms);
+}
+
+fn bytesPerSecToMiBMs(bytes: u64, elapsed_ms: u64) u64 {
+    if (elapsed_ms == 0) return 0;
+    const numerator = @as(u128, bytes) * 1000;
+    const denominator = @as(u128, elapsed_ms) * 1024 * 1024;
+    return @intCast(numerator / denominator);
+}
+
+fn makeSeed(worker_id: usize) u64 {
+    const now_ms = std.time.milliTimestamp();
+    const base: u64 = if (now_ms >= 0)
+        @intCast(now_ms)
+    else
+        @intCast(-now_ms);
+    var seed = base ^ (@as(u64, @intCast(worker_id + 1)) *% 0x9e3779b97f4a7c15);
+    if (seed == 0) seed = 1;
+    return seed;
+}
+
+fn nextRand(state: *u64) u64 {
+    state.* = state.* *% 6364136223846793005 +% 1442695040888963407;
+    return state.*;
+}
+
+fn nextPayloadLen(state: *u64, max_payload: usize) usize {
+    const hot_sizes = [_]usize{ 64, 256, 1024, 4096, 16384, 32768, 65535, 65536, 65537, 131072 };
+
+    const pick_hot = (nextRand(state) % 10) < 7;
+    if (pick_hot) {
+        const idx: usize = @intCast(nextRand(state) % hot_sizes.len);
+        const capped = @min(hot_sizes[idx], max_payload);
+        return if (capped == 0) 1 else capped;
+    }
+
+    const max_u64 = @as(u64, @intCast(@max(@as(usize, 1), max_payload)));
+    return 1 + @as(usize, @intCast(nextRand(state) % max_u64));
+}

--- a/src/protocol/middleproxy.zig
+++ b/src/protocol/middleproxy.zig
@@ -282,60 +282,55 @@ pub const MiddleProxyContext = struct {
         }
         if (all_zeros and client_data.len >= 8) flags |= Flag.not_encrypted;
 
-        // Construct inner RPC payload
-        var rpc_payload: [65536]u8 = undefined;
-        var rpc_len: usize = 0;
+        // Write directly into out_buf to avoid fixed-size stack buffer overflow
+        // on large client packets.
+        const extra_len: usize = if (self.ad_tag != null) 28 else 0;
+        const rpc_len = 56 + extra_len + client_data.len;
+        const frame_total_len = rpc_len + 12;
+        const padding_needed = (16 - (frame_total_len % 16)) % 16;
+        const encrypted_len = frame_total_len + padding_needed;
+        if (out_buf.len < encrypted_len) return error.OutBufOverflow;
 
-        @memcpy(rpc_payload[rpc_len .. rpc_len + 4], &rpc_proxy_req);
-        rpc_len += 4;
-        std.mem.writeInt(u32, rpc_payload[rpc_len..][0..4], flags, .little);
-        rpc_len += 4;
-        @memcpy(rpc_payload[rpc_len .. rpc_len + 8], &self.conn_id);
-        rpc_len += 8;
-        @memcpy(rpc_payload[rpc_len .. rpc_len + 20], &self.remote_ip_port);
-        rpc_len += 20;
-        @memcpy(rpc_payload[rpc_len .. rpc_len + 20], &self.our_ip_port);
-        rpc_len += 20;
-
-        if (self.ad_tag) |ad_tag| {
-            // EXTRA_SIZE field + TL proxy_tag bytes (24 bytes total)
-            const extra_size: u32 = 24;
-            std.mem.writeInt(u32, rpc_payload[rpc_len..][0..4], extra_size, .little);
-            rpc_len += 4;
-
-            const proxy_tag = [_]u8{ 0xae, 0x26, 0x1e, 0xdb };
-            @memcpy(rpc_payload[rpc_len .. rpc_len + 4], &proxy_tag);
-            rpc_len += 4;
-
-            // Bytes TL string with fixed 16-byte ad tag + 3-byte align padding.
-            rpc_payload[rpc_len] = 16;
-            rpc_len += 1;
-
-            @memcpy(rpc_payload[rpc_len .. rpc_len + 16], &ad_tag);
-            rpc_len += 16;
-
-            const aligner = [_]u8{ 0x00, 0x00, 0x00 };
-            @memcpy(rpc_payload[rpc_len .. rpc_len + 3], &aligner);
-            rpc_len += 3;
-        }
-
-        // Append client_data
-        @memcpy(rpc_payload[rpc_len .. rpc_len + client_data.len], client_data);
-        rpc_len += client_data.len;
-
-        // Wrap in MTProtoFrame
-        const frame_total_len: u32 = @intCast(rpc_len + 12);
-
-        // Let's write the frame directly to out_buf
         var out_len: usize = 0;
-        std.mem.writeInt(u32, out_buf[out_len..][0..4], frame_total_len, .little);
+        std.mem.writeInt(u32, out_buf[out_len..][0..4], @intCast(frame_total_len), .little);
         out_len += 4;
         std.mem.writeInt(i32, out_buf[out_len..][0..4], self.seq_no, .little);
         out_len += 4;
         self.seq_no += 1;
 
-        @memcpy(out_buf[out_len .. out_len + rpc_len], rpc_payload[0..rpc_len]);
-        out_len += rpc_len;
+        @memcpy(out_buf[out_len .. out_len + 4], &rpc_proxy_req);
+        out_len += 4;
+        std.mem.writeInt(u32, out_buf[out_len..][0..4], flags, .little);
+        out_len += 4;
+        @memcpy(out_buf[out_len .. out_len + 8], &self.conn_id);
+        out_len += 8;
+        @memcpy(out_buf[out_len .. out_len + 20], &self.remote_ip_port);
+        out_len += 20;
+        @memcpy(out_buf[out_len .. out_len + 20], &self.our_ip_port);
+        out_len += 20;
+
+        if (self.ad_tag) |ad_tag| {
+            const extra_size: u32 = 24;
+            std.mem.writeInt(u32, out_buf[out_len..][0..4], extra_size, .little);
+            out_len += 4;
+
+            const proxy_tag = [_]u8{ 0xae, 0x26, 0x1e, 0xdb };
+            @memcpy(out_buf[out_len .. out_len + 4], &proxy_tag);
+            out_len += 4;
+
+            out_buf[out_len] = 16;
+            out_len += 1;
+
+            @memcpy(out_buf[out_len .. out_len + 16], &ad_tag);
+            out_len += 16;
+
+            const aligner = [_]u8{ 0x00, 0x00, 0x00 };
+            @memcpy(out_buf[out_len .. out_len + 3], &aligner);
+            out_len += 3;
+        }
+
+        @memcpy(out_buf[out_len .. out_len + client_data.len], client_data);
+        out_len += client_data.len;
 
         // CRC32 of length + seq + payload (which starts at out_buf[0])
         const checksum = crc32(out_buf[0..out_len]);
@@ -343,7 +338,6 @@ pub const MiddleProxyContext = struct {
         out_len += 4;
 
         // AES CBC Padding requires NO-OP length markers (0x04000000)
-        const padding_needed = (16 - (out_len % 16)) % 16;
         var i: usize = 0;
         while (i < padding_needed) : (i += 4) {
             std.mem.writeInt(u32, out_buf[out_len + i ..][0..4], 4, .little);
@@ -958,4 +952,44 @@ test "decapsulate s2c validates seq and checksum" {
     try enc.encryptInPlace(wire2[0..]);
 
     try std.testing.expectError(error.BadMiddleProxySeqNo, ctx.decapsulateS2C(wire2[0..]));
+}
+
+test "encapsulate c2s supports payloads larger than 64KiB" {
+    const allocator = std.testing.allocator;
+
+    const key = [_]u8{0} ** 32;
+    const iv = [_]u8{0} ** 16;
+
+    var ctx = try MiddleProxyContext.init(
+        allocator,
+        crypto.AesCbc.init(&key, &iv),
+        crypto.AesCbc.init(&key, &iv),
+        [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 },
+        -2,
+        std.net.Address.initIp4(.{ 10, 20, 30, 40 }, 12345),
+        std.net.Address.initIp4(.{ 91, 105, 192, 110 }, 443),
+        .intermediate,
+        null,
+    );
+    defer ctx.deinit(allocator);
+
+    const payload_len = 96 * 1024;
+    const payload = try allocator.alloc(u8, payload_len);
+    defer allocator.free(payload);
+    @memset(payload, 0x42);
+
+    const out_buf = try allocator.alloc(u8, 128 * 1024);
+    defer allocator.free(out_buf);
+
+    const written = try ctx.encapsulateSingleMessageC2S(payload, false, out_buf);
+    try std.testing.expect(written > payload_len);
+
+    var decryptor = crypto.AesCbc.init(&key, &iv);
+    try decryptor.decryptInPlace(out_buf[0..written]);
+
+    const total_len = std.mem.readInt(u32, out_buf[0..4], .little);
+    try std.testing.expectEqual(@as(usize, total_len), 56 + payload_len + 12);
+
+    const rpc_payload = out_buf[8 .. total_len - 4];
+    try std.testing.expectEqualSlices(u8, &rpc_proxy_req, rpc_payload[0..4]);
 }


### PR DESCRIPTION
## Summary
- fix a middleproxy C2S encapsulation crash under load by removing the fixed 64 KiB stack RPC buffer and writing directly into `out_buf` with explicit bounds checks
- add a regression test for payloads larger than 64 KiB to lock in the crash fix
- add built-in performance/stability tooling (`zig build bench`, `zig build soak`, `make bench`, `make soak`) plus README docs for repeatable local validation

## Validation
- `zig build test`
- `zig build -Doptimize=ReleaseFast bench`
- `zig build -Doptimize=ReleaseFast soak -- --seconds=3 --threads=2 --max-payload=131072`
- `make bench`
- `make soak`