### PR TITLE
fix(deploy): keep tunnel unit and choose CPU-safe release artifact

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,8 +35,13 @@ jobs:
         include:
           - target: x86_64-linux
             artifact_name: mtproto-proxy-linux-x86_64
+            cpu: ""
+          - target: x86_64-linux
+            artifact_name: mtproto-proxy-linux-x86_64_v3
+            cpu: x86_64_v3
           - target: aarch64-linux
             artifact_name: mtproto-proxy-linux-aarch64
+            cpu: ""
 
     steps:
       - name: Checkout release tag
@@ -51,11 +56,11 @@ jobs:
 
       - name: Build release binary
         run: |
-          if [ "${{ matrix.target }}" = "x86_64-linux" ]; then
-            zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.target }} -Dcpu=x86_64_v3
-          else
-            zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.target }}
+          BUILD_ARGS="-Doptimize=ReleaseFast -Dtarget=${{ matrix.target }}"
+          if [ -n "${{ matrix.cpu }}" ]; then
+            BUILD_ARGS="$BUILD_ARGS -Dcpu=${{ matrix.cpu }}"
           fi
+          zig build $BUILD_ARGS
 
       - name: Package artifact
         run: |

--- a/README.md
+++ b/README.md
@@ -157,10 +157,13 @@ make update-server SERVER=<SERVER_IP> VERSION=v0.1.0
 ```
 
 What `update-server` does on the VPS:
-1. Downloads the latest (or pinned) release artifact for server architecture.
+1. Downloads the latest (or pinned) release artifact for server architecture (on x86_64 it auto-selects generic or `x86_64_v3` based on CPU features).
 2. Stops `mtproto-proxy`, replaces binary, and keeps `config.toml`/`env.sh` untouched.
-3. Refreshes helper scripts and service unit from the same release tag.
-4. Restarts service and rolls back binary automatically if restart fails.
+3. Refreshes helper scripts and updates the service unit from the same release tag (unless a tunnel-aware `mtproto-proxy.service` is detected).
+4. Checks that the downloaded binary is CPU-compatible before install and aborts on illegal-instruction mismatch.
+5. Restarts service and rolls back binary automatically if restart fails.
+
+If you intentionally want to reset a customized `mtproto-proxy.service` to the release default, run update with `FORCE_SERVICE_UPDATE=1`.
 
 If you are already on the server:
 

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -5,6 +5,7 @@
 # Usage:
 #   sudo bash update.sh
 #   sudo bash update.sh v0.1.0
+#   sudo FORCE_SERVICE_UPDATE=1 bash update.sh    # overwrite custom systemd unit
 
 set -euo pipefail
 
@@ -12,7 +13,9 @@ REPO_OWNER="${REPO_OWNER:-sleep3r}"
 REPO_NAME="${REPO_NAME:-mtproto.zig}"
 INSTALL_DIR="/opt/mtproto-proxy"
 SERVICE_NAME="mtproto-proxy"
+SERVICE_FILE="/etc/systemd/system/mtproto-proxy.service"
 VERSION="${1:-}"
+FORCE_SERVICE_UPDATE="${FORCE_SERVICE_UPDATE:-0}"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -25,6 +28,37 @@ info()  { echo -e "${CYAN}▸${RESET} $*"; }
 ok()    { echo -e "${GREEN}✓${RESET} $*"; }
 warn()  { echo -e "${RED}⚠${RESET} $*"; }
 fail()  { echo -e "${RED}✗${RESET} $*" >&2; exit 1; }
+
+is_tunnel_service_unit() {
+    local unit_path="$1"
+    [[ -f "$unit_path" ]] || return 1
+    grep -Eq 'setup_netns\.sh|ip[[:space:]]+netns[[:space:]]+exec|AmneziaWG[[:space:]]+Tunnel' "$unit_path"
+}
+
+cpu_supports_x86_64_v3() {
+    local flags=""
+    local required
+
+    if command -v lscpu >/dev/null 2>&1; then
+        flags="$(LC_ALL=C lscpu 2>/dev/null | awk -F: '/^Flags:/ {print tolower($2)}')"
+    fi
+
+    if [[ -z "$flags" && -r /proc/cpuinfo ]]; then
+        flags="$(LC_ALL=C grep -m1 -i '^flags[[:space:]]*:' /proc/cpuinfo | cut -d: -f2 | tr '[:upper:]' '[:lower:]')"
+    fi
+
+    [[ -n "$flags" ]] || return 1
+
+    for required in avx2 bmi1 bmi2 fma f16c movbe sse4_1 sse4_2 ssse3 popcnt aes xsave; do
+        [[ " $flags " == *" $required "* ]] || return 1
+    done
+
+    if [[ " $flags " != *" lzcnt "* && " $flags " != *" abm "* ]]; then
+        return 1
+    fi
+
+    return 0
+}
 
 [[ $EUID -eq 0 ]] || fail "Run as root: sudo bash update.sh"
 
@@ -45,6 +79,26 @@ case "$ARCH" in
         ;;
 esac
 
+ASSET_CANDIDATES=()
+if [[ "$ASSET_ARCH" == "x86_64" ]]; then
+    if cpu_supports_x86_64_v3; then
+        info "CPU supports x86_64_v3; preferring optimized artifact"
+        ASSET_CANDIDATES=(
+            "mtproto-proxy-linux-x86_64_v3"
+            "mtproto-proxy-linux-x86_64"
+        )
+    else
+        warn "CPU lacks x86_64_v3 features; using generic x86_64 artifact"
+        ASSET_CANDIDATES=(
+            "mtproto-proxy-linux-x86_64"
+        )
+    fi
+else
+    ASSET_CANDIDATES=(
+        "mtproto-proxy-linux-${ASSET_ARCH}"
+    )
+fi
+
 if [[ -z "$VERSION" ]]; then
     info "Resolving latest release tag..."
     TAG="$(curl -fsSL "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest" | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"[^"]+"' | head -1 | cut -d '"' -f4 || true)"
@@ -57,9 +111,6 @@ if [[ "$TAG" != v* ]]; then
     TAG="v${TAG}"
 fi
 
-ASSET_BASENAME="mtproto-proxy-linux-${ASSET_ARCH}"
-ASSET_FILE="${ASSET_BASENAME}.tar.gz"
-ASSET_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${TAG}/${ASSET_FILE}"
 RAW_BASE="https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${TAG}/deploy"
 
 TMP_DIR="$(mktemp -d)"
@@ -70,13 +121,40 @@ cleanup() {
 }
 trap cleanup EXIT
 
-info "Downloading ${TAG} artifact for ${ASSET_ARCH}..."
-curl -fsSL "$ASSET_URL" -o "${TMP_DIR}/${ASSET_FILE}" || fail "Release artifact not found: ${ASSET_URL}"
+SELECTED_ASSET_BASENAME=""
+SELECTED_ASSET_FILE=""
 
-tar -xzf "${TMP_DIR}/${ASSET_FILE}" -C "$TMP_DIR"
-NEW_BINARY="${TMP_DIR}/${ASSET_BASENAME}"
+info "Downloading ${TAG} artifact for ${ASSET_ARCH}..."
+for candidate in "${ASSET_CANDIDATES[@]}"; do
+    candidate_file="${candidate}.tar.gz"
+    candidate_url="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${TAG}/${candidate_file}"
+    info "Trying ${candidate_file}..."
+    if curl -fsSL "$candidate_url" -o "${TMP_DIR}/${candidate_file}" 2>/dev/null; then
+        ok "Selected artifact ${candidate_file}"
+        SELECTED_ASSET_BASENAME="$candidate"
+        SELECTED_ASSET_FILE="$candidate_file"
+        break
+    else
+        warn "Artifact ${candidate_file} is unavailable for ${TAG}, trying fallback"
+    fi
+done
+
+[[ -n "$SELECTED_ASSET_BASENAME" ]] || fail "No compatible release artifact found for ${ASSET_ARCH} in ${TAG} (tried: ${ASSET_CANDIDATES[*]})"
+
+tar -xzf "${TMP_DIR}/${SELECTED_ASSET_FILE}" -C "$TMP_DIR"
+NEW_BINARY="${TMP_DIR}/${SELECTED_ASSET_BASENAME}"
 [[ -f "$NEW_BINARY" ]] || fail "Extracted binary not found in artifact"
 chmod +x "$NEW_BINARY"
+
+info "Validating binary compatibility with this CPU..."
+set +e
+"$NEW_BINARY" "/tmp/mtproto-proxy-update-check-does-not-exist.toml" >/dev/null 2>&1
+BINARY_CHECK_RC=$?
+set -e
+
+if [[ "$BINARY_CHECK_RC" -eq 132 ]]; then
+    fail "Downloaded artifact (${SELECTED_ASSET_FILE}) is incompatible with this CPU (illegal instruction)."
+fi
 
 info "Downloading deploy scripts and service from ${TAG}..."
 for file in install.sh update.sh update_dns.sh ipv6-hop.sh setup_masking.sh setup_nfqws.sh capture_template.py mtproto-proxy.service; do
@@ -115,7 +193,15 @@ if [[ -f "${TMP_DIR}/setup_tunnel.sh" ]]; then
 fi
 install -m 0644 "${TMP_DIR}/capture_template.py" "${INSTALL_DIR}/capture_template.py"
 
-install -m 0644 "${TMP_DIR}/mtproto-proxy.service" "/etc/systemd/system/mtproto-proxy.service"
+if [[ "$FORCE_SERVICE_UPDATE" == "1" ]]; then
+    warn "FORCE_SERVICE_UPDATE=1: replacing ${SERVICE_FILE} from release"
+    install -m 0644 "${TMP_DIR}/mtproto-proxy.service" "$SERVICE_FILE"
+elif is_tunnel_service_unit "$SERVICE_FILE"; then
+    warn "Detected tunnel-aware service unit; preserving existing ${SERVICE_FILE}"
+    warn "Run with FORCE_SERVICE_UPDATE=1 if you intentionally want to overwrite it"
+else
+    install -m 0644 "${TMP_DIR}/mtproto-proxy.service" "$SERVICE_FILE"
+fi
 systemctl daemon-reload
 
 # Fix permissions up in case config or dir was modified as root
@@ -146,6 +232,7 @@ echo -e "${CYAN}═════════════════════�
 echo ""
 echo -e "  ${DIM}Version:${RESET}   ${TAG}"
 echo -e "  ${DIM}Arch:${RESET}      ${ASSET_ARCH}"
+echo -e "  ${DIM}Artifact:${RESET}  ${SELECTED_ASSET_FILE}"
 echo -e "  ${DIM}Status:${RESET}    systemctl status ${SERVICE_NAME} --no-pager"
 echo -e "  ${DIM}Logs:${RESET}      journalctl -u ${SERVICE_NAME} -f"
 if [[ -n "$BACKUP_BINARY" ]]; then


### PR DESCRIPTION
## Summary
- preserve tunnel-aware `mtproto-proxy.service` during `deploy/update.sh` runs so tunnel/netns wiring is not lost on regular updates (with `FORCE_SERVICE_UPDATE=1` as explicit override)
- add CPU-aware x86_64 artifact selection in `deploy/update.sh` with fallback and preflight binary compatibility check to prevent `SIGILL` installs
- update release workflow to publish both `mtproto-proxy-linux-x86_64` (generic) and `mtproto-proxy-linux-x86_64_v3`, and document the updated update flow in README

## Validation
- `bash -n deploy/update.sh`
- manual update run on `38.180.236.207` using the patched updater