### PR TITLE
feat: lightweight monitoring dashboard

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -50,7 +50,12 @@ jobs:
           version: 0.15.2
 
       - name: Build release binary
-        run: zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.target }}
+        run: |
+          if [ "${{ matrix.target }}" = "x86_64-linux" ]; then
+            zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.target }} -Dcpu=x86_64_v3
+          else
+            zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.target }}
+          fi
 
       - name: Package artifact
         run: |

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ clean:
 	rm -rf .zig-cache zig-out
 
 deploy:
-	zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux
+	zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux -Dcpu=x86_64_v3
 	ssh root@$(SERVER) 'systemctl stop mtproto-proxy || true'
 	scp zig-out/bin/mtproto-proxy root@$(SERVER):/opt/mtproto-proxy/
 	scp deploy/*.sh root@$(SERVER):/opt/mtproto-proxy/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build release run test bench soak clean fmt deploy update-server migrate update-dns release-manual stability-check stability-check-load capacity-probe-idle capacity-probe-active deploy-tunnel deploy-tunnel-only
+.PHONY: build release run test bench soak clean fmt deploy update-server migrate update-dns release-manual stability-check stability-check-load capacity-probe-idle capacity-probe-active deploy-tunnel deploy-tunnel-only deploy-monitor monitor
 
 SERVER ?= 185.125.46.60
 CONFIG ?= config.toml
@@ -133,3 +133,18 @@ capacity-probe-idle:
 # Capacity probe (authenticated traffic; memory-efficiency comparison)
 capacity-probe-active:
 	python3 test/capacity_connections_probe.py --profile mtproto.zig --traffic-mode tls-auth
+
+# Deploy monitoring dashboard to server
+deploy-monitor:
+	@if [ -z "$(SERVER)" ]; then echo "Usage: make deploy-monitor SERVER=<ip>"; exit 1; fi
+	ssh root@$(SERVER) 'mkdir -p /opt/mtproto-proxy/monitor/static'
+	scp deploy/monitor/server.py root@$(SERVER):/opt/mtproto-proxy/monitor/server.py
+	scp deploy/monitor/static/index.html deploy/monitor/static/style.css deploy/monitor/static/app.js root@$(SERVER):/opt/mtproto-proxy/monitor/static/
+	ssh root@$(SERVER) 'bash -s' < deploy/monitor/install.sh
+
+# Open SSH tunnel to monitoring dashboard
+monitor:
+	@if [ -z "$(SERVER)" ]; then echo "Usage: make monitor SERVER=<ip>"; exit 1; fi
+	@echo "Opening tunnel to monitor dashboard..."
+	@echo "→ http://localhost:61208"
+	ssh -L 61208:localhost:61208 root@$(SERVER)

--- a/README.md
+++ b/README.md
@@ -429,8 +429,9 @@ sudo systemctl stop mtproto-proxy
 The project includes a lightweight, Zig-themed web dashboard for real-time server monitoring. It runs as a separate systemd service (~30 MB RAM) and is accessible via SSH tunnel — no ports are exposed to the internet.
 
 **Features:**
+- **Interactive Charts** — glassmorphism hover tooltips with exact values and time
 - **CPU & Memory** — live gauges with sparkline history charts (0–100% Y-axis)
-- **Network** — realtime RX/TX throughput graph with auto-scaling Y-axis labels
+- **Network** — realtime RX/TX throughput graph with X-axis timeline and auto-scaling Y-axis labels
 - **Proxy stats** — active connections, handshakes, total served, drops breakdown
 - **AmneziaWG** — tunnel status, endpoint, handshakes, transfer metrics (optional, auto-hides if not installed)
 - **Live logs** — WebSocket-streamed `journalctl` output with color-coded log levels, search, and filters

--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ The project includes a lightweight, Zig-themed web dashboard for real-time serve
 - **CPU & Memory** — live gauges with sparkline history charts (0–100% Y-axis)
 - **Network** — realtime RX/TX throughput graph with auto-scaling Y-axis labels
 - **Proxy stats** — active connections, handshakes, total served, drops breakdown
+- **AmneziaWG** — tunnel status, endpoint, handshakes, transfer metrics (optional, auto-hides if not installed)
 - **Live logs** — WebSocket-streamed `journalctl` output with color-coded log levels, search, and filters
 - **Poll controls** — adjustable refresh interval (1s–10s), pause/resume, data freshness indicator
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Disguises Telegram traffic as standard TLS 1.3 HTTPS to bypass network censorshi
 [Update](#-update-existing-server) &nbsp;&bull;&nbsp;
 [Docker](#docker-image) &nbsp;&bull;&nbsp;
 [Deploy](#-deploy-to-server) &nbsp;&bull;&nbsp;
+[Monitoring](#-monitoring) &nbsp;&bull;&nbsp;
 [Tunnel](#-amneziawg-tunnel-blocked-regions) &nbsp;&bull;&nbsp;
 [Configuration](#-configuration) &nbsp;&bull;&nbsp;
 [Troubleshooting](#-troubleshooting-updating)
@@ -155,6 +156,8 @@ zig build -Doptimize=ReleaseFast soak -- --seconds=120 --threads=8 --max-payload
 | `make deploy-tunnel SERVER=<ip> AWG_CONF=<path> [PASSWORD=<pass>] [TUNNEL_MODE=direct\|preserve\|middleproxy]` | Full migration + AmneziaWG tunnel for blocked regions |
 | `make deploy-tunnel-only SERVER=<ip> AWG_CONF=<path> [TUNNEL_MODE=direct\|preserve\|middleproxy]` | Add AmneziaWG tunnel to existing installation |
 | `make update-server SERVER=<ip> [VERSION=vX.Y.Z]` | Update server binary from GitHub Release artifacts |
+| `make deploy-monitor SERVER=<ip>` | Deploy monitoring dashboard to server |
+| `make monitor SERVER=<ip>` | Open SSH tunnel to monitoring dashboard |
 
 </details>
 
@@ -419,6 +422,53 @@ sudo systemctl restart mtproto-proxy
 
 # Stop
 sudo systemctl stop mtproto-proxy
+```
+
+## &nbsp; Monitoring
+
+The project includes a lightweight, Zig-themed web dashboard for real-time server monitoring. It runs as a separate systemd service (~30 MB RAM) and is accessible via SSH tunnel — no ports are exposed to the internet.
+
+**Features:**
+- **CPU & Memory** — live gauges with sparkline history charts (0–100% Y-axis)
+- **Network** — realtime RX/TX throughput graph with auto-scaling Y-axis labels
+- **Proxy stats** — active connections, handshakes, total served, drops breakdown
+- **Live logs** — WebSocket-streamed `journalctl` output with color-coded log levels, search, and filters
+- **Poll controls** — adjustable refresh interval (1s–10s), pause/resume, data freshness indicator
+
+### Deploy
+
+```bash
+make deploy-monitor SERVER=<SERVER_IP>
+```
+
+This uploads `deploy/monitor/` (Python FastAPI backend + static frontend), installs Python dependencies (`fastapi`, `uvicorn`, `psutil`, `websockets`), creates a `proxy-monitor` systemd service, and starts it on `127.0.0.1:61208`.
+
+### Access
+
+The dashboard binds to `127.0.0.1` only — access it via SSH tunnel:
+
+```bash
+make monitor SERVER=<SERVER_IP>
+# Then open http://localhost:61208
+```
+
+Or manually:
+
+```bash
+ssh -L 61208:localhost:61208 root@<SERVER_IP>
+# open http://localhost:61208
+```
+
+### Structure
+
+```
+deploy/monitor/
+├── server.py          # FastAPI backend (stats API + WebSocket log streaming)
+├── install.sh         # Server-side install script
+└── static/
+    ├── index.html     # Dashboard markup
+    ├── style.css      # Zig-themed dark UI
+    └── app.js         # Charts, gauges, live logs, poll controls
 ```
 
 ## &nbsp; AmneziaWG Tunnel (Blocked Regions)

--- a/deploy/monitor/install.sh
+++ b/deploy/monitor/install.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install/update MTProto Proxy Monitor dashboard.
+# Usage: bash deploy/monitor/install.sh  (run on the target server)
+
+INSTALL_DIR="/opt/mtproto-proxy/monitor"
+SERVICE_NAME="proxy-monitor"
+SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
+PORT="61208"
+
+echo "=== MTProto Proxy Monitor — Install ==="
+
+# 1. Python deps
+echo "[1/4] Installing Python dependencies..."
+pip3 install --break-system-packages --quiet \
+  fastapi uvicorn psutil websockets 2>/dev/null || \
+pip3 install --quiet \
+  fastapi uvicorn psutil websockets
+
+# 2. Verify files
+if [ ! -f "${INSTALL_DIR}/server.py" ]; then
+  echo "ERROR: ${INSTALL_DIR}/server.py not found."
+  exit 1
+fi
+if [ ! -f "${INSTALL_DIR}/static/index.html" ]; then
+  echo "ERROR: ${INSTALL_DIR}/static/index.html not found."
+  exit 1
+fi
+echo "[2/4] Files verified"
+
+# 3. Systemd service
+echo "[3/4] Creating systemd service..."
+cat > "${SERVICE_FILE}" <<EOF
+[Unit]
+Description=MTProto Proxy Monitor
+After=network.target mtproto-proxy.service
+
+[Service]
+ExecStart=/usr/bin/python3 ${INSTALL_DIR}/server.py
+Restart=on-failure
+RestartSec=5
+WorkingDirectory=${INSTALL_DIR}
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable "${SERVICE_NAME}"
+
+# 4. Start/restart
+echo "[4/4] Starting ${SERVICE_NAME}..."
+systemctl restart "${SERVICE_NAME}"
+sleep 2
+
+if systemctl is-active --quiet "${SERVICE_NAME}"; then
+  echo ""
+  echo "✅ Monitor running on 127.0.0.1:${PORT}"
+  echo ""
+  echo "Access via SSH tunnel:"
+  echo "  ssh -L ${PORT}:localhost:${PORT} root@\$(hostname -I | awk '{print \$1}')"
+  echo "  open http://localhost:${PORT}"
+else
+  echo "❌ Failed to start. Check: journalctl -u ${SERVICE_NAME} --no-pager -n 20"
+  exit 1
+fi

--- a/deploy/monitor/server.py
+++ b/deploy/monitor/server.py
@@ -223,9 +223,9 @@ def api_stats():
             tx_rate = (net.bytes_sent - _prev_net["tx"]) / dt
     _prev_net = {"ts": now, "rx": net.bytes_recv, "tx": net.bytes_sent}
 
-    _net_history.append({"rx": rx_rate, "tx": tx_rate})
-    _cpu_history.append(round(cpu, 1))
-    _mem_history.append(round(mem.percent, 1))
+    _net_history.append({"ts": int(now * 1000), "rx": rx_rate, "tx": tx_rate})
+    _cpu_history.append({"ts": int(now * 1000), "v": round(cpu, 1)})
+    _mem_history.append({"ts": int(now * 1000), "v": round(mem.percent, 1)})
     for lst in (_net_history, _cpu_history, _mem_history):
         while len(lst) > MAX_HISTORY:
             lst.pop(0)

--- a/deploy/monitor/server.py
+++ b/deploy/monitor/server.py
@@ -141,6 +141,70 @@ def _proxy_info() -> dict:
     return dict(uptime="offline", pid=0, rss_mb=0, online=False)
 
 
+_awg_cache = {"ts": 0, "data": None}
+AWG_CACHE_TTL = 10  # seconds
+
+
+def _awg_status() -> dict:
+    """Check AmneziaWG tunnel status. Returns None if not installed."""
+    now = time.time()
+    if now - _awg_cache["ts"] < AWG_CACHE_TTL:
+        return _awg_cache["data"]
+
+    import shutil
+    if not shutil.which("awg"):
+        _awg_cache.update(ts=now, data=None)
+        return None
+
+    # Check if namespace exists
+    try:
+        ns_out = subprocess.check_output(["ip", "netns", "list"], text=True, timeout=2, stderr=subprocess.DEVNULL)
+        if "tg_proxy_ns" not in ns_out:
+            result = {"installed": True, "active": False, "reason": "namespace not found"}
+            _awg_cache.update(ts=now, data=result)
+            return result
+    except Exception:
+        _awg_cache.update(ts=now, data=None)
+        return None
+
+    try:
+        out = subprocess.check_output(
+            ["ip", "netns", "exec", "tg_proxy_ns", "awg", "show"],
+            text=True, timeout=3, stderr=subprocess.DEVNULL,
+        )
+        result = {"installed": True, "active": False, "endpoint": None,
+                  "handshake": None, "rx": None, "tx": None}
+
+        m = re.search(r"endpoint:\s*(\S+)", out)
+        if m:
+            result["endpoint"] = m[1]
+
+        m = re.search(r"latest handshake:\s*(.+)", out)
+        if m:
+            hs = m[1].strip()
+            result["handshake"] = hs
+            # Consider active if handshake was within last 3 minutes
+            if "second" in hs or "minute" in hs:
+                try:
+                    val = int(re.search(r"(\d+)", hs)[1])
+                    if "second" in hs or ("minute" in hs and val <= 3):
+                        result["active"] = True
+                except (TypeError, ValueError):
+                    pass
+
+        m = re.search(r"transfer:\s*([\d.]+\s*\S+)\s+received,\s*([\d.]+\s*\S+)\s+sent", out)
+        if m:
+            result["rx"] = m[1]
+            result["tx"] = m[2]
+
+        _awg_cache.update(ts=now, data=result)
+        return result
+    except Exception:
+        result = {"installed": True, "active": False, "reason": "awg show failed"}
+        _awg_cache.update(ts=now, data=result)
+        return result
+
+
 @app.get("/api/stats")
 def api_stats():
     global _prev_net, _net_history, _cpu_history, _mem_history
@@ -175,6 +239,7 @@ def api_stats():
         "net_history": _net_history[-MAX_HISTORY:],
         "uptime": f"{d}d {h}h {rem2 // 60}m",
         "proxy": _proxy_stats(), "proxy_info": _proxy_info(),
+        "awg": _awg_status(),
     })
 
 

--- a/deploy/monitor/server.py
+++ b/deploy/monitor/server.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""MTProto Proxy Monitor — API server."""
+
+import asyncio
+import json
+import re
+import time
+import threading
+import queue
+import subprocess
+from pathlib import Path
+
+import psutil
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import JSONResponse
+from fastapi.staticfiles import StaticFiles
+import uvicorn
+
+STATIC_DIR = Path(__file__).parent / "static"
+
+app = FastAPI()
+
+_prev_net = {"ts": 0, "rx": 0, "tx": 0}
+_net_history = []
+_cpu_history = []
+_mem_history = []
+MAX_HISTORY = 90
+
+# --- Thread-safe log buffer ---
+_log_buffer = queue.Queue(maxsize=500)
+_log_thread_started = False
+
+
+def _log_reader_thread():
+    while True:
+        try:
+            proc = subprocess.Popen(
+                ["journalctl", "-u", "mtproto-proxy", "-f", "--no-pager", "-n", "80"],
+                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True,
+            )
+            for line in proc.stdout:
+                text = line.strip()
+                if not text:
+                    continue
+                cls = "info"
+                if "error" in text.lower() or "err(" in text:
+                    cls = "error"
+                elif "warn" in text.lower():
+                    cls = "warn"
+                elif "drops:" in text:
+                    cls = "drops"
+                elif "conn stats:" in text:
+                    cls = "stats"
+                m = re.match(r"^.*?\s+\S+\s+\S+\[\d+\]:\s*(.*)", text)
+                short = m.group(1) if m else text
+                entry = {"text": short, "cls": cls, "ts": time.strftime("%H:%M:%S")}
+                try:
+                    _log_buffer.put_nowait(entry)
+                except queue.Full:
+                    try:
+                        _log_buffer.get_nowait()
+                    except queue.Empty:
+                        pass
+                    _log_buffer.put_nowait(entry)
+            proc.wait()
+        except Exception:
+            pass
+        time.sleep(2)
+
+
+def ensure_log_thread():
+    global _log_thread_started
+    if not _log_thread_started:
+        _log_thread_started = True
+        threading.Thread(target=_log_reader_thread, daemon=True).start()
+
+
+ensure_log_thread()
+
+_recent_logs = []
+_recent_lock = threading.Lock()
+MAX_RECENT = 100
+
+
+def _drain_to_recent():
+    drained = []
+    while True:
+        try:
+            drained.append(_log_buffer.get_nowait())
+        except queue.Empty:
+            break
+    if drained:
+        with _recent_lock:
+            _recent_logs.extend(drained)
+            del _recent_logs[: max(0, len(_recent_logs) - MAX_RECENT)]
+    return drained
+
+
+def _proxy_stats() -> dict:
+    try:
+        out = subprocess.check_output(
+            ["journalctl", "-u", "mtproto-proxy", "--no-pager", "-n", "40"],
+            text=True, timeout=3, stderr=subprocess.DEVNULL,
+        )
+        s = dict(active=0, max=0, hs_inflight=0, total=0, accepted=0,
+                 closed=0, tracked_fds=0, rate_drops=0, cap_drops=0,
+                 sat_drops=0, hs_budget_drops=0, hs_timeout=0)
+        for line in reversed(out.strip().split("\n")):
+            if "conn stats:" in line:
+                m = re.search(r"active=(\d+)/(\d+)", line)
+                if m: s["active"], s["max"] = int(m[1]), int(m[2])
+                for k, p in [("hs_inflight", r"hs_inflight=(\d+)"), ("total", r"total=(\d+)"),
+                              ("accepted", r"accepted\+=(\d+)"), ("closed", r"closed\+=(\d+)"),
+                              ("tracked_fds", r"tracked_fds=(\d+)")]:
+                    m2 = re.search(p, line)
+                    if m2: s[k] = int(m2[1])
+                break
+        for line in reversed(out.strip().split("\n")):
+            if "drops:" in line:
+                for k, p in [("rate_drops", r"rate\+=(\d+)"), ("cap_drops", r"cap\+=(\d+)"),
+                              ("sat_drops", r"sat\+=(\d+)"), ("hs_budget_drops", r"hs_budget\+=(\d+)"),
+                              ("hs_timeout", r"hs_timeout\+=(\d+)")]:
+                    m2 = re.search(p, line)
+                    if m2: s[k] = int(m2[1])
+                break
+        return s
+    except Exception:
+        return {}
+
+
+def _proxy_info() -> dict:
+    for proc in psutil.process_iter(["name", "create_time", "pid", "memory_info"]):
+        if proc.info["name"] == "mtproto-proxy":
+            el = time.time() - proc.info["create_time"]
+            h, rem = divmod(int(el), 3600)
+            m, sec = divmod(rem, 60)
+            d, h = divmod(h, 24)
+            up = f"{d}d {h}h {m}m" if d else f"{h}h {m}m {sec}s"
+            rss = proc.info["memory_info"].rss / 1048576 if proc.info["memory_info"] else 0
+            return dict(uptime=up, pid=proc.info["pid"], rss_mb=round(rss, 1), online=True)
+    return dict(uptime="offline", pid=0, rss_mb=0, online=False)
+
+
+@app.get("/api/stats")
+def api_stats():
+    global _prev_net, _net_history, _cpu_history, _mem_history
+    cpu = psutil.cpu_percent(interval=0.3)
+    mem = psutil.virtual_memory()
+    net = psutil.net_io_counters()
+    d, rem = divmod(int(time.time() - psutil.boot_time()), 86400)
+    h, rem2 = divmod(rem, 3600)
+
+    now = time.time()
+    rx_rate = tx_rate = 0.0
+    if _prev_net["ts"]:
+        dt = now - _prev_net["ts"]
+        if dt > 0:
+            rx_rate = (net.bytes_recv - _prev_net["rx"]) / dt
+            tx_rate = (net.bytes_sent - _prev_net["tx"]) / dt
+    _prev_net = {"ts": now, "rx": net.bytes_recv, "tx": net.bytes_sent}
+
+    _net_history.append({"rx": rx_rate, "tx": tx_rate})
+    _cpu_history.append(round(cpu, 1))
+    _mem_history.append(round(mem.percent, 1))
+    for lst in (_net_history, _cpu_history, _mem_history):
+        while len(lst) > MAX_HISTORY:
+            lst.pop(0)
+
+    return JSONResponse({
+        "cpu": round(cpu, 1), "cpu_history": list(_cpu_history),
+        "mem_used": round(mem.used / 1048576), "mem_total": round(mem.total / 1048576),
+        "mem_pct": round(mem.percent, 1), "mem_history": list(_mem_history),
+        "net_rx": round(rx_rate), "net_tx": round(tx_rate),
+        "net_rx_total": net.bytes_recv, "net_tx_total": net.bytes_sent,
+        "net_history": _net_history[-MAX_HISTORY:],
+        "uptime": f"{d}d {h}h {rem2 // 60}m",
+        "proxy": _proxy_stats(), "proxy_info": _proxy_info(),
+    })
+
+
+@app.get("/api/logs")
+def api_logs():
+    _drain_to_recent()
+    with _recent_lock:
+        return JSONResponse(list(_recent_logs))
+
+
+@app.websocket("/ws/logs")
+async def ws_logs(ws: WebSocket):
+    await ws.accept()
+    _drain_to_recent()
+    with _recent_lock:
+        backlog = list(_recent_logs)
+    for e in backlog:
+        await ws.send_json(e)
+    try:
+        while True:
+            new = _drain_to_recent()
+            for item in new:
+                await ws.send_json(item)
+            if not new:
+                await asyncio.sleep(0.5)
+    except (WebSocketDisconnect, Exception):
+        pass
+
+
+# Static files (index.html, style.css, app.js) — mounted last so API routes take priority
+app.mount("/", StaticFiles(directory=str(STATIC_DIR), html=True), name="static")
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="127.0.0.1", port=61208, log_level="warning")

--- a/deploy/monitor/static/app.js
+++ b/deploy/monitor/static/app.js
@@ -39,10 +39,10 @@ function showTooltip(e, canvas, padLeft, dataArr, formatCb) {
   tt.innerHTML = `<div class="tooltip-ts">${tStr}</div>` + formatCb(item);
   
   // Position tooltip safely
-  let tx = e.pageX + 15;
-  let ty = e.pageY + 15;
-  if (tx + 120 > window.innerWidth) tx = e.pageX - 130;
-  if (ty + 50 > window.innerHeight) ty = e.pageY - 60;
+  let tx = e.clientX + 15;
+  let ty = e.clientY + 15;
+  if (tx + 120 > window.innerWidth) tx = e.clientX - 130;
+  if (ty + 50 > window.innerHeight) ty = e.clientY - 60;
   
   tt.style.left = tx + 'px';
   tt.style.top = ty + 'px';

--- a/deploy/monitor/static/app.js
+++ b/deploy/monitor/static/app.js
@@ -229,6 +229,27 @@ async function poll() {
   $('pxDrops').textContent = drp;
   $('pxDrops').style.color = drp > 0 ? 'var(--amber)' : 'var(--text-muted)';
   $('pxDropLbl').textContent = 'rate +' + drp + ' · cap +' + (p.cap_drops || 0) + ' · hs_t +' + (p.hs_timeout || 0);
+
+  // AmneziaWG tunnel
+  const awg = d.awg;
+  const tc = $('tunnelCard');
+  if (!awg) {
+    tc.style.display = 'none';
+  } else {
+    tc.style.display = '';
+    const badge = $('awgBadge');
+    if (awg.active) {
+      badge.className = 'badge';
+      $('awgStatus').textContent = 'Active';
+    } else {
+      badge.className = 'badge off';
+      $('awgStatus').textContent = awg.reason || 'Down';
+    }
+    $('awgEndpoint').textContent = awg.endpoint || '—';
+    $('awgHandshake').textContent = awg.handshake || '—';
+    $('awgRx').textContent = awg.rx || '—';
+    $('awgTx').textContent = awg.tx || '—';
+  }
 }
 
 function setDataBadge(state, text) {

--- a/deploy/monitor/static/app.js
+++ b/deploy/monitor/static/app.js
@@ -5,13 +5,51 @@ const MH = 90;       // max history points
 const MAX_LINES = 300;
 let autoScrollEnabled = true;
 let userScrolledUp = false;
-let rxH = [], txH = [];
 let pollIntervalMs = 3000;
 let pollLoop = null;
 let pollInFlight = false;
 let pollingPaused = false;
 let lastSuccessAt = 0;
 let hasPollError = false;
+let lastData = null; // store last API response for tooltips
+
+const tt = $('chartTooltip');
+function showTooltip(e, canvas, padLeft, dataArr, formatCb) {
+  if (!dataArr || !dataArr.length) return;
+  const r = canvas.getBoundingClientRect();
+  const px = e.clientX - r.left;
+  // Account for padding left in responsive coordinates
+  const pL = (padLeft / canvas.width) * r.width;
+  if (px < pL) { tt.classList.remove('visible'); return; }
+
+  const cw = r.width - pL;
+  const step = cw / (MH - 1);
+  const idx = Math.round((px - pL) / step);
+  const off = MH - dataArr.length;
+  const dataIdx = idx - off;
+
+  if (dataIdx < 0 || dataIdx >= dataArr.length) { tt.classList.remove('visible'); return; }
+
+  const item = dataArr[dataIdx];
+  const d = new Date(item.ts);
+  const tStr = d.getHours().toString().padStart(2, '0') + ':' +
+               d.getMinutes().toString().padStart(2, '0') + ':' +
+               d.getSeconds().toString().padStart(2, '0');
+
+  tt.innerHTML = `<div class="tooltip-ts">${tStr}</div>` + formatCb(item);
+  
+  // Position tooltip safely
+  let tx = e.pageX + 15;
+  let ty = e.pageY + 15;
+  if (tx + 120 > window.innerWidth) tx = e.pageX - 130;
+  if (ty + 50 > window.innerHeight) ty = e.pageY - 60;
+  
+  tt.style.left = tx + 'px';
+  tt.style.top = ty + 'px';
+  tt.classList.add('visible');
+}
+
+function hideTooltip() { tt.classList.remove('visible'); }
 
 const logFilters = { error: true, warn: true, stats: true };
 let logSearchTerm = '';
@@ -37,11 +75,19 @@ resizeCanvas();
 window.addEventListener('resize', resizeCanvas);
 
 function drawNetChart() {
+  if (!lastData || !lastData.net_history) return;
+  const data = lastData.net_history;
   const w = canvas.width / 2, h = canvas.height / 2;
   ctx.clearRect(0, 0, w, h);
-  if (rxH.length < 2) return;
+  if (data.length < 2) return;
 
-  const peak = Math.max(4096, ...rxH, ...txH) * 1.2;
+  let peak = 4096;
+  for (let i = 0; i < data.length; i++) {
+    if (data[i].rx > peak) peak = data[i].rx;
+    if (data[i].tx > peak) peak = data[i].tx;
+  }
+  peak *= 1.2;
+
   const PAD = 42;           // left padding for Y-axis labels
   const PAD_TOP = 4;        // top padding so labels don't clip
   const PAD_BOT = 18;       // bottom padding for X-axis labels
@@ -57,14 +103,12 @@ function drawNetChart() {
   for (let i = 0; i <= 4; i++) {
     const frac = i / 4;
     const y = PAD_TOP + ch * (1 - frac);
-    // grid line
     ctx.strokeStyle = 'rgba(247,164,29,0.05)';
     ctx.lineWidth = 0.5;
     ctx.beginPath();
     ctx.moveTo(PAD, y);
     ctx.lineTo(w, y);
     ctx.stroke();
-    // label
     if (i > 0) {
       ctx.fillStyle = 'rgba(124,134,152,0.6)';
       ctx.fillText(fmtShort(peak * frac), PAD - 5, y);
@@ -75,18 +119,23 @@ function drawNetChart() {
   ctx.textAlign = 'left';
   ctx.textBaseline = 'bottom';
   ctx.fillStyle = 'rgba(124,134,152,0.6)';
-  const totalMins = (MH * pollIntervalMs) / 60000;
-  ctx.fillText('-' + totalMins.toFixed(1).replace('.0', '') + 'm', PAD, h - 3);
+  
+  const oldest = new Date(data[0].ts);
+  const newest = new Date(data[data.length - 1].ts);
+  
+  function fTime(d) { return d.getHours().toString().padStart(2, '0') + ':' + d.getMinutes().toString().padStart(2, '0'); }
+  ctx.fillText(fTime(oldest), PAD, h - 3);
   ctx.textAlign = 'right';
-  ctx.fillText('Now', w, h - 3);
+  ctx.fillText(fTime(newest), w, h - 3);
 
-  function drawLine(data, color) {
+  function drawLine(key, color) {
     const off = MH - data.length;
     ctx.beginPath();
     ctx.strokeStyle = color;
     ctx.lineWidth = 2;
     ctx.lineJoin = 'round';
-    data.forEach((v, i) => {
+    data.forEach((item, i) => {
+      const v = item[key];
       const x = PAD + (off + i) * step;
       const y = PAD_TOP + ch - (v / peak) * ch;
       i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
@@ -104,9 +153,16 @@ function drawNetChart() {
     ctx.fill();
   }
 
-  drawLine(txH, 'rgb(247,164,29)');
-  drawLine(rxH, 'rgb(52,211,153)');
+  drawLine('tx', 'rgb(247,164,29)');
+  drawLine('rx', 'rgb(52,211,153)');
 }
+
+canvas.addEventListener('mousemove', e => {
+  showTooltip(e, canvas, 42, lastData?.net_history, item => 
+    `<div class="tooltip-val" style="color:var(--green)">RX: ${fmt(item.rx)}</div><div class="tooltip-val" style="color:var(--zig)">TX: ${fmt(item.tx)}</div>`
+  );
+});
+canvas.addEventListener('mouseleave', hideTooltip);
 
 // ── Sparkline with Y-axis ──
 function drawSpark(canvasId, data, color, maxVal, unit) {
@@ -119,9 +175,17 @@ function drawSpark(canvasId, data, color, maxVal, unit) {
   x.setTransform(2, 0, 0, 2, 0, 0);
 
   const w = r.width, h = r.height;
-  if (data.length < 2) return;
+  if (!data || data.length < 2) return;
 
-  const peak = maxVal || Math.max(1, ...data) * 1.2;
+  let peak = maxVal;
+  if (!peak) {
+    peak = 1;
+    for (let i = 0; i < data.length; i++) {
+      if (data[i].v > peak) peak = data[i].v;
+    }
+  }
+  peak *= 1.2;
+
   const PAD = 32;       // left padding
   const PAD_TOP = 6;    // top padding
   const cw = w - PAD;
@@ -140,14 +204,12 @@ function drawSpark(canvasId, data, color, maxVal, unit) {
   for (const tv of ticks) {
     const frac = tv / peak;
     const y = PAD_TOP + ch * (1 - frac);
-    // grid
     x.strokeStyle = 'rgba(247,164,29,0.05)';
     x.lineWidth = 0.5;
     x.beginPath();
     x.moveTo(PAD, y);
     x.lineTo(w, y);
     x.stroke();
-    // label
     if (tv > 0) {
       x.fillStyle = 'rgba(124,134,152,0.5)';
       x.fillText(unit === '%' ? tv + '%' : tv.toFixed(0), PAD - 4, y);
@@ -159,9 +221,9 @@ function drawSpark(canvasId, data, color, maxVal, unit) {
   x.strokeStyle = color;
   x.lineWidth = 1.5;
   x.lineJoin = 'round';
-  data.forEach((v, i) => {
+  data.forEach((item, i) => {
     const px = PAD + (off + i) * step;
-    const py = PAD_TOP + ch - (v / peak) * ch;
+    const py = PAD_TOP + ch - (item.v / peak) * ch;
     i === 0 ? x.moveTo(px, py) : x.lineTo(px, py);
   });
   x.stroke();
@@ -176,6 +238,17 @@ function drawSpark(canvasId, data, color, maxVal, unit) {
   x.closePath();
   x.fillStyle = grad;
   x.fill();
+}
+
+const cpuCanvas = $('cpuSpark');
+if (cpuCanvas) {
+  cpuCanvas.addEventListener('mousemove', e => showTooltip(e, cpuCanvas, 32, lastData?.cpu_history, item => `<div class="tooltip-val" style="color:var(--zig)">Util: ${item.v}%</div>`));
+  cpuCanvas.addEventListener('mouseleave', hideTooltip);
+}
+const memCanvas = $('memSpark');
+if (memCanvas) {
+  memCanvas.addEventListener('mousemove', e => showTooltip(e, memCanvas, 32, lastData?.mem_history, item => `<div class="tooltip-val" style="color:var(--purple)">Mem: ${item.v}%</div>`));
+  memCanvas.addEventListener('mouseleave', hideTooltip);
 }
 
 // ── Formatters ──
@@ -200,6 +273,8 @@ async function poll() {
   if (!r.ok) throw new Error('stats request failed: ' + r.status);
   const d = await r.json();
 
+  lastData = d;
+
   // CPU
   setGauge('cpuArc', 'cpuPct', d.cpu);
   $('cpuVal').innerHTML = d.cpu + '<span style="font-size:18px;font-weight:400">%</span>';
@@ -213,8 +288,6 @@ async function poll() {
   if (d.mem_history) drawSpark('memSpark', d.mem_history, 'rgb(167,139,250)', 100, '%');
 
   // Network
-  rxH.push(d.net_rx); txH.push(d.net_tx);
-  if (rxH.length > MH) { rxH.shift(); txH.shift(); }
   drawNetChart();
   $('rxRate').textContent = fmt(d.net_rx);
   $('txRate').textContent = fmt(d.net_tx);

--- a/deploy/monitor/static/app.js
+++ b/deploy/monitor/static/app.js
@@ -44,8 +44,9 @@ function drawNetChart() {
   const peak = Math.max(4096, ...rxH, ...txH) * 1.2;
   const PAD = 42;           // left padding for Y-axis labels
   const PAD_TOP = 4;        // top padding so labels don't clip
+  const PAD_BOT = 18;       // bottom padding for X-axis labels
   const cw = w - PAD;
-  const ch = h - PAD_TOP;
+  const ch = h - PAD_TOP - PAD_BOT;
   const step = cw / (MH - 1);
 
   // Y-axis grid + labels
@@ -70,6 +71,15 @@ function drawNetChart() {
     }
   }
 
+  // X-axis labels
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'bottom';
+  ctx.fillStyle = 'rgba(124,134,152,0.6)';
+  const totalMins = (MH * pollIntervalMs) / 60000;
+  ctx.fillText('-' + totalMins.toFixed(1).replace('.0', '') + 'm', PAD, h - 3);
+  ctx.textAlign = 'right';
+  ctx.fillText('Now', w, h - 3);
+
   function drawLine(data, color) {
     const off = MH - data.length;
     ctx.beginPath();
@@ -84,11 +94,11 @@ function drawNetChart() {
     ctx.stroke();
     // gradient fill
     const c = color.match(/[\d.]+/g);
-    const grad = ctx.createLinearGradient(0, PAD_TOP, 0, h);
+    const grad = ctx.createLinearGradient(0, PAD_TOP, 0, PAD_TOP + ch);
     grad.addColorStop(0, `rgba(${c[0]},${c[1]},${c[2]},0.1)`);
     grad.addColorStop(1, 'transparent');
-    ctx.lineTo(PAD + (off + data.length - 1) * step, h);
-    ctx.lineTo(PAD + off * step, h);
+    ctx.lineTo(PAD + (off + data.length - 1) * step, PAD_TOP + ch);
+    ctx.lineTo(PAD + off * step, PAD_TOP + ch);
     ctx.closePath();
     ctx.fillStyle = grad;
     ctx.fill();

--- a/deploy/monitor/static/app.js
+++ b/deploy/monitor/static/app.js
@@ -1,0 +1,440 @@
+/* MTProto Proxy Monitor — frontend logic */
+
+const $ = id => document.getElementById(id);
+const MH = 90;       // max history points
+const MAX_LINES = 300;
+let autoScrollEnabled = true;
+let userScrolledUp = false;
+let rxH = [], txH = [];
+let pollIntervalMs = 3000;
+let pollLoop = null;
+let pollInFlight = false;
+let pollingPaused = false;
+let lastSuccessAt = 0;
+let hasPollError = false;
+
+const logFilters = { error: true, warn: true, stats: true };
+let logSearchTerm = '';
+const appRoot = document.querySelector('.app');
+
+// ── Gauges ──
+function setGauge(arcId, pctId, val) {
+  $(arcId).style.strokeDashoffset = 94.2 - (94.2 * val / 100);
+  $(pctId).textContent = val + '%';
+}
+
+// ── Network chart ──
+const canvas = $('netChart');
+const ctx = canvas.getContext('2d');
+
+function resizeCanvas() {
+  const r = canvas.parentElement.getBoundingClientRect();
+  canvas.width = r.width * 2;
+  canvas.height = r.height * 2;
+  ctx.setTransform(2, 0, 0, 2, 0, 0);
+}
+resizeCanvas();
+window.addEventListener('resize', resizeCanvas);
+
+function drawNetChart() {
+  const w = canvas.width / 2, h = canvas.height / 2;
+  ctx.clearRect(0, 0, w, h);
+  if (rxH.length < 2) return;
+
+  const peak = Math.max(4096, ...rxH, ...txH) * 1.2;
+  const PAD = 42;           // left padding for Y-axis labels
+  const PAD_TOP = 4;        // top padding so labels don't clip
+  const cw = w - PAD;
+  const ch = h - PAD_TOP;
+  const step = cw / (MH - 1);
+
+  // Y-axis grid + labels
+  ctx.font = '9px Inter, sans-serif';
+  ctx.textAlign = 'right';
+  ctx.textBaseline = 'middle';
+
+  for (let i = 0; i <= 4; i++) {
+    const frac = i / 4;
+    const y = PAD_TOP + ch * (1 - frac);
+    // grid line
+    ctx.strokeStyle = 'rgba(247,164,29,0.05)';
+    ctx.lineWidth = 0.5;
+    ctx.beginPath();
+    ctx.moveTo(PAD, y);
+    ctx.lineTo(w, y);
+    ctx.stroke();
+    // label
+    if (i > 0) {
+      ctx.fillStyle = 'rgba(124,134,152,0.6)';
+      ctx.fillText(fmtShort(peak * frac), PAD - 5, y);
+    }
+  }
+
+  function drawLine(data, color) {
+    const off = MH - data.length;
+    ctx.beginPath();
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 2;
+    ctx.lineJoin = 'round';
+    data.forEach((v, i) => {
+      const x = PAD + (off + i) * step;
+      const y = PAD_TOP + ch - (v / peak) * ch;
+      i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+    });
+    ctx.stroke();
+    // gradient fill
+    const c = color.match(/[\d.]+/g);
+    const grad = ctx.createLinearGradient(0, PAD_TOP, 0, h);
+    grad.addColorStop(0, `rgba(${c[0]},${c[1]},${c[2]},0.1)`);
+    grad.addColorStop(1, 'transparent');
+    ctx.lineTo(PAD + (off + data.length - 1) * step, h);
+    ctx.lineTo(PAD + off * step, h);
+    ctx.closePath();
+    ctx.fillStyle = grad;
+    ctx.fill();
+  }
+
+  drawLine(txH, 'rgb(247,164,29)');
+  drawLine(rxH, 'rgb(52,211,153)');
+}
+
+// ── Sparkline with Y-axis ──
+function drawSpark(canvasId, data, color, maxVal, unit) {
+  const c = document.getElementById(canvasId);
+  if (!c) return;
+  const x = c.getContext('2d');
+  const r = c.parentElement.getBoundingClientRect();
+  c.width = r.width * 2;
+  c.height = r.height * 2;
+  x.setTransform(2, 0, 0, 2, 0, 0);
+
+  const w = r.width, h = r.height;
+  if (data.length < 2) return;
+
+  const peak = maxVal || Math.max(1, ...data) * 1.2;
+  const PAD = 32;       // left padding
+  const PAD_TOP = 6;    // top padding
+  const cw = w - PAD;
+  const ch = h - PAD_TOP;
+  const step = cw / (MH - 1);
+  const off = MH - data.length;
+
+  x.clearRect(0, 0, w, h);
+
+  // Y-axis ticks
+  const ticks = unit === '%' ? [0, 50, 100] : [0, peak * 0.5, peak];
+  x.font = '8px Inter, sans-serif';
+  x.textAlign = 'right';
+  x.textBaseline = 'middle';
+
+  for (const tv of ticks) {
+    const frac = tv / peak;
+    const y = PAD_TOP + ch * (1 - frac);
+    // grid
+    x.strokeStyle = 'rgba(247,164,29,0.05)';
+    x.lineWidth = 0.5;
+    x.beginPath();
+    x.moveTo(PAD, y);
+    x.lineTo(w, y);
+    x.stroke();
+    // label
+    if (tv > 0) {
+      x.fillStyle = 'rgba(124,134,152,0.5)';
+      x.fillText(unit === '%' ? tv + '%' : tv.toFixed(0), PAD - 4, y);
+    }
+  }
+
+  // Data line
+  x.beginPath();
+  x.strokeStyle = color;
+  x.lineWidth = 1.5;
+  x.lineJoin = 'round';
+  data.forEach((v, i) => {
+    const px = PAD + (off + i) * step;
+    const py = PAD_TOP + ch - (v / peak) * ch;
+    i === 0 ? x.moveTo(px, py) : x.lineTo(px, py);
+  });
+  x.stroke();
+
+  // Fill
+  const cc = color.match(/[\d.]+/g);
+  const grad = x.createLinearGradient(0, PAD_TOP, 0, h);
+  grad.addColorStop(0, `rgba(${cc[0]},${cc[1]},${cc[2]},0.08)`);
+  grad.addColorStop(1, 'transparent');
+  x.lineTo(PAD + (off + data.length - 1) * step, h);
+  x.lineTo(PAD + off * step, h);
+  x.closePath();
+  x.fillStyle = grad;
+  x.fill();
+}
+
+// ── Formatters ──
+function fmt(b) {
+  if (b < 1024) return b.toFixed(0) + ' B/s';
+  if (b < 1048576) return (b / 1024).toFixed(1) + ' KB/s';
+  return (b / 1048576).toFixed(1) + ' MB/s';
+}
+function fmtShort(b) {
+  if (b < 1024) return b.toFixed(0) + ' B';
+  if (b < 1048576) return (b / 1024).toFixed(0) + ' KB';
+  return (b / 1048576).toFixed(1) + ' MB';
+}
+function fmtT(b) {
+  if (b < 1073741824) return (b / 1048576).toFixed(0) + ' MB';
+  return (b / 1073741824).toFixed(1) + ' GB';
+}
+
+// ── Polling ──
+async function poll() {
+  const r = await fetch('/api/stats', { cache: 'no-store' });
+  if (!r.ok) throw new Error('stats request failed: ' + r.status);
+  const d = await r.json();
+
+  // CPU
+  setGauge('cpuArc', 'cpuPct', d.cpu);
+  $('cpuVal').innerHTML = d.cpu + '<span style="font-size:18px;font-weight:400">%</span>';
+  // Memory
+  setGauge('memArc', 'memPct', d.mem_pct);
+  $('memVal').innerHTML = d.mem_used + '<span style="font-size:14px;font-weight:400"> MB</span>';
+  $('memSub').textContent = d.mem_used + ' / ' + d.mem_total + ' MB';
+
+  // Sparklines
+  if (d.cpu_history) drawSpark('cpuSpark', d.cpu_history, 'rgb(247,164,29)', 100, '%');
+  if (d.mem_history) drawSpark('memSpark', d.mem_history, 'rgb(167,139,250)', 100, '%');
+
+  // Network
+  rxH.push(d.net_rx); txH.push(d.net_tx);
+  if (rxH.length > MH) { rxH.shift(); txH.shift(); }
+  drawNetChart();
+  $('rxRate').textContent = fmt(d.net_rx);
+  $('txRate').textContent = fmt(d.net_tx);
+  $('rxTotal').textContent = fmtT(d.net_rx_total);
+  $('txTotal').textContent = fmtT(d.net_tx_total);
+
+  // Server
+  $('srvUptime').textContent = d.uptime;
+  const pi = d.proxy_info || {};
+  $('proxyUp').textContent = pi.uptime || '—';
+  $('proxyPid').textContent = pi.pid || '—';
+  $('proxyRss').textContent = (pi.rss_mb || 0) + ' MB';
+  $('statusBadge').className = pi.online ? 'badge' : 'badge off';
+
+  // Proxy stats
+  const p = d.proxy || {};
+  $('pxActive').textContent = p.active || 0;
+  $('pxMax').textContent = p.max || 0;
+  $('pxHs').textContent = p.hs_inflight || 0;
+  $('pxTotal').textContent = (p.total || 0).toLocaleString();
+  const drp = p.rate_drops || 0;
+  $('pxDrops').textContent = drp;
+  $('pxDrops').style.color = drp > 0 ? 'var(--amber)' : 'var(--text-muted)';
+  $('pxDropLbl').textContent = 'rate +' + drp + ' · cap +' + (p.cap_drops || 0) + ' · hs_t +' + (p.hs_timeout || 0);
+}
+
+function setDataBadge(state, text) {
+  $('dataBadge').className = 'badge data-badge ' + state;
+  $('dataBadgeText').textContent = text;
+}
+
+function setStaleMode(stale) {
+  appRoot.classList.toggle('stale', stale);
+}
+
+function updateFreshness() {
+  if (!lastSuccessAt) {
+    $('lastUpdate').textContent = 'never';
+  } else {
+    const age = Math.floor((Date.now() - lastSuccessAt) / 1000);
+    $('lastUpdate').textContent = age <= 0 ? 'just now' : age + 's ago';
+  }
+
+  if (pollingPaused) {
+    setDataBadge('paused', 'Paused');
+    setStaleMode(false);
+    return;
+  }
+
+  if (!lastSuccessAt) {
+    if (hasPollError) {
+      setDataBadge('stale', 'Data delayed');
+      setStaleMode(true);
+    } else {
+      setDataBadge('syncing', 'Syncing...');
+      setStaleMode(false);
+    }
+    return;
+  }
+
+  const age = Math.floor((Date.now() - lastSuccessAt) / 1000);
+  const staleThreshold = Math.max(8, Math.ceil((pollIntervalMs / 1000) * 2));
+  const stale = hasPollError || age > staleThreshold;
+  setDataBadge(stale ? 'stale' : 'ok', stale ? 'Data delayed' : 'Live');
+  setStaleMode(stale);
+}
+
+function updatePollControls() {
+  $('pollToggle').textContent = pollingPaused ? 'Resume' : 'Pause';
+  $('pollToggle').classList.toggle('active', !pollingPaused);
+}
+
+async function runPoll() {
+  if (pollInFlight || pollingPaused) return;
+  pollInFlight = true;
+  try {
+    await poll();
+    hasPollError = false;
+    lastSuccessAt = Date.now();
+  } catch (e) {
+    hasPollError = true;
+    console.error(e);
+  } finally {
+    pollInFlight = false;
+    updateFreshness();
+  }
+}
+
+function restartPollingLoop() {
+  if (pollLoop) clearInterval(pollLoop);
+  if (pollingPaused) {
+    pollLoop = null;
+    return;
+  }
+  pollLoop = setInterval(runPoll, pollIntervalMs);
+}
+
+function setPollingPaused(paused) {
+  pollingPaused = paused;
+  updatePollControls();
+  restartPollingLoop();
+  if (!pollingPaused) runPoll();
+  updateFreshness();
+}
+
+$('pollInterval').value = String(pollIntervalMs);
+$('pollInterval').addEventListener('change', (ev) => {
+  const v = Number(ev.target.value);
+  if (!v || v === pollIntervalMs) return;
+  pollIntervalMs = v;
+  restartPollingLoop();
+  updateFreshness();
+});
+
+$('pollToggle').addEventListener('click', () => {
+  setPollingPaused(!pollingPaused);
+});
+
+updatePollControls();
+updateFreshness();
+runPoll();
+restartPollingLoop();
+setInterval(updateFreshness, 1000);
+
+// ── Live logs ──
+const logsBody = $('logsBody');
+const logSearchInput = $('logSearch');
+const autoScrollBtn = $('autoScrollBtn');
+const jumpLatestBtn = $('jumpLatestBtn');
+const logFilterButtons = Array.from(document.querySelectorAll('.log-filter'));
+
+function isNearBottom() {
+  return logsBody.scrollTop + logsBody.clientHeight >= logsBody.scrollHeight - 40;
+}
+
+function jumpToLatest() {
+  logsBody.scrollTop = logsBody.scrollHeight;
+  userScrolledUp = false;
+}
+
+function updateAutoScrollButton() {
+  autoScrollBtn.textContent = autoScrollEnabled ? 'Auto-scroll: on' : 'Auto-scroll: off';
+  autoScrollBtn.classList.toggle('active', autoScrollEnabled);
+}
+
+function shouldShowLine(el) {
+  const cls = el.dataset.cls || 'info';
+  if (Object.prototype.hasOwnProperty.call(logFilters, cls) && !logFilters[cls]) return false;
+  if (!logSearchTerm) return true;
+  return (el.dataset.msg || '').includes(logSearchTerm) || (el.dataset.ts || '').includes(logSearchTerm);
+}
+
+function applyLineFilter(el) {
+  el.style.display = shouldShowLine(el) ? '' : 'none';
+}
+
+function applyAllLogFilters() {
+  for (const el of logsBody.children) applyLineFilter(el);
+}
+
+logsBody.addEventListener('scroll', () => {
+  if (!autoScrollEnabled) return;
+  userScrolledUp = !isNearBottom();
+});
+
+logFilterButtons.forEach((btn) => {
+  btn.addEventListener('click', () => {
+    const k = btn.dataset.filter;
+    logFilters[k] = !logFilters[k];
+    btn.classList.toggle('active', logFilters[k]);
+    applyAllLogFilters();
+  });
+});
+
+logSearchInput.addEventListener('input', () => {
+  logSearchTerm = logSearchInput.value.trim().toLowerCase();
+  applyAllLogFilters();
+});
+
+autoScrollBtn.addEventListener('click', () => {
+  autoScrollEnabled = !autoScrollEnabled;
+  if (autoScrollEnabled) jumpToLatest();
+  updateAutoScrollButton();
+});
+
+jumpLatestBtn.addEventListener('click', jumpToLatest);
+updateAutoScrollButton();
+
+function addLine(d, anim) {
+  const cls = d.cls || 'info';
+  const ts = d.ts || '';
+  const msg = d.text || '';
+  const el = document.createElement('div');
+  el.className = 'log-line ' + cls + (anim ? ' fresh' : '');
+  el.dataset.cls = cls;
+  el.dataset.ts = ts.toLowerCase();
+  el.dataset.msg = msg.toLowerCase();
+  el.innerHTML = '<span class="log-ts">' + esc(ts) + '</span><span class="log-msg">' + esc(msg) + '</span>';
+  logsBody.appendChild(el);
+  applyLineFilter(el);
+  while (logsBody.children.length > MAX_LINES) logsBody.removeChild(logsBody.firstChild);
+  if (autoScrollEnabled && !userScrolledUp) jumpToLatest();
+  if (anim) setTimeout(() => el.classList.remove('fresh'), 300);
+}
+
+function esc(s) {
+  const d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML;
+}
+
+function connectWS() {
+  const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+  const ws = new WebSocket(proto + '://' + location.host + '/ws/logs');
+  let initialBacklog = true;
+
+  ws.onopen = () => {
+    $('wsDot').className = 'ws-dot on';
+    $('wsLabel').textContent = 'live';
+  };
+  ws.onclose = () => {
+    $('wsDot').className = 'ws-dot off';
+    $('wsLabel').textContent = 'reconnecting…';
+    setTimeout(connectWS, 3000);
+  };
+  ws.onerror = () => ws.close();
+  ws.onmessage = (ev) => {
+    const d = JSON.parse(ev.data);
+    addLine(d, !initialBacklog);
+    if (initialBacklog) setTimeout(() => { initialBacklog = false; }, 500);
+  };
+}
+connectWS();

