### PR TITLE
feat: proxy resilience optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,11 +530,14 @@ ad_tag = "1234567890abcdef1234567890abcdef"    # Optional alias for [server].tag
 [server]
 port = 443
 backlog = 4096                             # TCP listen queue size
-middleproxy_buffer_kb = 256               # Per-connection ME buffers (4x this size), tune for VPS RAM
+middleproxy_buffer_kb = 1024              # Per-connection ME buffers (4x this size), tune for VPS RAM
 max_connections = 512                      # Safe default for small (1 vCPU / ~1 GB) VPS
 idle_timeout_sec = 120
 handshake_timeout_sec = 15
 tag = "1234567890abcdef1234567890abcdef"   # Optional: promotion tag from @MTProxybot
+log_level = "info"                         # Runtime log level: debug, info, warn, err
+rate_limit_per_subnet = 8                  # Max new connections/sec per /24 subnet (0 = disabled)
+# unsafe_override_limits = false           # Set true to disable auto-clamp of max_connections
 
 [censorship]
 tls_domain = "wb.ru"
@@ -561,8 +564,11 @@ bob   = "ffeeddccbbaa99887766554433221100"
 | `[server]` | `max_connections` | `512` | Concurrent connection cap (small-VPS tuned default). On Linux, runtime is auto-clamped by `RLIMIT_NOFILE` if configured higher than available FD budget |
 | `[server]` | `idle_timeout_sec` | `120` | Connection idle timeout in seconds (also used before first client byte) |
 | `[server]` | `handshake_timeout_sec` | `15` | Timeout for completing handshake after first byte |
