### PR TITLE
chore: fix bad permissions for config.toml

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -119,7 +119,6 @@ if ! id -u mtproto &>/dev/null; then
     useradd --system --no-create-home --shell /usr/sbin/nologin mtproto
     ok "Created system user 'mtproto'"
 fi
-chown -R mtproto:mtproto "$INSTALL_DIR"
 
 # ── Install systemd service ─────────────────────────────────
 cp "$TMPBUILD/deploy/mtproto-proxy.service" /etc/systemd/system/
@@ -216,6 +215,8 @@ elif curl -sk --max-time 5 "https://127.0.0.1:${MASK_PORT}/" >/dev/null 2>&1; th
 else
     warn "Masking validation failed: https://127.0.0.1:${MASK_PORT}/ is not responding"
 fi
+
+chown -R mtproto:mtproto "$INSTALL_DIR"
 
 # ── Cleanup ─────────────────────────────────────────────────
 rm -rf "$TMPBUILD"


### PR DESCRIPTION
Small fix for bug:

```
Apr 05 07:30:36 a253402271.local mtproto-proxy[67187]:   ✗ Failed to load config '/opt/mtproto-proxy/config.toml': error.AccessDenied
Apr 05 07:30:36 a253402271.local mtproto-proxy[67187]:   Usage: mtproto-proxy [config.toml]
Apr 05 07:30:36 a253402271.local systemd[1]: mtproto-proxy.service: Deactivated successfully.
░░ Subject: Unit succeeded
░░ Defined-By: systemd
░░ Support: http://www.ubuntu.com/support
░░
░░ The unit mtproto-proxy.service has successfully entered the 'dead' state.
root@a253402271:~# ls -la /opt/mtproto-proxy/
total 3400
drwxr-xr-x 2 mtproto mtproto    4096 Apr  5 07:26 .
drwxr-xr-x 4 root    root       4096 Apr  5 07:27 ..
-rwxr-xr-x 1 mtproto mtproto   12515 Apr  5 07:26 capture_template.py
-rwx--x--x 1 root    root        159 Apr  5 07:26 config.toml
-rwxr-xr-x 1 mtproto mtproto   10801 Apr  5 07:26 install.sh
-rwxr-xr-x 1 mtproto mtproto    6083 Apr  5 07:26 ipv6-hop.sh
-rwxr-xr-x 1 mtproto mtproto 3399472 Apr  5 07:26 mtproto-proxy
-rwxr-xr-x 1 mtproto mtproto    8631 Apr  5 07:26 setup_masking.sh
-rwxr-xr-x 1 mtproto mtproto    8147 Apr  5 07:26 setup_nfqws.sh
-rwxr-xr-x 1 mtproto mtproto    1512 Apr  5 07:26 update_dns.sh
-rwxr-xr-x 1 mtproto mtproto    5134 Apr  5 07:26 update.sh
```


