### PR TITLE
fix(proxy): stabilize tunnel middleproxy path and tune small-VPS defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 SERVER ?= 185.125.46.60
 CONFIG ?= config.toml
 AWG_CONF ?=
+TUNNEL_MODE ?= direct
 HOST ?= 127.0.0.1
 PORT ?= 443
 PID ?=
@@ -93,22 +94,24 @@ migrate:
 
 # Full migration + AmneziaWG tunnel (for servers where Telegram is blocked)
 deploy-tunnel:
-	@if [ -z "$(SERVER)" ]; then echo "Usage: make deploy-tunnel SERVER=<ip> AWG_CONF=<path> [PASSWORD=<pass>]"; exit 1; fi
+	@if [ -z "$(SERVER)" ]; then echo "Usage: make deploy-tunnel SERVER=<ip> AWG_CONF=<path> [PASSWORD=<pass>] [TUNNEL_MODE=direct|preserve|middleproxy]"; exit 1; fi
 	@if [ -z "$(AWG_CONF)" ]; then echo "AWG_CONF is required (path to AmneziaWG client config)"; exit 1; fi
 	@if [ ! -f "$(AWG_CONF)" ]; then echo "AWG_CONF file not found: $(AWG_CONF)"; exit 1; fi
+	@case "$(TUNNEL_MODE)" in direct|preserve|middleproxy) ;; *) echo "Invalid TUNNEL_MODE: $(TUNNEL_MODE). Allowed: direct, preserve, middleproxy"; exit 1 ;; esac
 	$(MAKE) migrate SERVER=$(SERVER) PASSWORD=$(PASSWORD)
 	@echo "--- Setting up AmneziaWG tunnel ---"
 	scp $(AWG_CONF) root@$(SERVER):/tmp/awg_client.conf
 	scp deploy/setup_tunnel.sh root@$(SERVER):/tmp/setup_tunnel.sh
-	ssh root@$(SERVER) 'bash /tmp/setup_tunnel.sh /tmp/awg_client.conf && rm -f /tmp/awg_client.conf /tmp/setup_tunnel.sh'
+	ssh root@$(SERVER) "bash /tmp/setup_tunnel.sh /tmp/awg_client.conf $(TUNNEL_MODE) && rm -f /tmp/awg_client.conf /tmp/setup_tunnel.sh"
 
 # Add tunnel to existing installation
 deploy-tunnel-only:
-	@if [ -z "$(SERVER)" ]; then echo "Usage: make deploy-tunnel-only SERVER=<ip> AWG_CONF=<path>"; exit 1; fi
+	@if [ -z "$(SERVER)" ]; then echo "Usage: make deploy-tunnel-only SERVER=<ip> AWG_CONF=<path> [TUNNEL_MODE=direct|preserve|middleproxy]"; exit 1; fi
 	@if [ -z "$(AWG_CONF)" ]; then echo "AWG_CONF is required (path to AmneziaWG client config)"; exit 1; fi
+	@case "$(TUNNEL_MODE)" in direct|preserve|middleproxy) ;; *) echo "Invalid TUNNEL_MODE: $(TUNNEL_MODE). Allowed: direct, preserve, middleproxy"; exit 1 ;; esac
 	scp $(AWG_CONF) root@$(SERVER):/tmp/awg_client.conf
 	scp deploy/setup_tunnel.sh root@$(SERVER):/tmp/setup_tunnel.sh
-	ssh root@$(SERVER) 'bash /tmp/setup_tunnel.sh /tmp/awg_client.conf && rm -f /tmp/awg_client.conf /tmp/setup_tunnel.sh'
+	ssh root@$(SERVER) "bash /tmp/setup_tunnel.sh /tmp/awg_client.conf $(TUNNEL_MODE) && rm -f /tmp/awg_client.conf /tmp/setup_tunnel.sh"
 
 update-dns:
 	@if [ -z "$(SERVER)" ]; then echo "Usage: make update-dns SERVER=<ip>"; exit 1; fi

--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ zig build -Doptimize=ReleaseFast soak -- --seconds=120 --threads=8 --max-payload
 | `make fmt` | Format all Zig source files |
 | `make deploy` | Cross-compile, upload binary/scripts/config to VPS, restart service |
 | `make deploy SERVER=<ip>` | Deploy to a specific server |
