### PR TITLE
fix: add stability harness and tune middleproxy buffers

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -250,10 +250,10 @@ We currently keep this section strict: no behavior claims without either (a) rep
 ### iOS (Telegram iOS)
 - **Field evidence (our captures/logs)**: iOS pre-warms multiple idle sockets, can fragment the 64-byte obfuscation handshake across TLS records, and may delay first payload after `ServerHello`.
 - **Version-pinned source snapshot**: `TelegramMessenger/Telegram-iOS` tag `build-26855` (target commit `b16d9acdffa9b3f88db68e26b77a3713e87a92e3`).
-- In this source snapshot, TCP connect timeout is `12s` in `submodules/MtProtoKit/Sources/MTTcpConnection.m:980`.
-- Response watchdog is based on `MTMinTcpResponseTimeout = 12.0` (`submodules/MtProtoKit/Sources/MTTcpConnection.m:576`) plus payload-dependent term (`submodules/MtProtoKit/Sources/MTTcpConnection.m:1339`), and is reset on partial reads (`submodules/MtProtoKit/Sources/MTTcpConnection.m:1398`).
-- Transport-level connection watchdog is `20s` in `submodules/MtProtoKit/Sources/MTTcpTransport.m:312`.
-- Reconnect backoff in `submodules/MtProtoKit/Sources/MTTcpConnectionBehaviour.m:66` is stepped (`1s` for early retries, then `4s`, then `8s`).
+- In this source snapshot, TCP connect timeout is `12s` in [`submodules/MtProtoKit/Sources/MTTcpConnection.m:980`](https://github.com/TelegramMessenger/Telegram-iOS/blob/b16d9acdffa9b3f88db68e26b77a3713e87a92e3/submodules/MtProtoKit/Sources/MTTcpConnection.m#L980).
+- Response watchdog is based on `MTMinTcpResponseTimeout = 12.0` ([`submodules/MtProtoKit/Sources/MTTcpConnection.m:576`](https://github.com/TelegramMessenger/Telegram-iOS/blob/b16d9acdffa9b3f88db68e26b77a3713e87a92e3/submodules/MtProtoKit/Sources/MTTcpConnection.m#L576)) plus payload-dependent term ([`submodules/MtProtoKit/Sources/MTTcpConnection.m:1339`](https://github.com/TelegramMessenger/Telegram-iOS/blob/b16d9acdffa9b3f88db68e26b77a3713e87a92e3/submodules/MtProtoKit/Sources/MTTcpConnection.m#L1339)), and is reset on partial reads ([`submodules/MtProtoKit/Sources/MTTcpConnection.m:1398`](https://github.com/TelegramMessenger/Telegram-iOS/blob/b16d9acdffa9b3f88db68e26b77a3713e87a92e3/submodules/MtProtoKit/Sources/MTTcpConnection.m#L1398)).
+- Transport-level connection watchdog is `20s` in [`submodules/MtProtoKit/Sources/MTTcpTransport.m:312`](https://github.com/TelegramMessenger/Telegram-iOS/blob/b16d9acdffa9b3f88db68e26b77a3713e87a92e3/submodules/MtProtoKit/Sources/MTTcpTransport.m#L312).
+- Reconnect backoff in [`submodules/MtProtoKit/Sources/MTTcpConnectionBehaviour.m:66`](https://github.com/TelegramMessenger/Telegram-iOS/blob/b16d9acdffa9b3f88db68e26b77a3713e87a92e3/submodules/MtProtoKit/Sources/MTTcpConnectionBehaviour.m#L66) is stepped (`1s` for early retries, then `4s`, then `8s`).
 
 **Proxy-side handling used for iOS compatibility:**
 - Two-stage timeout model: `poll()` idle phase (5 min), then active `SO_RCVTIMEO=10s` after payload starts.
@@ -263,19 +263,19 @@ We currently keep this section strict: no behavior claims without either (a) rep
 
 ### Android (Telegram Android)
 - **Version-pinned source snapshot**: `DrKLO/Telegram` tag `release-11.4.2-5469` (commit `fb2e545101f41303f1e2712de2e7611a9335f1c3`).
-- Socket setup in `TMessagesProj/jni/tgnet/ConnectionSocket.cpp:571` enables `TCP_NODELAY` (`TMessagesProj/jni/tgnet/ConnectionSocket.cpp:574`), switches socket to `O_NONBLOCK` (`TMessagesProj/jni/tgnet/ConnectionSocket.cpp:587`), and uses `connect(..., EINPROGRESS)` with edge-triggered epoll (`EPOLLIN|EPOLLOUT|EPOLLRDHUP|EPOLLERR|EPOLLET`, `TMessagesProj/jni/tgnet/ConnectionSocket.cpp:596`).
-- Timeout handling is internal logical timeout (`setTimeout`/`checkTimeout`) in `TMessagesProj/jni/tgnet/ConnectionSocket.cpp:1066` and `TMessagesProj/jni/tgnet/ConnectionSocket.cpp:1076`.
-- Per-connection-type timeout profile is explicitly assigned in `TMessagesProj/jni/tgnet/Connection.cpp:368` and after first useful data in `TMessagesProj/jni/tgnet/Connection.cpp:131`.
-- Connection type split is explicit (`ConnectionTypeGeneric/Download/Upload/Push/Temp/Proxy`) in `TMessagesProj/jni/tgnet/Defines.h:68`, with multiple parallel slots (`PROXY_CONNECTIONS_COUNT=4`, `DOWNLOAD_CONNECTIONS_COUNT=2`, `UPLOAD_CONNECTIONS_COUNT=4`) in `TMessagesProj/jni/tgnet/Defines.h:26`.
-- Datacenter keeps separate connection objects/arrays per type in `TMessagesProj/jni/tgnet/Datacenter.h:88` and lazily creates/connects them in `TMessagesProj/jni/tgnet/Datacenter.cpp:835` and `TMessagesProj/jni/tgnet/Datacenter.cpp:1311`.
+- Socket setup in [`TMessagesProj/jni/tgnet/ConnectionSocket.cpp:571`](https://github.com/DrKLO/Telegram/blob/fb2e545101f41303f1e2712de2e7611a9335f1c3/TMessagesProj/jni/tgnet/ConnectionSocket.cpp#L571) enables `TCP_NODELAY` ([`...:574`](https://github.com/DrKLO/Telegram/blob/fb2e545101f41303f1e2712de2e7611a9335f1c3/TMessagesProj/jni/tgnet/ConnectionSocket.cpp#L574)), switches socket to `O_NONBLOCK` ([`...:587`](https://github.com/DrKLO/Telegram/blob/fb2e545101f41303f1e2712de2e7611a9335f1c3/TMessagesProj/jni/tgnet/ConnectionSocket.cpp#L587)), and uses `connect(..., EINPROGRESS)` with edge-triggered epoll (`EPOLLIN|EPOLLOUT|EPOLLRDHUP|EPOLLERR|EPOLLET`, [`...:596`](https://github.com/DrKLO/Telegram/blob/fb2e545101f41303f1e2712de2e7611a9335f1c3/TMessagesProj/jni/tgnet/ConnectionSocket.cpp#L596)).
+- Timeout handling is internal logical timeout (`setTimeout`/`checkTimeout`) in [`TMessagesProj/jni/tgnet/ConnectionSocket.cpp:1066`](https://github.com/DrKLO/Telegram/blob/fb2e545101f41303f1e2712de2e7611a9335f1c3/TMessagesProj/jni/tgnet/ConnectionSocket.cpp#L1066) and [`...:1076`](https://github.com/DrKLO/Telegram/blob/fb2e545101f41303f1e2712de2e7611a9335f1c3/TMessagesProj/jni/tgnet/ConnectionSocket.cpp#L1076).
+- Per-connection-type timeout profile is explicitly assigned in [`TMessagesProj/jni/tgnet/Connection.cpp:368`](https://github.com/DrKLO/Telegram/blob/fb2e545101f41303f1e2712de2e7611a9335f1c3/TMessagesProj/jni/tgnet/Connection.cpp#L368) and after first useful data in [`...:131`](https://github.com/DrKLO/Telegram/blob/fb2e545101f41303f1e2712de2e7611a9335f1c3/TMessagesProj/jni/tgnet/Connection.cpp#L131).
+- Connection type split is explicit (`ConnectionTypeGeneric/Download/Upload/Push/Temp/Proxy`) in [`TMessagesProj/jni/tgnet/Defines.h:68`](https://github.com/DrKLO/Telegram/blob/fb2e545101f41303f1e2712de2e7611a9335f1c3/TMessagesProj/jni/tgnet/Defines.h#L68), with multiple parallel slots (`PROXY_CONNECTIONS_COUNT=4`, `DOWNLOAD_CONNECTIONS_COUNT=2`, `UPLOAD_CONNECTIONS_COUNT=4`) in [`...:26`](https://github.com/DrKLO/Telegram/blob/fb2e545101f41303f1e2712de2e7611a9335f1c3/TMessagesProj/jni/tgnet/Defines.h#L26).
+- Datacenter keeps separate connection objects/arrays per type in [`TMessagesProj/jni/tgnet/Datacenter.h:88`](https://github.com/DrKLO/Telegram/blob/fb2e545101f41303f1e2712de2e7611a9335f1c3/TMessagesProj/jni/tgnet/Datacenter.h#L88) and lazily creates/connects them in [`TMessagesProj/jni/tgnet/Datacenter.cpp:835`](https://github.com/DrKLO/Telegram/blob/fb2e545101f41303f1e2712de2e7611a9335f1c3/TMessagesProj/jni/tgnet/Datacenter.cpp#L835) and [`...:1311`](https://github.com/DrKLO/Telegram/blob/fb2e545101f41303f1e2712de2e7611a9335f1c3/TMessagesProj/jni/tgnet/Datacenter.cpp#L1311).
 
 ### Windows (Telegram Desktop)
 - **Version-pinned source snapshot**: `telegramdesktop/tdesktop` tag `v6.7.2` (commit `085c4ba65d1f8aa13abf0fd7fc8489f094552542`).
-- MTProto layer prepares multiple "test connections" across endpoint/protocol variants in `Telegram/SourceFiles/mtproto/session_private.cpp:1010` and `Telegram/SourceFiles/mtproto/session_private.cpp:1065`, then selects by priority from `appendTestConnection` (`Telegram/SourceFiles/mtproto/session_private.cpp:192`, priority formula at `Telegram/SourceFiles/mtproto/session_private.cpp:199`).
-- Connection wait timeout starts from `kMinConnectedTimeout = 1000ms` (`Telegram/SourceFiles/mtproto/session_private.cpp:34`), scheduled via `_waitForConnectedTimer.callOnce(_waitForConnected)` (`Telegram/SourceFiles/mtproto/session_private.cpp:1111`), and grows up to max in `waitConnectedFailed` (`Telegram/SourceFiles/mtproto/session_private.cpp:1236`).
-- Transport full-connect timeout in TCP path is `8s` (`Telegram/SourceFiles/mtproto/connection_tcp.cpp:21`, `Telegram/SourceFiles/mtproto/connection_tcp.cpp:581`), and HTTP path is `8s` (`Telegram/SourceFiles/mtproto/connection_http.cpp:18`, `Telegram/SourceFiles/mtproto/connection_http.cpp:242`).
-- Resolving wrapper uses per-IP timeout `kOneConnectionTimeout = 4000` (`Telegram/SourceFiles/mtproto/connection_resolving.cpp:16`) and multiplies by number of resolved IPs in `Telegram/SourceFiles/mtproto/connection_resolving.cpp:187`.
-- After first success, Desktop may wait `kWaitForBetterTimeout = 2000ms` for a better candidate (`Telegram/SourceFiles/mtproto/session_private.cpp:33`, `Telegram/SourceFiles/mtproto/session_private.cpp:2336`).
+- MTProto layer prepares multiple "test connections" across endpoint/protocol variants in [`Telegram/SourceFiles/mtproto/session_private.cpp:1010`](https://github.com/telegramdesktop/tdesktop/blob/085c4ba65d1f8aa13abf0fd7fc8489f094552542/Telegram/SourceFiles/mtproto/session_private.cpp#L1010) and [`...:1065`](https://github.com/telegramdesktop/tdesktop/blob/085c4ba65d1f8aa13abf0fd7fc8489f094552542/Telegram/SourceFiles/mtproto/session_private.cpp#L1065), then selects by priority from `appendTestConnection` ([`...:192`](https://github.com/telegramdesktop/tdesktop/blob/085c4ba65d1f8aa13abf0fd7fc8489f094552542/Telegram/SourceFiles/mtproto/session_private.cpp#L192), priority formula at [`...:199`](https://github.com/telegramdesktop/tdesktop/blob/085c4ba65d1f8aa13abf0fd7fc8489f094552542/Telegram/SourceFiles/mtproto/session_private.cpp#L199)).
+- Connection wait timeout starts from `kMinConnectedTimeout = 1000ms` ([`Telegram/SourceFiles/mtproto/session_private.cpp:34`](https://github.com/telegramdesktop/tdesktop/blob/085c4ba65d1f8aa13abf0fd7fc8489f094552542/Telegram/SourceFiles/mtproto/session_private.cpp#L34)), scheduled via `_waitForConnectedTimer.callOnce(_waitForConnected)` ([`...:1111`](https://github.com/telegramdesktop/tdesktop/blob/085c4ba65d1f8aa13abf0fd7fc8489f094552542/Telegram/SourceFiles/mtproto/session_private.cpp#L1111)), and grows up to max in `waitConnectedFailed` ([`...:1236`](https://github.com/telegramdesktop/tdesktop/blob/085c4ba65d1f8aa13abf0fd7fc8489f094552542/Telegram/SourceFiles/mtproto/session_private.cpp#L1236)).
+- Transport full-connect timeout in TCP path is `8s` ([`Telegram/SourceFiles/mtproto/connection_tcp.cpp:21`](https://github.com/telegramdesktop/tdesktop/blob/085c4ba65d1f8aa13abf0fd7fc8489f094552542/Telegram/SourceFiles/mtproto/connection_tcp.cpp#L21), [`...:581`](https://github.com/telegramdesktop/tdesktop/blob/085c4ba65d1f8aa13abf0fd7fc8489f094552542/Telegram/SourceFiles/mtproto/connection_tcp.cpp#L581)), and HTTP path is `8s` ([`Telegram/SourceFiles/mtproto/connection_http.cpp:18`](https://github.com/telegramdesktop/tdesktop/blob/085c4ba65d1f8aa13abf0fd7fc8489f094552542/Telegram/SourceFiles/mtproto/connection_http.cpp#L18), [`...:242`](https://github.com/telegramdesktop/tdesktop/blob/085c4ba65d1f8aa13abf0fd7fc8489f094552542/Telegram/SourceFiles/mtproto/connection_http.cpp#L242)).
+- Resolving wrapper uses per-IP timeout `kOneConnectionTimeout = 4000` ([`Telegram/SourceFiles/mtproto/connection_resolving.cpp:16`](https://github.com/telegramdesktop/tdesktop/blob/085c4ba65d1f8aa13abf0fd7fc8489f094552542/Telegram/SourceFiles/mtproto/connection_resolving.cpp#L16)) and multiplies by number of resolved IPs in [`...:187`](https://github.com/telegramdesktop/tdesktop/blob/085c4ba65d1f8aa13abf0fd7fc8489f094552542/Telegram/SourceFiles/mtproto/connection_resolving.cpp#L187).
+- After first success, Desktop may wait `kWaitForBetterTimeout = 2000ms` for a better candidate ([`Telegram/SourceFiles/mtproto/session_private.cpp:33`](https://github.com/telegramdesktop/tdesktop/blob/085c4ba65d1f8aa13abf0fd7fc8489f094552542/Telegram/SourceFiles/mtproto/session_private.cpp#L33), [`...:2336`](https://github.com/telegramdesktop/tdesktop/blob/085c4ba65d1f8aa13abf0fd7fc8489f094552542/Telegram/SourceFiles/mtproto/session_private.cpp#L2336)).
 
 ### Ubuntu/Linux (Telegram Desktop)
 - Source-backed connection behavior currently maps to the same `tdesktop` MTProto files referenced in the Windows section above (`Telegram/SourceFiles/mtproto/*`, tag `v6.7.2`).
@@ -330,6 +330,20 @@ All relay sockets use these settings:
 - Fixed by writing RPC payload directly into `out_buf` with precomputed frame size and explicit bounds checks (`error.OutBufOverflow`).
 - Added regression test for payloads larger than 64KiB.
 
+### Connection Pressure Stability Harness
+- Added a standalone Linux/VPS harness at `test/connection_stability_check.py`.
+- It reproduces two real-world load shapes: idle-socket pools and high-churn short-lived reconnect storms.
+- It snapshots `/proc/<pid>/status` (`VmRSS`, `VmSize`, `Threads`) + FD count + `ss -tan` TCP state distribution.
+- It fails when post-load process metrics do not recover to baseline within configured deltas.
+- Reproduced `TIME-WAIT` storms under churn as expected TCP behavior; treat this separately from leak checks (RSS/threads/fds recovery).
+- Integrated in Make targets: `make stability-check` and `make stability-check-load`.
+
+### MiddleProxy Buffer Footprint Tuning
+- Added config key `[server].middleproxy_buffer_kb` (default `256`, minimum `64`).
+- This controls per-connection MiddleProxy stream buffers (`s2c_buf`, `s2c_out_buf`, `c2s_buf`, `c2s_out_buf`).
+- Effective per active MiddleProxy session memory for these buffers is now `4 * middleproxy_buffer_kb`.
+- Runtime default lowers pressure on 1GB VPS nodes while preserving room for large frames.
+
 ---
 
 ## Chronological Bug Fixes
@@ -365,6 +379,8 @@ All relay sockets use these settings:
 30. **Media/non-media routing split**: retain fast direct fallback for non-media timeouts while keeping media paths on MiddleProxy transport to preserve media load behavior.
 31. **Soak Gate in CI**: added `bench` job to `.github/workflows/ci.yml` that runs microbenchmarks and soak stress tests after unit tests pass. Tiered durations: 10s on PRs, 60s on main. Results uploaded as artifacts for perf drift tracking.
 32. **DRS re-enabled**: restored Dynamic Record Sizing ramp logic (1369→16384 bytes after 8 records or 128KB), gated by `drs = true` config flag in `[censorship]`. Default off for backward compatibility.
+33. **Connection stability harness**: added `test/connection_stability_check.py` and Make targets (`stability-check*`) to reproduce idle/churn socket pressure and detect non-recovering RSS/thread/fd growth.
+34. **MiddleProxy buffer tuning**: added `[server].middleproxy_buffer_kb` to cap per-connection ME buffering footprint on low-memory VPS deployments.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: build release run test bench soak clean fmt deploy update-server migrate update-dns release-manual
+.PHONY: build release run test bench soak clean fmt deploy update-server migrate update-dns release-manual stability-check stability-check-load
 
 SERVER ?= 185.125.46.60
 CONFIG ?= config.toml
+HOST ?= 127.0.0.1
+PORT ?= 443
+PID ?=
 
 build:
 	zig build
@@ -89,3 +92,12 @@ migrate:
 update-dns:
 	@if [ -z "$(SERVER)" ]; then echo "Usage: make update-dns SERVER=<ip>"; exit 1; fi
 	bash deploy/update_dns.sh $(SERVER)
+
+# Linux/VPS regression harness (memory/socket churn)
+stability-check:
+	@if [ -z "$(PID)" ]; then echo "Usage: make stability-check PID=<mtproto_pid> [HOST=127.0.0.1 PORT=443]"; exit 1; fi
+	python3 test/connection_stability_check.py --host $(HOST) --port $(PORT) --pid $(PID) --idle-cycles 5
+
+# Load-only mode (no /proc assertions, useful for quick local smoke)
+stability-check-load:
+	python3 test/connection_stability_check.py --host $(HOST) --port $(PORT)

--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ ad_tag = "1234567890abcdef1234567890abcdef"    # Optional alias for [server].tag
 [server]
 port = 443
 backlog = 4096                             # TCP listen queue size
+middleproxy_buffer_kb = 256               # Per-connection ME buffers (4x this size), tune for VPS RAM
 tag = "1234567890abcdef1234567890abcdef"   # Optional: promotion tag from @MTProxybot
 
 [censorship]
@@ -414,6 +415,7 @@ bob   = "ffeeddccbbaa99887766554433221100"
 | `[general]` | `ad_tag` | _(none)_ | Telemt-compatible alias for promotion tag; ignored if `[server].tag` is set |
 | `[server]` | `port` | `443` | TCP port to listen on |
 | `[server]` | `backlog` | `4096` | TCP listen queue size (for high-traffic loads) |
+| `[server]` | `middleproxy_buffer_kb` | `256` | MiddleProxy per-connection buffer size in KiB (4 buffers allocated for active ME sessions) |
 | `[server]` | `tag` | _(none)_ | Optional 32 hex-char promotion tag from [@MTProxybot](https://t.me/MTProxybot) |
 | `[censorship]` | `tls_domain` | `"google.com"` | Domain to impersonate / forward bad clients to |
 | `[censorship]` | `mask` | `true` | Forward unauthenticated connections to `tls_domain` to defeat DPI |

--- a/config.toml.example
+++ b/config.toml.example
@@ -9,6 +9,9 @@ use_middle_proxy = true
 port = 443
 # TCP listen queue size (default is 4096)
 # backlog = 4096
+# MiddleProxy per-connection stream buffers in KiB (4 buffers per active ME connection)
+# Lower for small VPS RAM, raise for high-throughput media paths
+# middleproxy_buffer_kb = 256
 # Optional: 32 hex-char promotion tag from @MTProxybot
 # tag = "1234567890abcdef1234567890abcdef"
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -27,8 +27,14 @@ pub const Config = struct {
     drs: bool = false,
     /// Fast mode: skip S2C encryption by passing client keys to DC directly
     fast_mode: bool = false,
+    /// Per-connection MiddleProxy stream buffers size, in KiB (applies to 4 buffers)
+    middleproxy_buffer_kb: u32 = 256,
     /// Test-only hook to redirect upstream connections locally
     datacenter_override: ?std.net.Address = null,
+
+    pub fn middleProxyBufferBytes(self: *const Config) usize {
+        return @as(usize, self.middleproxy_buffer_kb) * 1024;
+    }
 
     pub fn loadFromFile(allocator: std.mem.Allocator, path: []const u8) !Config {
         const file = try std.fs.cwd().openFile(path, .{});
@@ -113,6 +119,9 @@ pub const Config = struct {
                         }
                     } else if (std.mem.eql(u8, key, "fast_mode")) {
                         cfg.fast_mode = std.mem.eql(u8, value, "true");
+                    } else if (std.mem.eql(u8, key, "middleproxy_buffer_kb")) {
+                        const parsed = std.fmt.parseInt(u32, value, 10) catch cfg.middleproxy_buffer_kb;
+                        cfg.middleproxy_buffer_kb = @max(@as(u32, 64), parsed);
                     }
                 } else if (in_censorship_section) {
                     if (std.mem.eql(u8, key, "tls_domain")) {
@@ -216,7 +225,38 @@ test "parse config - missing fields defaults" {
     try std.testing.expect(cfg.mask); // Default is true
     try std.testing.expect(cfg.desync); // Default is true
     try std.testing.expect(!cfg.fast_mode); // Default is false
+    try std.testing.expectEqual(@as(u32, 256), cfg.middleproxy_buffer_kb);
+    try std.testing.expectEqual(@as(usize, 256 * 1024), cfg.middleProxyBufferBytes());
     try std.testing.expectEqual(@as(usize, 1), cfg.users.count());
+}
+
+test "parse config - middleproxy buffer size" {
+    const content =
+        \\[server]
+        \\middleproxy_buffer_kb = 192
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(u32, 192), cfg.middleproxy_buffer_kb);
+    try std.testing.expectEqual(@as(usize, 192 * 1024), cfg.middleProxyBufferBytes());
+}
+
+test "parse config - middleproxy buffer lower bound" {
+    const content =
+        \\[server]
+        \\middleproxy_buffer_kb = 16
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(u32, 64), cfg.middleproxy_buffer_kb);
 }
 
 test "parse config - spaces and tabs" {

--- a/src/protocol/middleproxy.zig
+++ b/src/protocol/middleproxy.zig
@@ -124,7 +124,45 @@ pub const MiddleProxyContext = struct {
     c2s_len: usize = 0,
     c2s_out_buf: []u8,
 
-    pub fn init(allocator: std.mem.Allocator, encryptor: crypto.AesCbc, decryptor: crypto.AesCbc, conn_id: [8]u8, initial_seq_no: i32, remote_addr: net.Address, our_addr: net.Address, proto_tag: constants.ProtoTag, ad_tag: ?[16]u8) !MiddleProxyContext {
+    pub const default_stream_buffer_size: usize = 128 * 1024;
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        encryptor: crypto.AesCbc,
+        decryptor: crypto.AesCbc,
+        conn_id: [8]u8,
+        initial_seq_no: i32,
+        remote_addr: net.Address,
+        our_addr: net.Address,
+        proto_tag: constants.ProtoTag,
+        ad_tag: ?[16]u8,
+    ) !MiddleProxyContext {
+        return initWithBuffer(
+            allocator,
+            encryptor,
+            decryptor,
+            conn_id,
+            initial_seq_no,
+            remote_addr,
+            our_addr,
+            proto_tag,
+            ad_tag,
+            default_stream_buffer_size,
+        );
+    }
+
+    pub fn initWithBuffer(
+        allocator: std.mem.Allocator,
+        encryptor: crypto.AesCbc,
+        decryptor: crypto.AesCbc,
+        conn_id: [8]u8,
+        initial_seq_no: i32,
+        remote_addr: net.Address,
+        our_addr: net.Address,
+        proto_tag: constants.ProtoTag,
+        ad_tag: ?[16]u8,
+        buffer_size: usize,
+    ) !MiddleProxyContext {
         var rip: [20]u8 = undefined;
         var rport: u16 = 0;
         if (remote_addr.any.family == posix.AF.INET) {
@@ -151,16 +189,16 @@ pub const MiddleProxyContext = struct {
         } else return error.UnsupportedAddressType;
         std.mem.writeInt(u32, oip[16..20], std.mem.bigToNative(u16, oport), .little);
 
-        const s2c_buf = try allocator.alloc(u8, 512 * 1024); // 512KB for max TLS/MTProto frames
+        const s2c_buf = try allocator.alloc(u8, buffer_size);
         errdefer allocator.free(s2c_buf);
 
-        const s2c_out_buf = try allocator.alloc(u8, 512 * 1024);
+        const s2c_out_buf = try allocator.alloc(u8, buffer_size);
         errdefer allocator.free(s2c_out_buf);
 
-        const c2s_buf = try allocator.alloc(u8, 512 * 1024);
+        const c2s_buf = try allocator.alloc(u8, buffer_size);
         errdefer allocator.free(c2s_buf);
 
-        const c2s_out_buf = try allocator.alloc(u8, 512 * 1024);
+        const c2s_out_buf = try allocator.alloc(u8, buffer_size);
         errdefer allocator.free(c2s_out_buf);
 
         return .{
@@ -490,6 +528,7 @@ pub fn executeHandshake(
     client_addr: net.Address,
     proxy_secret_bytes: []const u8,
     ad_tag: ?[16]u8,
+    buffer_size: usize,
 ) !MiddleProxyContext {
     _ = dc_addr;
 
@@ -631,7 +670,7 @@ pub fn executeHandshake(
     var conn_id: [8]u8 = undefined;
     crypto.randomBytes(&conn_id);
 
-    return MiddleProxyContext.init(
+    return MiddleProxyContext.initWithBuffer(
         allocator,
         encryptor,
         decryptor,
@@ -641,6 +680,7 @@ pub fn executeHandshake(
         local_addr,
         proto_tag,
         ad_tag,
+        buffer_size,
     );
 }
 

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -1116,6 +1116,7 @@ fn handleConnectionInner(
             client_addr,
             mp_secret,
             state.config.tag,
+            state.config.middleProxyBufferBytes(),
         );
         log.debug("[{d}] MiddleProxy handshake successful (dc={d})", .{ conn_id, params.dc_idx });
     } else {

--- a/test/connection_stability_check.py
+++ b/test/connection_stability_check.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""
+Connection stability harness: connection churn + idle pool pressure.
+
+Designed for Linux VPS where mtproto-proxy is already running.
+It fails when memory/threads/fds do not recover after
+idle-connection pressure (leak-like behavior).
+"""
+
+from __future__ import annotations
+
+import argparse
+import errno
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+@dataclass
+class ProcStats:
+    rss_kb: Optional[int]
+    vms_kb: Optional[int]
+    threads: Optional[int]
+    fds: Optional[int]
+
+
+def read_proc_stats(pid: int) -> ProcStats:
+    status_path = f"/proc/{pid}/status"
+    fd_path = f"/proc/{pid}/fd"
+
+    rss_kb = None
+    vms_kb = None
+    threads = None
+    fds = None
+
+    try:
+        with open(status_path, "r", encoding="utf-8") as f:
+            for line in f:
+                if line.startswith("VmRSS:"):
+                    rss_kb = int(line.split()[1])
+                elif line.startswith("VmSize:"):
+                    vms_kb = int(line.split()[1])
+                elif line.startswith("Threads:"):
+                    threads = int(line.split()[1])
+    except (FileNotFoundError, OSError):
+        pass
+
+    try:
+        fds = len(os.listdir(fd_path))
+    except (FileNotFoundError, OSError):
+        pass
+
+    return ProcStats(rss_kb=rss_kb, vms_kb=vms_kb, threads=threads, fds=fds)
+
+
+def tcp_states(port: int) -> Dict[str, int]:
+    try:
+        out = subprocess.check_output(["ss", "-tan"], text=True)
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        return {}
+
+    suffix = f":{port}"
+    states: Dict[str, int] = {}
+
+    for line in out.splitlines():
+        line = line.strip()
+        if not line or line.startswith("State"):
+            continue
+
+        parts = line.split()
+        if len(parts) < 5:
+            continue
+
+        state, local_addr, peer_addr = parts[0], parts[3], parts[4]
+        if suffix in local_addr or suffix in peer_addr:
+            states[state] = states.get(state, 0) + 1
+
+    return states
+
+
+def print_snapshot(label: str, pid: Optional[int], port: int) -> Dict[str, object]:
+    stats = (
+        read_proc_stats(pid) if pid is not None else ProcStats(None, None, None, None)
+    )
+    states = tcp_states(port)
+    print(
+        f"[{label}] rss_kb={stats.rss_kb} vms_kb={stats.vms_kb} "
+        f"threads={stats.threads} fds={stats.fds} states={states}"
+    )
+    return {
+        "stats": stats,
+        "states": states,
+    }
+
+
+def has_stats(stats: ProcStats) -> bool:
+    return any(
+        v is not None for v in (stats.rss_kb, stats.vms_kb, stats.threads, stats.fds)
+    )
+
+
+def open_idle_connections(
+    host: str, port: int, count: int, timeout: float
+) -> tuple[list[socket.socket], int]:
+    conns: list[socket.socket] = []
+    failed = 0
+
+    for i in range(count):
+        try:
+            s = socket.create_connection((host, port), timeout=timeout)
+            conns.append(s)
+        except OSError as err:
+            failed += 1
+            if err.errno == errno.EMFILE:
+                failed += count - i - 1
+                break
+
+    return conns, failed
+
+
+def close_connections(conns: list[socket.socket]) -> None:
+    for s in conns:
+        try:
+            s.close()
+        except OSError:
+            pass
+
+
+def run_churn(
+    host: str,
+    port: int,
+    total: int,
+    concurrency: int,
+    timeout: float,
+    payload: bytes,
+) -> tuple[int, int, float]:
+    idx = 0
+    lock = threading.Lock()
+    ok = 0
+    fail = 0
+    ok_fail_lock = threading.Lock()
+
+    def worker() -> None:
+        nonlocal idx, ok, fail
+
+        while True:
+            with lock:
+                if idx >= total:
+                    return
+                idx += 1
+
+            try:
+                s = socket.create_connection((host, port), timeout=timeout)
+                if payload:
+                    s.sendall(payload)
+                    s.settimeout(0.3)
+                    try:
+                        _ = s.recv(128)
+                    except OSError:
+                        pass
+                s.close()
+                with ok_fail_lock:
+                    ok += 1
+            except OSError:
+                with ok_fail_lock:
+                    fail += 1
+
+    threads = [
+        threading.Thread(target=worker, daemon=True) for _ in range(max(1, concurrency))
+    ]
+    start = time.time()
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    elapsed = time.time() - start
+    return ok, fail, elapsed
+
+
+def assert_threshold(
+    name: str,
+    value: Optional[int],
+    baseline: Optional[int],
+    delta_limit: int,
+    failures: list[str],
+) -> None:
+    if value is None or baseline is None:
+        return
+    if value > baseline + delta_limit:
+        failures.append(
+            f"{name} too high after settle: baseline={baseline}, now={value}, limit={baseline + delta_limit}"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Connection memory/socket stability harness"
+    )
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=443)
+    parser.add_argument(
+        "--pid", type=int, default=None, help="mtproto-proxy PID for /proc monitoring"
+    )
+
+    parser.add_argument("--idle-connections", type=int, default=6000)
+    parser.add_argument("--idle-cycles", type=int, default=3)
+    parser.add_argument("--idle-hold-seconds", type=int, default=30)
+    parser.add_argument("--idle-settle-seconds", type=int, default=8)
+    parser.add_argument("--connect-timeout", type=float, default=1.0)
+
+    parser.add_argument("--churn-total", type=int, default=30000)
+    parser.add_argument("--churn-concurrency", type=int, default=300)
+
+    parser.add_argument("--rss-delta-mb", type=int, default=48)
+    parser.add_argument("--threads-delta", type=int, default=64)
+    parser.add_argument("--fds-delta", type=int, default=128)
+    parser.add_argument("--close-wait-limit", type=int, default=128)
+
+    args = parser.parse_args()
+
+    if args.pid is not None and not os.path.exists(f"/proc/{args.pid}"):
+        print(f"error: /proc/{args.pid} not found. pass a valid proxy PID")
+        return 2
+
+    if args.idle_connections <= 0 or args.churn_total <= 0:
+        print("error: idle-connections and churn-total must be > 0")
+        return 2
+
+    print("== stability check start ==")
+    print(
+        f"target={args.host}:{args.port} pid={args.pid} "
+        f"idle={args.idle_connections}x{args.idle_cycles} hold={args.idle_hold_seconds}s "
+        f"churn={args.churn_total}x{args.churn_concurrency}"
+    )
+
+    baseline = print_snapshot("baseline", args.pid, args.port)
+
+    idle_closes: list[Dict[str, object]] = []
+    stats_skipped_cycles = 0
+    for cycle in range(1, args.idle_cycles + 1):
+        conns, failed_open = open_idle_connections(
+            args.host,
+            args.port,
+            args.idle_connections,
+            args.connect_timeout,
+        )
+        print(f"idle_open[{cycle}]: opened={len(conns)} failed={failed_open}")
+        open_snap = print_snapshot(f"idle_open_{cycle}", args.pid, args.port)
+        if args.pid is not None and not has_stats(open_snap["stats"]):  # type: ignore[arg-type]
+            stats_skipped_cycles += 1
+
+        time.sleep(max(0, args.idle_hold_seconds))
+        hold_snap = print_snapshot(f"idle_hold_done_{cycle}", args.pid, args.port)
+        if args.pid is not None and not has_stats(hold_snap["stats"]):  # type: ignore[arg-type]
+            stats_skipped_cycles += 1
+
+        close_connections(conns)
+        print(f"idle_close[{cycle}]: closed all sockets")
+        time.sleep(max(0, args.idle_settle_seconds))
+        close_snap = print_snapshot(f"after_idle_close_{cycle}", args.pid, args.port)
+        if args.pid is not None and not has_stats(close_snap["stats"]):  # type: ignore[arg-type]
+            stats_skipped_cycles += 1
+        idle_closes.append(close_snap)
+
+    after_idle_close = idle_closes[-1]
+
+    payload = b"GET / HTTP/1.1\r\nHost: test\r\n\r\n"
+    ok, fail, elapsed = run_churn(
+        args.host,
+        args.port,
+        args.churn_total,
+        args.churn_concurrency,
+        args.connect_timeout,
+        payload,
+    )
+    print(f"churn_done: ok={ok} fail={fail} elapsed={elapsed:.2f}s")
+
+    time.sleep(2)
+    after_churn = print_snapshot("after_churn", args.pid, args.port)
+    if args.pid is not None and not has_stats(after_churn["stats"]):  # type: ignore[arg-type]
+        stats_skipped_cycles += 1
+
+    if args.pid is None:
+        print("PASS (load-only mode, no PID assertions)")
+        return 0
+
+    failures: list[str] = []
+    base_stats: ProcStats = baseline["stats"]  # type: ignore[assignment]
+    idle_close_stats: ProcStats = after_idle_close["stats"]  # type: ignore[assignment]
+    churn_stats: ProcStats = after_churn["stats"]  # type: ignore[assignment]
+
+    rss_delta_kb = args.rss_delta_mb * 1024
+    assert_threshold(
+        "rss_kb", idle_close_stats.rss_kb, base_stats.rss_kb, rss_delta_kb, failures
+    )
+    assert_threshold(
+        "threads",
+        idle_close_stats.threads,
+        base_stats.threads,
+        args.threads_delta,
+        failures,
+    )
+    assert_threshold(
+        "fds", idle_close_stats.fds, base_stats.fds, args.fds_delta, failures
+    )
+
+    assert_threshold(
+        "rss_kb(churn)", churn_stats.rss_kb, base_stats.rss_kb, rss_delta_kb, failures
+    )
+    assert_threshold(
+        "threads(churn)",
+        churn_stats.threads,
+        base_stats.threads,
+        args.threads_delta,
+        failures,
+    )
+    assert_threshold(
+        "fds(churn)", churn_stats.fds, base_stats.fds, args.fds_delta, failures
+    )
+
+    idle_close_states: Dict[str, int] = after_idle_close["states"]  # type: ignore[assignment]
+    churn_states: Dict[str, int] = after_churn["states"]  # type: ignore[assignment]
+
+    for i, snap in enumerate(idle_closes, start=1):
+        snap_stats: ProcStats = snap["stats"]  # type: ignore[assignment]
+        assert_threshold(
+            f"rss_kb(cycle{i})",
+            snap_stats.rss_kb,
+            base_stats.rss_kb,
+            rss_delta_kb,
+            failures,
+        )
+        assert_threshold(
+            f"threads(cycle{i})",
+            snap_stats.threads,
+            base_stats.threads,
+            args.threads_delta,
+            failures,
+        )
+        assert_threshold(
+            f"fds(cycle{i})", snap_stats.fds, base_stats.fds, args.fds_delta, failures
+        )
+
+        snap_states: Dict[str, int] = snap["states"]  # type: ignore[assignment]
+        close_wait_cycle = snap_states.get("CLOSE-WAIT", 0)
+        if close_wait_cycle > args.close_wait_limit:
+            failures.append(
+                f"CLOSE-WAIT too high after idle cycle {i}: {close_wait_cycle} > {args.close_wait_limit}"
+            )
+
+    close_wait_idle = idle_close_states.get("CLOSE-WAIT", 0)
+    close_wait_churn = churn_states.get("CLOSE-WAIT", 0)
+    if close_wait_idle > args.close_wait_limit:
+        failures.append(
+            f"CLOSE-WAIT too high after idle settle: {close_wait_idle} > {args.close_wait_limit}"
+        )
+    if close_wait_churn > args.close_wait_limit:
+        failures.append(
+            f"CLOSE-WAIT too high after churn settle: {close_wait_churn} > {args.close_wait_limit}"
+        )
+
+    if stats_skipped_cycles > 0:
+        print(
+            "WARN: snapshot stats were unavailable during high-fd pressure "
+            f"({stats_skipped_cycles} points). Increase launcher nofile for cleaner metrics."
+        )
+
+    if failures:
+        print("FAIL")
+        for item in failures:
+            print(f" - {item}")
+        return 1
+
+    print("PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a Linux-focused stability harness at `test/connection_stability_check.py` that reproduces high connection pressure with idle pools and churn
- add `make stability-check` and `make stability-check-load` to run the harness consistently on local/stand environments
- make MiddleProxy per-connection stream buffers tunable via `[server].middleproxy_buffer_kb` (default `256`, minimum `64`) to reduce RAM pressure on small VPS under connection storms
- wire the new buffer setting through config parsing, handshake path, and docs (`README.md`, `config.toml.example`, `GEMINI.md`)

## Validation
- `python3 -m py_compile test/connection_stability_check.py`
- `make stability-check-load HOST=127.0.0.1 PORT=443`
- `zig build test`
- `zig build -Doptimize=ReleaseFast`
- run on stand VPS (`38.180.236.207`, 1 vCPU), completed with `PASS`; observed expected `TIME-WAIT` storm under churn while RSS/threads/fds recovered after load

Refs #46