### PR TITLE
tune capacity baseline and benchmark guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Disguises Telegram traffic as standard TLS 1.3 HTTPS to bypass network censorshi
 [Features](#-features) &nbsp;&bull;&nbsp;
 [Quick Start](#-quick-start) &nbsp;&bull;&nbsp;
 [Update](#-update-existing-server) &nbsp;&bull;&nbsp;
-[Benchmark Snapshot](#-benchmark-snapshot) &nbsp;&bull;&nbsp;
 [Docker](#docker-image) &nbsp;&bull;&nbsp;
 [Deploy](#-deploy-to-server) &nbsp;&bull;&nbsp;
 [Configuration](#-configuration) &nbsp;&bull;&nbsp;

--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ Disguises Telegram traffic as standard TLS 1.3 HTTPS to bypass network censorshi
 
 ### Connection Capacity (same benchmark host)
 
-- Stable through **12,000** held concurrent sockets (`ESTABLISHED`).
-- Practical ceiling around **13,000** on this 1 vCPU / 1 GB VPS profile.
+| Metric | Value |
+|--------|-------|
+| Stable held connections | **12,000** |
+| Practical ceiling | **~13,000** |
 
 Memory growth while holding connections (mtproto.zig RSS):
 

--- a/README.md
+++ b/README.md
@@ -54,15 +54,15 @@ Disguises Telegram traffic as standard TLS 1.3 HTTPS to bypass network censorshi
 
 > VPS benchmark (1 vCPU / 1 GB RAM, Ubuntu 24.04, April 2026). Each proxy tested in isolation after page-cache flush.
 
-| Proxy | Language | Binary | Idle RSS | Startup | Dependencies | LoC (Files) | Max ESTABLISHED | Max stable target | RSS at peak connections |
-|-------|----------|--------|----------|---------|--------------|-------------|------------------|-------------------|--------------------------|
-| **mtproto.zig** | Zig | **177 KB** | **256 KB** ⚡ | **< 10 ms**\* | **0** | **5.5k** (9) | **12,000** | **12,000** | **144.3 MB** |
-| [Official MTProxy](https://github.com/TelegramMessenger/MTProxy) | C | 524 KB | 8.3 MB | < 10 ms | openssl, zlib | 29.6k (87) | 12,000 | 12,000 | 72.4 MB |
-| [Teleproxy](https://github.com/teleproxy/teleproxy) | C | 14 MB | 4.6 MB | ~ 30 ms | openssl, zlib, libc | 40.5k (120) | 12,000 | 12,000 | 76.1 MB |
-| [Telemt](https://github.com/telemt/telemt) | Rust | 15 MB | 16 MB | > 15 s | 423 crates (total) | 106.6k (231) | 8,000 | 8,000 | 50.7 MB |
-| [mtg](https://github.com/9seconds/mtg) | Go | 13 MB | 12.5 MB | ~ 30 ms | 78 modules | 17.8k (205) | 8,172 | 4,000 | 124.0 MB |
-| [mtprotoproxy](https://github.com/alexbers/mtprotoproxy) | Python | N/A (script) | 35 MB | ~ 800 ms | python3 (~30 MB) | 3.3k (6) | 8,000 | 8,000 | 92.0 MB |
-| [mtproto_proxy](https://github.com/seriyps/mtproto_proxy) | Erlang | N/A (release)| 88 MB | ~ 6 s | erlang (~200 MB) | 7.8k (43) | 2,000 | 2,000 | 138.7 MB |
+| Proxy | Language | Binary | Idle RSS | Startup | Dependencies | LoC (Files) |
+|-------|----------|--------|----------|---------|--------------|-------------|
+| **mtproto.zig** | Zig | **177 KB** | **256 KB** ⚡ | **< 10 ms**\* | **0** | **5.5k** (9) |
+| [Official MTProxy](https://github.com/TelegramMessenger/MTProxy) | C | 524 KB | 8.3 MB | < 10 ms | openssl, zlib | 29.6k (87) |
+| [Teleproxy](https://github.com/teleproxy/teleproxy) | C | 14 MB | 4.6 MB | ~ 30 ms | openssl, zlib, libc | 40.5k (120) |
+| [Telemt](https://github.com/telemt/telemt) | Rust | 15 MB | 16 MB | > 15 s | 423 crates (total) | 106.6k (231) |
+| [mtg](https://github.com/9seconds/mtg) | Go | 13 MB | 12.5 MB | ~ 30 ms | 78 modules | 17.8k (205) |
+| [mtprotoproxy](https://github.com/alexbers/mtprotoproxy) | Python | N/A (script) | 35 MB | ~ 800 ms | python3 (~30 MB) | 3.3k (6) |
+| [mtproto_proxy](https://github.com/seriyps/mtproto_proxy) | Erlang | N/A (release)| 88 MB | ~ 6 s | erlang (~200 MB) | 7.8k (43) |
 
 \* `mtproto.zig` also performs online bootstrap at startup (public IP detection + Telegram metadata refresh). On this VPS, cold boot is typically ~0.4 s; warm/steady restart remains sub-10 ms.
 

--- a/README.md
+++ b/README.md
@@ -54,35 +54,19 @@ Disguises Telegram traffic as standard TLS 1.3 HTTPS to bypass network censorshi
 
 > VPS benchmark (1 vCPU / 1 GB RAM, Ubuntu 24.04, April 2026). Each proxy tested in isolation after page-cache flush.
 
-| Proxy | Language | Binary | Idle RSS | Startup | Dependencies | LoC (Files) |
-|-------|----------|--------|----------|---------|--------------|-------------|
-| **mtproto.zig** | Zig | **177 KB** | **256 KB** ⚡ | **< 10 ms**\* | **0** | **5.5k** (9) |
-| [Official MTProxy](https://github.com/TelegramMessenger/MTProxy) | C | 524 KB | 8.3 MB | < 10 ms | openssl, zlib | 29.6k (87) |
-| [Teleproxy](https://github.com/teleproxy/teleproxy) | C | 14 MB | 4.6 MB | ~ 30 ms | openssl, zlib, libc | 40.5k (120) |
-| [Telemt](https://github.com/telemt/telemt) | Rust | 15 MB | 16 MB | > 15 s | 423 crates (total) | 106.6k (231) |
-| [mtg](https://github.com/9seconds/mtg) | Go | 13 MB | 12.5 MB | ~ 30 ms | 78 modules | 17.8k (205) |
-| [mtprotoproxy](https://github.com/alexbers/mtprotoproxy) | Python | N/A (script) | 35 MB | ~ 800 ms | python3 (~30 MB) | 3.3k (6) |
-| [mtproto_proxy](https://github.com/seriyps/mtproto_proxy) | Erlang | N/A (release)| 88 MB | ~ 6 s | erlang (~200 MB) | 7.8k (43) |
+| Proxy | Language | Binary | Idle RSS | Startup | Dependencies | LoC (Files) | Max ESTABLISHED | Max stable target | RSS at peak connections |
+|-------|----------|--------|----------|---------|--------------|-------------|------------------|-------------------|--------------------------|
+| **mtproto.zig** | Zig | **177 KB** | **256 KB** ⚡ | **< 10 ms**\* | **0** | **5.5k** (9) | **12,000** | **12,000** | **144.3 MB** |
+| [Official MTProxy](https://github.com/TelegramMessenger/MTProxy) | C | 524 KB | 8.3 MB | < 10 ms | openssl, zlib | 29.6k (87) | 12,000 | 12,000 | 72.4 MB |
+| [Teleproxy](https://github.com/teleproxy/teleproxy) | C | 14 MB | 4.6 MB | ~ 30 ms | openssl, zlib, libc | 40.5k (120) | 12,000 | 12,000 | 76.1 MB |
+| [Telemt](https://github.com/telemt/telemt) | Rust | 15 MB | 16 MB | > 15 s | 423 crates (total) | 106.6k (231) | 8,000 | 8,000 | 50.7 MB |
+| [mtg](https://github.com/9seconds/mtg) | Go | 13 MB | 12.5 MB | ~ 30 ms | 78 modules | 17.8k (205) | 8,172 | 4,000 | 124.0 MB |
+| [mtprotoproxy](https://github.com/alexbers/mtprotoproxy) | Python | N/A (script) | 35 MB | ~ 800 ms | python3 (~30 MB) | 3.3k (6) | 8,000 | 8,000 | 92.0 MB |
+| [mtproto_proxy](https://github.com/seriyps/mtproto_proxy) | Erlang | N/A (release)| 88 MB | ~ 6 s | erlang (~200 MB) | 7.8k (43) | 2,000 | 2,000 | 138.7 MB |
 
 \* `mtproto.zig` also performs online bootstrap at startup (public IP detection + Telegram metadata refresh). On this VPS, cold boot is typically ~0.4 s; warm/steady restart remains sub-10 ms.
 
-### Connection Capacity (same benchmark host)
-
-| Metric | Value |
-|--------|-------|
-| Stable held connections | **12,000** |
-| Practical ceiling | **~13,000** |
-
-Memory growth while holding connections (mtproto.zig RSS):
-
-| Held sockets | RSS |
-|--------------|-----|
-| 5,000 | 60.6 MB |
-| 8,000 | 96.5 MB |
-| 10,000 | 120.5 MB |
-| 12,000 | 144.3 MB |
-
-Full capacity methodology and command profiles: `test/README.md`.
+Connection-capacity methodology and command profiles: `test/README.md`.
 
 ## &nbsp; Quick Start
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,22 @@ Disguises Telegram traffic as standard TLS 1.3 HTTPS to bypass network censorshi
 
 \* `mtproto.zig` also performs online bootstrap at startup (public IP detection + Telegram metadata refresh). On this VPS, cold boot is typically ~0.4 s; warm/steady restart remains sub-10 ms.
 
+### Connection Capacity (same benchmark host)
+
+- Stable through **12,000** held concurrent sockets (`ESTABLISHED`).
+- Practical ceiling around **13,000** on this 1 vCPU / 1 GB VPS profile.
+
+Memory growth while holding connections (mtproto.zig RSS):
+
+| Held sockets | RSS |
+|--------------|-----|
+| 5,000 | 60.6 MB |
+| 8,000 | 96.5 MB |
+| 10,000 | 120.5 MB |
+| 12,000 | 144.3 MB |
+
+Full capacity methodology and command profiles: `test/README.md`.
+
 ## &nbsp; Quick Start
 
 ### Prerequisites
@@ -110,26 +126,6 @@ zig build -Doptimize=ReleaseFast soak -- --seconds=120 --threads=8 --max-payload
 
 `bench` prints per-payload throughput (`in_mib_per_s`, `out_mib_per_s`) and `ns_per_op`.
 `soak` prints aggregate `ops/s`, throughput, and `errors`; non-zero errors fail the step.
-
-## &nbsp; Benchmark Snapshot
-
-Capacity measurements are documented in `test/README.md` and produced by `test/capacity_connections_probe.py`.
-
-Latest mtproto.zig snapshot on benchmark host `38.180.236.207` (1 vCPU / 1 GB):
-
-- stable through **12,000** concurrent held sockets
-- practical ceiling around **13,000** (14,000 becomes unstable on this host)
-
-Memory growth for held sockets (RSS):
-
-| Held sockets | RSS |
-|--------------|-----|
-| 5,000 | 60.6 MB |
-| 8,000 | 96.5 MB |
-| 10,000 | 120.5 MB |
-| 12,000 | 144.3 MB |
-
-For full methodology, command profiles, and cross-implementation table, see `test/README.md`.
 
 <details>
 <summary>All Make targets</summary>

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Disguises Telegram traffic as standard TLS 1.3 HTTPS to bypass network censorshi
 [Features](#-features) &nbsp;&bull;&nbsp;
 [Quick Start](#-quick-start) &nbsp;&bull;&nbsp;
 [Update](#-update-existing-server) &nbsp;&bull;&nbsp;
+[Benchmark Snapshot](#-benchmark-snapshot) &nbsp;&bull;&nbsp;
 [Docker](#docker-image) &nbsp;&bull;&nbsp;
 [Deploy](#-deploy-to-server) &nbsp;&bull;&nbsp;
 [Configuration](#-configuration) &nbsp;&bull;&nbsp;
@@ -95,6 +96,26 @@ zig build -Doptimize=ReleaseFast soak -- --seconds=120 --threads=8 --max-payload
 
 `bench` prints per-payload throughput (`in_mib_per_s`, `out_mib_per_s`) and `ns_per_op`.
 `soak` prints aggregate `ops/s`, throughput, and `errors`; non-zero errors fail the step.
+
+## &nbsp; Benchmark Snapshot
+
+Capacity measurements are documented in `test/README.md` and produced by `test/capacity_connections_probe.py`.
+
+Latest mtproto.zig snapshot on benchmark host `38.180.236.207` (1 vCPU / 1 GB):
+
+- stable through **12,000** concurrent held sockets
+- practical ceiling around **13,000** (14,000 becomes unstable on this host)
+
+Memory growth for held sockets (RSS):
+
+| Held sockets | RSS |
+|--------------|-----|
+| 5,000 | 60.6 MB |
+| 8,000 | 96.5 MB |
+| 10,000 | 120.5 MB |
+| 12,000 | 144.3 MB |
+
+For full methodology, command profiles, and cross-implementation table, see `test/README.md`.
 
 <details>
 <summary>All Make targets</summary>

--- a/config.toml.example
+++ b/config.toml.example
@@ -9,6 +9,16 @@ use_middle_proxy = true
 port = 443
 # TCP listen queue size (default is 4096)
 # backlog = 4096
+# Hard cap for concurrently served client sockets (default 65535)
+# max_connections = 65535
+# Per-connection handler stack in KiB (default/minimum 256)
+# Values below 256 are clamped for stability.
+# thread_stack_kb = 256
+# Idle timeout before first byte from client in seconds (default 300)
+# Keep high enough for mobile pre-warmed pools.
+# idle_timeout_sec = 300
+# Handshake timeout after first byte arrives in seconds (default 60)
+# handshake_timeout_sec = 60
 # MiddleProxy per-connection stream buffers in KiB (4 buffers per active ME connection)
 # Lower for small VPS RAM, raise for high-throughput media paths
 # middleproxy_buffer_kb = 256

--- a/src/config.zig
+++ b/src/config.zig
@@ -14,6 +14,14 @@ pub const Config = struct {
     port: u16 = 443,
     /// TCP listen(2) backlog for client-facing sockets
     backlog: u32 = 4096,
+    /// Hard cap for concurrently handled client connections
+    max_connections: u32 = 65535,
+    /// Per-connection thread stack size in KiB (minimum 256)
+    thread_stack_kb: u32 = 256,
+    /// Pre-handshake idle timeout: wait for first client byte
+    idle_timeout_sec: u32 = 300,
+    /// Handshake read timeout after first byte arrives
+    handshake_timeout_sec: u32 = 60,
     tag: ?[16]u8 = null,
     tls_domain: []const u8 = "google.com",
     users: std.StringHashMap([16]u8),
@@ -34,6 +42,10 @@ pub const Config = struct {
 
     pub fn middleProxyBufferBytes(self: *const Config) usize {
         return @as(usize, self.middleproxy_buffer_kb) * 1024;
+    }
+
+    pub fn threadStackBytes(self: *const Config) usize {
+        return @as(usize, self.thread_stack_kb) * 1024;
     }
 
     pub fn loadFromFile(allocator: std.mem.Allocator, path: []const u8) !Config {
@@ -109,6 +121,18 @@ pub const Config = struct {
                         cfg.port = std.fmt.parseInt(u16, value, 10) catch 443;
                     } else if (std.mem.eql(u8, key, "backlog")) {
                         cfg.backlog = std.fmt.parseInt(u32, value, 10) catch 4096;
+                    } else if (std.mem.eql(u8, key, "max_connections")) {
+                        const parsed = std.fmt.parseInt(u32, value, 10) catch cfg.max_connections;
+                        cfg.max_connections = @max(@as(u32, 32), parsed);
+                    } else if (std.mem.eql(u8, key, "thread_stack_kb")) {
+                        const parsed = std.fmt.parseInt(u32, value, 10) catch cfg.thread_stack_kb;
+                        cfg.thread_stack_kb = @max(@as(u32, 256), parsed);
+                    } else if (std.mem.eql(u8, key, "idle_timeout_sec")) {
+                        const parsed = std.fmt.parseInt(u32, value, 10) catch cfg.idle_timeout_sec;
+                        cfg.idle_timeout_sec = @max(@as(u32, 5), parsed);
+                    } else if (std.mem.eql(u8, key, "handshake_timeout_sec")) {
+                        const parsed = std.fmt.parseInt(u32, value, 10) catch cfg.handshake_timeout_sec;
+                        cfg.handshake_timeout_sec = @max(@as(u32, 5), parsed);
                     } else if (std.mem.eql(u8, key, "tag")) {
                         if (value.len == 32) {
                             var tag: [16]u8 = undefined;
@@ -181,6 +205,10 @@ test "parse config - valid complete" {
         \\[server]
         \\port = 8443
         \\backlog = 8192
+        \\max_connections = 6000
+        \\thread_stack_kb = 320
+        \\idle_timeout_sec = 180
+        \\handshake_timeout_sec = 30
         \\fast_mode = true
         \\
         \\[censorship]
@@ -198,6 +226,10 @@ test "parse config - valid complete" {
 
     try std.testing.expectEqual(@as(u16, 8443), cfg.port);
     try std.testing.expectEqual(@as(u32, 8192), cfg.backlog);
+    try std.testing.expectEqual(@as(u32, 6000), cfg.max_connections);
+    try std.testing.expectEqual(@as(u32, 320), cfg.thread_stack_kb);
+    try std.testing.expectEqual(@as(u32, 180), cfg.idle_timeout_sec);
+    try std.testing.expectEqual(@as(u32, 30), cfg.handshake_timeout_sec);
     try std.testing.expectEqualStrings("example.com", cfg.tls_domain);
     try std.testing.expect(cfg.use_middle_proxy);
     try std.testing.expect(cfg.mask);
@@ -220,6 +252,10 @@ test "parse config - missing fields defaults" {
 
     try std.testing.expectEqual(@as(u16, 443), cfg.port);
     try std.testing.expectEqual(@as(u32, 4096), cfg.backlog); // Default is 4096
+    try std.testing.expectEqual(@as(u32, 65535), cfg.max_connections);
+    try std.testing.expectEqual(@as(u32, 256), cfg.thread_stack_kb);
+    try std.testing.expectEqual(@as(u32, 300), cfg.idle_timeout_sec);
+    try std.testing.expectEqual(@as(u32, 60), cfg.handshake_timeout_sec);
     try std.testing.expectEqualStrings("google.com", cfg.tls_domain);
     try std.testing.expect(!cfg.use_middle_proxy); // Default is false
     try std.testing.expect(cfg.mask); // Default is true
@@ -257,6 +293,26 @@ test "parse config - middleproxy buffer lower bound" {
     defer cfg.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(u32, 64), cfg.middleproxy_buffer_kb);
+}
+
+test "parse config - server runtime tunables lower bounds" {
+    const content =
+        \\[server]
+        \\max_connections = 1
+        \\thread_stack_kb = 16
+        \\idle_timeout_sec = 1
+        \\handshake_timeout_sec = 1
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(u32, 32), cfg.max_connections);
+    try std.testing.expectEqual(@as(u32, 256), cfg.thread_stack_kb);
+    try std.testing.expectEqual(@as(u32, 5), cfg.idle_timeout_sec);
+    try std.testing.expectEqual(@as(u32, 5), cfg.handshake_timeout_sec);
 }
 
 test "parse config - spaces and tabs" {

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -20,15 +20,6 @@ const tls_header_len = 5;
 const max_tls_payload = constants.max_tls_ciphertext_size;
 /// Idle timeout for relay poll() and write backpressure (5 minutes)
 const relay_timeout_ms = 5 * 60 * 1000;
-/// Idle Phase: wait for first byte from client (5 minutes).
-/// Mobile clients (iOS Telegram) aggressively pre-warm TCP connection pools,
-/// opening 2-5 idle sockets that sit empty until the app needs to send data.
-/// A short timeout here kills these pooled connections, causing iOS to mark
-/// the proxy as unstable and enter long reconnect cycles.
-const idle_timeout_ms: i32 = 5 * 60 * 1000;
-/// Active Phase: once data starts arriving, apply tight SO_RCVTIMEO
-/// to protect against Slowloris-style attacks (seconds).
-const active_timeout_sec: u32 = 10;
 /// Maximum connection lifetime (30 minutes). Hard cap to prevent thread
 /// accumulation from long-lived connections or half-open sockets that
 /// somehow survive keepalive probes.
@@ -168,10 +159,6 @@ pub const ProxyState = struct {
     /// Valid length of middle_proxy_secret bytes.
     middle_proxy_secret_len: usize,
 
-    /// Maximum concurrent connections before rejecting new ones.
-    /// Prevents thread exhaustion under load.
-    const max_connections: u32 = 65535;
-
     pub fn init(allocator: std.mem.Allocator, cfg: Config) ProxyState {
         var secrets: std.ArrayList(obfuscation.UserSecret) = .empty;
         var it = @constCast(&cfg.users).iterator();
@@ -284,18 +271,15 @@ pub const ProxyState = struct {
 
             // Overload protection: reject if too many concurrent connections
             const active = self.active_connections.load(.monotonic);
-            if (active >= max_connections) {
-                log.warn("[{d}] Connection rejected: at capacity ({d}/{d})", .{ conn_id, active, max_connections });
+            if (active >= self.config.max_connections) {
+                log.warn("[{d}] Connection rejected: at capacity ({d}/{d})", .{ conn_id, active, self.config.max_connections });
                 conn.stream.close();
                 continue;
             }
 
             const thread = std.Thread.spawn(.{
-                // Proxy threads shuffle bytes between sockets + AES-CTR (no deep recursion).
-                // 256 KB is plenty with safety margin for stack-heavy operations.
-                // Default 8-16 MB per thread would exhaust memory with thousands
-                // of idle iOS pool connections (e.g. 4000 threads * 8 MB = 32 GB virtual memory).
-                .stack_size = 256 * 1024,
+                // Tunable via [server].thread_stack_kb.
+                .stack_size = self.config.threadStackBytes(),
             }, handleConnection, .{ self, conn.stream, conn.address, conn_id }) catch |err| {
                 log.err("[{d}] Spawn error: {any}", .{ conn_id, err });
                 conn.stream.close();
@@ -681,20 +665,11 @@ fn handleConnectionInner(
     peer_str: []const u8,
     conn_id: u64,
 ) !void {
-    // === Two-Stage Timeout (Split Timeout) ===
-    //
-    // Stage 1 — Idle Phase: wait for the first byte with a long timeout.
-    // Mobile clients (iOS Telegram) pre-warm TCP connection pools by opening
-    // several idle sockets. Killing them too early causes reconnect storms.
-    // A sleeping thread in poll() consumes zero CPU.
-    //
-    // Stage 2 — Active Phase: once data arrives, apply a tight SO_RCVTIMEO
-    // to catch real Slowloris attacks (slow-drip partial sends).
-
+    // Stage 1 (idle pool): wait for first byte.
+    // Keep this path tiny on stack because benchmark/real clients may hold
+    // many idle pooled sockets concurrently.
     const fd = client_stream.handle;
-
-    // Stage 1: wait for first byte (idle pool phase)
-    const first_byte_timeout_ms: i32 = idle_timeout_ms;
+    const first_byte_timeout_ms = secondsToPollTimeoutMs(state.config.idle_timeout_sec);
 
     var poll_fds = [_]posix.pollfd{
         .{ .fd = fd, .events = posix.POLL.IN, .revents = 0 },
@@ -709,12 +684,32 @@ fn handleConnectionInner(
         return error.IdleConnectionClosed;
     }
 
-    // Stage 2: data is coming — apply generous handshake timeout.
+    try handleConnectionActive(state, client_stream, client_addr, peer_str, conn_id);
+}
+
+fn handleConnectionActive(
+    state: *ProxyState,
+    client_stream: net.Stream,
+    client_addr: net.Address,
+    peer_str: []const u8,
+    conn_id: u64,
+) !void {
+    // Stage 2 (active): once data starts arriving, apply handshake timeout.
+    const fd = client_stream.handle;
+
+    // Data is coming — apply generous handshake timeout.
     // DON'T use the tight 10s timeout yet — iOS Telegram may delay the
     // MTProto handshake after ServerHello (pool warming, timing differences).
     // Tight timeout is applied after the full 64-byte handshake is assembled.
-    const handshake_timeout_sec: u32 = 60;
-    setRecvTimeout(fd, handshake_timeout_sec);
+    setRecvTimeout(fd, state.config.handshake_timeout_sec);
+
+    // Keep large handshake/record buffers off thread stack so low stack sizes
+    // remain stable under load.
+    const app_body_buf = try state.allocator.alloc(u8, constants.max_tls_ciphertext_size);
+    defer state.allocator.free(app_body_buf);
+
+    const pipelined_buf = try state.allocator.alloc(u8, constants.max_tls_ciphertext_size);
+    defer state.allocator.free(pipelined_buf);
 
     // Read first 5 bytes to determine TLS vs direct
     var first_bytes: [5]u8 = undefined;
@@ -738,9 +733,12 @@ fn handleConnectionInner(
         return;
     }
 
-    var client_hello_buf: [5 + constants.max_tls_plaintext_size]u8 = undefined;
+    const client_hello_len: usize = 5 + record_len;
+    const client_hello_buf = try state.allocator.alloc(u8, client_hello_len);
+    defer state.allocator.free(client_hello_buf);
+
     @memcpy(client_hello_buf[0..5], &first_bytes);
-    const body_n = try readExact(client_stream, client_hello_buf[5..][0..record_len]);
+    const body_n = try readExact(client_stream, client_hello_buf[5..client_hello_len]);
     if (body_n < record_len) {
         log.info("[{d}] ({s}) DIAG: Short read on ClientHello body (got {d}, expected {d}), dropping.", .{ conn_id, peer_str, body_n, record_len });
         maskConnection(state, client_stream, peer_str, conn_id, client_hello_buf[0 .. 5 + body_n], null);
@@ -820,7 +818,6 @@ fn handleConnectionInner(
     // Desktop typically sends all 64 bytes in one AppData record, but we must not assume that.
     var handshake_assembly: [constants.handshake_len]u8 = undefined;
     var hs_pos: usize = 0;
-    var pipelined_buf: [constants.max_tls_ciphertext_size]u8 = undefined;
     var pipelined_len: usize = 0;
     var app_records_used: u8 = 0;
 
@@ -846,8 +843,8 @@ fn handleConnectionInner(
             },
             constants.tls_record_application => {
                 if (body_len == 0 or body_len > constants.max_tls_ciphertext_size) return;
-                var body_buf: [constants.max_tls_ciphertext_size]u8 = undefined;
-                if (try readExact(client_stream, body_buf[0..body_len]) < body_len) {
+                const body_buf = app_body_buf[0..body_len];
+                if (try readExact(client_stream, body_buf) < body_len) {
                     log.debug("[{d}] ({s}) Short read on AppData body, dropping.", .{ conn_id, peer_str });
                     return;
                 }
@@ -1254,6 +1251,7 @@ fn handleConnectionInner(
     }
 
     relayBidirectional(
+        state.allocator,
         client_stream,
         dc_stream,
         &client_decryptor,
@@ -1287,6 +1285,7 @@ const RelayProgress = enum {
 ///   C2S: TLS record → unwrap → AES-CTR decrypt (client) → AES-CTR encrypt (DC) → DC
 ///   S2C: DC → AES-CTR decrypt (DC) → AES-CTR encrypt (client) → TLS record wrap → client
 fn relayBidirectional(
+    allocator: std.mem.Allocator,
     client: net.Stream,
     dc: net.Stream,
     client_decryptor: *crypto.AesCtr,
@@ -1307,7 +1306,8 @@ fn relayBidirectional(
     // State for reading TLS records from client
     var tls_hdr_buf: [tls_header_len]u8 = undefined;
     var tls_hdr_pos: usize = 0;
-    var tls_body_buf: [max_tls_payload]u8 = undefined;
+    const tls_body_buf = try allocator.alloc(u8, max_tls_payload);
+    defer allocator.free(tls_body_buf);
     var tls_body_pos: usize = 0;
     var tls_body_len: usize = 0;
 
@@ -1316,6 +1316,9 @@ fn relayBidirectional(
 
     // Buffer for DC → client direction
     var dc_read_buf: [constants.default_buffer_size]u8 = undefined;
+
+    const tls_record_buf = try allocator.alloc(u8, tls_header_len + constants.max_tls_plaintext_size);
+    defer allocator.free(tls_record_buf);
 
     // Byte counters for diagnostics
     var c2s_bytes: u64 = initial_c2s_bytes;
@@ -1366,7 +1369,7 @@ fn relayBidirectional(
                 middle_proxy,
                 &tls_hdr_buf,
                 &tls_hdr_pos,
-                &tls_body_buf,
+                tls_body_buf,
                 &tls_body_pos,
                 &tls_body_len,
                 &c2s_bytes,
@@ -1386,6 +1389,7 @@ fn relayBidirectional(
                 if (fast_mode) null else client_encryptor,
                 middle_proxy,
                 &dc_read_buf,
+                tls_record_buf,
                 &drs,
                 &s2c_bytes,
             ) catch |err| {
@@ -1453,7 +1457,7 @@ fn relayClientToDc(
     middle_proxy: ?*middleproxy.MiddleProxyContext,
     tls_hdr_buf: *[tls_header_len]u8,
     tls_hdr_pos: *usize,
-    tls_body_buf: *[max_tls_payload]u8,
+    tls_body_buf: []u8,
     tls_body_pos: *usize,
     tls_body_len: *usize,
     bytes_counter: *u64,
@@ -1576,6 +1580,7 @@ fn relayDcToClient(
     client_encryptor: ?*crypto.AesCtr,
     middle_proxy: ?*middleproxy.MiddleProxyContext,
     dc_read_buf: *[constants.default_buffer_size]u8,
+    tls_record_buf: []u8,
     drs: *DynamicRecordSizer,
     bytes_counter: *u64,
 ) !RelayProgress {
@@ -1596,19 +1601,18 @@ fn relayDcToClient(
         if (client_encryptor) |enc| enc.apply(payload);
 
         // Wrap in TLS Application Data record(s)
-        var record_buf: [tls_header_len + constants.max_tls_plaintext_size]u8 = undefined;
         var offset: usize = 0;
         while (offset < payload.len) {
             const max_chunk = drs.nextRecordSize();
             const chunk_len = @min(payload.len - offset, max_chunk);
 
-            record_buf[0] = constants.tls_record_application;
-            record_buf[1] = constants.tls_version[0];
-            record_buf[2] = constants.tls_version[1];
-            std.mem.writeInt(u16, record_buf[3..5], @intCast(chunk_len), .big);
-            @memcpy(record_buf[tls_header_len..][0..chunk_len], payload[offset..][0..chunk_len]);
+            tls_record_buf[0] = constants.tls_record_application;
+            tls_record_buf[1] = constants.tls_version[0];
+            tls_record_buf[2] = constants.tls_version[1];
+            std.mem.writeInt(u16, tls_record_buf[3..5], @intCast(chunk_len), .big);
+            @memcpy(tls_record_buf[tls_header_len..][0..chunk_len], payload[offset..][0..chunk_len]);
 
-            try writeAll(client, record_buf[0 .. tls_header_len + chunk_len]);
+            try writeAll(client, tls_record_buf[0 .. tls_header_len + chunk_len]);
             drs.recordSent(chunk_len);
             offset += chunk_len;
         }
@@ -1628,20 +1632,19 @@ fn relayDcToClient(
     // Wrap in TLS Application Data record(s) using DRS-controlled sizes.
     // Header and body are written in a single writeAll call to reduce syscalls
     // and ensure atomic TLS record delivery (avoids tiny 5-byte header packets).
-    var record_buf: [tls_header_len + constants.max_tls_plaintext_size]u8 = undefined;
     var offset: usize = 0;
     while (offset < data.len) {
         const max_chunk = drs.nextRecordSize();
         const chunk_len = @min(data.len - offset, max_chunk);
 
         // Build TLS record: header + payload in one buffer
-        record_buf[0] = constants.tls_record_application;
-        record_buf[1] = constants.tls_version[0];
-        record_buf[2] = constants.tls_version[1];
-        std.mem.writeInt(u16, record_buf[3..5], @intCast(chunk_len), .big);
-        @memcpy(record_buf[tls_header_len..][0..chunk_len], data[offset..][0..chunk_len]);
+        tls_record_buf[0] = constants.tls_record_application;
+        tls_record_buf[1] = constants.tls_version[0];
+        tls_record_buf[2] = constants.tls_version[1];
+        std.mem.writeInt(u16, tls_record_buf[3..5], @intCast(chunk_len), .big);
+        @memcpy(tls_record_buf[tls_header_len..][0..chunk_len], data[offset..][0..chunk_len]);
 
-        try writeAll(client, record_buf[0 .. tls_header_len + chunk_len]);
+        try writeAll(client, tls_record_buf[0 .. tls_header_len + chunk_len]);
 
         drs.recordSent(chunk_len);
         offset += chunk_len;
@@ -1772,6 +1775,12 @@ fn setNonBlocking(fd: posix.fd_t) void {
 fn setRecvTimeout(fd: posix.fd_t, timeout_sec: u32) void {
     const tv = posix.timeval{ .sec = @intCast(timeout_sec), .usec = 0 };
     posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.RCVTIMEO, std.mem.asBytes(&tv)) catch return;
+}
+
+fn secondsToPollTimeoutMs(timeout_sec: u32) i32 {
+    const max_i32_u32: u32 = @intCast(std.math.maxInt(i32));
+    const capped = @min(timeout_sec, max_i32_u32 / 1000);
+    return @as(i32, @intCast(capped * 1000));
 }
 
 /// Set SO_SNDTIMEO on a socket to prevent write hangs on dead peers.

--- a/test/README.md
+++ b/test/README.md
@@ -96,7 +96,7 @@ Host: `38.180.236.207` (1 vCPU / 1 GB RAM)
 
 | Proxy | Max observed ESTABLISHED | Max fully stable target* | RSS at peak target |
 |-------|---------------------------|---------------------------|--------------------|
-| **mtproto.zig (pre-tuning)** | 2,000 | 2,000 | 31.5 MB |
+| **mtproto.zig** | 12,000 | 12,000 | 144.3 MB |
 | Official MTProxy | 12,000 | 12,000 | 72.4 MB |
 | Teleproxy | 12,000 | 12,000 | 76.1 MB |
 | Telemt | 8,000 | 8,000 | 50.7 MB |

--- a/test/README.md
+++ b/test/README.md
@@ -92,7 +92,19 @@ Each result includes:
 
 Host: `38.180.236.207` (1 vCPU / 1 GB RAM)
 
-### Stable baseline
+### Cross-proxy snapshot (baseline run)
+
+| Proxy | Max observed ESTABLISHED | Max fully stable target* | RSS at peak target |
+|-------|---------------------------|---------------------------|--------------------|
+| **mtproto.zig (pre-tuning)** | 2,000 | 2,000 | 31.5 MB |
+| Official MTProxy | 12,000 | 12,000 | 72.4 MB |
+| Teleproxy | 12,000 | 12,000 | 76.1 MB |
+| Telemt | 8,000 | 8,000 | 50.7 MB |
+| mtg | 8,172 | 4,000 | 124.0 MB |
+| mtprotoproxy | 8,000 | 8,000 | 92.0 MB |
+| mtproto_proxy | 2,000 | 2,000 | 138.7 MB |
+
+### mtproto.zig tuned snapshot (latest)
 
 Baseline sweep (`2000..5000`) shows:
 
@@ -117,6 +129,8 @@ Practical ceiling on this host/profile: about 13k held sockets.
 | 12000 | 144.3 MB |
 
 Observed slope is roughly +12 MB per additional 1000 held sockets on this VPS.
+
+\* "Fully stable target" means `established_server_side == target` at that level.
 
 ## Tuning Notes
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,150 @@
+# Test Utilities
+
+## Capacity Probe
+
+`capacity_connections_probe.py` estimates how many concurrent TCP sessions each implementation can hold on one host.
+
+### What it measures
+
+- held concurrent sockets (`ESTABLISHED` on server side)
+- process-tree RSS while those sockets are held
+
+This is a **capacity snapshot**, not full real-user throughput under Telegram traffic mix.
+
+### Prerequisites
+
+- Linux host with `ss` command (`iproute2`)
+- Python 3.10+
+- benchmark workspace prepared under `/root/benchmarks` (default)
+
+### Typical usage
+
+```bash
+# list available profiles
+python3 test/capacity_connections_probe.py --list-profiles
+
+# full sweep with best-effort local tuning
+sudo -E python3 test/capacity_connections_probe.py --profile all --sysctl-tune
+
+# single implementation
+sudo -E python3 test/capacity_connections_probe.py --profile mtproto.zig
+
+# custom levels / budget / nofile
+sudo -E python3 test/capacity_connections_probe.py \
+  --profile mtproto.zig \
+  --levels 500,1000,2000,4000,8000 \
+  --open-budget-sec 12 \
+  --nofile 300000 \
+  --nproc 12000
+```
+
+### Recommended mtproto.zig profiles
+
+```bash
+# "safe" profile for this VPS
+sudo -E python3 test/capacity_connections_probe.py \
+  --profile mtproto.zig \
+  --levels 2000,3000,3500,4000,4500 \
+  --open-budget-sec 16 \
+  --hold-seconds 0.8 \
+  --settle-seconds 1.0 \
+  --connect-timeout-sec 0.1 \
+  --nofile 200000 \
+  --nproc 12000
+
+# "stress" profile (checks post-4.5k behavior)
+sudo -E python3 test/capacity_connections_probe.py \
+  --profile mtproto.zig \
+  --levels 4000,4500,5000,5500,6000 \
+  --open-budget-sec 18 \
+  --hold-seconds 0.8 \
+  --settle-seconds 1.0 \
+  --connect-timeout-sec 0.1 \
+  --nofile 250000 \
+  --nproc 12000
+
+# high-capacity profile (host/perf ceiling discovery)
+sudo -E python3 test/capacity_connections_probe.py \
+  --profile mtproto.zig \
+  --levels 6000,8000,10000,12000 \
+  --open-budget-sec 24 \
+  --hold-seconds 0.8 \
+  --settle-seconds 1.0 \
+  --connect-timeout-sec 0.1 \
+  --nofile 300000 \
+  --nproc 20000
+```
+
+For `mtproto.zig`, the probe now auto-raises `max_connections` in the benchmark config
+above the requested `--levels`, so results reflect runtime/host capacity instead of
+being clipped by config.
+
+### Output
+
+By default, JSON is written to `/root/benchmarks/results/`:
+
+- multi-profile: `capacity_connections.json`
+- single-profile: `capacity_connections_<profile>.json`
+
+Each profile result includes:
+
+- `max_established_observed`
+- `max_stable_target` (stable when `established >= target * stable_ratio`)
+- per-level `rss_kb`, client-side successes, failures
+
+### Current snapshot (`38.180.236.207`, 1 vCPU / 1 GB)
+
+| Proxy | Max observed ESTABLISHED | Max fully stable target* | RSS at peak target |
+|-------|---------------------------|---------------------------|--------------------|
+| **mtproto.zig** | 2,000 | 2,000 | 31.5 MB |
+| Official MTProxy | 12,000 | 12,000 | 72.4 MB |
+| Teleproxy | 12,000 | 12,000 | 76.1 MB |
+| Telemt | 8,000 | 8,000 | 50.7 MB |
+| mtg | 8,172 | 4,000 | 124.0 MB |
+| mtprotoproxy | 8,000 | 8,000 | 92.0 MB |
+| mtproto_proxy | 2,000 | 2,000 | 138.7 MB |
+
+### Tuned mtproto.zig snapshot (same VPS)
+
+Applied runtime config:
+
+```toml
+[server]
+max_connections = 4500
+thread_stack_kb = 128
+idle_timeout_sec = 300
+handshake_timeout_sec = 30
+backlog = 8192
+```
+
+Probe result (`--levels 2000,3000,3500,4000,4500,5000`):
+
+- `max_established_observed`: **4517**
+- `max_stable_target`: **4500**
+- RSS at stable 4500 target: **72.5 MB**
+- at target 5000: accepted on client side, but only ~4517 reached `ESTABLISHED`
+
+### Updated tuned snapshot (same VPS, stable baseline)
+
+With stack-safe runtime changes and capacity probe auto-lifting `max_connections`:
+
+- levels `2000..5000`: stable through **5000** (`5000/5000` established)
+- levels `6000,7000,8000`: stable through **8000**
+- levels `9000,10000,11000,12000`: stable through **12000**
+- upper sweep `13000,14000` (with explicit high cap):
+  - **13000 stable**
+  - **14000 unstable** (about `7371` established)
+
+So current practical ceiling on this host/profile is around **13k concurrent held sockets**.
+
+\* "Fully stable target" means `established_server_side == target` at that level.
+
+### Notes for tuning mtproto.zig
+
+Primary bottlenecks on this VPS are config cap (`max_connections`) first, then host thread/process budget and memory pressure.
+To push higher safely:
+
+- host limits (`ulimit -u`, cgroup `pids.max`)
+- `[server].thread_stack_kb`
+- `[server].max_connections`
+- probe launcher `--nofile`, `--nproc`, and optional `--sysctl-tune`

--- a/test/README.md
+++ b/test/README.md
@@ -1,50 +1,47 @@
 # Test Utilities
 
+This directory contains lightweight tools used for local and remote validation.
+
+- `capacity_connections_probe.py`: concurrent connection capacity sweeps
+- `connection_stability_check.py`: long-running stability harness
+
 ## Capacity Probe
 
 `capacity_connections_probe.py` estimates how many concurrent TCP sessions each implementation can hold on one host.
 
 ### What it measures
 
-- held concurrent sockets (`ESTABLISHED` on server side)
-- process-tree RSS while those sockets are held
+- server-side held sockets (`ESTABLISHED`)
+- process-tree memory (`RSS`) while sockets are held
 
-This is a **capacity snapshot**, not full real-user throughput under Telegram traffic mix.
+This is a capacity snapshot, not a full Telegram real-user throughput benchmark.
 
-### Prerequisites
+## Environment
 
-- Linux host with `ss` command (`iproute2`)
+- Linux host with `ss` (`iproute2`)
 - Python 3.10+
 - benchmark workspace prepared under `/root/benchmarks` (default)
 
-### Typical usage
+## Quick Start
 
 ```bash
-# list available profiles
+# list profiles
 python3 test/capacity_connections_probe.py --list-profiles
 
-# full sweep with best-effort local tuning
-sudo -E python3 test/capacity_connections_probe.py --profile all --sysctl-tune
-
-# single implementation
+# run one profile with defaults
 sudo -E python3 test/capacity_connections_probe.py --profile mtproto.zig
 
-# custom levels / budget / nofile
-sudo -E python3 test/capacity_connections_probe.py \
-  --profile mtproto.zig \
-  --levels 500,1000,2000,4000,8000 \
-  --open-budget-sec 12 \
-  --nofile 300000 \
-  --nproc 12000
+# full sweep for all configured profiles
+sudo -E python3 test/capacity_connections_probe.py --profile all --sysctl-tune
 ```
 
-### Recommended mtproto.zig profiles
+## Recommended mtproto.zig runs
 
 ```bash
-# "safe" profile for this VPS
+# baseline profile (safe, production-like)
 sudo -E python3 test/capacity_connections_probe.py \
   --profile mtproto.zig \
-  --levels 2000,3000,3500,4000,4500 \
+  --levels 2000,3000,3500,4000,4500,5000 \
   --open-budget-sec 16 \
   --hold-seconds 0.8 \
   --settle-seconds 1.0 \
@@ -52,18 +49,7 @@ sudo -E python3 test/capacity_connections_probe.py \
   --nofile 200000 \
   --nproc 12000
 
-# "stress" profile (checks post-4.5k behavior)
-sudo -E python3 test/capacity_connections_probe.py \
-  --profile mtproto.zig \
-  --levels 4000,4500,5000,5500,6000 \
-  --open-budget-sec 18 \
-  --hold-seconds 0.8 \
-  --settle-seconds 1.0 \
-  --connect-timeout-sec 0.1 \
-  --nofile 250000 \
-  --nproc 12000
-
-# high-capacity profile (host/perf ceiling discovery)
+# high-capacity profile (find host ceiling)
 sudo -E python3 test/capacity_connections_probe.py \
   --profile mtproto.zig \
   --levels 6000,8000,10000,12000 \
@@ -73,78 +59,75 @@ sudo -E python3 test/capacity_connections_probe.py \
   --connect-timeout-sec 0.1 \
   --nofile 300000 \
   --nproc 20000
+
+# explicit ceiling probe
+sudo -E python3 test/capacity_connections_probe.py \
+  --profile mtproto.zig \
+  --levels 13000,14000 \
+  --open-budget-sec 26 \
+  --hold-seconds 0.8 \
+  --settle-seconds 1.0 \
+  --connect-timeout-sec 0.1 \
+  --nofile 350000 \
+  --nproc 20000
 ```
 
-For `mtproto.zig`, the probe now auto-raises `max_connections` in the benchmark config
-above the requested `--levels`, so results reflect runtime/host capacity instead of
-being clipped by config.
+For `mtproto.zig`, the probe auto-raises `max_connections` in benchmark config above requested `--levels`.
+This prevents config clipping and reflects runtime and host limits.
 
-### Output
+## Output
 
-By default, JSON is written to `/root/benchmarks/results/`:
+Default output directory: `/root/benchmarks/results/`
 
-- multi-profile: `capacity_connections.json`
-- single-profile: `capacity_connections_<profile>.json`
+- single profile: `capacity_connections_<profile>.json`
+- multi profile: `capacity_connections.json`
 
-Each profile result includes:
+Each result includes:
 
 - `max_established_observed`
-- `max_stable_target` (stable when `established >= target * stable_ratio`)
-- per-level `rss_kb`, client-side successes, failures
+- `max_stable_target` (`established >= target * stable_ratio`)
+- per-level `connected_client_side`, `established_server_side`, `rss_kb`, `failures`
 
-### Current snapshot (`38.180.236.207`, 1 vCPU / 1 GB)
+## Latest Snapshot (2026-04-04)
 
-| Proxy | Max observed ESTABLISHED | Max fully stable target* | RSS at peak target |
-|-------|---------------------------|---------------------------|--------------------|
-| **mtproto.zig** | 2,000 | 2,000 | 31.5 MB |
-| Official MTProxy | 12,000 | 12,000 | 72.4 MB |
-| Teleproxy | 12,000 | 12,000 | 76.1 MB |
-| Telemt | 8,000 | 8,000 | 50.7 MB |
-| mtg | 8,172 | 4,000 | 124.0 MB |
-| mtprotoproxy | 8,000 | 8,000 | 92.0 MB |
-| mtproto_proxy | 2,000 | 2,000 | 138.7 MB |
+Host: `38.180.236.207` (1 vCPU / 1 GB RAM)
 
-### Tuned mtproto.zig snapshot (same VPS)
+### Stable baseline
 
-Applied runtime config:
+Baseline sweep (`2000..5000`) shows:
 
-```toml
-[server]
-max_connections = 4500
-thread_stack_kb = 128
-idle_timeout_sec = 300
-handshake_timeout_sec = 30
-backlog = 8192
-```
+- stable through `5000/5000`
+- no connection failures in probe client
+- memory scales near-linearly with held sockets
 
-Probe result (`--levels 2000,3000,3500,4000,4500,5000`):
+### High-capacity sweeps
 
-- `max_established_observed`: **4517**
-- `max_stable_target`: **4500**
-- RSS at stable 4500 target: **72.5 MB**
-- at target 5000: accepted on client side, but only ~4517 reached `ESTABLISHED`
+- `6000,8000,10000,12000`: all stable (`12000/12000`)
+- `13000,14000`: `13000` stable, `14000` unstable (`~7371` established)
 
-### Updated tuned snapshot (same VPS, stable baseline)
+Practical ceiling on this host/profile: about 13k held sockets.
 
-With stack-safe runtime changes and capacity probe auto-lifting `max_connections`:
+### Memory growth (mtproto.zig)
 
-- levels `2000..5000`: stable through **5000** (`5000/5000` established)
-- levels `6000,7000,8000`: stable through **8000**
-- levels `9000,10000,11000,12000`: stable through **12000**
-- upper sweep `13000,14000` (with explicit high cap):
-  - **13000 stable**
-  - **14000 unstable** (about `7371` established)
+| Held sockets | RSS |
+|--------------|-----|
+| 5000 | 60.6 MB |
+| 8000 | 96.5 MB |
+| 10000 | 120.5 MB |
+| 12000 | 144.3 MB |
 
-So current practical ceiling on this host/profile is around **13k concurrent held sockets**.
+Observed slope is roughly +12 MB per additional 1000 held sockets on this VPS.
 
-\* "Fully stable target" means `established_server_side == target` at that level.
+## Tuning Notes
 
-### Notes for tuning mtproto.zig
+Primary bottlenecks are, in order:
 
-Primary bottlenecks on this VPS are config cap (`max_connections`) first, then host thread/process budget and memory pressure.
-To push higher safely:
+1. config cap (`max_connections`)
+2. host process/thread limits (`ulimit -u`, cgroup `pids.max`)
+3. available memory
 
-- host limits (`ulimit -u`, cgroup `pids.max`)
-- `[server].thread_stack_kb`
+When pushing higher, tune these together:
+
 - `[server].max_connections`
-- probe launcher `--nofile`, `--nproc`, and optional `--sysctl-tune`
+- `[server].thread_stack_kb`
+- probe flags `--nofile` and `--nproc`

--- a/test/capacity_connections_probe.py
+++ b/test/capacity_connections_probe.py
@@ -1,0 +1,570 @@
+#!/usr/bin/env python3
+"""
+Connection capacity probe for MTProto proxy implementations.
+
+What it measures:
+- held concurrent TCP sessions (server-side ESTABLISHED count)
+- process tree RSS growth while connections are held
+
+Default profile paths are tuned for the benchmark host layout used in README:
+- binaries/configs under /root/benchmarks
+- mtproto_proxy release script at /opt/mtp_proxy/bin/mtp_proxy
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import resource
+import signal
+import socket
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class Profile:
+    name: str
+    port: int
+    command: list[str]
+    levels: list[int]
+    prep: Optional[str] = None
+
+
+def build_profiles(bench_dir: Path) -> list[Profile]:
+    bin_dir = bench_dir / "bin"
+    cfg_dir = bench_dir / "configs"
+    work_dir = bench_dir / "work"
+
+    secret = "00112233445566778899aabbccddeeff"
+
+    return [
+        Profile(
+            name="mtproto.zig",
+            port=16543,
+            command=[
+                str(bin_dir / "mtproto-zig-local"),
+                str(cfg_dir / "capacity-mtproto-zig.toml"),
+            ],
+            prep="mtproto_zig_autocap",
+            levels=[200, 500, 1000, 2000, 4000, 8000, 12000],
+        ),
+        Profile(
+            name="Official MTProxy",
+            port=16544,
+            command=[
+                str(bin_dir / "official-mtproxy"),
+                "-u",
+                "nobody",
+                "-p",
+                "18888",
+                "-H",
+                "16544",
+                "-S",
+                secret,
+                "--aes-pwd",
+                str(work_dir / "proxy-secret"),
+                str(work_dir / "proxy-multi.conf"),
+            ],
+            prep="set_low_pid",
+            levels=[200, 500, 1000, 2000, 4000, 8000, 12000],
+        ),
+        Profile(
+            name="Teleproxy",
+            port=16545,
+            command=[
+                str(bin_dir / "teleproxy-release"),
+                "-u",
+                "root",
+                "-p",
+                "18890",
+                "-H",
+                "16545",
+                "-S",
+                secret,
+                "--aes-pwd",
+                str(work_dir / "proxy-secret"),
+                str(work_dir / "proxy-multi.conf"),
+            ],
+            levels=[200, 500, 1000, 2000, 4000, 8000, 12000],
+        ),
+        Profile(
+            name="Telemt",
+            port=16546,
+            command=[
+                str(bin_dir / "telemt"),
+                str(cfg_dir / "capacity-telemt.toml"),
+            ],
+            levels=[100, 200, 500, 1000, 2000, 4000, 8000],
+        ),
+        Profile(
+            name="mtg",
+            port=16547,
+            command=[
+                str(bin_dir / "mtg-release"),
+                "run",
+                str(cfg_dir / "capacity-mtg.toml"),
+            ],
+            levels=[200, 500, 1000, 2000, 4000, 8000, 12000],
+        ),
+        Profile(
+            name="mtprotoproxy",
+            port=16548,
+            command=[
+                "python3",
+                str(bin_dir / "mtprotoproxy.py"),
+                str(cfg_dir / "capacity-mtprotoproxy.py"),
+            ],
+            levels=[200, 500, 1000, 2000, 4000, 8000],
+        ),
+        Profile(
+            name="mtproto_proxy",
+            port=1443,
+            command=["/opt/mtp_proxy/bin/mtp_proxy", "foreground"],
+            levels=[100, 200, 500, 1000, 2000],
+        ),
+    ]
+
+
+def parse_ppid_map() -> dict[int, int]:
+    out: dict[int, int] = {}
+    for entry in os.listdir("/proc"):
+        if not entry.isdigit():
+            continue
+        pid = int(entry)
+        try:
+            stat = Path(f"/proc/{pid}/stat").read_text().split()
+            out[pid] = int(stat[3])
+        except OSError:
+            continue
+    return out
+
+
+def descendants(root_pid: int) -> set[int]:
+    ppid = parse_ppid_map()
+    children: dict[int, list[int]] = {}
+    for pid, pp in ppid.items():
+        children.setdefault(pp, []).append(pid)
+
+    seen: set[int] = set()
+    stack = [root_pid]
+    while stack:
+        cur = stack.pop()
+        if cur in seen:
+            continue
+        seen.add(cur)
+        stack.extend(children.get(cur, []))
+    return seen
+
+
+def rss_kb_for_pid(pid: int) -> int:
+    try:
+        for line in Path(f"/proc/{pid}/status").read_text().splitlines():
+            if line.startswith("VmRSS:"):
+                return int(line.split()[1])
+    except OSError:
+        return 0
+    return 0
+
+
+def tree_rss_kb(pid: int) -> int:
+    return sum(rss_kb_for_pid(p) for p in descendants(pid))
+
+
+def listener_pid(port: int) -> Optional[int]:
+    try:
+        out = subprocess.check_output(
+            ["ss", "-ltnp"], text=True, stderr=subprocess.DEVNULL
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return None
+
+    ids: list[int] = []
+    needle = f":{port} "
+    for line in out.splitlines():
+        if needle not in line:
+            continue
+        ids.extend(int(m.group(1)) for m in re.finditer(r"pid=(\d+)", line))
+
+    if not ids:
+        return None
+    return sorted(ids)[0]
+
+
+def established_count(port: int) -> int:
+    est_state = "01"
+    port_hex = f"{port:04X}"
+
+    def count_in(path: str) -> int:
+        p = Path(path)
+        if not p.exists():
+            return 0
+        try:
+            lines = p.read_text().splitlines()
+        except OSError:
+            return 0
+
+        total = 0
+        for line in lines[1:]:
+            cols = line.split()
+            if len(cols) < 4:
+                continue
+            local = cols[1]
+            state = cols[3]
+            if state != est_state:
+                continue
+            if ":" not in local:
+                continue
+            local_port = local.split(":", 1)[1]
+            if local_port.upper() == port_hex:
+                total += 1
+        return total
+
+    return count_in("/proc/net/tcp") + count_in("/proc/net/tcp6")
+
+
+def kill_tree(root_pid: Optional[int]) -> None:
+    if not root_pid:
+        return
+    for pid in sorted(descendants(root_pid), reverse=True):
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except OSError:
+            pass
+    time.sleep(0.25)
+    for pid in sorted(descendants(root_pid), reverse=True):
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except OSError:
+            pass
+
+
+def cleanup_port(port: int) -> None:
+    kill_tree(listener_pid(port))
+    time.sleep(0.15)
+
+
+def wait_for_listen(port: int, timeout_sec: float) -> bool:
+    deadline = time.time() + timeout_sec
+    while time.time() < deadline:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(0.05)
+        try:
+            if s.connect_ex(("127.0.0.1", port)) == 0:
+                return True
+        finally:
+            s.close()
+        time.sleep(0.02)
+    return False
+
+
+def open_connections(
+    port: int,
+    target: int,
+    connect_timeout_sec: float,
+    open_budget_sec: float,
+    fail_streak_limit: int,
+) -> tuple[list[socket.socket], int]:
+    sockets: list[socket.socket] = []
+    failures = 0
+    fail_streak = 0
+    deadline = time.time() + open_budget_sec
+
+    while len(sockets) < target and time.time() < deadline:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(connect_timeout_sec)
+        rc = s.connect_ex(("127.0.0.1", port))
+        if rc == 0:
+            s.settimeout(None)
+            sockets.append(s)
+            fail_streak = 0
+        else:
+            failures += 1
+            fail_streak += 1
+            s.close()
+            if fail_streak >= fail_streak_limit:
+                break
+
+    return sockets, failures
+
+
+def close_connections(connections: list[socket.socket]) -> None:
+    for s in connections:
+        try:
+            s.close()
+        except OSError:
+            pass
+
+
+def tune_nofile(target: int) -> None:
+    if target <= 0:
+        return
+    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    desired = target
+    if hard != resource.RLIM_INFINITY:
+        desired = min(desired, hard)
+    desired = max(desired, soft)
+    try:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (desired, hard))
+    except (OSError, ValueError):
+        pass
+
+
+def tune_nproc(target: int) -> None:
+    if target <= 0 or not hasattr(resource, "RLIMIT_NPROC"):
+        return
+    soft, hard = resource.getrlimit(resource.RLIMIT_NPROC)
+    desired = target
+    if hard != resource.RLIM_INFINITY:
+        desired = min(desired, hard)
+    desired = max(desired, soft)
+    try:
+        resource.setrlimit(resource.RLIMIT_NPROC, (desired, hard))
+    except (OSError, ValueError):
+        pass
+
+
+def maybe_apply_sysctl(args: argparse.Namespace) -> None:
+    if not args.sysctl_tune:
+        return
+    cmds = [
+        ["sysctl", "-w", "net.ipv4.ip_local_port_range=10000 65535"],
+        ["sysctl", "-w", "net.ipv4.tcp_tw_reuse=1"],
+    ]
+    for cmd in cmds:
+        try:
+            subprocess.run(
+                cmd, check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+            )
+        except (OSError, FileNotFoundError):
+            pass
+
+
+def run_profile(
+    profile: Profile, args: argparse.Namespace, results_dir: Path
+) -> dict[str, object]:
+    cleanup_port(profile.port)
+
+    if profile.prep == "set_low_pid":
+        try:
+            Path("/proc/sys/kernel/ns_last_pid").write_text("50000")
+        except OSError:
+            pass
+    elif profile.prep == "mtproto_zig_autocap":
+        # Keep max_connections comfortably above the highest probed level,
+        # so the probe measures host/runtime limits rather than config cap.
+        levels = profile.levels
+        if args.levels:
+            levels = [int(x) for x in args.levels.split(",") if x.strip()]
+        max_target = max(levels) if levels else 0
+        desired = max(65535, max_target + 1024)
+
+        cfg_path = Path(profile.command[-1])
+        try:
+            cfg_text = cfg_path.read_text()
+            next_text, replaced = re.subn(
+                r"(?m)^\s*max_connections\s*=\s*\d+\s*$",
+                f"max_connections = {desired}",
+                cfg_text,
+                count=1,
+            )
+            if replaced:
+                cfg_path.write_text(next_text)
+        except OSError:
+            pass
+
+    safe = profile.name.replace(" ", "_").replace(".", "_")
+    log_path = results_dir / f"capacity_{safe}.log"
+
+    with log_path.open("w") as log_file:
+        process = subprocess.Popen(profile.command, stdout=log_file, stderr=log_file)
+
+    if not wait_for_listen(profile.port, args.startup_timeout_sec):
+        rc = process.poll()
+        if rc is None:
+            kill_tree(process.pid)
+            rc = -999
+        return {
+            "name": profile.name,
+            "ok": False,
+            "error": "startup_failed",
+            "rc": rc,
+            "log": str(log_path),
+            "command": profile.command,
+        }
+
+    time.sleep(1.0)
+    root_pid = listener_pid(profile.port) or process.pid
+    base_rss = tree_rss_kb(root_pid)
+
+    levels = profile.levels
+    if args.levels:
+        levels = [int(x) for x in args.levels.split(",") if x.strip()]
+
+    level_results: list[dict[str, object]] = []
+    max_established = 0
+    max_stable_target = 0
+    for level in levels:
+        connections, failures = open_connections(
+            profile.port,
+            level,
+            args.connect_timeout_sec,
+            args.open_budget_sec,
+            args.fail_streak_limit,
+        )
+        time.sleep(args.hold_seconds)
+
+        established = established_count(profile.port)
+        rss_now = tree_rss_kb(root_pid)
+        stable = established >= int(level * args.stable_ratio)
+
+        if established > max_established:
+            max_established = established
+        if stable and level > max_stable_target:
+            max_stable_target = level
+
+        level_results.append(
+            {
+                "target": level,
+                "connected_client_side": len(connections),
+                "established_server_side": established,
+                "failures": failures,
+                "rss_kb": rss_now,
+                "stable": stable,
+            }
+        )
+
+        close_connections(connections)
+        time.sleep(args.settle_seconds)
+
+    kill_tree(root_pid)
+    kill_tree(process.pid)
+    cleanup_port(profile.port)
+
+    return {
+        "name": profile.name,
+        "ok": True,
+        "base_rss_kb": base_rss,
+        "max_established_observed": max_established,
+        "max_stable_target": max_stable_target,
+        "levels": level_results,
+        "log": str(log_path),
+        "command": profile.command,
+    }
+
+
+def select_profiles(all_profiles: list[Profile], selectors: list[str]) -> list[Profile]:
+    if not selectors or "all" in {s.lower() for s in selectors}:
+        return all_profiles
+
+    selected: list[Profile] = []
+    lowered = [s.lower() for s in selectors]
+    for profile in all_profiles:
+        name = profile.name.lower()
+        if any(sel == name or sel in name for sel in lowered):
+            selected.append(profile)
+    return selected
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Concurrent connection capacity probe")
+    parser.add_argument(
+        "--profile",
+        action="append",
+        default=[],
+        help="Profile name (repeatable). Use 'all' for full run.",
+    )
+    parser.add_argument(
+        "--list-profiles", action="store_true", help="Print profile names and exit"
+    )
+    parser.add_argument(
+        "--bench-dir", default="/root/benchmarks", help="Benchmark workspace root"
+    )
+    parser.add_argument(
+        "--results-dir",
+        default="/root/benchmarks/results",
+        help="Directory for logs/json",
+    )
+    parser.add_argument("--output", default="", help="Override output JSON path")
+    parser.add_argument(
+        "--levels",
+        default="",
+        help="Override levels for all selected profiles, e.g. 200,500,1000",
+    )
+    parser.add_argument(
+        "--stable-ratio",
+        type=float,
+        default=0.98,
+        help="Stable threshold: established >= target * ratio",
+    )
+    parser.add_argument("--startup-timeout-sec", type=float, default=45.0)
+    parser.add_argument("--connect-timeout-sec", type=float, default=0.08)
+    parser.add_argument("--open-budget-sec", type=float, default=8.0)
+    parser.add_argument("--hold-seconds", type=float, default=0.25)
+    parser.add_argument("--settle-seconds", type=float, default=0.45)
+    parser.add_argument("--fail-streak-limit", type=int, default=128)
+    parser.add_argument(
+        "--nofile",
+        type=int,
+        default=200000,
+        help="Attempt to raise RLIMIT_NOFILE soft limit",
+    )
+    parser.add_argument(
+        "--nproc",
+        type=int,
+        default=12000,
+        help="Attempt to raise RLIMIT_NPROC soft limit",
+    )
+    parser.add_argument(
+        "--sysctl-tune",
+        action="store_true",
+        help="Try best-effort sysctl tuning for local load generation",
+    )
+    args = parser.parse_args()
+
+    profiles = build_profiles(Path(args.bench_dir))
+
+    if args.list_profiles:
+        for p in profiles:
+            print(p.name)
+        return 0
+
+    selected = select_profiles(profiles, args.profile)
+    if not selected:
+        print("No matching profiles selected.")
+        return 2
+
+    results_dir = Path(args.results_dir)
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    tune_nofile(args.nofile)
+    tune_nproc(args.nproc)
+    maybe_apply_sysctl(args)
+
+    all_results: list[dict[str, object]] = []
+    for profile in selected:
+        print(f"=== {profile.name} ===", flush=True)
+        result = run_profile(profile, args, results_dir)
+        all_results.append(result)
+        print(json.dumps(result, ensure_ascii=False), flush=True)
+
+    if args.output:
+        output_path = Path(args.output)
+    elif len(selected) == 1:
+        safe_name = selected[0].name.lower().replace(" ", "_").replace(".", "_")
+        output_path = results_dir / f"capacity_connections_{safe_name}.json"
+    else:
+        output_path = results_dir / "capacity_connections.json"
+
+    output_path.write_text(json.dumps(all_results, indent=2, ensure_ascii=False))
+    print(f"RESULT_FILE {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Move large per-connection handshake/relay buffers off thread stack and keep idle-path handling lightweight to stabilize high-connection operation while preserving current protocol behavior.
- Keep runtime guardrails explicit in config parsing/docs (`max_connections`, timeout knobs, and a safe minimum for `thread_stack_kb`) so production and benchmark behavior are predictable.
- Update benchmark tooling/docs in `test/` so mtproto.zig capacity probes auto-avoid config clipping and reflect host/runtime ceilings.

## Validation
- `zig build test`
- `python3 -m py_compile test/capacity_connections_probe.py`
- Bench host sweeps (38.180.236.207) with the updated binary:
  - stable through 12k (`9000..12000` all stable)
  - explicit high-cap sweep shows ~13k stable and 14k unstable