### PR TITLE
fix(middleproxy): assert computed C2S frame size

### DIFF
--- a/src/protocol/middleproxy.zig
+++ b/src/protocol/middleproxy.zig
@@ -344,6 +344,8 @@ pub const MiddleProxyContext = struct {
         }
         out_len += padding_needed;
 
+        std.debug.assert(out_len == encrypted_len);
+
         try self.encryptor.encryptInPlace(out_buf[0..out_len]);
         return out_len;
     }


### PR DESCRIPTION
## Summary
- add a debug assertion that validates computed encrypted frame size matches actual serialized output length in `encapsulateSingleMessageC2S`
- keep this as a tiny follow-up fix commit so release-please picks up the middleproxy overflow work in release notes

## Validation
- `zig build test`