-| `make deploy-tunnel SERVER=<ip> AWG_CONF=<path> [PASSWORD=<pass>]` | Full migration + AmneziaWG tunnel for blocked regions |
-| `make deploy-tunnel-only SERVER=<ip> AWG_CONF=<path>` | Add AmneziaWG tunnel to existing installation |
+| `make deploy-tunnel SERVER=<ip> AWG_CONF=<path> [PASSWORD=<pass>] [TUNNEL_MODE=direct\|preserve\|middleproxy]` | Full migration + AmneziaWG tunnel for blocked regions |
+| `make deploy-tunnel-only SERVER=<ip> AWG_CONF=<path> [TUNNEL_MODE=direct\|preserve\|middleproxy]` | Add AmneziaWG tunnel to existing installation |
 | `make update-server SERVER=<ip> [VERSION=vX.Y.Z]` | Update server binary from GitHub Release artifacts |
 
 </details>
@@ -452,12 +452,18 @@ From your workstation:
 make deploy-tunnel SERVER=<VPS_IP> AWG_CONF=awg.conf PASSWORD=<root_password>
 ```
 
+Optionally choose tunnel mode for `use_middle_proxy` handling:
+
+```bash
+make deploy-tunnel SERVER=<VPS_IP> AWG_CONF=awg.conf TUNNEL_MODE=middleproxy
+```
+
 This will:
 1. Set up SSH key, install deps, build and deploy the proxy (via `make migrate`)
 2. Install **amneziawg-tools** (DKMS kernel module + userspace tools)
 3. Create network namespace `tg_proxy_ns` with AmneziaWG tunnel inside
 4. Set up **DNAT** (incoming `:443` → namespace) and **policy routing** (responses go back to client, not into tunnel)
-5. Patch the systemd service to run the proxy inside the namespace in **direct mode**
+5. Patch the systemd service to run the proxy inside the namespace and apply selected tunnel mode (`direct` by default)
 6. Validate connectivity to all 5 Telegram DCs through the tunnel
 7. Print the ready-to-use `tg://` link
 
@@ -469,11 +475,17 @@ If the proxy is already installed and running:
 make deploy-tunnel-only SERVER=<VPS_IP> AWG_CONF=awg.conf
 ```
 
+With explicit mode:
+
+```bash
+make deploy-tunnel-only SERVER=<VPS_IP> AWG_CONF=awg.conf TUNNEL_MODE=preserve
+```
+
 ### On the server directly
 
 ```bash
 scp awg.conf root@<VPS_IP>:/tmp/awg.conf
