### PR TITLE
fix(deploy): prevent config.toml access denied error on installs

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -189,6 +189,7 @@ info "Setting up zapret nfqws TCP desync..."
 bash "$TMPBUILD/deploy/setup_nfqws.sh" || warn "nfqws setup failed"
 
 # Restart proxy to apply Mask Port and NFQUEUE capabilities
+chown -R mtproto:mtproto "$INSTALL_DIR"
 systemctl restart "$SERVICE_NAME"
 ok "Advanced OS-Level DPI Evasion and Masking successfully configured!"
 

--- a/deploy/setup_masking.sh
+++ b/deploy/setup_masking.sh
@@ -206,6 +206,8 @@ if [[ -f "$CONFIG_FILE" ]]; then
         }
     ' "$CONFIG_FILE" > "$TMP_CONFIG"; then
         mv "$TMP_CONFIG" "$CONFIG_FILE"
+        chmod 0644 "$CONFIG_FILE"
+        chown mtproto:mtproto "$CONFIG_FILE" 2>/dev/null || true
     else
         rm -f "$TMP_CONFIG"
         fail "Failed to update ${CONFIG_FILE} with mask_port=${NGINX_PORT}"

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -109,6 +109,9 @@ install -m 0644 "${TMP_DIR}/capture_template.py" "${INSTALL_DIR}/capture_templat
 install -m 0644 "${TMP_DIR}/mtproto-proxy.service" "/etc/systemd/system/mtproto-proxy.service"
 systemctl daemon-reload
 
+# Fix permissions up in case config or dir was modified as root
+chown -R mtproto:mtproto "$INSTALL_DIR" 2>/dev/null || true
+
 info "Starting ${SERVICE_NAME}..."
 if ! systemctl restart "$SERVICE_NAME"; then
     warn "Service failed to start after update"


### PR DESCRIPTION
## Description
Fixes an issue where `mtproto-proxy.service` would fail to start immediately after installation with `error.AccessDenied` on `config.toml`.

## Root Cause
The `setup_masking.sh` script manipulated `config.toml` using `mktemp` and `mv`, which changed the file ownership to `root:root` with `0644` permissions (or inherited from root umask). When `mtproto-proxy.service` attempted to start under the `mtproto` service user with `ReadOnlyPaths=/opt/mtproto-proxy`, it failed to read the configuration.

## Changes
- **deploy/setup_masking.sh**: Explicitly restore `mtproto:mtproto` ownership and `0644` permissions after replacing the configuration file.
- **deploy/install.sh**: Add defensive `chown -R mtproto:mtproto` directly before starting the systemd service to enforce correct permissions globally.
- **deploy/update.sh**: Preemptively apply `chown -R mtproto:mtproto` before restarting the service to repair existing broken deployments upon their next update.