-| `[server]` | `middleproxy_buffer_kb` | `256` | MiddleProxy per-connection buffer size in KiB (4 buffers allocated for active ME sessions) |
+| `[server]` | `middleproxy_buffer_kb` | `1024` | MiddleProxy per-connection buffer size in KiB (4 buffers allocated per active ME session). Values below 1024 may cause `MiddleProxyBufferOverflow` on media-heavy traffic (Stories, video messages) |
 | `[server]` | `tag` | _(none)_ | Optional 32 hex-char promotion tag from [@MTProxybot](https://t.me/MTProxybot) |
+| `[server]` | `log_level` | `"info"` | Runtime log verbosity: `debug` (all DC routing, relay, close details), `info` (default — connection stats, warnings), `warn`, `err`. Change without recompilation; takes effect on restart |
+| `[server]` | `rate_limit_per_subnet` | `8` | Max new connections per second per /24 (IPv4) or /48 (IPv6) subnet. Blocks scanner/DPI-probe flood. Set `0` to disable |
+| `[server]` | `unsafe_override_limits` | `false` | Disable auto-clamping of `max_connections` to the RAM-safe estimate. Use only if you're sure your host has enough memory |
 | `[censorship]` | `tls_domain` | `"google.com"` | Domain to impersonate / forward bad clients to |
 | `[censorship]` | `mask` | `true` | Forward unauthenticated connections to `tls_domain` to defeat DPI |
 | `[censorship]` | `mask_port` | `443` | Non-standard port override for masking locally (e.g. `8443` for zero-RTT local Nginx) |
@@ -576,6 +582,10 @@ bob   = "ffeeddccbbaa99887766554433221100"
 > **Operational note** &nbsp; High-churn mobile networks can produce many normal disconnects (`ConnectionResetByPeer`/`EndOfStream`). In release builds these are logged at debug level to keep production logs signal-focused.
 
 > **Operational note** &nbsp; `deploy/mtproto-proxy.service` ships with `LimitNOFILE=131582` to allow higher custom caps when needed. Default `max_connections=512` is tuned for small VPS profiles; increase it only after capacity testing.
+
+> **Operational note** &nbsp; On startup, `max_connections` is automatically clamped to a RAM-safe estimate (with a warning). Set `unsafe_override_limits = true` in `[server]` to disable this. The proxy also has built-in admission control: at 90% capacity it pauses `accept()` and resumes at 80%, preventing CPU-wasteful accept→close spin loops.
+
+> **Operational note** &nbsp; The proxy limits new connections to 8/sec per /24 subnet by default (`rate_limit_per_subnet`). This blocks ТСПУ scanners and DPI replay probes without affecting legitimate Telegram clients.
 
 > **Tip** &nbsp; Generate a random secret: `openssl rand -hex 16`
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -28,8 +28,26 @@ port = 443
 # handshake_timeout_sec = 60
 
 # Per-connection MiddleProxy stream buffer size in KiB.
-# Lower (64–128) for RAM-constrained VPS, raise (256–512) for high-throughput media.
-# middleproxy_buffer_kb = 256
+# 1024 (default) is the validated minimum for reliable media downloads (Stories, video).
+# Values below 1024 may cause MiddleProxyBufferOverflow on media-heavy sessions.
+# Raise to 2048 for high-throughput media; values below 512 are not recommended.
+# middleproxy_buffer_kb = 1024
+
+# Runtime log verbosity: debug, info (default), warn, err.
+# Set to "debug" to see DC routing, relay errors, and connection lifecycle details.
+# Change takes effect on restart — no recompilation needed.
+# log_level = "info"
+
+# Max new connections per second per /24 (IPv4) or /48 (IPv6) subnet.
+# Limits scanner/flood/DPI-probe impact. Default of 8 is generous for
+# legitimate Telegram clients (3-6 connections at startup, then hold).
+# Set to 0 to disable rate limiting entirely.
+# rate_limit_per_subnet = 8
+
+# By default, max_connections is auto-clamped to a RAM-safe estimate on startup.
+# Set to true to disable this safety mechanism (only if you're sure your host
+# has enough memory for the configured limits).
+# unsafe_override_limits = false
 
 [censorship]
 # Domain to impersonate in TLS ServerHello and forward unauthenticated clients to.

--- a/src/config.zig
+++ b/src/config.zig
@@ -34,13 +34,46 @@ pub const Config = struct {
     drs: bool = false,
     /// Fast mode: skip S2C encryption by passing client keys to DC directly
     fast_mode: bool = false,
-    /// Per-connection MiddleProxy stream buffers size, in KiB (applies to 4 buffers)
-    middleproxy_buffer_kb: u32 = 256,
+    /// Per-connection MiddleProxy stream buffers size, in KiB (applies to 4 buffers).
+    /// Minimum 1024 recommended — lower values cause MiddleProxyBufferOverflow on media
+    /// downloads (Stories, video messages) through middle proxy.
+    middleproxy_buffer_kb: u32 = 1024,
+    /// Runtime log level: "debug", "info" (default), "warn", "err"
+    log_level: std.log.Level = .info,
+    /// Max new connections per second per /24 subnet (0 = disabled).
+    /// Limits scanner/flood/DPI-probe impact. Generous for legitimate Telegram clients
+    /// which open 3-6 connections at startup and hold them.
+    rate_limit_per_subnet: u8 = 8,
+    /// When true, disables auto-clamping of max_connections to the RAM-safe estimate.
+    /// Use only if you know your host has enough memory for the configured limits.
+    unsafe_override_limits: bool = false,
     /// Test-only hook to redirect upstream connections locally
     datacenter_override: ?std.net.Address = null,
 
     pub fn middleProxyBufferBytes(self: *const Config) usize {
         return @as(usize, self.middleproxy_buffer_kb) * 1024;
+    }
+
+    /// Emit startup warnings for configuration values known to cause issues.
+    pub fn emitWarnings(self: *const Config) void {
+        if (self.use_middle_proxy and self.middleproxy_buffer_kb < 1024) {
+            const log = std.log.scoped(.config);
+            log.warn(
+                "middleproxy_buffer_kb={d} is below recommended minimum (1024). " ++
+                    "This may cause MiddleProxyBufferOverflow errors on media-heavy " ++
+                    "traffic (Stories, video downloads). Consider increasing to 1024+.",
+                .{self.middleproxy_buffer_kb},
+            );
+        }
+        if (self.use_middle_proxy and self.max_connections > 2000) {
+            const log = std.log.scoped(.config);
+            const mem_per_conn_mb = (self.middleProxyBufferBytes() * 4) / (1024 * 1024);
+            log.warn(
+                "max_connections={d} with middleproxy_buffer_kb={d} may require " ++
+                    "up to {d} MB of RAM at full capacity. Ensure your VPS has sufficient memory.",
+                .{ self.max_connections, self.middleproxy_buffer_kb, mem_per_conn_mb * self.max_connections },
+            );
+        }
     }
 
     pub fn loadFromFile(allocator: std.mem.Allocator, path: []const u8) !Config {
@@ -138,6 +171,20 @@ pub const Config = struct {
                     } else if (std.mem.eql(u8, key, "middleproxy_buffer_kb")) {
                         const parsed = std.fmt.parseInt(u32, value, 10) catch cfg.middleproxy_buffer_kb;
                         cfg.middleproxy_buffer_kb = @max(@as(u32, 64), parsed);
+                    } else if (std.mem.eql(u8, key, "log_level")) {
+                        if (std.mem.eql(u8, value, "debug")) {
+                            cfg.log_level = .debug;
+                        } else if (std.mem.eql(u8, value, "info")) {
+                            cfg.log_level = .info;
+                        } else if (std.mem.eql(u8, value, "warn")) {
+                            cfg.log_level = .warn;
+                        } else if (std.mem.eql(u8, value, "err")) {
+                            cfg.log_level = .err;
+                        }
+                    } else if (std.mem.eql(u8, key, "rate_limit_per_subnet")) {
+                        cfg.rate_limit_per_subnet = std.fmt.parseInt(u8, value, 10) catch cfg.rate_limit_per_subnet;
+                    } else if (std.mem.eql(u8, key, "unsafe_override_limits")) {
+                        cfg.unsafe_override_limits = std.mem.eql(u8, value, "true");
                     }
                 } else if (in_censorship_section) {
                     if (std.mem.eql(u8, key, "tls_domain")) {
@@ -250,8 +297,10 @@ test "parse config - missing fields defaults" {
     try std.testing.expect(cfg.mask); // Default is true
     try std.testing.expect(cfg.desync); // Default is true
     try std.testing.expect(!cfg.fast_mode); // Default is false
-    try std.testing.expectEqual(@as(u32, 256), cfg.middleproxy_buffer_kb);
-    try std.testing.expectEqual(@as(usize, 256 * 1024), cfg.middleProxyBufferBytes());
+    try std.testing.expectEqual(@as(u32, 1024), cfg.middleproxy_buffer_kb);
+    try std.testing.expectEqual(@as(usize, 1024 * 1024), cfg.middleProxyBufferBytes());
+    try std.testing.expectEqual(@as(u8, 8), cfg.rate_limit_per_subnet);
+    try std.testing.expect(!cfg.unsafe_override_limits);
     try std.testing.expectEqual(@as(usize, 1), cfg.users.count());
 }
 
@@ -282,6 +331,46 @@ test "parse config - middleproxy buffer lower bound" {
     defer cfg.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(u32, 64), cfg.middleproxy_buffer_kb);
+}
+
+test "parse config - log_level debug" {
+    const content =
+        \\[server]
+        \\log_level = "debug"
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(std.log.Level.debug, cfg.log_level);
+}
+
+test "parse config - log_level warn" {
+    const content =
+        \\[server]
+        \\log_level = "warn"
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(std.log.Level.warn, cfg.log_level);
+}
+
+test "parse config - log_level default is info" {
+    const content =
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(std.log.Level.info, cfg.log_level);
 }
 
 test "parse config - server runtime tunables lower bounds" {
@@ -433,4 +522,194 @@ test "parse config - server tag overrides general ad_tag" {
     try std.testing.expect(cfg.tag != null);
     const expected_tag = [_]u8{ 0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef, 0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef };
     try std.testing.expectEqual(expected_tag, cfg.tag.?);
+}
+
+test "parse config - rate_limit_per_subnet custom" {
+    const content =
+        \\[server]
+        \\rate_limit_per_subnet = 20
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(u8, 20), cfg.rate_limit_per_subnet);
+}
+
+test "parse config - rate_limit_per_subnet disabled" {
+    const content =
+        \\[server]
+        \\rate_limit_per_subnet = 0
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(u8, 0), cfg.rate_limit_per_subnet);
+}
+
+test "parse config - unsafe_override_limits true" {
+    const content =
+        \\[server]
+        \\unsafe_override_limits = true
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expect(cfg.unsafe_override_limits);
+}
+
+test "parse config - unsafe_override_limits default false" {
+    const content =
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expect(!cfg.unsafe_override_limits);
+}
+
+test "parse config - full production-like config" {
+    const content =
+        \\[general]
+        \\use_middle_proxy = true
+        \\
+        \\[server]
+        \\port = 443
+        \\tag = 9649114fbafd6fe2ae98ca635c4e4007
+        \\middleproxy_buffer_kb = 1024
+        \\max_connections = 512
+        \\idle_timeout_sec = 120
+        \\handshake_timeout_sec = 15
+        \\backlog = 8192
+        \\log_level = "info"
+        \\rate_limit_per_subnet = 8
+        \\
+        \\[censorship]
+        \\tls_domain = "wb.ru"
+        \\mask = true
+        \\fast_mode = true
+        \\mask_port = 8443
+        \\drs = true
+        \\
+        \\[access.users]
+        \\alexander = "0b513f6e83524354984a8835939fa9af"
+        \\debug_user = "c8f31d0a8b7f4d2c91e6a5b3d4f8e102"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expect(cfg.use_middle_proxy);
+    try std.testing.expectEqual(@as(u16, 443), cfg.port);
+    try std.testing.expect(cfg.tag != null);
+    try std.testing.expectEqual(@as(u32, 1024), cfg.middleproxy_buffer_kb);
+    try std.testing.expectEqual(@as(u32, 512), cfg.max_connections);
+    try std.testing.expectEqual(@as(u32, 120), cfg.idle_timeout_sec);
+    try std.testing.expectEqual(@as(u32, 15), cfg.handshake_timeout_sec);
+    try std.testing.expectEqual(@as(u32, 8192), cfg.backlog);
+    try std.testing.expectEqual(std.log.Level.info, cfg.log_level);
+    try std.testing.expectEqual(@as(u8, 8), cfg.rate_limit_per_subnet);
+    try std.testing.expect(!cfg.unsafe_override_limits);
+    try std.testing.expectEqualStrings("wb.ru", cfg.tls_domain);
+    try std.testing.expect(cfg.mask);
+    try std.testing.expect(cfg.fast_mode);
+    try std.testing.expectEqual(@as(u16, 8443), cfg.mask_port);
+    try std.testing.expect(cfg.drs);
+    try std.testing.expectEqual(@as(usize, 2), cfg.users.count());
+    try std.testing.expect(cfg.users.contains("alexander"));
+    try std.testing.expect(cfg.users.contains("debug_user"));
+}
+
+test "parse config - log_level err" {
+    const content =
+        \\[server]
+        \\log_level = "err"
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(std.log.Level.err, cfg.log_level);
+}
+
+test "parse config - invalid log_level keeps default" {
+    const content =
+        \\[server]
+        \\log_level = "banana"
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(std.log.Level.info, cfg.log_level);
+}
+
+test "parse config - invalid rate_limit keeps default" {
+    const content =
+        \\[server]
+        \\rate_limit_per_subnet = notanumber
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(u8, 8), cfg.rate_limit_per_subnet);
+}
+
+test "parse config - censorship section booleans" {
+    const content =
+        \\[censorship]
+        \\mask = false
+        \\desync = false
+        \\drs = true
+        \\fast_mode = true
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expect(!cfg.mask);
+    try std.testing.expect(!cfg.desync);
+    try std.testing.expect(cfg.drs);
+    try std.testing.expect(cfg.fast_mode);
+}
+
+test "parse config - multiple users" {
+    const content =
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+        \\bob = "aabbccddeeff00112233445566778899"
+        \\charlie = "ffeeddccbbaa99887766554433221100"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), cfg.users.count());
+    try std.testing.expect(cfg.users.contains("alice"));
+    try std.testing.expect(cfg.users.contains("bob"));
+    try std.testing.expect(cfg.users.contains("charlie"));
+
+    // Verify secret bytes are correct
+    const alice_secret = cfg.users.get("alice").?;
+    try std.testing.expectEqual(@as(u8, 0x00), alice_secret[0]);
+    try std.testing.expectEqual(@as(u8, 0xff), alice_secret[15]);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -18,11 +18,14 @@ const proxy = @import("proxy/proxy.zig");
 // don't interleave. This avoids the global stderr_mutex that Zig's
 // default logger uses, which causes catastrophic contention under
 // hundreds of concurrent threads.
