### PR TITLE
feat: make tcp listen backlog configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ ad_tag = "1234567890abcdef1234567890abcdef"    # Optional alias for [server].tag
 
 [server]
 port = 443
+backlog = 4096                             # TCP listen queue size
 tag = "1234567890abcdef1234567890abcdef"   # Optional: promotion tag from @MTProxybot
 
 [censorship]
@@ -342,6 +343,7 @@ bob   = "ffeeddccbbaa99887766554433221100"
 | `[general]` | `use_middle_proxy` | `false` | Telemt-compatible ME mode for regular DC1..5 (recommended for promo-channel parity) |
 | `[general]` | `ad_tag` | _(none)_ | Telemt-compatible alias for promotion tag; ignored if `[server].tag` is set |
 | `[server]` | `port` | `443` | TCP port to listen on |
+| `[server]` | `backlog` | `4096` | TCP listen queue size (for high-traffic loads) |
 | `[server]` | `tag` | _(none)_ | Optional 32 hex-char promotion tag from [@MTProxybot](https://t.me/MTProxybot) |
 | `[censorship]` | `tls_domain` | `"google.com"` | Domain to impersonate / forward bad clients to |
 | `[censorship]` | `mask` | `true` | Forward unauthenticated connections to `tls_domain` to defeat DPI |

--- a/config.toml.example
+++ b/config.toml.example
@@ -7,6 +7,8 @@ use_middle_proxy = true
 
 [server]
 port = 443
+# TCP listen queue size (default is 4096)
+# backlog = 4096
 # Optional: 32 hex-char promotion tag from @MTProxybot
 # tag = "1234567890abcdef1234567890abcdef"
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -12,6 +12,8 @@ pub const Config = struct {
     /// Mirrors telemt's [general].use_middle_proxy behavior.
     use_middle_proxy: bool = false,
     port: u16 = 443,
+    /// TCP listen(2) backlog for client-facing sockets
+    backlog: u32 = 4096,
     tag: ?[16]u8 = null,
     tls_domain: []const u8 = "google.com",
     users: std.StringHashMap([16]u8),
@@ -97,6 +99,8 @@ pub const Config = struct {
                 } else if (in_server_section) {
                     if (std.mem.eql(u8, key, "port")) {
                         cfg.port = std.fmt.parseInt(u16, value, 10) catch 443;
+                    } else if (std.mem.eql(u8, key, "backlog")) {
+                        cfg.backlog = std.fmt.parseInt(u32, value, 10) catch 4096;
                     } else if (std.mem.eql(u8, key, "tag")) {
                         if (value.len == 32) {
                             var tag: [16]u8 = undefined;
@@ -163,6 +167,7 @@ test "parse config - valid complete" {
         \\
         \\[server]
         \\port = 8443
+        \\backlog = 8192
         \\fast_mode = true
         \\
         \\[censorship]
@@ -179,6 +184,7 @@ test "parse config - valid complete" {
     defer cfg.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(u16, 8443), cfg.port);
+    try std.testing.expectEqual(@as(u32, 8192), cfg.backlog);
     try std.testing.expectEqualStrings("example.com", cfg.tls_domain);
     try std.testing.expect(cfg.use_middle_proxy);
     try std.testing.expect(cfg.mask);
@@ -200,6 +206,7 @@ test "parse config - missing fields defaults" {
     defer cfg.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(u16, 443), cfg.port);
+    try std.testing.expectEqual(@as(u32, 4096), cfg.backlog); // Default is 4096
     try std.testing.expectEqualStrings("google.com", cfg.tls_domain);
     try std.testing.expect(!cfg.use_middle_proxy); // Default is false
     try std.testing.expect(cfg.mask); // Default is true

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -230,6 +230,7 @@ pub const ProxyState = struct {
         );
         var server = try address.listen(.{
             .reuse_address = true,
+            .kernel_backlog = self.config.backlog,
         });
         defer server.deinit();
 

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -230,7 +230,7 @@ pub const ProxyState = struct {
         );
         var server = try address.listen(.{
             .reuse_address = true,
-            .kernel_backlog = self.config.backlog,
+            .kernel_backlog = @intCast(self.config.backlog),
         });
         defer server.deinit();
 


### PR DESCRIPTION
Resolves #35. Default is set to 4096 to support high-load environments. Modifies proxy listener to use configurable `kernel_backlog`, and documents this setting.