### PR TITLE
chore(ci): automate version bumping in main.zig via release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,10 @@
       "include-component-in-tag": false,
       "include-v-in-tag": true,
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "extra-files": [
+        "src/main.zig"
+      ]
     }
   }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -40,7 +40,7 @@ fn lockFreeLog(
 
 const log = std.log.scoped(.mtproto);
 
-const version = "0.1.0";
+const version = "0.4.0"; // x-release-please-version
 
 // ============= Output Helpers (Zig 0.15 compatible) =============
 


### PR DESCRIPTION
Adds `src/main.zig` to `extra-files` in the release-please config so the proxy banner version is automatically kept in sync with the manifest.