+// Runtime log level, set from config.toml at startup.
+// Checked by lockFreeLog to filter messages without recompilation.
+pub var runtime_log_level: std.log.Level = .info;
+
 pub const std_options = std.Options{
-    // Do NOT set log_level here. In ReleaseFast, Zig's default is .info,
-    // which eliminates all log.debug calls at comptime (zero overhead).
-    // Setting .debug here floods stderr with thousands of messages/sec
-    // under heavy load, even with the lock-free logger.
+    // Set comptime level to .debug so all log calls are compiled in.
+    // Runtime filtering is done in lockFreeLog via runtime_log_level.
+    .log_level = .debug,
     .logFn = lockFreeLog,
 };
 
@@ -32,6 +35,9 @@ fn lockFreeLog(
     comptime format: []const u8,
     args: anytype,
 ) void {
+    // Runtime filter: skip messages below configured level
+    if (@intFromEnum(message_level) > @intFromEnum(runtime_log_level)) return;
+
     const level_txt = comptime message_level.asText();
     const prefix2 = comptime if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
     var buf: [4096]u8 = undefined;
@@ -302,15 +308,41 @@ pub fn main() !void {
     const config_path = args.next() orelse "config.toml";
 
     // Parse config
-    const cfg = config.Config.loadFromFile(allocator, config_path) catch |err| {
+    var cfg = config.Config.loadFromFile(allocator, config_path) catch |err| {
         writeStderr("\x1b[1m\x1b[31m  ✗ Failed to load config '{s}': {}\x1b[0m\n", .{ config_path, err });
         writeStderr("\n  Usage: mtproto-proxy [config.toml]\n\n", .{});
         return;
     };
     defer cfg.deinit(allocator);
 
+    // Apply runtime log level from config
+    runtime_log_level = cfg.log_level;
+
+    // Auto-clamp max_connections to RAM-safe estimate (unless explicitly opted out)
+    if (detectTotalRamBytes(allocator)) |total_ram| {
+        const est = estimateCapacity(&cfg, total_ram);
+        if (cfg.max_connections > est.safe_connections and !cfg.unsafe_override_limits) {
+            const log_main = std.log.scoped(.config);
+            log_main.warn(
+                "auto-clamping max_connections from {d} to {d} " ++
+                    "(host has {d} MiB RAM, ~{d} KiB/connection). " ++
+                    "To disable this safety clamp, set unsafe_override_limits = true in [server].",
+                .{
+                    cfg.max_connections,
+                    est.safe_connections,
+                    est.total_ram_bytes / (1024 * 1024),
+                    est.per_conn_bytes / 1024,
+                },
+            );
+            cfg.max_connections = est.safe_connections;
+        }
+    }
+
     // Print the startup banner (includes IP detection)
     printBanner(allocator, cfg);
+
+    // Emit config warnings (e.g. buffer too small, memory concerns)
+    cfg.emitWarnings();
 
     // Create shared state (DI — no globals)
     var state = proxy.ProxyState.init(allocator, cfg);

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -35,6 +35,61 @@ const client_hello_inline_size: usize = 512;
 const mp_handshake_frame_buf_size: usize = 2048;
 const read_buf_size: usize = 4096;
 
+/// Per-/24 (IPv4) or /48 (IPv6) subnet rate limiter.
+/// Fixed 256-bucket hash table — zero heap allocation.
+/// Token bucket per subnet: each second refills up to max_per_sec tokens.
+const SubnetRateLimit = struct {
+    const BUCKETS = 256;
+    const Entry = struct {
+        subnet_key: u32 = 0,
+        tokens: u8 = 0,
+        last_refill_s: i64 = 0,
+    };
+    entries: [BUCKETS]Entry = [_]Entry{.{}} ** BUCKETS,
+
+    /// Returns true if the connection is allowed, false if rate-limited.
+    fn check(self: *SubnetRateLimit, addr: net.Address, max_per_sec: u8) bool {
+        if (max_per_sec == 0) return true;
+        const key = subnetKey(addr);
+        const idx = key % BUCKETS;
+        const e = &self.entries[idx];
+        const now_s = @divTrunc(std.time.milliTimestamp(), 1000);
+
+        if (e.subnet_key != key or now_s - e.last_refill_s > 60) {
+            // New subnet or stale entry — reset
+            e.* = .{ .subnet_key = key, .tokens = max_per_sec -| 1, .last_refill_s = now_s };
+            return true;
+        }
+
+        // Refill tokens based on elapsed seconds
+        const elapsed = now_s - e.last_refill_s;
+        if (elapsed > 0) {
+            const refill: u16 = @intCast(@min(elapsed, 255));
+            e.tokens = @min(max_per_sec, e.tokens +| @as(u8, @intCast(@min(refill * @as(u16, max_per_sec), 255))));
+            e.last_refill_s = now_s;
+        }
+
+        if (e.tokens > 0) {
+            e.tokens -= 1;
+            return true;
+        }
+        return false;
+    }
+
+    fn subnetKey(addr: net.Address) u32 {
+        if (addr.any.family == posix.AF.INET) {
+            // /24 subnet: mask off last octet
+            const ip_bytes = std.mem.asBytes(&addr.in.sa.addr);
+            return @as(u32, ip_bytes[0]) << 16 | @as(u32, ip_bytes[1]) << 8 | @as(u32, ip_bytes[2]);
+        } else if (addr.any.family == posix.AF.INET6) {
+            // /48 subnet: first 6 bytes hashed to u32
+            const ip6 = &addr.in6.sa.addr;
+            return @as(u32, ip6[0]) << 24 | @as(u32, ip6[1]) << 16 | @as(u32, ip6[2]) << 8 | @as(u32, ip6[3]) ^ (@as(u32, ip6[4]) << 8 | @as(u32, ip6[5]));
+        }
+        return 0;
+    }
+};
+
 const MsgBlockClass = enum(u2) {
     tiny = 0,
     small = 1,
@@ -621,8 +676,17 @@ pub const ProxyState = struct {
     user_secrets: []const obfuscation.UserSecret,
     connection_count: std.atomic.Value(u64),
     active_connections: std.atomic.Value(u32),
+    handshakes_inflight: std.atomic.Value(u32),
     mask_addr: ?net.Address,
     replay_cache: ReplayCache,
+
+    // Degradation counters (monotonic totals, delta'd in stats log)
+    stats_dropped_cap: std.atomic.Value(u64),
+    stats_dropped_saturation: std.atomic.Value(u64),
+    stats_dropped_rate_limit: std.atomic.Value(u64),
+    stats_dropped_hs_budget: std.atomic.Value(u64),
+    stats_hs_timeout: std.atomic.Value(u64),
+    stats_mp_fallback: std.atomic.Value(u64),
 
     middle_proxy_lock: std.Thread.RwLock = .{},
     middle_proxy_addrs_primary: [5]net.Address,
@@ -679,8 +743,15 @@ pub const ProxyState = struct {
             .user_secrets = secrets.toOwnedSlice(allocator) catch &.{},
             .connection_count = std.atomic.Value(u64).init(0),
             .active_connections = std.atomic.Value(u32).init(0),
+            .handshakes_inflight = std.atomic.Value(u32).init(0),
             .mask_addr = resolved_addr,
             .replay_cache = .{},
+            .stats_dropped_cap = std.atomic.Value(u64).init(0),
+            .stats_dropped_saturation = std.atomic.Value(u64).init(0),
+            .stats_dropped_rate_limit = std.atomic.Value(u64).init(0),
+            .stats_dropped_hs_budget = std.atomic.Value(u64).init(0),
+            .stats_hs_timeout = std.atomic.Value(u64).init(0),
+            .stats_mp_fallback = std.atomic.Value(u64).init(0),
             .middle_proxy_addrs_primary = constants.tg_middle_proxies_v4,
             .middle_proxy_addr_203 = constants.getDcAddressV4(203),
             .middle_proxy_addrs_dc4 = [_]net.Address{constants.tg_middle_proxies_v4[3]} ++ ([_]net.Address{constants.tg_middle_proxies_v4[3]} ** 15),
@@ -924,10 +995,19 @@ const EventLoop = struct {
     pool: ConnectionPool,
     accept_paused: bool,
     accept_resume_ns: i128,
+    saturation_paused: bool,
     timer_scan_cursor: u32,
     stats_next_log_ns: i128,
     accepted_since_log: u64,
     closed_since_log: u64,
+    subnet_limiter: SubnetRateLimit,
+    // Snapshot of degradation counters for delta logging
+    prev_dropped_cap: u64,
+    prev_dropped_saturation: u64,
+    prev_dropped_rate_limit: u64,
+    prev_dropped_hs_budget: u64,
+    prev_hs_timeout: u64,
+    prev_mp_fallback: u64,
 
     fn init(state: *ProxyState, listen_fd: posix.fd_t) !EventLoop {
         const epoll_fd = try epollCreate();
@@ -940,10 +1020,18 @@ const EventLoop = struct {
             .pool = try ConnectionPool.init(state.allocator, state.config.max_connections),
             .accept_paused = false,
             .accept_resume_ns = 0,
+            .saturation_paused = false,
             .timer_scan_cursor = 0,
             .stats_next_log_ns = std.time.nanoTimestamp() + stats_log_interval_ns,
             .accepted_since_log = 0,
             .closed_since_log = 0,
+            .subnet_limiter = .{},
+            .prev_dropped_cap = 0,
+            .prev_dropped_saturation = 0,
+            .prev_dropped_rate_limit = 0,
+            .prev_dropped_hs_budget = 0,
+            .prev_hs_timeout = 0,
+            .prev_mp_fallback = 0,
         };
         errdefer loop.pool.deinit();
 
@@ -995,6 +1083,14 @@ const EventLoop = struct {
             if (self.accept_paused and now_ns >= self.accept_resume_ns) {
                 self.resumeAccepting();
             }
+            // Saturation hysteresis: resume accepting when active drops below 80%
+            if (self.saturation_paused) {
+                const active = self.state.active_connections.load(.monotonic);
+                const resume_threshold = (self.state.config.max_connections * 8) / 10;
+                if (active <= resume_threshold) {
+                    self.resumeSaturation();
+                }
+            }
             if (now_ns >= next_timer_tick_ns) {
                 self.runTimers();
                 next_timer_tick_ns = now_ns + timer_tick_ns;
@@ -1042,6 +1138,18 @@ const EventLoop = struct {
     }
 
     fn acceptNewConnections(self: *EventLoop) !void {
+        // Saturation hysteresis: if active > 90% of max, stop accepting entirely.
+        // Resume only when active drops below 80% (checked in run() loop).
+        const active_now = self.state.active_connections.load(.monotonic);
+        const max = self.state.config.max_connections;
+        if (active_now >= (max * 9) / 10) {
+            if (!self.saturation_paused) {
+                self.pauseSaturation();
+            }
+            _ = self.state.stats_dropped_saturation.fetchAdd(1, .monotonic);
+            return;
+        }
+
         var accepted_this_round: usize = 0;
         while (accepted_this_round < accept_batch_limit) {
             var client_addr: net.Address = undefined;
@@ -1058,14 +1166,35 @@ const EventLoop = struct {
             };
             accepted_this_round += 1;
 
+            // Per-/24 subnet rate limit (before we allocate any slot)
+            if (!self.subnet_limiter.check(client_addr, self.state.config.rate_limit_per_subnet)) {
+                _ = self.state.stats_dropped_rate_limit.fetchAdd(1, .monotonic);
+                posix.close(cfd);
+                continue;
+            }
+
             const active_before = self.state.active_connections.fetchAdd(1, .monotonic);
             if (active_before >= self.state.config.max_connections) {
                 _ = self.state.active_connections.fetchSub(1, .monotonic);
+                _ = self.state.stats_dropped_cap.fetchAdd(1, .monotonic);
+                posix.close(cfd);
+                continue;
+            }
+
+            // Handshake inflight budget: cap at 30% of max_connections.
+            // Prevents churn (scanners/probes) from starving established relay sessions.
+            const hs_inflight = self.state.handshakes_inflight.fetchAdd(1, .monotonic);
+            const hs_max = (self.state.config.max_connections * 3) / 10;
+            if (hs_max > 0 and hs_inflight >= hs_max) {
+                _ = self.state.handshakes_inflight.fetchSub(1, .monotonic);
+                _ = self.state.active_connections.fetchSub(1, .monotonic);
+                _ = self.state.stats_dropped_hs_budget.fetchAdd(1, .monotonic);
                 posix.close(cfd);
                 continue;
             }
 
             const slot = self.pool.acquire() orelse {
+                _ = self.state.handshakes_inflight.fetchSub(1, .monotonic);
                 _ = self.state.active_connections.fetchSub(1, .monotonic);
                 posix.close(cfd);
                 continue;
@@ -1095,16 +1224,50 @@ const EventLoop = struct {
 
     fn logPeriodicStats(self: *EventLoop, now_ns: i128) void {
         const active = self.state.active_connections.load(.monotonic);
+        const hs = self.state.handshakes_inflight.load(.monotonic);
         const accepted_total = self.state.connection_count.load(.monotonic);
-        log.info("conn stats: active={d}/{d} accepted+={d} closed+={d} tracked_fds={d} total={d} accept_paused={}", .{
+
+        // Snapshot degradation counters and compute deltas
+        const cur_cap = self.state.stats_dropped_cap.load(.monotonic);
+        const cur_sat = self.state.stats_dropped_saturation.load(.monotonic);
+        const cur_rate = self.state.stats_dropped_rate_limit.load(.monotonic);
+        const cur_hs = self.state.stats_dropped_hs_budget.load(.monotonic);
+        const cur_hst = self.state.stats_hs_timeout.load(.monotonic);
+        const cur_mpf = self.state.stats_mp_fallback.load(.monotonic);
+
+        const d_cap = cur_cap - self.prev_dropped_cap;
+        const d_sat = cur_sat - self.prev_dropped_saturation;
+        const d_rate = cur_rate - self.prev_dropped_rate_limit;
+        const d_hs = cur_hs - self.prev_dropped_hs_budget;
+        const d_hst = cur_hst - self.prev_hs_timeout;
+        const d_mpf = cur_mpf - self.prev_mp_fallback;
+
+        self.prev_dropped_cap = cur_cap;
+        self.prev_dropped_saturation = cur_sat;
+        self.prev_dropped_rate_limit = cur_rate;
+        self.prev_dropped_hs_budget = cur_hs;
+        self.prev_hs_timeout = cur_hst;
+        self.prev_mp_fallback = cur_mpf;
+
+        const has_drops = d_cap + d_sat + d_rate + d_hs + d_hst + d_mpf > 0;
+
+        log.info("conn stats: active={d}/{d} hs_inflight={d} accepted+={d} closed+={d} tracked_fds={d} total={d} paused={}/{}", .{
             active,
             self.state.config.max_connections,
+            hs,
             self.accepted_since_log,
             self.closed_since_log,
             self.pool.fd_to_slot.count(),
             accepted_total,
             self.accept_paused,
+            self.saturation_paused,
         });
+
+        if (has_drops) {
+            log.info("  drops: cap+={d} sat+={d} rate+={d} hs_budget+={d} hs_timeout+={d} mp_fallback+={d}", .{
+                d_cap, d_sat, d_rate, d_hs, d_hst, d_mpf,
+            });
+        }
 
         self.accepted_since_log = 0;
         self.closed_since_log = 0;
@@ -1143,6 +1306,38 @@ const EventLoop = struct {
 
         self.accept_paused = false;
         self.accept_resume_ns = 0;
+    }
+
+    fn pauseSaturation(self: *EventLoop) void {
+        if (self.saturation_paused) return;
+
+        self.modFd(self.listen_fd, false, false) catch |mod_err| {
+            log.err("failed to pause accepts for saturation: {any}", .{mod_err});
+            return;
+        };
+
+        self.saturation_paused = true;
+        const active = self.state.active_connections.load(.monotonic);
+        const max = self.state.config.max_connections;
+        log.warn(
+            "connection saturation: active={d}/{d} (>{d}%); pausing new accepts. " ++
+                "Will resume when active drops below {d} ({d}%). " ++
+                "To handle more clients, increase max_connections or upgrade VPS RAM.",
+            .{ active, max, @as(u32, 90), (max * 8) / 10, @as(u32, 80) },
+        );
+    }
+
+    fn resumeSaturation(self: *EventLoop) void {
+        if (!self.saturation_paused) return;
+
+        self.modFd(self.listen_fd, true, false) catch |err| {
+            log.warn("failed to resume accepts after saturation ease: {any}", .{err});
+            return;
+        };
+
+        self.saturation_paused = false;
+        const active = self.state.active_connections.load(.monotonic);
+        log.info("saturation eased: active={d}/{d}; resuming accepts", .{ active, self.state.config.max_connections });
     }
 
     fn onClientReadable(self: *EventLoop, slot: *ConnectionSlot) void {
@@ -1542,6 +1737,21 @@ const EventLoop = struct {
         slot.direct_fallback_addr = plan.direct_fallback;
         slot.direct_fallback_used = false;
 
+        // Log DC routing decisions at debug level (enable with log_level = "debug" in config)
+        if (plan.is_media_path) {
+            var addr_buf: [64]u8 = undefined;
+            const addr_str = formatAddress(plan.candidates[0], &addr_buf);
+            log.debug("[{d}] route: dc_idx={d} dc_abs={d} media={} middle_proxy={} candidates={d} -> {s}", .{
+                slot.conn_id,
+                slot.dc_idx,
+                dc_abs,
+                plan.is_media_path,
+                plan.use_middle_proxy,
+                plan.count,
+                addr_str,
+            });
+        }
+
         if (slot.upstream_candidates) |old| {
             self.state.allocator.free(old);
             slot.upstream_candidates = null;
@@ -1611,7 +1821,12 @@ const EventLoop = struct {
                 return;
             }
 
-            log.debug("[{d}] connect completion failed: {any}", .{ slot.conn_id, err });
+            log.debug("[{d}] connect completion failed: dc_idx={d} media={} err={any}", .{
+                slot.conn_id,
+                slot.dc_idx,
+                slot.is_media_path,
+                err,
+            });
             self.closeSlot(slot, "connect failed");
             return;
         }
@@ -1630,6 +1845,8 @@ const EventLoop = struct {
                     return;
                 }
             }
+            // Handshake complete (mask path) — release from handshake budget
+            _ = self.state.handshakes_inflight.fetchSub(1, .monotonic);
             slot.phase = .mask_relaying;
             return;
         }
@@ -1813,6 +2030,8 @@ const EventLoop = struct {
     }
 
     fn startRelay(self: *EventLoop, slot: *ConnectionSlot) void {
+        // Handshake complete — release from handshake budget
+        _ = self.state.handshakes_inflight.fetchSub(1, .monotonic);
         slot.phase = .relaying;
 
         if (slot.pipelined_data) |buf| {
@@ -1845,7 +2064,12 @@ const EventLoop = struct {
     fn relayClientToUpstream(self: *EventLoop, slot: *ConnectionSlot) void {
         if (slot.hasUpstreamPending()) return;
 
-        const progress = relayClientToUpstreamStep(slot, self.state.allocator) catch {
+        const progress = relayClientToUpstreamStep(slot, self.state.allocator) catch |err| {
+            if (slot.is_media_path) {
+                log.debug("[{d}] relay c2s error: dc_idx={d} err={any} c2s={d} s2c={d}", .{
+                    slot.conn_id, slot.dc_idx, err, slot.c2s_bytes, slot.s2c_bytes,
+                });
+            }
             self.closeSlot(slot, "relay c2s failed");
             return;
         };
@@ -1857,7 +2081,12 @@ const EventLoop = struct {
     fn relayUpstreamToClient(self: *EventLoop, slot: *ConnectionSlot) void {
         if (slot.hasClientPending()) return;
 
-        const progress = relayUpstreamToClientStep(slot, self.state.allocator) catch {
+        const progress = relayUpstreamToClientStep(slot, self.state.allocator) catch |err| {
+            if (slot.is_media_path) {
+                log.debug("[{d}] relay s2c error: dc_idx={d} err={any} c2s={d} s2c={d}", .{
+                    slot.conn_id, slot.dc_idx, err, slot.c2s_bytes, slot.s2c_bytes,
+                });
+            }
             self.closeSlot(slot, "relay s2c failed");
             return;
         };
@@ -2197,6 +2426,7 @@ const EventLoop = struct {
 
         _ = slot.obf_params orelse return false;
         slot.direct_fallback_used = true;
+        _ = self.state.stats_mp_fallback.fetchAdd(1, .monotonic);
         slot.use_middle_proxy = false;
         slot.mp_step = .none;
         slot.mp_enc = null;
@@ -2390,6 +2620,7 @@ const EventLoop = struct {
                         continue;
                     }
                 } else if (now_ms - slot.first_byte_at_ms > secondsToMs(self.state.config.handshake_timeout_sec)) {
+                    _ = self.state.stats_hs_timeout.fetchAdd(1, .monotonic);
                     self.closeSlot(slot, "handshake timeout");
                     continue;
                 }
@@ -2485,7 +2716,15 @@ const EventLoop = struct {
 
     fn closeSlot(self: *EventLoop, slot: *ConnectionSlot, reason: []const u8) void {
         if (slot.phase == .idle) return;
-        log.debug("[{d}] closing: {s}", .{ slot.conn_id, reason });
+        log.debug("[{d}] closing: dc_idx={d} media={} phase={s} reason={s} c2s={d} s2c={d}", .{
+            slot.conn_id,
+            slot.dc_idx,
+            slot.is_media_path,
+            @tagName(slot.phase),
+            reason,
+            slot.c2s_bytes,
+            slot.s2c_bytes,
+        });
 
         if (slot.client_fd != -1) {
             _ = self.delFd(slot.client_fd) catch {};
@@ -2505,6 +2744,10 @@ const EventLoop = struct {
 
         if (slot.active_reserved) {
             _ = self.state.active_connections.fetchSub(1, .monotonic);
+            // If connection was still in handshake phase, release from handshake budget
+            if (slot.handshakeInProgress()) {
+                _ = self.state.handshakes_inflight.fetchSub(1, .monotonic);
+            }
             slot.active_reserved = false;
             self.closed_since_log += 1;
         }
@@ -3259,4 +3502,104 @@ test "parse ipv4 literal" {
     try std.testing.expectEqual([4]u8{ 179, 43, 141, 146 }, parsed);
     try std.testing.expect(parseIpv4Literal("179.43.141") == null);
     try std.testing.expect(parseIpv4Literal("179.43.141.999") == null);
+}
+
+test "subnet rate limit - subnet key groups /24 IPv4" {
+    // 10.0.1.5 and 10.0.1.200 should have the same /24 key
+    const addr1 = net.Address.initIp4(.{ 10, 0, 1, 5 }, 443);
+    const addr2 = net.Address.initIp4(.{ 10, 0, 1, 200 }, 443);
+    const addr3 = net.Address.initIp4(.{ 10, 0, 2, 5 }, 443);
+
+    const key1 = SubnetRateLimit.subnetKey(addr1);
+    const key2 = SubnetRateLimit.subnetKey(addr2);
+    const key3 = SubnetRateLimit.subnetKey(addr3);
+
+    try std.testing.expectEqual(key1, key2); // same /24
+    try std.testing.expect(key1 != key3); // different /24
+}
+
+test "subnet rate limit - allows up to max then blocks" {
+    var limiter = SubnetRateLimit{};
+    const addr = net.Address.initIp4(.{ 192, 168, 1, 100 }, 443);
+
+    // max_per_sec = 3 → should allow 3 then block
+    // First call resets entry with tokens = max-1 = 2, returns true
+    try std.testing.expect(limiter.check(addr, 3));
+    // Two more with existing tokens
+    try std.testing.expect(limiter.check(addr, 3));
+    try std.testing.expect(limiter.check(addr, 3));
+    // Now should be blocked
+    try std.testing.expect(!limiter.check(addr, 3));
+    try std.testing.expect(!limiter.check(addr, 3));
+}
+
+test "subnet rate limit - disabled when max_per_sec is 0" {
+    var limiter = SubnetRateLimit{};
+    const addr = net.Address.initIp4(.{ 1, 2, 3, 4 }, 443);
+
+    // With max_per_sec = 0, always allows
+    for (0..100) |_| {
+        try std.testing.expect(limiter.check(addr, 0));
+    }
+}
+
+test "subnet rate limit - stale entry resets" {
+    var limiter = SubnetRateLimit{};
+    const addr = net.Address.initIp4(.{ 10, 20, 30, 40 }, 443);
+
+    // Drain tokens
+    _ = limiter.check(addr, 1);
+    try std.testing.expect(!limiter.check(addr, 1));
+
+    // Make entry stale (>60s old)
+    const key = SubnetRateLimit.subnetKey(addr);
+    const idx = key % SubnetRateLimit.BUCKETS;
+    limiter.entries[idx].last_refill_s -= 61;
+
+    // Should reset and allow again
+    try std.testing.expect(limiter.check(addr, 1));
+}
+
+test "subnet rate limit - different subnets are independent" {
+    var limiter = SubnetRateLimit{};
+    const addr_a = net.Address.initIp4(.{ 10, 0, 1, 100 }, 443);
+    const addr_b = net.Address.initIp4(.{ 10, 0, 2, 100 }, 443);
+
+    // Drain subnet A
+    _ = limiter.check(addr_a, 1);
+    try std.testing.expect(!limiter.check(addr_a, 1));
+
+    // Subnet B should still work
+    try std.testing.expect(limiter.check(addr_b, 1));
+}
+
+test "handshakeInProgress - phases" {
+    var slot: ConnectionSlot = undefined;
+
+    const hs_phases = [_]ConnectionPhase{
+        .reading_tls_header,
+        .reading_client_hello_body,
+        .writing_server_hello_first,
+        .desync_wait,
+        .writing_server_hello_rest,
+        .reading_mtproto_tls_header,
+        .reading_mtproto_tls_body,
+        .connecting_upstream,
+        .writing_dc_nonce,
+        .middle_proxy_handshake,
+    };
+    for (hs_phases) |phase| {
+        slot.phase = phase;
+        try std.testing.expect(slot.handshakeInProgress());
+    }
+
+    // Non-handshake phases
+    slot.phase = .idle;
+    try std.testing.expect(!slot.handshakeInProgress());
+    slot.phase = .relaying;
+    try std.testing.expect(!slot.handshakeInProgress());
+    slot.phase = .mask_relaying;
+    try std.testing.expect(!slot.handshakeInProgress());
+    slot.phase = .closing;
+    try std.testing.expect(!slot.handshakeInProgress());
 }


### PR DESCRIPTION
## Proxy Resilience Optimizations

This PR introduces multiple layers of protection against resource exhaustion and external abuse:

### 1. Admission Control with Hysteresis
When active connections reach >= 90% of max capacity, the proxy pauses accepting new connections on the `listen_fd`. It resumes only when active connections drop below 80%. This safely mitigates accept/close spin loops under saturated load.

### 2. Handshake Inflight Budget
Concurrent handshakes are now capped at 30% of `max_connections`. This ensures that high churn from DPI probes or scanner floods does not exhaust the available pool of slots, keeping established relay sessions active.

### 3. Per-/24 Subnet Rate Limiting
A zero-allocation token bucket tracks and limits new connections per /24 (IPv4) or /48 (IPv6) subnet. By default, it allows up to 8 connections per second. Configuration parameter: `rate_limit_per_subnet`.

### 4. Auto-Clamping by Host Profile
To protect small VPS instances from out-of-memory errors, `max_connections` is automatically clamped at startup based on a RAM-safe estimate. Users can bypass this using the `unsafe_override_limits = true` setting.

### 5. Degradation Metrics
Six new counters tracking drops or fallbacks during degradation periods have been added to the periodic stats log output cleanly:
- `cap` (reached `max_connections`)
- `sat` (dropped due to saturation override)
- `rate` (hit per-subnet rate limit)
- `hs_budget` (hit handshakes_inflight limit)
- `hs_timeout` (handshake timeout reached)
- `mp_fallback` (MiddleProxy fallback to direct triggered)

### Testing
- Added comprehensive unit tests for SubnetRateLimit structure, TOML config parsing limits, and phase tracking.
- Passed local and Linux cross-compiled suite.
- Successfully deployed onto `proxy.sleep3r.ru`.