-ssh root@<VPS_IP> 'bash /opt/mtproto-proxy/setup_tunnel.sh /tmp/awg.conf'
+ssh root@<VPS_IP> 'bash /opt/mtproto-proxy/setup_tunnel.sh /tmp/awg.conf middleproxy'
 ```
 
 ### How it works
@@ -486,7 +498,7 @@ ssh root@<VPS_IP> 'bash /opt/mtproto-proxy/setup_tunnel.sh /tmp/awg.conf'
 | Policy routing (`from 10.200.200.2 table 100`) | Inside namespace | Response packets return via veth (not via tunnel) |
 | `mtproto-proxy` | Inside `tg_proxy_ns` | Listens on `:443`, connects to Telegram via `awg0` |
 
-> **Note** &nbsp; The tunnel setup automatically switches the proxy to **direct mode** (`use_middle_proxy = false`). Middleproxy mode requires per-IP registration with `@MTProxyBot`, which doesn't work when the proxy's outgoing IP is the VPN exit node.
+> **Note** &nbsp; Tunnel setup supports three modes: `direct` (default, sets `use_middle_proxy=false`), `preserve` (keeps current config), and `middleproxy` (sets `use_middle_proxy=true`). Use `middleproxy` if you need promo-tag parity and stable media behavior on non-premium clients.
 
 > **Note** &nbsp; To check tunnel status: `ssh root@<VPS_IP> 'ip netns exec tg_proxy_ns awg show'`
 
@@ -519,6 +531,9 @@ ad_tag = "1234567890abcdef1234567890abcdef"    # Optional alias for [server].tag
 port = 443
 backlog = 4096                             # TCP listen queue size
 middleproxy_buffer_kb = 256               # Per-connection ME buffers (4x this size), tune for VPS RAM
+max_connections = 512                      # Safe default for small (1 vCPU / ~1 GB) VPS
+idle_timeout_sec = 120
+handshake_timeout_sec = 15
 tag = "1234567890abcdef1234567890abcdef"   # Optional: promotion tag from @MTProxybot
 
 [censorship]
@@ -543,7 +558,9 @@ bob   = "ffeeddccbbaa99887766554433221100"
 | `[general]` | `ad_tag` | _(none)_ | Telemt-compatible alias for promotion tag; ignored if `[server].tag` is set |
 | `[server]` | `port` | `443` | TCP port to listen on |
 | `[server]` | `backlog` | `4096` | TCP listen queue size (for high-traffic loads) |
-| `[server]` | `max_connections` | `65535` | Concurrent connection cap. On Linux, runtime is auto-clamped by `RLIMIT_NOFILE` if configured higher than available FD budget |
+| `[server]` | `max_connections` | `512` | Concurrent connection cap (small-VPS tuned default). On Linux, runtime is auto-clamped by `RLIMIT_NOFILE` if configured higher than available FD budget |
+| `[server]` | `idle_timeout_sec` | `120` | Connection idle timeout in seconds (also used before first client byte) |
+| `[server]` | `handshake_timeout_sec` | `15` | Timeout for completing handshake after first byte |
 | `[server]` | `middleproxy_buffer_kb` | `256` | MiddleProxy per-connection buffer size in KiB (4 buffers allocated for active ME sessions) |
 | `[server]` | `tag` | _(none)_ | Optional 32 hex-char promotion tag from [@MTProxybot](https://t.me/MTProxybot) |
 | `[censorship]` | `tls_domain` | `"google.com"` | Domain to impersonate / forward bad clients to |
@@ -558,7 +575,7 @@ bob   = "ffeeddccbbaa99887766554433221100"
 
 > **Operational note** &nbsp; High-churn mobile networks can produce many normal disconnects (`ConnectionResetByPeer`/`EndOfStream`). In release builds these are logged at debug level to keep production logs signal-focused.
 
-> **Operational note** &nbsp; `deploy/mtproto-proxy.service` ships with `LimitNOFILE=131582` (fits `max_connections=65535` with reserve). If your host applies a lower limit, the proxy auto-clamps effective `max_connections` at startup and logs a warning.
+> **Operational note** &nbsp; `deploy/mtproto-proxy.service` ships with `LimitNOFILE=131582` to allow higher custom caps when needed. Default `max_connections=512` is tuned for small VPS profiles; increase it only after capacity testing.
 
 > **Tip** &nbsp; Generate a random secret: `openssl rand -hex 16`
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -98,6 +98,9 @@ if [[ ! -f "$INSTALL_DIR/config.toml" ]]; then
     cat > "$INSTALL_DIR/config.toml" << EOF
 [server]
 port = 443
+max_connections = 512
+idle_timeout_sec = 120
+handshake_timeout_sec = 15
 
 [censorship]
 tls_domain = "$TLS_DOMAIN"

--- a/deploy/setup_tunnel.sh
+++ b/deploy/setup_tunnel.sh
@@ -6,10 +6,10 @@
 # so Telegram DCs become reachable while the host keeps normal connectivity.
 #
 # Usage (on server):
-#   bash setup_tunnel.sh /path/to/awg-client.conf
+#   bash setup_tunnel.sh /path/to/awg-client.conf [direct|preserve|middleproxy]
 #
 # Usage (via Makefile from workstation):
-#   make deploy-tunnel SERVER=<ip> AWG_CONF=awg.conf
+#   make deploy-tunnel SERVER=<ip> AWG_CONF=awg.conf [TUNNEL_MODE=direct|preserve|middleproxy]
 #
 # Prerequisites:
 #   - mtproto-proxy already installed via install.sh or make deploy
@@ -22,7 +22,7 @@
 #   4. Sets up DNAT so incoming :443 traffic is forwarded into the namespace
 #   5. Adds policy routing so response packets go back to clients (not into tunnel)
 #   6. Patches the systemd service to run the proxy inside the namespace
-#   7. Switches config to direct mode (middleproxy requires per-IP registration)
+#   7. Applies selected tunnel mode for use_middle_proxy (direct/preserve/middleproxy)
 #   8. Restarts the proxy
 #
 # Architecture:
@@ -59,9 +59,41 @@ fail()  { echo -e "${RED}✗${RESET} $*" >&2; exit 1; }
 
 # ── Argument parsing ────────────────────────────────────────
 AWG_CONF="${1:-}"
-[[ -n "$AWG_CONF" ]] || fail "Usage: bash setup_tunnel.sh /path/to/awg-client.conf"
+TUNNEL_MODE="${2:-direct}"
+
+[[ -n "$AWG_CONF" ]] || fail "Usage: bash setup_tunnel.sh /path/to/awg-client.conf [direct|preserve|middleproxy]"
 [[ -f "$AWG_CONF" ]] || fail "Config file not found: $AWG_CONF"
 [[ $EUID -eq 0 ]] || fail "Run as root: sudo bash setup_tunnel.sh ..."
+
+case "$TUNNEL_MODE" in
+    direct|preserve|middleproxy) ;;
+    *) fail "Invalid tunnel mode '$TUNNEL_MODE'. Allowed: direct, preserve, middleproxy" ;;
+esac
+
+set_use_middle_proxy() {
+    local value="$1"
+    local cfg="$INSTALL_DIR/config.toml"
+
+    if grep -Eq '^[[:space:]]*use_middle_proxy[[:space:]]*=' "$cfg"; then
+        sed -i "0,/^[[:space:]]*use_middle_proxy[[:space:]]*=/{s/^[[:space:]]*use_middle_proxy[[:space:]]*=.*/use_middle_proxy = ${value}/}" "$cfg"
+        return
+    fi
+
+    if grep -Eq '^[[:space:]]*\[general\][[:space:]]*$' "$cfg"; then
+        sed -i "0,/^[[:space:]]*\[general\][[:space:]]*$/s//[general]\nuse_middle_proxy = ${value}/" "$cfg"
+        return
+    fi
+
+    local tmp_cfg
+    tmp_cfg="$(mktemp)"
+    {
+        echo "[general]"
+        echo "use_middle_proxy = ${value}"
+        echo ""
+        cat "$cfg"
+    } > "$tmp_cfg"
+    mv "$tmp_cfg" "$cfg"
+}
 
 # ── Validate proxy is installed ─────────────────────────────
 [[ -f "$INSTALL_DIR/mtproto-proxy" ]] || fail "mtproto-proxy not found at $INSTALL_DIR. Run install.sh first."
@@ -180,15 +212,38 @@ SVC_EOF
 systemctl daemon-reload
 ok "Systemd service patched for tunnel mode"
 
-# ── Step 5: Switch to direct mode ───────────────────────────
-info "Switching config to direct mode..."
-if grep -q 'use_middle_proxy\s*=\s*true' "$INSTALL_DIR/config.toml"; then
-    sed -i 's/use_middle_proxy\s*=\s*true/use_middle_proxy = false/' "$INSTALL_DIR/config.toml"
-    # Remove tag (not needed in direct mode)
-    sed -i '/^\s*tag\s*=/d' "$INSTALL_DIR/config.toml"
-    ok "Switched to direct mode (middleproxy requires per-IP registration with @MTProxyBot)"
-else
-    ok "Already in direct mode"
+# ── Step 5: Apply selected tunnel mode ──────────────────────
+info "Applying tunnel mode: $TUNNEL_MODE..."
+MODE_STATUS=""
+case "$TUNNEL_MODE" in
+    direct)
+        set_use_middle_proxy false
+        MODE_STATUS="Direct mode for regular DC traffic (media keeps MiddleProxy path when available)"
+        ;;
+    preserve)
+        MODE_STATUS="Preserved existing use_middle_proxy setting from config"
+        ;;
+    middleproxy)
+        set_use_middle_proxy true
+        MODE_STATUS="MiddleProxy mode enabled for regular and media traffic"
+        ;;
+esac
+ok "$MODE_STATUS"
+
+if grep -Eq '^[[:space:]]*tag[[:space:]]*=' "$INSTALL_DIR/config.toml"; then
+    ok "Promotion tag preserved"
+fi
+
+if ! grep -Eq '^[[:space:]]*tag[[:space:]]*=' "$INSTALL_DIR/config.toml"; then
+    if [[ -f "$INSTALL_DIR/env.sh" ]]; then
+        TAG_FROM_ENV="$(awk -F= '/^[[:space:]]*export[[:space:]]+TAG[[:space:]]*=/{gsub(/"/,"",$2); gsub(/[[:space:]]/,"",$2); print tolower($2)}' "$INSTALL_DIR/env.sh" | head -1)"
+        if [[ "$TAG_FROM_ENV" =~ ^[0-9a-f]{32}$ ]]; then
+            if grep -Eq '^[[:space:]]*\[server\][[:space:]]*$' "$INSTALL_DIR/config.toml"; then
+                sed -i "0,/^[[:space:]]*\[server\][[:space:]]*$/s//[server]\ntag = \"${TAG_FROM_ENV}\"/" "$INSTALL_DIR/config.toml"
+                ok "Promotion tag restored from env.sh"
+            fi
+        fi
+    fi
 fi
 
 # ── Step 6: Restart proxy ───────────────────────────────────
@@ -251,6 +306,6 @@ echo ""
 echo -e "  ${BOLD}Architecture:${RESET}"
 echo -e "  ${GREEN}✓${RESET} Proxy runs inside isolated network namespace"
 echo -e "  ${GREEN}✓${RESET} AmneziaWG tunnel active (host network untouched)"
-echo -e "  ${GREEN}✓${RESET} Direct mode (no middleproxy registration needed)"
+echo -e "  ${GREEN}✓${RESET} ${MODE_STATUS}"
 echo -e "  ${GREEN}✓${RESET} SSH and host services unaffected by tunnel"
 echo ""

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -83,6 +83,12 @@ for file in install.sh update.sh update_dns.sh ipv6-hop.sh setup_masking.sh setu
     curl -fsSL "${RAW_BASE}/${file}" -o "${TMP_DIR}/${file}" || fail "Failed to download ${file}"
 done
 
+if curl -fsSL "${RAW_BASE}/setup_tunnel.sh" -o "${TMP_DIR}/setup_tunnel.sh"; then
+    ok "Downloaded setup_tunnel.sh"
+else
+    warn "setup_tunnel.sh is missing in ${TAG}, keeping existing local copy if present"
+fi
+
 [[ -d "$INSTALL_DIR" ]] || fail "Install directory not found: $INSTALL_DIR"
 
 if [[ -f "${INSTALL_DIR}/mtproto-proxy" ]]; then
@@ -104,6 +110,9 @@ install -m 0755 "${TMP_DIR}/update_dns.sh" "${INSTALL_DIR}/update_dns.sh"
 install -m 0755 "${TMP_DIR}/ipv6-hop.sh" "${INSTALL_DIR}/ipv6-hop.sh"
 install -m 0755 "${TMP_DIR}/setup_masking.sh" "${INSTALL_DIR}/setup_masking.sh"
 install -m 0755 "${TMP_DIR}/setup_nfqws.sh" "${INSTALL_DIR}/setup_nfqws.sh"
+if [[ -f "${TMP_DIR}/setup_tunnel.sh" ]]; then
+    install -m 0755 "${TMP_DIR}/setup_tunnel.sh" "${INSTALL_DIR}/setup_tunnel.sh"
+fi
 install -m 0644 "${TMP_DIR}/capture_template.py" "${INSTALL_DIR}/capture_template.py"
 
 install -m 0644 "${TMP_DIR}/mtproto-proxy.service" "/etc/systemd/system/mtproto-proxy.service"

--- a/src/config.zig
+++ b/src/config.zig
@@ -15,11 +15,12 @@ pub const Config = struct {
     /// TCP listen(2) backlog for client-facing sockets
     backlog: u32 = 4096,
     /// Hard cap for concurrently handled client connections
-    max_connections: u32 = 65535,
+    /// Default tuned for 1 vCPU / 1 GB VPS profile.
+    max_connections: u32 = 512,
     /// Pre-handshake idle timeout: wait for first client byte
-    idle_timeout_sec: u32 = 300,
+    idle_timeout_sec: u32 = 120,
     /// Handshake read timeout after first byte arrives
-    handshake_timeout_sec: u32 = 60,
+    handshake_timeout_sec: u32 = 15,
     tag: ?[16]u8 = null,
     tls_domain: []const u8 = "google.com",
     users: std.StringHashMap([16]u8),
@@ -241,9 +242,9 @@ test "parse config - missing fields defaults" {
 
     try std.testing.expectEqual(@as(u16, 443), cfg.port);
     try std.testing.expectEqual(@as(u32, 4096), cfg.backlog); // Default is 4096
-    try std.testing.expectEqual(@as(u32, 65535), cfg.max_connections);
-    try std.testing.expectEqual(@as(u32, 300), cfg.idle_timeout_sec);
-    try std.testing.expectEqual(@as(u32, 60), cfg.handshake_timeout_sec);
+    try std.testing.expectEqual(@as(u32, 512), cfg.max_connections);
+    try std.testing.expectEqual(@as(u32, 120), cfg.idle_timeout_sec);
+    try std.testing.expectEqual(@as(u32, 15), cfg.handshake_timeout_sec);
     try std.testing.expectEqualStrings("google.com", cfg.tls_domain);
     try std.testing.expect(!cfg.use_middle_proxy); // Default is false
     try std.testing.expect(cfg.mask); // Default is true

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -22,8 +22,10 @@ const tls_header_len = 5;
 const event_loop_wait_ms = 37;
 const accept_backoff_ms: i64 = 500;
 const accept_backoff_ns: i128 = @as(i128, accept_backoff_ms) * std.time.ns_per_ms;
+const accept_batch_limit: usize = 256;
 const stats_log_interval_s: i64 = 10;
 const stats_log_interval_ns: i128 = @as(i128, stats_log_interval_s) * std.time.ns_per_s;
+const timer_scan_budget: usize = 512;
 const nofile_fd_overhead: usize = 512;
 const middle_proxy_config_url = "https://core.telegram.org/getProxyConfig";
 const middle_proxy_secret_url = "https://core.telegram.org/getProxySecret";
@@ -631,6 +633,7 @@ pub const ProxyState = struct {
     middle_proxy_addrs_203_len: usize,
     middle_proxy_secret: [256]u8,
     middle_proxy_secret_len: usize,
+    middle_proxy_nat_ip4: ?[4]u8,
 
     pub fn init(allocator: std.mem.Allocator, cfg: Config) ProxyState {
         var secrets: std.ArrayList(obfuscation.UserSecret) = .empty;
@@ -661,6 +664,15 @@ pub const ProxyState = struct {
         var default_middle_proxy_secret = [_]u8{0} ** 256;
         @memcpy(default_middle_proxy_secret[0..middleproxy.proxy_secret.len], middleproxy.proxy_secret[0..]);
 
+        const detected_nat_ip4 = if (cfg.datacenter_override == null)
+            detectPublicIpv4(allocator)
+        else
+            null;
+        if (detected_nat_ip4) |ip| {
+            var ip_buf: [16]u8 = undefined;
+            log.info("Detected public IPv4 for middle-proxy NAT translation: {s}", .{formatIpv4Bytes(ip, &ip_buf)});
+        }
+
         return .{
             .allocator = allocator,
             .config = cfg,
@@ -677,6 +689,7 @@ pub const ProxyState = struct {
             .middle_proxy_addrs_203_len = 1,
             .middle_proxy_secret = default_middle_proxy_secret,
             .middle_proxy_secret_len = middleproxy.proxy_secret.len,
+            .middle_proxy_nat_ip4 = detected_nat_ip4,
         };
     }
 
@@ -911,6 +924,7 @@ const EventLoop = struct {
     pool: ConnectionPool,
     accept_paused: bool,
     accept_resume_ns: i128,
+    timer_scan_cursor: u32,
     stats_next_log_ns: i128,
     accepted_since_log: u64,
     closed_since_log: u64,
@@ -926,6 +940,7 @@ const EventLoop = struct {
             .pool = try ConnectionPool.init(state.allocator, state.config.max_connections),
             .accept_paused = false,
             .accept_resume_ns = 0,
+            .timer_scan_cursor = 0,
             .stats_next_log_ns = std.time.nanoTimestamp() + stats_log_interval_ns,
             .accepted_since_log = 0,
             .closed_since_log = 0,
@@ -1027,7 +1042,8 @@ const EventLoop = struct {
     }
 
     fn acceptNewConnections(self: *EventLoop) !void {
-        while (true) {
+        var accepted_this_round: usize = 0;
+        while (accepted_this_round < accept_batch_limit) {
             var client_addr: net.Address = undefined;
             var client_len: posix.socklen_t = @sizeOf(net.Address);
             const cfd = posix.accept(self.listen_fd, &client_addr.any, &client_len, posix.SOCK.CLOEXEC | posix.SOCK.NONBLOCK) catch |err| {
@@ -1040,6 +1056,7 @@ const EventLoop = struct {
                     else => return err,
                 }
             };
+            accepted_this_round += 1;
 
             const active_before = self.state.active_connections.fetchAdd(1, .monotonic);
             if (active_before >= self.state.config.max_connections) {
@@ -1671,7 +1688,7 @@ const EventLoop = struct {
             return true;
         }
 
-        if (!slot.direct_fallback_used and slot.direct_fallback_addr != null and slot.use_middle_proxy and !slot.is_media_path) {
+        if (!slot.direct_fallback_used and slot.direct_fallback_addr != null and slot.use_middle_proxy) {
             slot.direct_fallback_used = true;
             slot.use_middle_proxy = false;
             const fallback = slot.direct_fallback_addr.?;
@@ -2003,6 +2020,7 @@ const EventLoop = struct {
                     self.closeSlot(slot, "mp getsockname failed");
                     return;
                 };
+                var middle_local_addr = local_addr;
 
                 var tg_port: [2]u8 = undefined;
                 var my_port: [2]u8 = undefined;
@@ -2020,6 +2038,12 @@ const EventLoop = struct {
                     var my_ip_v4: [4]u8 = undefined;
                     @memcpy(&my_ip_v4, std.mem.asBytes(&local_addr.in.sa.addr));
                     std.mem.reverse(u8, &my_ip_v4);
+
+                    if (self.state.middle_proxy_nat_ip4) |nat_ip| {
+                        my_ip_v4 = ipv4NetworkToHostBytes(nat_ip);
+                        middle_local_addr = net.Address.initIp4(nat_ip, std.mem.bigToNative(u16, local_addr.in.sa.port));
+                    }
+
                     my_ip_v4_opt = my_ip_v4;
 
                     std.mem.writeInt(u16, &tg_port, std.mem.bigToNative(u16, peer_addr.in.sa.port), .little);
@@ -2133,6 +2157,13 @@ const EventLoop = struct {
                     return;
                 };
 
+                var middle_local_addr = local_addr;
+                if (self.state.middle_proxy_nat_ip4) |nat_ip| {
+                    if (local_addr.any.family == posix.AF.INET) {
+                        middle_local_addr = net.Address.initIp4(nat_ip, std.mem.bigToNative(u16, local_addr.in.sa.port));
+                    }
+                }
+
                 var conn_id: [8]u8 = undefined;
                 crypto.randomBytes(&conn_id);
 
@@ -2143,7 +2174,7 @@ const EventLoop = struct {
                     conn_id,
                     slot.mp_write_seq_no,
                     slot.peer_addr,
-                    local_addr,
+                    middle_local_addr,
                     slot.proto_tag,
                     self.state.config.tag,
                     self.state.config.middleProxyBufferBytes(),
@@ -2319,7 +2350,18 @@ const EventLoop = struct {
         const now_ns = std.time.nanoTimestamp();
 
         const hi: usize = @intCast(self.pool.allocated_hi);
-        for (self.pool.slots[0..hi]) |slot_opt| {
+        if (hi == 0) return;
+
+        var idx: usize = @intCast(self.timer_scan_cursor);
+        if (idx >= hi) idx = 0;
+
+        const budget = @min(hi, timer_scan_budget);
+        var scanned: usize = 0;
+        while (scanned < budget) : (scanned += 1) {
+            const slot_opt = self.pool.slots[idx];
+            idx += 1;
+            if (idx >= hi) idx = 0;
+
             const slot = slot_opt orelse continue;
             if (slot.phase == .idle) continue;
 
@@ -2363,6 +2405,8 @@ const EventLoop = struct {
                 self.closeSlot(slot, "sync interest error");
             };
         }
+
+        self.timer_scan_cursor = @intCast(idx);
     }
 
     fn syncInterests(self: *EventLoop, slot: *ConnectionSlot) !void {
@@ -2797,6 +2841,49 @@ fn fetchUrlBytes(allocator: std.mem.Allocator, url: []const u8) ![]u8 {
     return runCurl(allocator, &strict_argv);
 }
 
+fn parseIpv4Literal(text: []const u8) ?[4]u8 {
+    var parts = std.mem.splitScalar(u8, text, '.');
+    var ip: [4]u8 = undefined;
+    var idx: usize = 0;
+
+    while (parts.next()) |part| {
+        if (idx >= ip.len or part.len == 0 or part.len > 3) return null;
+        const octet = std.fmt.parseInt(u16, part, 10) catch return null;
+        if (octet > 255) return null;
+        ip[idx] = @intCast(octet);
+        idx += 1;
+    }
+
+    if (idx != ip.len) return null;
+    return ip;
+}
+
+fn detectPublicIpv4(allocator: std.mem.Allocator) ?[4]u8 {
+    const services = [_][]const []const u8{
+        &.{ "curl", "-fsSL", "--max-time", "3", "https://api.ipify.org" },
+        &.{ "curl", "-fsSL", "--max-time", "3", "https://ifconfig.me" },
+        &.{ "curl", "-fsSL", "--max-time", "3", "https://ipv4.icanhazip.com" },
+    };
+
+    for (services) |argv| {
+        const stdout = runCurl(allocator, argv) catch continue;
+        const trimmed = std.mem.trim(u8, stdout, &[_]u8{ ' ', '\t', '\r', '\n' });
+        const parsed = parseIpv4Literal(trimmed);
+        allocator.free(stdout);
+        if (parsed) |ip| return ip;
+    }
+
+    return null;
+}
+
+fn formatIpv4Bytes(ip: [4]u8, buf: *[16]u8) []const u8 {
+    return std.fmt.bufPrint(buf, "{d}.{d}.{d}.{d}", .{ ip[0], ip[1], ip[2], ip[3] }) catch "?.?.?.?";
+}
+
+fn ipv4NetworkToHostBytes(ip: [4]u8) [4]u8 {
+    return .{ ip[3], ip[2], ip[1], ip[0] };
+}
+
 fn isSameIpEndpoint(a: net.Address, b: net.Address) bool {
     if (a.any.family != b.any.family) return false;
 
@@ -2883,8 +2970,10 @@ fn buildDcConnectPlan(
         return plan;
     }
 
-    // Non-media paths may fall back to direct DC if all middle-proxy candidates fail.
-    plan.direct_fallback = if (!plan.is_media_path) constants.getDcAddressV4(dc_abs) else null;
+    // If middle-proxy connect/handshake fails, retry the same DC via direct mode.
+    // This keeps media paths functional in environments where middle-proxy transport
+    // itself is degraded (for example due to strict NAT behavior in upstream tunnels).
+    plan.direct_fallback = constants.getDcAddressV4(dc_abs);
     return plan;
 }
 
@@ -3163,4 +3252,11 @@ test "fd requirement helpers" {
     try std.testing.expectEqual(@as(usize, 131582), requiredFdsForConnections(65535));
     try std.testing.expectEqual(@as(u32, 65535), maxConnectionsForNofile(131582));
     try std.testing.expectEqual(@as(u32, 32511), maxConnectionsForNofile(65535));
+}
+
+test "parse ipv4 literal" {
+    const parsed = parseIpv4Literal("179.43.141.146") orelse return error.TestExpectedEqual;
+    try std.testing.expectEqual([4]u8{ 179, 43, 141, 146 }, parsed);
+    try std.testing.expect(parseIpv4Literal("179.43.141") == null);
+    try std.testing.expect(parseIpv4Literal("179.43.141.999") == null);
 }


### PR DESCRIPTION
## Summary
- add tunnel mode controls (`direct|preserve|middleproxy`) to `setup_tunnel.sh`/Makefile, keep promo tags intact, and preserve backward compatibility in `deploy/update.sh`
- fix middleproxy handshake under AmneziaWG by deriving ME keys with detected public IPv4 (NAT-aware), and allow direct fallback for media-path sessions when ME handshake/connect fails
- improve event-loop fairness under high churn by batching accept and limiting timer-scan work per tick to avoid single-core CPU starvation
- tune default runtime limits for small VPS profiles (`max_connections=512`, `idle_timeout_sec=120`, `handshake_timeout_sec=15`) in config defaults, installer template, and README guidance

## Validation
- `zig build test`
- `bash -n deploy/setup_tunnel.sh deploy/update.sh deploy/install.sh`
- production checks on `proxy.sleep3r.ru`:
  - deploy tunnel in `middleproxy` mode succeeded
  - media path restored for non-premium clients; promo tag restored after setting server tag
  - service/tunnel health verified after reboot (`systemctl`, `awg show`, conn stats)
  - stress runs via `test/connection_stability_check.py` completed with passing results under tuned limits