--- a/deploy/monitor/static/index.html
+++ b/deploy/monitor/static/index.html
@@ -118,6 +118,33 @@
     </div>
   </div>
 
+  <!-- AmneziaWG Tunnel -->
+  <div class="tunnel-card" id="tunnelCard" style="display:none">
+    <div class="tunnel-header">
+      <div class="tunnel-icon">🛡</div>
+      <div class="tunnel-title">AmneziaWG Tunnel</div>
+      <div class="badge" id="awgBadge"><div class="pulse-dot"></div><span id="awgStatus">—</span></div>
+    </div>
+    <div class="tunnel-details">
+      <div class="tunnel-stat">
+        <span class="tunnel-lbl">Endpoint</span>
+        <span class="tunnel-val" id="awgEndpoint">—</span>
+      </div>
+      <div class="tunnel-stat">
+        <span class="tunnel-lbl">Handshake</span>
+        <span class="tunnel-val" id="awgHandshake">—</span>
+      </div>
+      <div class="tunnel-stat">
+        <span class="tunnel-lbl">↓ Received</span>
+        <span class="tunnel-val" id="awgRx">—</span>
+      </div>
+      <div class="tunnel-stat">
+        <span class="tunnel-lbl">↑ Sent</span>
+        <span class="tunnel-val" id="awgTx">—</span>
+      </div>
+    </div>
+  </div>
+
   <!-- Live logs -->
   <div class="logs-card">
     <div class="logs-header">

