### PR TITLE
fix(proxy): harden relay security and reduce middleproxy memory

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -11,6 +11,9 @@ pub const Config = struct {
     /// Route regular DC traffic via Telegram MiddleProxy transport.
     /// Mirrors telemt's [general].use_middle_proxy behavior.
     use_middle_proxy: bool = false,
+    /// Force media-path traffic (DC203 / negative dc_idx) through MiddleProxy,
+    /// even when use_middle_proxy is false.
+    force_media_middle_proxy: bool = true,
     port: u16 = 443,
     /// TCP listen(2) backlog for client-facing sockets
     backlog: u32 = 4096,
@@ -134,6 +137,8 @@ pub const Config = struct {
                 } else if (in_general_section) {
                     if (std.mem.eql(u8, key, "use_middle_proxy")) {
                         cfg.use_middle_proxy = std.mem.eql(u8, value, "true");
+                    } else if (std.mem.eql(u8, key, "force_media_middle_proxy")) {
+                        cfg.force_media_middle_proxy = std.mem.eql(u8, value, "true");
                     } else if (std.mem.eql(u8, key, "fast_mode")) {
                         // telemt compatibility: [general].fast_mode
                         cfg.fast_mode = std.mem.eql(u8, value, "true");

--- a/src/config.zig
+++ b/src/config.zig
@@ -34,7 +34,9 @@ pub const Config = struct {
     drs: bool = false,
     /// Fast mode: skip S2C encryption by passing client keys to DC directly
     fast_mode: bool = false,
-    /// Per-connection MiddleProxy stream buffers size, in KiB (applies to 4 buffers).
+    /// MiddleProxy stream buffer size in KiB.
+    /// In current design, each connection keeps 2 such buffers and EventLoop
+    /// keeps 2 shared scratch buffers.
     /// Minimum 1024 recommended — lower values cause MiddleProxyBufferOverflow on media
     /// downloads (Stories, video messages) through middle proxy.
     middleproxy_buffer_kb: u32 = 1024,
@@ -67,11 +69,12 @@ pub const Config = struct {
         }
         if (self.use_middle_proxy and self.max_connections > 2000) {
             const log = std.log.scoped(.config);
-            const mem_per_conn_mb = (self.middleProxyBufferBytes() * 4) / (1024 * 1024);
+            const mem_per_conn_mb = (self.middleProxyBufferBytes() * 2) / (1024 * 1024);
+            const shared_mb = (self.middleProxyBufferBytes() * 2) / (1024 * 1024);
             log.warn(
                 "max_connections={d} with middleproxy_buffer_kb={d} may require " ++
-                    "up to {d} MB of RAM at full capacity. Ensure your VPS has sufficient memory.",
-                .{ self.max_connections, self.middleproxy_buffer_kb, mem_per_conn_mb * self.max_connections },
+                    "up to {d} MB + {d} MB shared RAM at full capacity. Ensure your VPS has sufficient memory.",
+                .{ self.max_connections, self.middleproxy_buffer_kb, mem_per_conn_mb * self.max_connections, shared_mb },
             );
         }
     }

--- a/src/crypto/crypto.zig
+++ b/src/crypto/crypto.zig
@@ -94,13 +94,20 @@ pub const AesCtr = struct {
 /// Unlike CTR, CBC is NOT symmetric.
 pub const AesCbc = struct {
     key: [32]u8,
+    /// Cached expanded AES contexts (avoid re-computing schedule per call).
+    enc_ctx: EncCtx,
+    dec_ctx: DecCtx,
     iv: [16]u8,
 
     const block_size = 16;
+    const EncCtx = @TypeOf(Aes256.initEnc([_]u8{0} ** 32));
+    const DecCtx = @TypeOf(Aes256.initDec([_]u8{0} ** 32));
 
     pub fn init(key: *const [32]u8, iv: *const [16]u8) AesCbc {
         return .{
             .key = key.*,
+            .enc_ctx = Aes256.initEnc(key.*),
+            .dec_ctx = Aes256.initDec(key.*),
             .iv = iv.*,
         };
     }
@@ -119,7 +126,6 @@ pub const AesCbc = struct {
         if (data.len % block_size != 0) return error.UnalignedData;
         if (data.len == 0) return;
 
-        const ctx = Aes256.initEnc(self.key);
         var prev: [16]u8 = self.iv;
 
         var offset: usize = 0;
@@ -131,7 +137,7 @@ pub const AesCbc = struct {
             }
             // Encrypt
             var encrypted: [16]u8 = undefined;
-            ctx.encrypt(&encrypted, block);
+            self.enc_ctx.encrypt(&encrypted, block);
             block.* = encrypted;
             prev = encrypted;
         }
@@ -146,7 +152,6 @@ pub const AesCbc = struct {
         if (data.len % block_size != 0) return error.UnalignedData;
         if (data.len == 0) return;
 
-        const ctx = Aes256.initDec(self.key);
         var prev: [16]u8 = self.iv;
 
         var offset: usize = 0;
@@ -155,7 +160,7 @@ pub const AesCbc = struct {
             const saved = block.*;
             // Decrypt
             var decrypted: [16]u8 = undefined;
-            ctx.decrypt(&decrypted, block);
+            self.dec_ctx.decrypt(&decrypted, block);
             block.* = decrypted;
             // XOR with previous ciphertext
             for (0..16) |j| {
@@ -171,6 +176,8 @@ pub const AesCbc = struct {
     pub fn wipe(self: *AesCbc) void {
         std.crypto.secureZero(u8, &self.key);
         std.crypto.secureZero(u8, &self.iv);
+        std.crypto.secureZero(u8, std.mem.asBytes(&self.enc_ctx));
+        std.crypto.secureZero(u8, std.mem.asBytes(&self.dec_ctx));
     }
 };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -344,6 +344,15 @@ pub fn main() !void {
     // Apply runtime log level from config
     runtime_log_level = cfg.log_level;
 
+    if (!std.crypto.core.aes.has_hardware_support and (builtin.cpu.arch == .x86_64 or builtin.cpu.arch == .aarch64)) {
+        const log_main = std.log.scoped(.config);
+        log_main.warn(
+            "AES backend is software-only for this build/target. MiddleProxy video traffic will be CPU-heavy. " ++
+                "Rebuild with CPU features enabled (example: -Dcpu=native or -Dcpu=x86_64_v3).",
+            .{},
+        );
+    }
+
     // Auto-clamp max_connections to RAM-safe estimate (unless explicitly opted out)
     if (detectTotalRamBytes(allocator)) |total_ram| {
         const est = estimateCapacity(&cfg, total_ram);

--- a/src/main.zig
+++ b/src/main.zig
@@ -177,20 +177,27 @@ fn detectTotalRamBytes(allocator: std.mem.Allocator) ?u64 {
 fn estimateCapacity(cfg: *const config.Config, total_ram_bytes: u64) CapacityEstimate {
     // Approximate per-connection user-space working set in the epoll model:
     // - preallocated slot state and small relay buffers
-    // - optional middle-proxy stream buffers (4 buffers)
+    // - optional middle-proxy stream buffers (2 per-connection buffers)
     // - allocator/socket bookkeeping cushion
     const tls_working_bytes: u64 = @intCast(6 * 1024);
-    const middleproxy_bytes: u64 = if (cfg.use_middle_proxy)
-        @intCast(cfg.middleProxyBufferBytes() * 4)
+    const middleproxy_per_conn_bytes: u64 = if (cfg.use_middle_proxy)
+        @intCast(cfg.middleProxyBufferBytes() * 2)
+    else
+        0;
+    // Event loop also keeps 2 shared scratch buffers for middle-proxy
+    // encapsulate/decapsulate temporary output.
+    const middleproxy_shared_bytes: u64 = if (cfg.use_middle_proxy)
+        @intCast(cfg.middleProxyBufferBytes() * 2)
     else
         0;
     const overhead_bytes: u64 = 2 * 1024;
-    const per_conn_bytes = tls_working_bytes + middleproxy_bytes + overhead_bytes;
+    const per_conn_bytes = tls_working_bytes + middleproxy_per_conn_bytes + overhead_bytes;
 
     // Keep safety headroom for kernel TCP memory, page cache, and baseline process state.
     const usable_bytes = (total_ram_bytes * 70) / 100;
     const reserve_bytes = @max(@as(u64, 256 * 1024 * 1024), (total_ram_bytes * 10) / 100);
-    const budget_bytes = if (usable_bytes > reserve_bytes) usable_bytes - reserve_bytes else 0;
+    const fixed_overhead_bytes = reserve_bytes + middleproxy_shared_bytes;
+    const budget_bytes = if (usable_bytes > fixed_overhead_bytes) usable_bytes - fixed_overhead_bytes else 0;
 
     const raw_cap = if (per_conn_bytes > 0) budget_bytes / per_conn_bytes else 0;
     const safe_connections_u64 = @max(@as(u64, 32), @min(raw_cap, @as(u64, std.math.maxInt(u32))));

--- a/src/main.zig
+++ b/src/main.zig
@@ -79,25 +79,44 @@ fn writeRaw(s: []const u8) void {
 
 // ============= Public IP Detection =============
 
+fn fetchUrlBytes(allocator: std.mem.Allocator, url: []const u8) ![]u8 {
+    const uri = try std.Uri.parse(url);
+
+    var client: std.http.Client = .{ .allocator = allocator };
+    defer client.deinit();
+
+    var req = try client.request(.GET, uri, .{
+        .redirect_behavior = @enumFromInt(3),
+        .keep_alive = false,
+        .headers = .{
+            .accept_encoding = .{ .override = "identity" },
+        },
+    });
+    defer req.deinit();
+
+    try req.sendBodiless();
+
+    var redirect_buf: [8 * 1024]u8 = undefined;
+    var response = try req.receiveHead(&redirect_buf);
+    if (response.head.status.class() != .success) return error.HttpRequestFailed;
+
+    var transfer_buf: [4 * 1024]u8 = undefined;
+    const reader = response.reader(&transfer_buf);
+    return reader.allocRemaining(allocator, .limited(64 * 1024));
+}
+
 /// Try to detect the server's public IP address via external services.
 /// Returns the IP string (caller owns memory) or null on failure.
 fn detectPublicIp(allocator: std.mem.Allocator) ?[]const u8 {
     // Try multiple services in order
-    const services = [_][]const []const u8{
-        &.{ "curl", "-s", "--max-time", "3", "https://ifconfig.me" },
-        &.{ "curl", "-s", "--max-time", "3", "https://api.ipify.org" },
-        &.{ "curl", "-s", "--max-time", "3", "https://icanhazip.com" },
+    const services = [_][]const u8{
+        "https://ifconfig.me",
+        "https://api.ipify.org",
+        "https://icanhazip.com",
     };
 
-    for (services) |argv| {
-        const result = std.process.Child.run(.{
-            .allocator = allocator,
-            .argv = argv,
-        }) catch continue;
-
-        defer allocator.free(result.stderr);
-
-        const stdout = result.stdout;
+    for (services) |url| {
+        const stdout = fetchUrlBytes(allocator, url) catch continue;
         // Trim whitespace/newlines
         const trimmed = std.mem.trim(u8, stdout, &[_]u8{ ' ', '\t', '\n', '\r' });
         if (trimmed.len == 0 or trimmed.len > 45) {

--- a/src/protocol/middleproxy.zig
+++ b/src/protocol/middleproxy.zig
@@ -392,23 +392,18 @@ pub const MiddleProxyContext = struct {
         }
 
         var out_pos: usize = 0;
+        var parse_pos: usize = 0;
 
         // Parse fully decrypted MTProto frames.
         // Mirrors telemt behavior: parse by frame_len, treat 0x04 words as NO-OP,
         // keep decrypt stream running continuously across arbitrary read boundaries.
-        while (self.s2c_decrypted_len >= 4) {
-            const frame_len = std.mem.readInt(u32, self.s2c_buf[0..4], .little);
+        while (self.s2c_decrypted_len - parse_pos >= 4) {
+            const frame_len = std.mem.readInt(u32, self.s2c_buf[parse_pos..][0..4], .little);
 
             // MTProto CBC stream may contain standalone NO-OP padding words
             // (0x04 00 00 00). Python reference reader skips them.
             if (frame_len == 4) {
-                if (self.s2c_len < 4 or self.s2c_decrypted_len < 4) break;
-                const remaining_noop = self.s2c_len - 4;
-                if (remaining_noop > 0) {
-                    std.mem.copyForwards(u8, self.s2c_buf[0..remaining_noop], self.s2c_buf[4..self.s2c_len]);
-                }
-                self.s2c_len = remaining_noop;
-                self.s2c_decrypted_len -= 4;
+                parse_pos += 4;
                 continue;
             }
 
@@ -421,20 +416,21 @@ pub const MiddleProxyContext = struct {
                 break;
             }
 
-            if (self.s2c_decrypted_len < frame_len) {
+            if (self.s2c_decrypted_len - parse_pos < frame_len) {
                 break; // Not enough decrypted data yet
             }
 
-            const expected_checksum = std.mem.readInt(u32, self.s2c_buf[frame_len - 4 ..][0..4], .little);
-            const computed_checksum = crc32(self.s2c_buf[0 .. frame_len - 4]);
+            const frame_end = parse_pos + frame_len;
+            const expected_checksum = std.mem.readInt(u32, self.s2c_buf[frame_end - 4 ..][0..4], .little);
+            const computed_checksum = crc32(self.s2c_buf[parse_pos .. frame_end - 4]);
             if (expected_checksum != computed_checksum) return error.BadMiddleProxyChecksum;
 
-            const frame_seq_no = std.mem.readInt(i32, self.s2c_buf[4..8], .little);
+            const frame_seq_no = std.mem.readInt(i32, self.s2c_buf[parse_pos + 4 ..][0..4], .little);
             if (frame_seq_no != self.read_seq_no) return error.BadMiddleProxySeqNo;
             self.read_seq_no += 1;
 
             // Payload is after Length (4) and SeqNo (4), and before CRC32 (4)
-            const payload = self.s2c_buf[8 .. frame_len - 4];
+            const payload = self.s2c_buf[parse_pos + 8 .. frame_end - 4];
 
             if (payload.len >= 16 and std.mem.eql(u8, payload[0..4], &rpc_simple_ack)) {
                 // RPC_SIMPLE_ACK format: type(4) + conn_id(8) + confirm(4)
@@ -495,11 +491,16 @@ pub const MiddleProxyContext = struct {
             }
             // Ignore other RPC types (e.g. RPC_SIMPLE_ACK, RPC_CLOSE_EXT)
 
-            // Shift buffer
-            const remaining = self.s2c_len - frame_len;
-            std.mem.copyForwards(u8, self.s2c_buf[0..remaining], self.s2c_buf[frame_len..self.s2c_len]);
+            parse_pos = frame_end;
+        }
+
+        if (parse_pos > 0 and parse_pos <= self.s2c_len) {
+            const remaining = self.s2c_len - parse_pos;
+            if (remaining > 0) {
+                std.mem.copyForwards(u8, self.s2c_buf[0..remaining], self.s2c_buf[parse_pos..self.s2c_len]);
+            }
             self.s2c_len = remaining;
-            self.s2c_decrypted_len -= frame_len;
+            self.s2c_decrypted_len -= parse_pos;
         }
 
         return out_buf[0..out_pos];

--- a/src/protocol/middleproxy.zig
+++ b/src/protocol/middleproxy.zig
@@ -385,10 +385,14 @@ pub const MiddleProxyContext = struct {
         @memcpy(self.s2c_buf[self.s2c_len .. self.s2c_len + dc_chunk.len], dc_chunk);
         self.s2c_len += dc_chunk.len;
 
-        // Decrypt any new full 16-byte blocks
-        while (self.s2c_decrypted_len + 16 <= self.s2c_len) {
-            try self.decryptor.decryptInPlace(self.s2c_buf[self.s2c_decrypted_len .. self.s2c_decrypted_len + 16]);
-            self.s2c_decrypted_len += 16;
+        // Decrypt any newly arrived full 16-byte blocks in one batch.
+        const undec_len = self.s2c_len - self.s2c_decrypted_len;
+        const decrypt_len = undec_len - (undec_len % 16);
+        if (decrypt_len > 0) {
+            const start = self.s2c_decrypted_len;
+            const end = start + decrypt_len;
+            try self.decryptor.decryptInPlace(self.s2c_buf[start..end]);
+            self.s2c_decrypted_len = end;
         }
 
         var out_pos: usize = 0;

--- a/src/protocol/middleproxy.zig
+++ b/src/protocol/middleproxy.zig
@@ -117,12 +117,10 @@ pub const MiddleProxyContext = struct {
     s2c_buf: []u8,
     s2c_len: usize = 0,
     s2c_decrypted_len: usize = 0,
-    s2c_out_buf: []u8,
 
     // For C2S fragment parsing
     c2s_buf: []u8,
     c2s_len: usize = 0,
-    c2s_out_buf: []u8,
 
     pub const default_stream_buffer_size: usize = 128 * 1024;
 
@@ -192,14 +190,8 @@ pub const MiddleProxyContext = struct {
         const s2c_buf = try allocator.alloc(u8, buffer_size);
         errdefer allocator.free(s2c_buf);
 
-        const s2c_out_buf = try allocator.alloc(u8, buffer_size);
-        errdefer allocator.free(s2c_out_buf);
-
         const c2s_buf = try allocator.alloc(u8, buffer_size);
         errdefer allocator.free(c2s_buf);
-
-        const c2s_out_buf = try allocator.alloc(u8, buffer_size);
-        errdefer allocator.free(c2s_out_buf);
 
         return .{
             .encryptor = encryptor,
@@ -212,23 +204,19 @@ pub const MiddleProxyContext = struct {
             .proto_tag = proto_tag,
             .ad_tag = ad_tag,
             .s2c_buf = s2c_buf,
-            .s2c_out_buf = s2c_out_buf,
             .c2s_buf = c2s_buf,
-            .c2s_out_buf = c2s_out_buf,
         };
     }
 
     pub fn deinit(self: *MiddleProxyContext, allocator: std.mem.Allocator) void {
         allocator.free(self.s2c_buf);
-        allocator.free(self.s2c_out_buf);
         allocator.free(self.c2s_buf);
-        allocator.free(self.c2s_out_buf);
     }
 
     /// Takes arbitrary bytes from the client stream, wraps them in RPC_PROXY_REQ,
     /// frames them into MTProtoFrame(s), encrypts with AES-CBC, and stores them in `out_buf`.
     /// Returns the number of bytes written to `out_buf` (which must be sent to the DC).
-    pub fn encapsulateC2S(self: *MiddleProxyContext, client_data: []const u8) ![]const u8 {
+    pub fn encapsulateC2S(self: *MiddleProxyContext, client_data: []const u8, out_buf: []u8) ![]const u8 {
         if (self.c2s_len + client_data.len > self.c2s_buf.len) return error.MiddleProxyBufferOverflow;
         @memcpy(self.c2s_buf[self.c2s_len .. self.c2s_len + client_data.len], client_data);
         self.c2s_len += client_data.len;
@@ -281,7 +269,7 @@ pub const MiddleProxyContext = struct {
             const payload = self.c2s_buf[pos + header_len .. pos + header_len + actual_payload_len];
 
             // 3. Pass is_quickack to the encapsulator
-            const written = try self.encapsulateSingleMessageC2S(payload, is_quickack, self.c2s_out_buf[total_written..]);
+            const written = try self.encapsulateSingleMessageC2S(payload, is_quickack, out_buf[total_written..]);
             total_written += written;
 
             // Note: Advance `pos` by the FULL payload_len so we safely consume/discard the padding bytes
@@ -296,10 +284,12 @@ pub const MiddleProxyContext = struct {
             self.c2s_len = remaining;
         }
 
-        return self.c2s_out_buf[0..total_written];
+        return out_buf[0..total_written];
     }
 
     pub fn encapsulateSingleMessageC2S(self: *MiddleProxyContext, client_data: []const u8, is_quickack: bool, out_buf: []u8) !usize {
+        if ((client_data.len & 3) != 0) return error.InvalidPayloadLength;
+
         var flags = Flag.magic | Flag.extmode2;
         if (self.ad_tag != null) {
             flags |= Flag.has_ad_tag;
@@ -390,7 +380,7 @@ pub const MiddleProxyContext = struct {
 
     /// Takes raw AES-CBC bytes from DC, decrypts them block by block, parses MTProtoFrames,
     /// strips RPC_PROXY_ANS, and writes the inner payload into `out_buf`.
-    pub fn decapsulateS2C(self: *MiddleProxyContext, dc_chunk: []const u8) ![]u8 {
+    pub fn decapsulateS2C(self: *MiddleProxyContext, dc_chunk: []const u8, out_buf: []u8) ![]u8 {
         if (self.s2c_len + dc_chunk.len > self.s2c_buf.len) return error.MiddleProxyBufferOverflow;
         @memcpy(self.s2c_buf[self.s2c_len .. self.s2c_len + dc_chunk.len], dc_chunk);
         self.s2c_len += dc_chunk.len;
@@ -449,8 +439,8 @@ pub const MiddleProxyContext = struct {
             if (payload.len >= 16 and std.mem.eql(u8, payload[0..4], &rpc_simple_ack)) {
                 // RPC_SIMPLE_ACK format: type(4) + conn_id(8) + confirm(4)
                 const confirm = payload[12..16];
-                if (out_pos + confirm.len > self.s2c_out_buf.len) return error.OutBufOverflow;
-                @memcpy(self.s2c_out_buf[out_pos .. out_pos + confirm.len], confirm);
+                if (out_pos + confirm.len > out_buf.len) return error.OutBufOverflow;
+                @memcpy(out_buf[out_pos .. out_pos + confirm.len], confirm);
                 out_pos += confirm.len;
             } else if (payload.len >= 4 and std.mem.eql(u8, payload[0..4], &rpc_close_ext)) {
                 return error.ConnectionReset;
@@ -490,16 +480,16 @@ pub const MiddleProxyContext = struct {
                     },
                 }
 
-                if (out_pos + header_len + conn_data.len + pad_len > self.s2c_out_buf.len) return error.OutBufOverflow;
+                if (out_pos + header_len + conn_data.len + pad_len > out_buf.len) return error.OutBufOverflow;
 
-                @memcpy(self.s2c_out_buf[out_pos .. out_pos + header_len], header_buf[0..header_len]);
+                @memcpy(out_buf[out_pos .. out_pos + header_len], header_buf[0..header_len]);
                 out_pos += header_len;
 
-                @memcpy(self.s2c_out_buf[out_pos .. out_pos + conn_data.len], conn_data);
+                @memcpy(out_buf[out_pos .. out_pos + conn_data.len], conn_data);
                 out_pos += conn_data.len;
 
                 if (pad_len > 0) {
-                    @memcpy(self.s2c_out_buf[out_pos .. out_pos + pad_len], pad_buf[0..pad_len]);
+                    @memcpy(out_buf[out_pos .. out_pos + pad_len], pad_buf[0..pad_len]);
                     out_pos += pad_len;
                 }
             }
@@ -512,7 +502,7 @@ pub const MiddleProxyContext = struct {
             self.s2c_decrypted_len -= frame_len;
         }
 
-        return self.s2c_out_buf[0..out_pos];
+        return out_buf[0..out_pos];
     }
 };
 
@@ -590,6 +580,34 @@ test "encapsulated c2s omits ad_tag block when absent" {
     const flags = std.mem.readInt(u32, payload[4..8], .little);
     try std.testing.expect((flags & Flag.has_ad_tag) == 0);
     try std.testing.expectEqual(@as(usize, 56 + client_data.len), payload.len);
+}
+
+test "encapsulate c2s rejects unaligned payload length" {
+    const allocator = std.testing.allocator;
+
+    const key = [_]u8{0} ** 32;
+    const iv = [_]u8{0} ** 16;
+
+    var ctx = try MiddleProxyContext.init(
+        allocator,
+        crypto.AesCbc.init(&key, &iv),
+        crypto.AesCbc.init(&key, &iv),
+        [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 },
+        -2,
+        std.net.Address.initIp4(.{ 10, 20, 30, 40 }, 12345),
+        std.net.Address.initIp4(.{ 91, 105, 192, 110 }, 443),
+        .intermediate,
+        null,
+    );
+    defer ctx.deinit(allocator);
+
+    const client_data = [_]u8{ 0xde, 0xad, 0xbe };
+    var encrypted_out: [128]u8 = undefined;
+
+    try std.testing.expectError(
+        error.InvalidPayloadLength,
+        ctx.encapsulateSingleMessageC2S(client_data[0..], false, encrypted_out[0..]),
+    );
 }
 
 test "encapsulated c2s includes ad_tag block when present" {
@@ -689,7 +707,8 @@ test "decapsulate s2c skips noop padding words" {
     var wire = plain;
     try enc.encryptInPlace(wire[0..]);
 
-    const out = try ctx.decapsulateS2C(wire[0..]);
+    var out_buf: [128]u8 = undefined;
+    const out = try ctx.decapsulateS2C(wire[0..], out_buf[0..]);
     try std.testing.expectEqual(@as(usize, 4), out.len);
     try std.testing.expectEqualSlices(u8, &confirm, out);
 }
@@ -729,7 +748,8 @@ test "decapsulate s2c validates seq and checksum" {
     var wire = plain;
     try enc.encryptInPlace(wire[0..]);
 
-    const out = try ctx.decapsulateS2C(wire[0..]);
+    var out_buf: [128]u8 = undefined;
+    const out = try ctx.decapsulateS2C(wire[0..], out_buf[0..]);
     try std.testing.expectEqual(@as(usize, 8), out.len); // len(4) + data(4)
 
     // Send a second valid frame with wrong seq (5 instead of expected 1)
@@ -746,7 +766,7 @@ test "decapsulate s2c validates seq and checksum" {
     var wire2 = plain2;
     try enc.encryptInPlace(wire2[0..]);
 
-    try std.testing.expectError(error.BadMiddleProxySeqNo, ctx.decapsulateS2C(wire2[0..]));
+    try std.testing.expectError(error.BadMiddleProxySeqNo, ctx.decapsulateS2C(wire2[0..], out_buf[0..]));
 }
 
 test "encapsulate c2s supports payloads larger than 64KiB" {

--- a/src/protocol/tls.zig
+++ b/src/protocol/tls.zig
@@ -131,10 +131,22 @@ pub fn buildServerHello(
     client_digest: *const [constants.tls_digest_len]u8,
     session_id: []const u8,
 ) ![]u8 {
+    return buildServerHelloWithTemplate(allocator, &nginx_template, secret, client_digest, session_id);
+}
+
+pub fn buildServerHelloWithTemplate(
+    allocator: std.mem.Allocator,
+    template: []const u8,
+    secret: []const u8,
+    client_digest: *const [constants.tls_digest_len]u8,
+    session_id: []const u8,
+) ![]u8 {
+    if (template.len != nginx_template_len) return error.BadServerHelloTemplate;
+
     // 1. Copy the pre-built Nginx template (random and session_id are zeroed in template)
-    const response = try allocator.alloc(u8, nginx_template.len);
+    const response = try allocator.alloc(u8, template.len);
     errdefer allocator.free(response);
-    @memcpy(response, &nginx_template);
+    @memcpy(response, template);
 
     // 2. Patch Session ID (echo from client). Template assumes 32-byte session ID.
     if (session_id.len == 32) {
@@ -192,12 +204,22 @@ const fake_cert_payload_len: u16 = 2878;
 
 /// Total template size: ServerHello(127) + CCS(6) + AppData(5 + 2878)
 const nginx_template_len: usize = 127 + 6 + 5 + fake_cert_payload_len;
+pub const server_hello_template_len: usize = nginx_template_len;
+
+const default_template_seed: u64 = 0x4E67_696E_785F_544C;
 
 /// The pre-built template, constructed at comptime.
-const nginx_template: [nginx_template_len]u8 = buildNginxTemplate();
-
-fn buildNginxTemplate() [nginx_template_len]u8 {
+const nginx_template: [nginx_template_len]u8 = blk: {
     @setEvalBranchQuota(100_000);
+    break :blk buildNginxTemplate(default_template_seed);
+};
+
+pub fn buildServerHelloTemplate(seed: ?u64) [nginx_template_len]u8 {
+    const actual_seed = seed orelse std.crypto.random.int(u64);
+    return buildNginxTemplate(actual_seed);
+}
+
+fn buildNginxTemplate(seed: u64) [nginx_template_len]u8 {
     var t: [nginx_template_len]u8 = undefined;
     var pos: usize = 0;
 
@@ -301,7 +323,7 @@ fn buildNginxTemplate() [nginx_template_len]u8 {
 
     // Fill with deterministic pseudo-random bytes (SplitMix64).
     // Looks like encrypted data to DPI, same every time like a real cert.
-    var prng_state: u64 = 0x4E67_696E_785F_544C; // "NginX_TL" as seed
+    var prng_state: u64 = seed;
     for (0..fake_cert_payload_len) |i| {
         prng_state +%= 0x9E3779B97F4A7C15;
         var z = prng_state;
@@ -495,6 +517,14 @@ test "buildServerHello deterministic AppData (no random size fingerprint)" {
     // AppData bodies are identical (deterministic PRNG, same "certificate" every time)
     const app_offset = 127 + 6 + 5; // after ServerHello + CCS + AppData header
     try std.testing.expectEqualSlices(u8, r1[app_offset..], r2[app_offset..]);
+}
+
+test "buildServerHelloTemplate depends on seed" {
+    const t1 = buildServerHelloTemplate(0x1111_2222_3333_4444);
+    const t2 = buildServerHelloTemplate(0x5555_6666_7777_8888);
+
+    const app_offset = 127 + 6 + 5;
+    try std.testing.expect(!std.mem.eql(u8, t1[app_offset..], t2[app_offset..]));
 }
 
 test "validateTlsHandshake - valid handshake" {

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -34,8 +34,6 @@ const min_nofile_soft: usize = 65535;
 const client_hello_inline_size: usize = 512;
 const mp_handshake_frame_buf_size: usize = 2048;
 const read_buf_size: usize = 4096;
-const relay_batch_steps: usize = 16;
-const mask_relay_batch_steps: usize = 8;
 
 /// Per-/24 (IPv4) or /48 (IPv6) subnet rate limiter.
 /// Fixed-size open-addressed hash table — zero heap allocation.
@@ -2213,26 +2211,16 @@ const EventLoop = struct {
         else
             null;
 
-        var progressed_any = false;
-        var step: usize = 0;
-        while (step < relay_batch_steps and !slot.hasUpstreamPending()) : (step += 1) {
-            const progress = relayClientToUpstreamStep(slot, self.state.allocator, mp_c2s_scratch) catch |err| {
-                if (slot.is_media_path) {
-                    log.debug("[{d}] relay c2s error: dc_idx={d} err={any} c2s={d} s2c={d}", .{
-                        slot.conn_id, slot.dc_idx, err, slot.c2s_bytes, slot.s2c_bytes,
-                    });
-                }
-                self.closeSlot(slot, "relay c2s failed");
-                return;
-            };
-
-            switch (progress) {
-                .none => break,
-                .partial, .forwarded => progressed_any = true,
+        const progress = relayClientToUpstreamStep(slot, self.state.allocator, mp_c2s_scratch) catch |err| {
+            if (slot.is_media_path) {
+                log.debug("[{d}] relay c2s error: dc_idx={d} err={any} c2s={d} s2c={d}", .{
+                    slot.conn_id, slot.dc_idx, err, slot.c2s_bytes, slot.s2c_bytes,
+                });
             }
-        }
-
-        if (progressed_any) {
+            self.closeSlot(slot, "relay c2s failed");
+            return;
+        };
+        if (progress == .forwarded or progress == .partial) {
             slot.last_activity_ms = std.time.milliTimestamp();
         }
     }
@@ -2248,26 +2236,16 @@ const EventLoop = struct {
         else
             null;
 
-        var progressed_any = false;
-        var step: usize = 0;
-        while (step < relay_batch_steps and !slot.hasClientPending()) : (step += 1) {
-            const progress = relayUpstreamToClientStep(slot, self.state.allocator, mp_s2c_scratch) catch |err| {
-                if (slot.is_media_path) {
-                    log.debug("[{d}] relay s2c error: dc_idx={d} err={any} c2s={d} s2c={d}", .{
-                        slot.conn_id, slot.dc_idx, err, slot.c2s_bytes, slot.s2c_bytes,
-                    });
-                }
-                self.closeSlot(slot, "relay s2c failed");
-                return;
-            };
-
-            switch (progress) {
-                .none => break,
-                .partial, .forwarded => progressed_any = true,
+        const progress = relayUpstreamToClientStep(slot, self.state.allocator, mp_s2c_scratch) catch |err| {
+            if (slot.is_media_path) {
+                log.debug("[{d}] relay s2c error: dc_idx={d} err={any} c2s={d} s2c={d}", .{
+                    slot.conn_id, slot.dc_idx, err, slot.c2s_bytes, slot.s2c_bytes,
+                });
             }
-        }
-
-        if (progressed_any) {
+            self.closeSlot(slot, "relay s2c failed");
+            return;
+        };
+        if (progress == .forwarded or progress == .partial) {
             slot.last_activity_ms = std.time.milliTimestamp();
         }
     }
@@ -2280,23 +2258,20 @@ const EventLoop = struct {
             return;
         };
 
-        var step: usize = 0;
-        while (step < mask_relay_batch_steps and !slot.hasUpstreamPending()) : (step += 1) {
-            const n = posix.read(slot.client_fd, read_buf) catch |err| {
-                if (err == error.WouldBlock) return;
-                slot.phase = .closing;
-                return;
-            };
-            if (n == 0) {
-                slot.phase = .closing;
-                return;
-            }
-
-            _ = queueUpstream(slot, self.state.allocator, read_buf[0..n]) catch {
-                slot.phase = .closing;
-                return;
-            };
+        const n = posix.read(slot.client_fd, read_buf) catch |err| {
+            if (err == error.WouldBlock) return;
+            slot.phase = .closing;
+            return;
+        };
+        if (n == 0) {
+            slot.phase = .closing;
+            return;
         }
+
+        _ = queueUpstream(slot, self.state.allocator, read_buf[0..n]) catch {
+            slot.phase = .closing;
+            return;
+        };
     }
 
     fn relayRawUpstreamToClient(self: *EventLoop, slot: *ConnectionSlot) void {
@@ -2307,23 +2282,20 @@ const EventLoop = struct {
             return;
         };
 
-        var step: usize = 0;
-        while (step < mask_relay_batch_steps and !slot.hasClientPending()) : (step += 1) {
-            const n = posix.read(slot.upstream_fd, read_buf) catch |err| {
-                if (err == error.WouldBlock) return;
-                slot.phase = .closing;
-                return;
-            };
-            if (n == 0) {
-                slot.phase = .closing;
-                return;
-            }
-
-            _ = queueClient(slot, self.state.allocator, read_buf[0..n]) catch {
-                slot.phase = .closing;
-                return;
-            };
+        const n = posix.read(slot.upstream_fd, read_buf) catch |err| {
+            if (err == error.WouldBlock) return;
+            slot.phase = .closing;
+            return;
+        };
+        if (n == 0) {
+            slot.phase = .closing;
+            return;
         }
+
+        _ = queueClient(slot, self.state.allocator, read_buf[0..n]) catch {
+            slot.phase = .closing;
+            return;
+        };
     }
 
     fn middleProxyBegin(self: *EventLoop, slot: *ConnectionSlot) void {

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -36,44 +36,102 @@ const mp_handshake_frame_buf_size: usize = 2048;
 const read_buf_size: usize = 4096;
 
 /// Per-/24 (IPv4) or /48 (IPv6) subnet rate limiter.
-/// Fixed 256-bucket hash table — zero heap allocation.
+/// Fixed-size open-addressed hash table — zero heap allocation.
 /// Token bucket per subnet: each second refills up to max_per_sec tokens.
 const SubnetRateLimit = struct {
-    const BUCKETS = 256;
+    const BUCKETS = 65536;
+    const MAX_PROBES = 8;
+    const stale_after_s: i64 = 60;
+
     const Entry = struct {
+        used: bool = false,
         subnet_key: u32 = 0,
         tokens: u8 = 0,
         last_refill_s: i64 = 0,
     };
+
+    hash_seed: u64 = 0,
     entries: [BUCKETS]Entry = [_]Entry{.{}} ** BUCKETS,
+
+    fn init() SubnetRateLimit {
+        return .{
+            .hash_seed = std.crypto.random.int(u64),
+        };
+    }
+
+    fn indexFor(self: *const SubnetRateLimit, key: u32) usize {
+        var x = self.hash_seed ^ @as(u64, key);
+        x +%= 0x9E3779B97F4A7C15;
+        x ^= x >> 30;
+        x *%= 0xBF58476D1CE4E5B9;
+        x ^= x >> 27;
+        x *%= 0x94D049BB133111EB;
+        x ^= x >> 31;
+        return @as(usize, @intCast(x & (BUCKETS - 1)));
+    }
+
+    fn findEntry(self: *SubnetRateLimit, key: u32) ?*Entry {
+        const start = self.indexFor(key);
+        var probe: usize = 0;
+        while (probe < MAX_PROBES) : (probe += 1) {
+            const idx = (start + probe) & (BUCKETS - 1);
+            const e = &self.entries[idx];
+            if (!e.used) return null;
+            if (e.subnet_key == key) return e;
+        }
+        return null;
+    }
 
     /// Returns true if the connection is allowed, false if rate-limited.
     fn check(self: *SubnetRateLimit, addr: net.Address, max_per_sec: u8) bool {
         if (max_per_sec == 0) return true;
         const key = subnetKey(addr);
-        const idx = key % BUCKETS;
-        const e = &self.entries[idx];
         const now_s = @divTrunc(std.time.milliTimestamp(), 1000);
 
-        if (e.subnet_key != key or now_s - e.last_refill_s > 60) {
-            // New subnet or stale entry — reset
-            e.* = .{ .subnet_key = key, .tokens = max_per_sec -| 1, .last_refill_s = now_s };
-            return true;
+        const start = self.indexFor(key);
+        var first_stale_idx: ?usize = null;
+        var oldest_idx: usize = start;
+        var oldest_ts: i64 = std.math.maxInt(i64);
+
+        var probe: usize = 0;
+        while (probe < MAX_PROBES) : (probe += 1) {
+            const idx = (start + probe) & (BUCKETS - 1);
+            const e = &self.entries[idx];
+
+            if (!e.used) {
+                e.* = .{ .used = true, .subnet_key = key, .tokens = max_per_sec -| 1, .last_refill_s = now_s };
+                return true;
+            }
+
+            if (e.subnet_key == key) {
+                // Refill tokens based on elapsed seconds
+                const elapsed = now_s - e.last_refill_s;
+                if (elapsed > 0) {
+                    const refill: u16 = @intCast(@min(elapsed, 255));
+                    const topped = @as(u16, e.tokens) + refill * @as(u16, max_per_sec);
+                    e.tokens = @intCast(@min(@as(u16, max_per_sec), topped));
+                    e.last_refill_s = now_s;
+                }
+
+                if (e.tokens > 0) {
+                    e.tokens -= 1;
+                    return true;
+                }
+                return false;
+            }
+
+            if (now_s - e.last_refill_s > stale_after_s and first_stale_idx == null) {
+                first_stale_idx = idx;
+            }
+            if (e.last_refill_s < oldest_ts) {
+                oldest_ts = e.last_refill_s;
+                oldest_idx = idx;
+            }
         }
 
-        // Refill tokens based on elapsed seconds
-        const elapsed = now_s - e.last_refill_s;
-        if (elapsed > 0) {
-            const refill: u16 = @intCast(@min(elapsed, 255));
-            e.tokens = @min(max_per_sec, e.tokens +| @as(u8, @intCast(@min(refill * @as(u16, max_per_sec), 255))));
-            e.last_refill_s = now_s;
-        }
-
-        if (e.tokens > 0) {
-            e.tokens -= 1;
-            return true;
-        }
-        return false;
+        const victim_idx = first_stale_idx orelse oldest_idx;
+        self.entries[victim_idx] = .{ .used = true, .subnet_key = key, .tokens = max_per_sec -| 1, .last_refill_s = now_s };
+        return true;
     }
 
     fn subnetKey(addr: net.Address) u32 {
@@ -227,7 +285,9 @@ const MessageQueue = struct {
             remaining -= blk_left;
             self.offset = 0;
             self.head_idx += 1;
-            try self.recycleBlock(blk);
+            self.recycleBlock(blk) catch {
+                self.allocator.destroy(blk);
+            };
         }
 
         if (self.head_idx > 0 and (self.head_idx >= self.blocks.items.len or self.head_idx >= 64)) {
@@ -367,20 +427,75 @@ const DynamicRecordSizer = struct {
 };
 
 const ReplayCache = struct {
-    mutex: std.Thread.Mutex = .{},
-    entries: [4096][32]u8 = [_][32]u8{[_]u8{0} ** 32} ** 4096,
-    idx: usize = 0,
+    const BUCKETS = 8192;
+    const MAX_PROBES = 8;
+    const stale_after_s: i64 = 60 * 60;
+
+    const Entry = struct {
+        used: bool = false,
+        key: u64 = 0,
+        last_seen_s: i64 = 0,
+    };
+
+    hash_seed: u64 = 0,
+    entries: [BUCKETS]Entry = [_]Entry{.{}} ** BUCKETS,
+
+    fn init() ReplayCache {
+        return .{
+            .hash_seed = std.crypto.random.int(u64),
+        };
+    }
+
+    fn digestKey(digest: *const [32]u8) u64 {
+        return std.mem.readInt(u64, digest[0..8], .little);
+    }
+
+    fn indexFor(self: *const ReplayCache, key: u64) usize {
+        var x = self.hash_seed ^ key;
+        x +%= 0x9E3779B97F4A7C15;
+        x ^= x >> 30;
+        x *%= 0xBF58476D1CE4E5B9;
+        x ^= x >> 27;
+        x *%= 0x94D049BB133111EB;
+        x ^= x >> 31;
+        return @as(usize, @intCast(x & (BUCKETS - 1)));
+    }
 
     pub fn checkAndInsert(self: *ReplayCache, digest: *const [32]u8) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const key = digestKey(digest);
+        const now_s = @divTrunc(std.time.milliTimestamp(), 1000);
+        const start = self.indexFor(key);
 
-        for (&self.entries) |*cached| {
-            if (std.mem.eql(u8, cached, digest)) return true;
+        var first_stale_idx: ?usize = null;
+        var oldest_idx: usize = start;
+        var oldest_ts: i64 = std.math.maxInt(i64);
+
+        var probe: usize = 0;
+        while (probe < MAX_PROBES) : (probe += 1) {
+            const idx = (start + probe) & (BUCKETS - 1);
+            const e = &self.entries[idx];
+
+            if (!e.used) {
+                e.* = .{ .used = true, .key = key, .last_seen_s = now_s };
+                return false;
+            }
+
+            if (e.key == key) {
+                e.last_seen_s = now_s;
+                return true;
+            }
+
+            if (now_s - e.last_seen_s > stale_after_s and first_stale_idx == null) {
+                first_stale_idx = idx;
+            }
+            if (e.last_seen_s < oldest_ts) {
+                oldest_ts = e.last_seen_s;
+                oldest_idx = idx;
+            }
         }
 
-        self.entries[self.idx] = digest.*;
-        self.idx = (self.idx + 1) % self.entries.len;
+        const victim_idx = first_stale_idx orelse oldest_idx;
+        self.entries[victim_idx] = .{ .used = true, .key = key, .last_seen_s = now_s };
         return false;
     }
 };
@@ -687,6 +802,7 @@ pub const ProxyState = struct {
     handshakes_inflight: std.atomic.Value(u32),
     mask_addr: ?net.Address,
     replay_cache: ReplayCache,
+    tls_server_hello_template: [tls.server_hello_template_len]u8,
 
     // Degradation counters (monotonic totals, delta'd in stats log)
     stats_dropped_cap: std.atomic.Value(u64),
@@ -753,7 +869,8 @@ pub const ProxyState = struct {
             .active_connections = std.atomic.Value(u32).init(0),
             .handshakes_inflight = std.atomic.Value(u32).init(0),
             .mask_addr = resolved_addr,
-            .replay_cache = .{},
+            .replay_cache = ReplayCache.init(),
+            .tls_server_hello_template = tls.buildServerHelloTemplate(null),
             .stats_dropped_cap = std.atomic.Value(u64).init(0),
             .stats_dropped_saturation = std.atomic.Value(u64).init(0),
             .stats_dropped_rate_limit = std.atomic.Value(u64).init(0),
@@ -1016,6 +1133,8 @@ const EventLoop = struct {
     prev_dropped_hs_budget: u64,
     prev_hs_timeout: u64,
     prev_mp_fallback: u64,
+    mp_c2s_scratch: ?[]u8,
+    mp_s2c_scratch: ?[]u8,
 
     fn init(state: *ProxyState, listen_fd: posix.fd_t) !EventLoop {
         const epoll_fd = try epollCreate();
@@ -1033,13 +1152,15 @@ const EventLoop = struct {
             .stats_next_log_ns = std.time.nanoTimestamp() + stats_log_interval_ns,
             .accepted_since_log = 0,
             .closed_since_log = 0,
-            .subnet_limiter = .{},
+            .subnet_limiter = SubnetRateLimit.init(),
             .prev_dropped_cap = 0,
             .prev_dropped_saturation = 0,
             .prev_dropped_rate_limit = 0,
             .prev_dropped_hs_budget = 0,
             .prev_hs_timeout = 0,
             .prev_mp_fallback = 0,
+            .mp_c2s_scratch = null,
+            .mp_s2c_scratch = null,
         };
         errdefer loop.pool.deinit();
 
@@ -1055,6 +1176,10 @@ const EventLoop = struct {
                 }
             }
         }
+
+        if (self.mp_c2s_scratch) |buf| self.state.allocator.free(buf);
+        if (self.mp_s2c_scratch) |buf| self.state.allocator.free(buf);
+
         self.pool.deinit();
         posix.close(self.epoll_fd);
     }
@@ -1573,8 +1698,9 @@ const EventLoop = struct {
         slot.validation_user_len = @intCast(ulen);
         @memcpy(slot.validation_user[0..ulen], v.user[0..ulen]);
 
-        slot.server_hello = tls.buildServerHello(
+        slot.server_hello = tls.buildServerHelloWithTemplate(
             self.state.allocator,
+            self.state.tls_server_hello_template[0..],
             &slot.validation_secret,
             &slot.validation_digest,
             slot.validation_session_id[0..slot.validation_session_id_len],
@@ -1794,28 +1920,28 @@ const EventLoop = struct {
     }
 
     fn startConnectUpstream(self: *EventLoop, slot: *ConnectionSlot, addr: net.Address, kind: UpstreamKind) !void {
-        slot.current_upstream_addr = addr;
-
         const fd = try posix.socket(addr.any.family, posix.SOCK.STREAM | posix.SOCK.NONBLOCK | posix.SOCK.CLOEXEC, posix.IPPROTO.TCP);
-        slot.upstream_fd = fd;
-        slot.upstream_kind = kind;
-        slot.phase = .connecting_upstream;
+        errdefer posix.close(fd);
 
         try self.addFd(fd, false, true);
+        errdefer _ = self.delFd(fd) catch {};
+
         try self.pool.mapFd(fd, slot.index);
+        errdefer self.pool.unmapFd(fd);
 
-        posix.connect(fd, &addr.any, addr.getOsSockLen()) catch |err| {
-            if (err == error.WouldBlock or err == error.ConnectionPending) {
-                return;
-            }
-
-            self.pool.unmapFd(fd);
-            _ = self.delFd(fd) catch {};
-            posix.close(fd);
+        slot.upstream_fd = fd;
+        slot.upstream_kind = kind;
+        slot.current_upstream_addr = addr;
+        slot.phase = .connecting_upstream;
+        errdefer {
             slot.upstream_fd = -1;
             slot.upstream_kind = .none;
             slot.current_upstream_addr = null;
-            return err;
+        }
+
+        posix.connect(fd, &addr.any, addr.getOsSockLen()) catch |err| switch (err) {
+            error.WouldBlock, error.ConnectionPending => return,
+            else => return err,
         };
 
         self.onUpstreamConnectComplete(slot);
@@ -2046,7 +2172,12 @@ const EventLoop = struct {
             if (slot.client_decryptor) |*dec| dec.apply(buf);
 
             if (slot.middle_ctx) |*mp| {
-                const out_data = mp.encapsulateC2S(buf) catch {
+                const scratch = self.ensureMpC2sScratch() catch {
+                    self.closeSlot(slot, "alloc middleproxy c2s scratch failed");
+                    return;
+                };
+                const out_data = mp.encapsulateC2S(buf, scratch) catch {
+                    self.closeSlot(slot, "encapsulate pipelined middleproxy payload failed");
                     return;
                 };
                 if (out_data.len > 0) {
@@ -2072,7 +2203,15 @@ const EventLoop = struct {
     fn relayClientToUpstream(self: *EventLoop, slot: *ConnectionSlot) void {
         if (slot.hasUpstreamPending()) return;
 
-        const progress = relayClientToUpstreamStep(slot, self.state.allocator) catch |err| {
+        const mp_c2s_scratch = if (slot.middle_ctx != null)
+            self.ensureMpC2sScratch() catch {
+                self.closeSlot(slot, "alloc middleproxy c2s scratch failed");
+                return;
+            }
+        else
+            null;
+
+        const progress = relayClientToUpstreamStep(slot, self.state.allocator, mp_c2s_scratch) catch |err| {
             if (slot.is_media_path) {
                 log.debug("[{d}] relay c2s error: dc_idx={d} err={any} c2s={d} s2c={d}", .{
                     slot.conn_id, slot.dc_idx, err, slot.c2s_bytes, slot.s2c_bytes,
@@ -2089,7 +2228,15 @@ const EventLoop = struct {
     fn relayUpstreamToClient(self: *EventLoop, slot: *ConnectionSlot) void {
         if (slot.hasClientPending()) return;
 
-        const progress = relayUpstreamToClientStep(slot, self.state.allocator) catch |err| {
+        const mp_s2c_scratch = if (slot.middle_ctx != null)
+            self.ensureMpS2cScratch() catch {
+                self.closeSlot(slot, "alloc middleproxy s2c scratch failed");
+                return;
+            }
+        else
+            null;
+
+        const progress = relayUpstreamToClientStep(slot, self.state.allocator, mp_s2c_scratch) catch |err| {
             if (slot.is_media_path) {
                 log.debug("[{d}] relay s2c error: dc_idx={d} err={any} c2s={d} s2c={d}", .{
                     slot.conn_id, slot.dc_idx, err, slot.c2s_bytes, slot.s2c_bytes,
@@ -2722,6 +2869,20 @@ const EventLoop = struct {
         }
     }
 
+    fn ensureMpC2sScratch(self: *EventLoop) ![]u8 {
+        if (self.mp_c2s_scratch) |buf| return buf;
+        const buf = try self.state.allocator.alloc(u8, self.state.config.middleProxyBufferBytes());
+        self.mp_c2s_scratch = buf;
+        return buf;
+    }
+
+    fn ensureMpS2cScratch(self: *EventLoop) ![]u8 {
+        if (self.mp_s2c_scratch) |buf| return buf;
+        const buf = try self.state.allocator.alloc(u8, self.state.config.middleProxyBufferBytes());
+        self.mp_s2c_scratch = buf;
+        return buf;
+    }
+
     fn closeSlot(self: *EventLoop, slot: *ConnectionSlot, reason: []const u8) void {
         if (slot.phase == .idle) return;
         log.debug("[{d}] closing: dc_idx={d} media={} phase={s} reason={s} c2s={d} s2c={d}", .{
@@ -2816,7 +2977,7 @@ const EventLoop = struct {
     }
 };
 
-fn relayClientToUpstreamStep(slot: *ConnectionSlot, allocator: std.mem.Allocator) !RelayProgress {
+fn relayClientToUpstreamStep(slot: *ConnectionSlot, allocator: std.mem.Allocator, mp_c2s_scratch: ?[]u8) !RelayProgress {
     const read_buf = try ensureReadBuf(slot, allocator);
     var consumed_any = false;
 
@@ -2879,7 +3040,8 @@ fn relayClientToUpstreamStep(slot: *ConnectionSlot, allocator: std.mem.Allocator
         if (slot.client_decryptor) |*dec| dec.apply(payload);
 
         if (slot.middle_ctx) |*mp| {
-            const out_data = try mp.encapsulateC2S(payload);
+            const scratch = mp_c2s_scratch orelse return error.MissingMiddleProxyScratch;
+            const out_data = try mp.encapsulateC2S(payload, scratch);
             if (out_data.len > 0) {
                 _ = try queueUpstream(slot, allocator, out_data);
             }
@@ -2901,7 +3063,7 @@ fn relayClientToUpstreamStep(slot: *ConnectionSlot, allocator: std.mem.Allocator
     }
 }
 
-fn relayUpstreamToClientStep(slot: *ConnectionSlot, allocator: std.mem.Allocator) !RelayProgress {
+fn relayUpstreamToClientStep(slot: *ConnectionSlot, allocator: std.mem.Allocator, mp_s2c_scratch: ?[]u8) !RelayProgress {
     const read_buf = try ensureReadBuf(slot, allocator);
     const n = posix.read(slot.upstream_fd, read_buf) catch |err| {
         if (err == error.WouldBlock) return .none;
@@ -2912,7 +3074,8 @@ fn relayUpstreamToClientStep(slot: *ConnectionSlot, allocator: std.mem.Allocator
     const raw = read_buf[0..n];
 
     if (slot.middle_ctx) |*mp| {
-        const payload = try mp.decapsulateS2C(raw);
+        const scratch = mp_s2c_scratch orelse return error.MissingMiddleProxyScratch;
+        const payload = try mp.decapsulateS2C(raw, scratch);
         if (payload.len == 0) return .partial;
         if (slot.client_encryptor) |*enc| enc.apply(payload);
         try queueTlsAppRecords(slot, allocator, payload);
@@ -2932,19 +3095,18 @@ fn relayUpstreamToClientStep(slot: *ConnectionSlot, allocator: std.mem.Allocator
 
 fn queueTlsAppRecords(slot: *ConnectionSlot, allocator: std.mem.Allocator, payload: []u8) !void {
     var off: usize = 0;
+    var header: [tls_header_len]u8 = undefined;
+
     while (off < payload.len) {
         const chunk_len = @min(payload.len - off, slot.drs.nextRecordSize());
-        const frame_len = tls_header_len + chunk_len;
-        var frame = try allocator.alloc(u8, frame_len);
-        errdefer allocator.free(frame);
 
-        frame[0] = constants.tls_record_application;
-        frame[1] = constants.tls_version[0];
-        frame[2] = constants.tls_version[1];
-        std.mem.writeInt(u16, frame[3..5], @intCast(chunk_len), .big);
-        @memcpy(frame[5..], payload[off .. off + chunk_len]);
+        header[0] = constants.tls_record_application;
+        header[1] = constants.tls_version[0];
+        header[2] = constants.tls_version[1];
+        std.mem.writeInt(u16, header[3..5], @intCast(chunk_len), .big);
 
-        _ = try queueClientOwned(slot, allocator, frame);
+        _ = try queueClient(slot, allocator, header[0..]);
+        _ = try queueClient(slot, allocator, payload[off .. off + chunk_len]);
         slot.drs.recordSent(chunk_len);
         off += chunk_len;
     }
@@ -3027,7 +3189,13 @@ fn setTcpKeepalive(fd: posix.fd_t) void {
     posix.setsockopt(fd, sol_tcp, 6, std.mem.asBytes(&count)) catch return;
 }
 
+fn setTcpNoDelay(fd: posix.fd_t) void {
+    const enable: c_int = 1;
+    posix.setsockopt(fd, posix.IPPROTO.TCP, posix.TCP.NODELAY, std.mem.asBytes(&enable)) catch return;
+}
+
 fn configureRelaySocket(fd: posix.fd_t) void {
+    setTcpNoDelay(fd);
     setTcpKeepalive(fd);
     setSendTimeout(fd, 30);
 }
@@ -3071,25 +3239,30 @@ fn ensureMpFrameBuf(slot: *ConnectionSlot, allocator: std.mem.Allocator) ![]u8 {
     return buf;
 }
 
-fn runCurl(allocator: std.mem.Allocator, argv: []const []const u8) ![]u8 {
-    const result = try std.process.Child.run(.{
-        .allocator = allocator,
-        .argv = argv,
-    });
-    defer allocator.free(result.stderr);
-    errdefer allocator.free(result.stdout);
-
-    switch (result.term) {
-        .Exited => |code| if (code != 0) return error.CurlFailed,
-        else => return error.CurlFailed,
-    }
-
-    return result.stdout;
-}
-
 fn fetchUrlBytes(allocator: std.mem.Allocator, url: []const u8) ![]u8 {
-    const strict_argv = [_][]const u8{ "curl", "-fsSL", "--max-time", "10", url };
-    return runCurl(allocator, &strict_argv);
+    const uri = try std.Uri.parse(url);
+
+    var client: std.http.Client = .{ .allocator = allocator };
+    defer client.deinit();
+
+    var req = try client.request(.GET, uri, .{
+        .redirect_behavior = @enumFromInt(3),
+        .keep_alive = false,
+        .headers = .{
+            .accept_encoding = .{ .override = "identity" },
+        },
+    });
+    defer req.deinit();
+
+    try req.sendBodiless();
+
+    var redirect_buf: [8 * 1024]u8 = undefined;
+    var response = try req.receiveHead(&redirect_buf);
+    if (response.head.status.class() != .success) return error.HttpRequestFailed;
+
+    var transfer_buf: [4 * 1024]u8 = undefined;
+    const reader = response.reader(&transfer_buf);
+    return reader.allocRemaining(allocator, .limited(1 * 1024 * 1024));
 }
 
 fn parseIpv4Literal(text: []const u8) ?[4]u8 {
@@ -3110,14 +3283,14 @@ fn parseIpv4Literal(text: []const u8) ?[4]u8 {
 }
 
 fn detectPublicIpv4(allocator: std.mem.Allocator) ?[4]u8 {
-    const services = [_][]const []const u8{
-        &.{ "curl", "-fsSL", "--max-time", "3", "https://api.ipify.org" },
-        &.{ "curl", "-fsSL", "--max-time", "3", "https://ifconfig.me" },
-        &.{ "curl", "-fsSL", "--max-time", "3", "https://ipv4.icanhazip.com" },
+    const services = [_][]const u8{
+        "https://api.ipify.org",
+        "https://ifconfig.me",
+        "https://ipv4.icanhazip.com",
     };
 
-    for (services) |argv| {
-        const stdout = runCurl(allocator, argv) catch continue;
+    for (services) |url| {
+        const stdout = fetchUrlBytes(allocator, url) catch continue;
         const trimmed = std.mem.trim(u8, stdout, &[_]u8{ ' ', '\t', '\r', '\n' });
         const parsed = parseIpv4Literal(trimmed);
         allocator.free(stdout);
@@ -3571,8 +3744,8 @@ test "subnet rate limit - stale entry resets" {
 
     // Make entry stale (>60s old)
     const key = SubnetRateLimit.subnetKey(addr);
-    const idx = key % SubnetRateLimit.BUCKETS;
-    limiter.entries[idx].last_refill_s -= 61;
+    const entry = limiter.findEntry(key) orelse return error.TestExpectedEqual;
+    entry.last_refill_s -= SubnetRateLimit.stale_after_s + 1;
 
     // Should reset and allow again
     try std.testing.expect(limiter.check(addr, 1));
@@ -3589,6 +3762,23 @@ test "subnet rate limit - different subnets are independent" {
 
     // Subnet B should still work
     try std.testing.expect(limiter.check(addr_b, 1));
+}
+
+test "replay cache detects duplicate digest" {
+    var cache = ReplayCache.init();
+    const digest = [_]u8{0xAB} ** 32;
+
+    try std.testing.expect(!cache.checkAndInsert(&digest));
+    try std.testing.expect(cache.checkAndInsert(&digest));
+}
+
+test "replay cache accepts distinct digests" {
+    var cache = ReplayCache.init();
+    const digest_a = [_]u8{0x11} ** 32;
+    const digest_b = [_]u8{0x22} ** 32;
+
+    try std.testing.expect(!cache.checkAndInsert(&digest_a));
+    try std.testing.expect(!cache.checkAndInsert(&digest_b));
 }
 
 test "handshakeInProgress - phases" {

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -3353,7 +3353,7 @@ fn buildDcConnectPlan(
         middle_addr = snap.getForDc(dc_abs);
     }
 
-    const force_media_middle_proxy = plan.is_media_path and middle_addr != null;
+    const force_media_middle_proxy = cfg.force_media_middle_proxy and plan.is_media_path and middle_addr != null;
     plan.use_middle_proxy = if (force_media_middle_proxy)
         true
     else

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -3105,8 +3105,7 @@ fn queueTlsAppRecords(slot: *ConnectionSlot, allocator: std.mem.Allocator, paylo
         header[2] = constants.tls_version[1];
         std.mem.writeInt(u16, header[3..5], @intCast(chunk_len), .big);
 
-        _ = try queueClient(slot, allocator, header[0..]);
-        _ = try queueClient(slot, allocator, payload[off .. off + chunk_len]);
+        _ = try slotQueueClientPair(slot, allocator, header[0..], payload[off .. off + chunk_len]);
         slot.drs.recordSent(chunk_len);
         off += chunk_len;
     }
@@ -3504,6 +3503,52 @@ fn queueOrWriteMsg(fd: posix.fd_t, queue: *MessageQueue, data: []const u8) !bool
     return false;
 }
 
+fn queueOrWriteMsgPair(fd: posix.fd_t, queue: *MessageQueue, first: []const u8, second: []const u8) !bool {
+    if (first.len == 0 and second.len == 0) return true;
+
+    if (queue.isEmpty()) {
+        var iovecs: [2]posix.iovec_const = undefined;
+        var n_iov: usize = 0;
+        if (first.len > 0) {
+            iovecs[n_iov] = .{ .base = first.ptr, .len = first.len };
+            n_iov += 1;
+        }
+        if (second.len > 0) {
+            iovecs[n_iov] = .{ .base = second.ptr, .len = second.len };
+            n_iov += 1;
+        }
+
+        const total_len = first.len + second.len;
+        const n = posix.writev(fd, iovecs[0..n_iov]) catch |err| {
+            if (err == error.WouldBlock) {
+                try queue.appendCopy(first);
+                try queue.appendCopy(second);
+                return false;
+            }
+            return err;
+        };
+
+        if (n == 0) return error.ConnectionReset;
+        if (n == total_len) return true;
+
+        if (n < first.len) {
+            try queue.appendCopy(first[n..]);
+            try queue.appendCopy(second);
+            return false;
+        }
+
+        const consumed_second = n - first.len;
+        if (consumed_second < second.len) {
+            try queue.appendCopy(second[consumed_second..]);
+        }
+        return false;
+    }
+
+    try queue.appendCopy(first);
+    try queue.appendCopy(second);
+    return false;
+}
+
 fn queueOrWriteOwnedMsg(fd: posix.fd_t, queue: *MessageQueue, owned: []u8) !bool {
     if (owned.len == 0) {
         queue.allocator.free(owned);
@@ -3561,6 +3606,11 @@ fn flushQueue(fd: posix.fd_t, queue: *MessageQueue) !bool {
 fn slotQueueClient(slot: *ConnectionSlot, allocator: std.mem.Allocator, data: []const u8) !bool {
     _ = allocator;
     return queueOrWriteMsg(slot.client_fd, &slot.client_queue, data);
+}
+
+fn slotQueueClientPair(slot: *ConnectionSlot, allocator: std.mem.Allocator, first: []const u8, second: []const u8) !bool {
+    _ = allocator;
+    return queueOrWriteMsgPair(slot.client_fd, &slot.client_queue, first, second);
 }
 
 fn slotQueueClientOwned(slot: *ConnectionSlot, allocator: std.mem.Allocator, owned: []u8) !bool {

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -34,6 +34,8 @@ const min_nofile_soft: usize = 65535;
 const client_hello_inline_size: usize = 512;
 const mp_handshake_frame_buf_size: usize = 2048;
 const read_buf_size: usize = 4096;
+const relay_batch_steps: usize = 16;
+const mask_relay_batch_steps: usize = 8;
 
 /// Per-/24 (IPv4) or /48 (IPv6) subnet rate limiter.
 /// Fixed-size open-addressed hash table — zero heap allocation.
@@ -2211,16 +2213,26 @@ const EventLoop = struct {
         else
             null;
 
-        const progress = relayClientToUpstreamStep(slot, self.state.allocator, mp_c2s_scratch) catch |err| {
-            if (slot.is_media_path) {
-                log.debug("[{d}] relay c2s error: dc_idx={d} err={any} c2s={d} s2c={d}", .{
-                    slot.conn_id, slot.dc_idx, err, slot.c2s_bytes, slot.s2c_bytes,
-                });
+        var progressed_any = false;
+        var step: usize = 0;
+        while (step < relay_batch_steps and !slot.hasUpstreamPending()) : (step += 1) {
+            const progress = relayClientToUpstreamStep(slot, self.state.allocator, mp_c2s_scratch) catch |err| {
+                if (slot.is_media_path) {
+                    log.debug("[{d}] relay c2s error: dc_idx={d} err={any} c2s={d} s2c={d}", .{
+                        slot.conn_id, slot.dc_idx, err, slot.c2s_bytes, slot.s2c_bytes,
+                    });
+                }
+                self.closeSlot(slot, "relay c2s failed");
+                return;
+            };
+
+            switch (progress) {
+                .none => break,
+                .partial, .forwarded => progressed_any = true,
             }
-            self.closeSlot(slot, "relay c2s failed");
-            return;
-        };
-        if (progress == .forwarded or progress == .partial) {
+        }
+
+        if (progressed_any) {
             slot.last_activity_ms = std.time.milliTimestamp();
         }
     }
@@ -2236,16 +2248,26 @@ const EventLoop = struct {
         else
             null;
 
-        const progress = relayUpstreamToClientStep(slot, self.state.allocator, mp_s2c_scratch) catch |err| {
-            if (slot.is_media_path) {
-                log.debug("[{d}] relay s2c error: dc_idx={d} err={any} c2s={d} s2c={d}", .{
-                    slot.conn_id, slot.dc_idx, err, slot.c2s_bytes, slot.s2c_bytes,
-                });
+        var progressed_any = false;
+        var step: usize = 0;
+        while (step < relay_batch_steps and !slot.hasClientPending()) : (step += 1) {
+            const progress = relayUpstreamToClientStep(slot, self.state.allocator, mp_s2c_scratch) catch |err| {
+                if (slot.is_media_path) {
+                    log.debug("[{d}] relay s2c error: dc_idx={d} err={any} c2s={d} s2c={d}", .{
+                        slot.conn_id, slot.dc_idx, err, slot.c2s_bytes, slot.s2c_bytes,
+                    });
+                }
+                self.closeSlot(slot, "relay s2c failed");
+                return;
+            };
+
+            switch (progress) {
+                .none => break,
+                .partial, .forwarded => progressed_any = true,
             }
-            self.closeSlot(slot, "relay s2c failed");
-            return;
-        };
-        if (progress == .forwarded or progress == .partial) {
+        }
+
+        if (progressed_any) {
             slot.last_activity_ms = std.time.milliTimestamp();
         }
     }
@@ -2258,20 +2280,23 @@ const EventLoop = struct {
             return;
         };
 
-        const n = posix.read(slot.client_fd, read_buf) catch |err| {
-            if (err == error.WouldBlock) return;
-            slot.phase = .closing;
-            return;
-        };
-        if (n == 0) {
-            slot.phase = .closing;
-            return;
-        }
+        var step: usize = 0;
+        while (step < mask_relay_batch_steps and !slot.hasUpstreamPending()) : (step += 1) {
+            const n = posix.read(slot.client_fd, read_buf) catch |err| {
+                if (err == error.WouldBlock) return;
+                slot.phase = .closing;
+                return;
+            };
+            if (n == 0) {
+                slot.phase = .closing;
+                return;
+            }
 
-        _ = queueUpstream(slot, self.state.allocator, read_buf[0..n]) catch {
-            slot.phase = .closing;
-            return;
-        };
+            _ = queueUpstream(slot, self.state.allocator, read_buf[0..n]) catch {
+                slot.phase = .closing;
+                return;
+            };
+        }
     }
 
     fn relayRawUpstreamToClient(self: *EventLoop, slot: *ConnectionSlot) void {
@@ -2282,20 +2307,23 @@ const EventLoop = struct {
             return;
         };
 
-        const n = posix.read(slot.upstream_fd, read_buf) catch |err| {
-            if (err == error.WouldBlock) return;
-            slot.phase = .closing;
-            return;
-        };
-        if (n == 0) {
-            slot.phase = .closing;
-            return;
-        }
+        var step: usize = 0;
+        while (step < mask_relay_batch_steps and !slot.hasClientPending()) : (step += 1) {
+            const n = posix.read(slot.upstream_fd, read_buf) catch |err| {
+                if (err == error.WouldBlock) return;
+                slot.phase = .closing;
+                return;
+            };
+            if (n == 0) {
+                slot.phase = .closing;
+                return;
+            }
 
-        _ = queueClient(slot, self.state.allocator, read_buf[0..n]) catch {
-            slot.phase = .closing;
-            return;
-        };
+            _ = queueClient(slot, self.state.allocator, read_buf[0..n]) catch {
+                slot.phase = .closing;
+                return;
+            };
+        }
     }
 
     fn middleProxyBegin(self: *EventLoop, slot: *ConnectionSlot) void {


### PR DESCRIPTION
## Summary
- harden security-sensitive relay paths: randomize FakeTLS server template per process, validate middle-proxy payload alignment, and improve replay/rate-limit resilience with hashed fixed-size tables
- reduce middle-proxy memory pressure by moving temporary C2S/S2C output buffers from per-connection context to shared event-loop scratch buffers
- replace external `curl` process execution with `std.http.Client` for proxy config/secret fetch and public IP detection in both runtime and startup paths

## Testing
- zig build test
- zig build