### PR TITLE
chore: add issue templates with mandatory diagnostics checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,131 @@
+name: "🐛 Bug Report"
+description: "Proxy doesn't connect, crashes, or behaves unexpectedly."
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Before you open this issue
+
+        Most connection problems are caused by **environment misconfiguration**, not proxy bugs.
+        Please go through the checklist below — every checkbox is **mandatory**.
+        Issues without a completed checklist will be closed automatically.
+
+  # ── Version & Environment ───────────────────────────────
+  - type: input
+    id: version
+    attributes:
+      label: Proxy version
+      description: "Output of `mtproto-proxy --version` or the version you downloaded."
+      placeholder: "0.6.0"
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: OS & kernel
+      description: "Output of `uname -sr`."
+      placeholder: "Linux 6.1.0-18-amd64"
+    validations:
+      required: true
+
+  - type: input
+    id: telegram-client
+    attributes:
+      label: Telegram client & version
+      description: "Which client are you connecting from?"
+      placeholder: "Telegram Desktop 6.7.2 / Android 12.6.4 / iOS 11.8"
+    validations:
+      required: true
+
+  # ── Mandatory Self-Diagnostics ──────────────────────────
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-flight checklist
+      description: "You **must** confirm every item. If an item does not apply, explain why in the description."
+      options:
+        - label: "I am running the **latest release** (checked [Releases](https://github.com/sleep3r/mtproto.zig/releases))."
+          required: true
+        - label: "System clock is synchronized (`timedatectl status` shows `NTP synchronized: yes`)."
+          required: true
+        - label: "The proxy port (default 443) is open in the firewall (`ss -tlnp | grep <port>` shows LISTEN)."
+          required: true
+        - label: "I can reach the proxy port from the outside (`curl -v --connect-timeout 5 https://<server-ip>:<port>` returns a TLS error, not a timeout)."
+          required: true
+        - label: "Secret key in config.toml matches the tg:// link I use on the client (I re-checked byte-for-byte)."
+          required: true
+        - label: "`RLIMIT_NOFILE` warning (if present) is just a warning — I understand it does **not** block connections."
+          required: true
+        - label: "I have read the logs with `journalctl -u mtproto-proxy -n 200 --no-pager` and the **full** output is attached below."
+          required: true
+
+  # ── Config ──────────────────────────────────────────────
+  - type: textarea
+    id: config
+    attributes:
+      label: config.toml (secrets redacted)
+      description: |
+        Paste your full `config.toml` with secrets replaced by `***`.
+        **Do not skip sections** — omitting config lines makes debugging impossible.
+      render: toml
+      placeholder: |
+        [general]
+        ad_tag = "***"
+        use_middle_proxy = true
+
+        [server]
+        port = 443
+
+        [censorship]
+        tls_domain = "google.com"
+        desync = true
+        mask = true
+
+        [access.users]
+        user = "***"
+    validations:
+      required: true
+
+  # ── Logs ────────────────────────────────────────────────
+  - type: textarea
+    id: logs
+    attributes:
+      label: Full proxy log (last 200 lines)
+      description: |
+        `journalctl -u mtproto-proxy -n 200 --no-pager`
+        Do **not** cherry-pick single lines — paste the full block.
+      render: text
+    validations:
+      required: true
+
+  # ── Diagnostics output ─────────────────────────────────
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics output
+      description: |
+        Run these commands and paste the combined output:
+        ```bash
+        echo "=== date ===" && date -u
+        echo "=== timedatectl ===" && timedatectl status 2>/dev/null || echo "N/A"
+        echo "=== ulimit ===" && ulimit -n
+        echo "=== ss ===" && ss -tlnp | grep -E '443|mtproto'
+        echo "=== uname ===" && uname -a
+        echo "=== memory ===" && free -h
+        echo "=== systemctl ===" && systemctl status mtproto-proxy --no-pager -l 2>/dev/null || echo "N/A"
+        ```
+      render: text
+    validations:
+      required: true
+
+  # ── Extra context ───────────────────────────────────────
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: "Anything else: screenshots, network topology, VPS provider, etc."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "❓ General question"
+    url: https://github.com/sleep3r/mtproto.zig/discussions
+    about: "For questions about usage, configuration, or troubleshooting — please use Discussions instead of Issues."

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,20 @@
+name: "✨ Feature Request"
+description: "Suggest an improvement or a new feature."
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What do you want?
+      description: "Clear description of the feature or improvement."
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Why?
+      description: "What problem does this solve? What is your use case?"
+    validations:
+      required: true

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ deploy:
 		ssh root@$(SERVER) 'chmod 600 /opt/mtproto-proxy/env.sh'; \
 		rm .env.tmp_deploy; \
 	fi
+	ssh root@$(SERVER) 'chown -R mtproto:mtproto /opt/mtproto-proxy/'
 	ssh root@$(SERVER) 'systemctl start mtproto-proxy && systemctl status mtproto-proxy --no-pager'
 
 update-server:


### PR DESCRIPTION
## What

Structured GitHub Issue Forms that **force** users to self-diagnose before opening bug reports.

### Bug Report Template
- 7 mandatory checkboxes: latest release, NTP sync, firewall, port reachability, secret match, RLIMIT understanding, full logs attached
- Required fields: proxy version, OS, Telegram client, full `config.toml`, last 200 log lines, diagnostics output
- Diagnostics section includes a ready-made script block for `timedatectl`, `ulimit`, `ss`, `uname`, `free`, `systemctl status`

### Feature Request Template
- Simple description + motivation form

### Config
- **Blank issues disabled** — users must go through templates
- General questions redirected to Discussions

### Makefile
- Fix deploy `chown` for mtproto user (ensures config.toml permissions are correct after deploy)

## Why

Users repeatedly open issues with single log lines (e.g. RLIMIT warnings) without checking basics like NTP sync, firewall rules, or secret keys. This wastes maintainer time on environment issues that are not proxy bugs.

Closes: context from #41