--- a/deploy/monitor/static/index.html
+++ b/deploy/monitor/static/index.html
@@ -165,6 +165,9 @@
   </div>
 
   <div class="footer">Built with <a href="https://ziglang.org" target="_blank">Zig</a> · proxy.sleep3r.ru</div>
+
+  <!-- Shared tooltip for all charts -->
+  <div id="chartTooltip" class="chart-tooltip"></div>
 </div>
 
 <script src="/app.js"></script>

--- a/deploy/monitor/static/index.html
+++ b/deploy/monitor/static/index.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>⚡ MTProto Proxy — Zig Monitor</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+<div class="app">
+
+  <!-- Header -->
+  <div class="header">
+    <div class="header-left">
+      <div class="zig-logo">
+        <svg viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg">
+          <path d="M46 320L126 80h104L150 320H46z" fill="#f7a41d"/>
+          <path d="M250 320L330 80h18L268 320h-18z" fill="#f7a41d" opacity="0.7"/>
+          <path d="M160 80l80 0-80 240h-80l80-240z" fill="#f7a41d" opacity="0.4"/>
+        </svg>
+      </div>
+      <h1>
+        <span class="accent">MTProto</span>Proxy
+        <span class="dim">monitor</span>
+      </h1>
+    </div>
+    <div class="header-right">
+      <div class="badge" id="statusBadge"><div class="pulse-dot"></div><span id="proxyUp">—</span></div>
+      <div class="badge data-badge syncing" id="dataBadge"><div class="pulse-dot"></div><span id="dataBadgeText">Syncing...</span></div>
+      <div class="poll-controls">
+        <label for="pollInterval">Refresh</label>
+        <select id="pollInterval" class="ui-select">
+          <option value="1000">1s</option>
+          <option value="3000" selected>3s</option>
+          <option value="5000">5s</option>
+          <option value="10000">10s</option>
+        </select>
+        <button id="pollToggle" class="ui-btn" type="button">Pause</button>
+      </div>
+      <div class="meta">PID <b id="proxyPid">—</b> · <b id="proxyRss">—</b></div>
+      <div class="meta">Uptime <b id="srvUptime">—</b></div>
+      <div class="meta">Last update <b id="lastUpdate">never</b></div>
+    </div>
+  </div>
+
+  <!-- Metrics -->
+  <div class="grid">
+    <!-- CPU -->
+    <div class="card col-3">
+      <div class="card-label">⬡ CPU</div>
+      <div class="gauge-container">
+        <div class="gauge">
+          <svg viewBox="0 0 36 36">
+            <circle class="track" cx="18" cy="18" r="15"/>
+            <circle class="fill" id="cpuArc" cx="18" cy="18" r="15"
+              stroke="var(--zig)" stroke-dasharray="94.2" stroke-dashoffset="94.2"/>
+          </svg>
+          <div class="pct" style="color:var(--zig)" id="cpuPct">0%</div>
+        </div>
+        <div>
+          <div class="card-value" style="color:var(--zig)" id="cpuVal">0<span style="font-size:18px;font-weight:400">%</span></div>
+          <div class="card-sub">utilization</div>
+        </div>
+      </div>
+      <div class="spark-wrap"><canvas id="cpuSpark"></canvas></div>
+    </div>
+
+    <!-- Memory -->
+    <div class="card col-3">
+      <div class="card-label">◈ Memory</div>
+      <div class="gauge-container">
+        <div class="gauge">
+          <svg viewBox="0 0 36 36">
+            <circle class="track" cx="18" cy="18" r="15"/>
+            <circle class="fill" id="memArc" cx="18" cy="18" r="15"
+              stroke="var(--purple)" stroke-dasharray="94.2" stroke-dashoffset="94.2"/>
+          </svg>
+          <div class="pct" style="color:var(--purple)" id="memPct">0%</div>
+        </div>
+        <div>
+          <div class="card-value" style="color:var(--purple)" id="memVal">0<span style="font-size:14px;font-weight:400"> MB</span></div>
+          <div class="card-sub" id="memSub">— / — MB</div>
+        </div>
+      </div>
+      <div class="spark-wrap"><canvas id="memSpark"></canvas></div>
+    </div>
+
+    <!-- Network -->
+    <div class="card col-6">
+      <div class="card-label">◎ Network Throughput</div>
+      <div class="chart-wrap"><canvas id="netChart"></canvas></div>
+      <div class="chart-legend">
+        <span><div class="ldot" style="background:var(--green)"></div>RX <b id="rxRate">—</b></span>
+        <span><div class="ldot" style="background:var(--zig)"></div>TX <b id="txRate">—</b></span>
+        <span style="margin-left:auto">↓<b id="rxTotal">—</b> ↑<b id="txTotal">—</b></span>
+      </div>
+    </div>
+  </div>
+
+  <!-- Proxy stats -->
+  <div class="stat-row">
+    <div class="stat-cell">
+      <div class="val" style="color:var(--green)" id="pxActive">0</div>
+      <div class="lbl">Active / <span id="pxMax">0</span></div>
+    </div>
+    <div class="stat-cell">
+      <div class="val" style="color:var(--cyan)" id="pxHs">0</div>
+      <div class="lbl">Handshakes</div>
+    </div>
+    <div class="stat-cell">
+      <div class="val" style="color:var(--text)" id="pxTotal">0</div>
+      <div class="lbl">Total Connections</div>
+    </div>
+    <div class="stat-cell">
+      <div class="val" id="pxDrops" style="color:var(--text-muted)">0</div>
+      <div class="lbl" id="pxDropLbl">Drops</div>
+    </div>
+  </div>
+
+  <!-- Live logs -->
+  <div class="logs-card">
+    <div class="logs-header">
+      <div class="title">▸ Live Logs</div>
+      <div class="ws-badge"><div class="ws-dot off" id="wsDot"></div><span id="wsLabel">connecting…</span></div>
+    </div>
+    <div class="logs-controls">
+      <div class="log-filters">
+        <button class="ui-btn log-filter active" type="button" data-filter="error">Error</button>
+        <button class="ui-btn log-filter active" type="button" data-filter="warn">Warn</button>
+        <button class="ui-btn log-filter active" type="button" data-filter="stats">Stats</button>
+      </div>
+      <input id="logSearch" class="ui-input log-search" type="search" placeholder="Search logs">
+      <button class="ui-btn active" id="autoScrollBtn" type="button">Auto-scroll: on</button>
+      <button class="ui-btn" id="jumpLatestBtn" type="button">Jump to latest</button>
+    </div>
+    <div class="logs-body" id="logsBody"></div>
+  </div>
+
+  <div class="footer">Built with <a href="https://ziglang.org" target="_blank">Zig</a> · proxy.sleep3r.ru</div>
+</div>
+
+<script src="/app.js"></script>
+</body>
+</html>

--- a/deploy/monitor/static/style.css
+++ b/deploy/monitor/static/style.css
@@ -283,6 +283,51 @@ body::after {
   color: var(--text-dim); margin-top: 6px;
 }
 
+/* ── Tunnel card ── */
+.tunnel-card {
+  background: var(--card);
+  backdrop-filter: blur(24px);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  margin-bottom: 14px;
+  overflow: hidden;
+  transition: border-color 0.3s;
+}
+.tunnel-card:hover { border-color: var(--card-hover); }
+.tunnel-header {
+  padding: 16px 24px;
+  display: flex; align-items: center; gap: 12px;
+  border-bottom: 1px solid rgba(247,164,29,0.04);
+}
+.tunnel-icon { font-size: 18px; }
+.tunnel-title {
+  font-size: 12px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 1.4px;
+  color: var(--text-dim);
+  flex: 1;
+}
+.tunnel-details {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  gap: 1px; background: rgba(247,164,29,0.03);
+}
+.tunnel-stat {
+  background: var(--card);
+  padding: 14px 24px;
+  display: flex; flex-direction: column; gap: 4px;
+}
+.tunnel-lbl {
+  font-size: 10px; font-weight: 500;
+  text-transform: uppercase; letter-spacing: 1px;
+  color: var(--text-muted);
+}
+.tunnel-val {
+  font-size: 13px; font-weight: 600;
+  font-family: 'JetBrains Mono', monospace;
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+}
+.app.stale .tunnel-card { opacity: 0.62; }
+
 /* ── Live logs ── */
 .logs-card {
   background: var(--card);

--- a/deploy/monitor/static/style.css
+++ b/deploy/monitor/static/style.css
@@ -328,6 +328,23 @@ body::after {
 }
 .app.stale .tunnel-card { opacity: 0.62; }
 
+/* ── Tooltips ── */
+.chart-tooltip {
+  position: absolute; pointer-events: none;
+  background: rgba(18, 22, 30, 0.9);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(247,164,29,0.15);
+  border-radius: 8px; padding: 6px 10px;
+  font-size: 11px; font-family: 'JetBrains Mono', monospace;
+  color: var(--text); z-index: 100;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+  opacity: 0; transition: opacity 0.15s;
+  display: flex; flex-direction: column; gap: 4px;
+}
+.chart-tooltip.visible { opacity: 1; }
+.tooltip-ts { color: var(--text-dim); font-size: 10px; }
+.tooltip-val { font-weight: 600; }
+
 /* ── Live logs ── */
 .logs-card {
   background: var(--card);

--- a/deploy/monitor/static/style.css
+++ b/deploy/monitor/static/style.css
@@ -330,7 +330,7 @@ body::after {
 
 /* ── Tooltips ── */
 .chart-tooltip {
-  position: absolute; pointer-events: none;
+  position: fixed; pointer-events: none;
   background: rgba(18, 22, 30, 0.9);
   backdrop-filter: blur(8px);
   border: 1px solid rgba(247,164,29,0.15);

--- a/deploy/monitor/static/style.css
+++ b/deploy/monitor/static/style.css
@@ -1,0 +1,394 @@
+:root {
+  --bg: #0a0c10;
+  --card: rgba(18, 22, 30, 0.75);
+  --card-border: rgba(247, 164, 29, 0.08);
+  --card-hover: rgba(247, 164, 29, 0.15);
+  --text: #e8ecf4;
+  --text-dim: #7c8698;
+  --text-muted: #4a5568;
+  --zig: #f7a41d;
+  --zig-dim: rgba(247, 164, 29, 0.15);
+  --green: #34d399;
+  --blue: #60a5fa;
+  --purple: #a78bfa;
+  --cyan: #22d3ee;
+  --amber: #fbbf24;
+  --red: #f87171;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  font-family: 'Inter', -apple-system, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+body::before {
+  content: ''; position: fixed;
+  top: -30%; left: -10%;
+  width: 60%; height: 60%;
+  background: radial-gradient(ellipse, rgba(247,164,29,0.04) 0%, transparent 70%);
+  pointer-events: none; z-index: 0;
+}
+body::after {
+  content: ''; position: fixed;
+  bottom: -20%; right: -10%;
+  width: 50%; height: 50%;
+  background: radial-gradient(ellipse, rgba(247,164,29,0.03) 0%, transparent 70%);
+  pointer-events: none; z-index: 0;
+}
+
+.app {
+  position: relative; z-index: 1;
+  max-width: 1400px; margin: 0 auto; padding: 0 28px;
+}
+
+/* ── Header ── */
+.header {
+  padding: 28px 0 20px;
+  display: flex; align-items: center; justify-content: space-between;
+  border-bottom: 1px solid rgba(247,164,29,0.06);
+  margin-bottom: 24px;
+}
+.header-left { display: flex; align-items: center; gap: 16px; }
+.zig-logo { width: 44px; height: 44px; }
+.zig-logo svg { width: 100%; height: 100%; }
+.header h1 {
+  font-size: 21px; font-weight: 700; letter-spacing: -0.5px;
+  display: flex; align-items: baseline; gap: 8px;
+}
+.header h1 .accent { color: var(--zig); }
+.header h1 .dim { color: var(--text-dim); font-weight: 400; font-size: 15px; }
+.header-right {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.badge {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 6px 16px; border-radius: 100px;
+  font-size: 12px; font-weight: 600;
+  background: rgba(52,211,153,0.08);
+  border: 1px solid rgba(52,211,153,0.15);
+  color: var(--green);
+}
+.badge.off { background: rgba(248,113,113,0.08); border-color: rgba(248,113,113,0.15); color: var(--red); }
+
+.data-badge {
+  background: rgba(96,165,250,0.08);
+  border-color: rgba(96,165,250,0.15);
+  color: var(--blue);
+}
+.data-badge.ok {
+  background: rgba(52,211,153,0.08);
+  border-color: rgba(52,211,153,0.15);
+  color: var(--green);
+}
+.data-badge.stale {
+  background: rgba(248,113,113,0.08);
+  border-color: rgba(248,113,113,0.2);
+  color: var(--red);
+}
+.data-badge.paused {
+  background: rgba(251,191,36,0.08);
+  border-color: rgba(251,191,36,0.18);
+  color: var(--amber);
+}
+
+.poll-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(247,164,29,0.1);
+  background: rgba(10,12,16,0.35);
+}
+
+.poll-controls label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1.1px;
+  color: var(--text-dim);
+}
+
+.ui-select,
+.ui-btn,
+.ui-input {
+  border: 1px solid rgba(247,164,29,0.16);
+  background: rgba(16,20,28,0.8);
+  color: var(--text);
+  border-radius: 8px;
+  font-family: 'Inter', -apple-system, sans-serif;
+  font-size: 11px;
+}
+
+.ui-select {
+  height: 28px;
+  padding: 0 8px;
+}
+
+.ui-btn {
+  height: 28px;
+  padding: 0 10px;
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s, background 0.2s;
+}
+
+.ui-btn.active {
+  color: var(--zig);
+  border-color: rgba(247,164,29,0.35);
+  background: rgba(247,164,29,0.08);
+}
+
+.ui-input {
+  height: 28px;
+  padding: 0 10px;
+}
+
+.ui-btn:hover,
+.ui-select:hover,
+.ui-input:hover {
+  border-color: rgba(247,164,29,0.3);
+}
+
+.ui-btn:focus-visible,
+.ui-select:focus-visible,
+.ui-input:focus-visible {
+  outline: 1px solid rgba(247,164,29,0.45);
+  outline-offset: 1px;
+}
+
+.pulse-dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 6px currentColor;
+  animation: pulse 2.5s ease infinite;
+}
+@keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.4} }
+
+.meta { font-size: 12px; color: var(--text-dim); }
+.meta b { color: var(--text); font-weight: 600; }
+
+/* ── Grid ── */
+.grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 14px; margin-bottom: 14px; }
+.col-3 { grid-column: span 3; }
+.col-6 { grid-column: span 6; }
+
+/* ── Card ── */
+.card {
+  background: var(--card);
+  backdrop-filter: blur(24px);
+  border: 1px solid var(--card-border);
+  border-radius: 18px;
+  padding: 22px 24px;
+  position: relative; overflow: hidden;
+  transition: border-color 0.3s, box-shadow 0.3s;
+}
+.card:hover {
+  border-color: var(--card-hover);
+  box-shadow: 0 0 30px rgba(247,164,29,0.04);
+}
+.card::before {
+  content: ''; position: absolute;
+  top: 0; left: 0; right: 0; height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(247,164,29,0.1), transparent);
+}
+
+.app.stale .card,
+.app.stale .stat-cell {
+  opacity: 0.62;
+}
+
+.card-label {
+  font-size: 10px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 1.8px;
+  color: var(--text-dim); margin-bottom: 16px;
+  display: flex; align-items: center; gap: 8px;
+}
+.card-value {
+  font-size: 38px; font-weight: 800;
+  letter-spacing: -2px; line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+.card-sub { font-size: 11px; color: var(--text-muted); margin-top: 6px; }
+
+/* ── Gauge ── */
+.gauge-container { display: flex; align-items: center; gap: 22px; }
+.gauge { width: 90px; height: 90px; position: relative; flex-shrink: 0; }
+.gauge svg { transform: rotate(-90deg); }
+.gauge circle { fill: none; stroke-linecap: round; }
+.gauge .track { stroke: rgba(247,164,29,0.06); stroke-width: 5; }
+.gauge .fill { stroke-width: 5; transition: stroke-dashoffset 1s cubic-bezier(0.4,0,0.2,1); }
+.gauge .pct {
+  position: absolute; top: 50%; left: 50%;
+  transform: translate(-50%,-50%);
+  font-size: 17px; font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Sparkline ── */
+.spark-wrap {
+  height: 80px;
+  margin-top: 14px;
+  position: relative;
+  border-top: 1px solid rgba(247,164,29,0.04);
+  padding-top: 6px;
+}
+.spark-wrap canvas { width: 100% !important; height: 100% !important; }
+
+/* ── Network chart ── */
+.chart-wrap {
+  height: 160px;
+  position: relative;
+  margin-top: 6px;
+  padding-top: 8px;
+}
+.chart-wrap canvas { width: 100% !important; height: 100% !important; }
+
+.chart-legend {
+  display: flex; gap: 18px; margin-top: 8px;
+  font-size: 11px; color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+}
+.chart-legend span { display: flex; align-items: center; gap: 6px; }
+.ldot { width: 10px; height: 3px; border-radius: 2px; }
+
+/* ── Stats row ── */
+.stat-row {
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 1px;
+  background: rgba(247,164,29,0.06); border-radius: 16px; overflow: hidden;
+  margin-bottom: 14px;
+}
+.stat-cell {
+  background: var(--card);
+  backdrop-filter: blur(24px);
+  padding: 20px; text-align: center;
+  transition: background 0.2s;
+}
+.stat-cell:hover { background: rgba(18,22,30,0.9); }
+.stat-cell .val {
+  font-size: 30px; font-weight: 800; letter-spacing: -1px;
+  font-variant-numeric: tabular-nums;
+}
+.stat-cell .lbl {
+  font-size: 10px; font-weight: 500;
+  text-transform: uppercase; letter-spacing: 1.2px;
+  color: var(--text-dim); margin-top: 6px;
+}
+
+/* ── Live logs ── */
+.logs-card {
+  background: var(--card);
+  backdrop-filter: blur(24px);
+  border: 1px solid var(--card-border);
+  border-radius: 18px;
+  overflow: hidden;
+  margin-bottom: 32px;
+}
+.logs-header {
+  padding: 14px 24px;
+  display: flex; align-items: center; justify-content: space-between;
+  border-bottom: 1px solid rgba(247,164,29,0.06);
+}
+.logs-header .title {
+  font-size: 10px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 1.8px;
+  color: var(--text-dim);
+  display: flex; align-items: center; gap: 8px;
+}
+.logs-header .ws-badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 11px; color: var(--text-muted);
+}
+
+.logs-controls {
+  padding: 10px 24px;
+  border-bottom: 1px solid rgba(247,164,29,0.06);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.log-filters {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.log-filter:not(.active) {
+  color: var(--text-dim);
+  border-color: rgba(247,164,29,0.1);
+  background: rgba(16,20,28,0.35);
+}
+
+.log-search {
+  width: 220px;
+  max-width: 100%;
+}
+
+.ws-dot { width: 6px; height: 6px; border-radius: 50%; }
+.ws-dot.on { background: var(--green); box-shadow: 0 0 6px var(--green); }
+.ws-dot.off { background: var(--amber); }
+
+.logs-body {
+  height: 300px; overflow-y: auto;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11.5px; line-height: 1.8;
+  padding: 8px 0;
+  scroll-behavior: smooth;
+}
+.logs-body::-webkit-scrollbar { width: 5px; }
+.logs-body::-webkit-scrollbar-track { background: transparent; }
+.logs-body::-webkit-scrollbar-thumb { background: rgba(247,164,29,0.1); border-radius: 3px; }
+
+.log-line {
+  padding: 1px 24px;
+  display: flex; gap: 14px;
+  transition: background 0.12s;
+}
+.log-line:hover { background: rgba(247,164,29,0.03); }
+.log-ts {
+  color: var(--text-muted); flex-shrink: 0;
+  user-select: none; font-size: 10px; line-height: 1.8; opacity: 0.7;
+}
+.log-msg { word-break: break-all; }
+.log-line.info  .log-msg { color: var(--text-dim); }
+.log-line.stats .log-msg { color: var(--zig); }
+.log-line.drops .log-msg { color: var(--amber); }
+.log-line.error .log-msg { color: var(--red); font-weight: 500; }
+.log-line.warn  .log-msg { color: var(--amber); }
+.log-line.fresh { animation: slideIn 0.25s ease; }
+@keyframes slideIn { from{opacity:0;transform:translateY(-3px)} to{opacity:1;transform:none} }
+
+/* ── Footer ── */
+.footer {
+  text-align: center; padding: 0 0 24px;
+  font-size: 11px; color: var(--text-muted);
+}
+.footer a { color: var(--zig); text-decoration: none; }
+
+/* ── Responsive ── */
+@media (max-width: 1000px) {
+  .grid { grid-template-columns: repeat(6, 1fr); }
+  .col-3 { grid-column: span 3; }
+  .col-6 { grid-column: span 6; }
+  .stat-row { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 640px) {
+  .grid { grid-template-columns: 1fr; }
+  .col-3, .col-6 { grid-column: span 1; }
+  .stat-row { grid-template-columns: repeat(2, 1fr); }
+  .header { flex-direction: column; gap: 12px; align-items: flex-start; }
+  .header-right { width: 100%; justify-content: flex-start; }
+  .poll-controls { width: 100%; }
+  .logs-controls { padding: 10px 14px; }
+  .log-search { width: 100%; }
+}


### PR DESCRIPTION
## Monitoring Dashboard

Lightweight, Zig-themed web dashboard for real-time server monitoring. Runs as a separate `systemd` service (~30 MB RAM) bound to `127.0.0.1:61208` — no ports exposed.

### Features
- **Interactive Charts** — glassmorphism tooltips with exact timestamp and value on hover
- **CPU & Memory** — live ring gauges + sparkline history (0–100% Y-axis)
- **Network** — realtime RX/TX throughput graph with X-axis exact timestamps — realtime RX/TX throughput chart with auto-scaling Y-axis
- **Proxy stats** — active connections, handshakes, total served, drops
- **AmneziaWG** — optional tunnel tracking (endpoint, handshakes, transfer)
- **Live logs** — WebSocket-streamed `journalctl` with color-coded levels, search & filters
- **Poll controls** — adjustable refresh (1s–10s), pause/resume, freshness indicator

### Stack
- **Backend:** Python FastAPI + psutil + websockets
- **Frontend:** Vanilla HTML/CSS/JS (Inter + JetBrains Mono, canvas charts)
- **Deploy:** `make deploy-monitor SERVER=<ip>` → installs deps, creates systemd service
- **Access:** `make monitor SERVER=<ip>` → SSH tunnel, then `http://localhost:61208`

### Files
```
deploy/monitor/
├── server.py          # FastAPI API + WebSocket log streaming
├── install.sh         # Server-side install script
└── static/
    ├── index.html     # Dashboard markup
    ├── style.css      # Zig-orange dark theme
    └── app.js         # Charts, gauges, live logs
```

### README
- New **Monitoring** section with deploy & access instructions
- Added `deploy-monitor` and `monitor` to Make targets table