### PR TITLE
config: bump rate_limit_per_subnet default 8 → 30

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ idle_timeout_sec = 120
 handshake_timeout_sec = 15
 tag = "1234567890abcdef1234567890abcdef"   # Optional: promotion tag from @MTProxybot
 log_level = "info"                         # Runtime log level: debug, info, warn, err
-rate_limit_per_subnet = 8                  # Max new connections/sec per /24 subnet (0 = disabled)
+rate_limit_per_subnet = 30                # Max new connections/sec per /24 subnet (0 = disabled)
 # unsafe_override_limits = false           # Set true to disable auto-clamp of max_connections
 
 [censorship]
@@ -603,7 +603,7 @@ bob   = "ffeeddccbbaa99887766554433221100"
 | `[server]` | `middleproxy_buffer_kb` | `1024` | MiddleProxy per-connection buffer size in KiB (4 buffers allocated per active ME session). Values below 1024 may cause `MiddleProxyBufferOverflow` on media-heavy traffic (Stories, video messages) |
 | `[server]` | `tag` | _(none)_ | Optional 32 hex-char promotion tag from [@MTProxybot](https://t.me/MTProxybot) |
 | `[server]` | `log_level` | `"info"` | Runtime log verbosity: `debug` (all DC routing, relay, close details), `info` (default — connection stats, warnings), `warn`, `err`. Change without recompilation; takes effect on restart |
-| `[server]` | `rate_limit_per_subnet` | `8` | Max new connections per second per /24 (IPv4) or /48 (IPv6) subnet. Blocks scanner/DPI-probe flood. Set `0` to disable |
+| `[server]` | `rate_limit_per_subnet` | `30` | Max new connections per second per /24 (IPv4) or /48 (IPv6) subnet. Blocks scanner/DPI-probe flood. Set `0` to disable |
 | `[server]` | `unsafe_override_limits` | `false` | Disable auto-clamping of `max_connections` to the RAM-safe estimate. Use only if you're sure your host has enough memory |
 | `[censorship]` | `tls_domain` | `"google.com"` | Domain to impersonate / forward bad clients to |
 | `[censorship]` | `mask` | `true` | Forward unauthenticated connections to `tls_domain` to defeat DPI |
@@ -621,7 +621,7 @@ bob   = "ffeeddccbbaa99887766554433221100"
 
 > **Operational note** &nbsp; On startup, `max_connections` is automatically clamped to a RAM-safe estimate (with a warning). Set `unsafe_override_limits = true` in `[server]` to disable this. The proxy also has built-in admission control: at 90% capacity it pauses `accept()` and resumes at 80%, preventing CPU-wasteful accept→close spin loops.
 
-> **Operational note** &nbsp; The proxy limits new connections to 8/sec per /24 subnet by default (`rate_limit_per_subnet`). This blocks ТСПУ scanners and DPI replay probes without affecting legitimate Telegram clients.
+> **Operational note** &nbsp; The proxy limits new connections to 30/sec per /24 subnet by default (`rate_limit_per_subnet`). This blocks ТСПУ scanners and DPI replay probes without affecting legitimate Telegram clients.
 
 > **Tip** &nbsp; Generate a random secret: `openssl rand -hex 16`
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -45,10 +45,10 @@ port = 443
 # log_level = "info"
 
 # Max new connections per second per /24 (IPv4) or /48 (IPv6) subnet.
-# Limits scanner/flood/DPI-probe impact. Default of 8 is generous for
+# Limits scanner/flood/DPI-probe impact. Default of 30 is generous for
 # legitimate Telegram clients (3-6 connections at startup, then hold).
 # Set to 0 to disable rate limiting entirely.
-# rate_limit_per_subnet = 8
+# rate_limit_per_subnet = 30
 
 # By default, max_connections is auto-clamped to a RAM-safe estimate on startup.
 # Set to true to disable this safety mechanism (only if you're sure your host

--- a/src/config.zig
+++ b/src/config.zig
@@ -50,7 +50,7 @@ pub const Config = struct {
     /// Max new connections per second per /24 subnet (0 = disabled).
     /// Limits scanner/flood/DPI-probe impact. Generous for legitimate Telegram clients
     /// which open 3-6 connections at startup and hold them.
-    rate_limit_per_subnet: u8 = 8,
+    rate_limit_per_subnet: u8 = 30,
     /// When true, disables auto-clamping of max_connections to the RAM-safe estimate.
     /// Use only if you know your host has enough memory for the configured limits.
     unsafe_override_limits: bool = false,
@@ -314,7 +314,7 @@ test "parse config - missing fields defaults" {
     try std.testing.expect(!cfg.fast_mode); // Default is false
     try std.testing.expectEqual(@as(u32, 1024), cfg.middleproxy_buffer_kb);
     try std.testing.expectEqual(@as(usize, 1024 * 1024), cfg.middleProxyBufferBytes());
-    try std.testing.expectEqual(@as(u8, 8), cfg.rate_limit_per_subnet);
+    try std.testing.expectEqual(@as(u8, 30), cfg.rate_limit_per_subnet);
     try std.testing.expect(!cfg.unsafe_override_limits);
     try std.testing.expectEqual(@as(usize, 1), cfg.users.count());
 }
@@ -607,7 +607,7 @@ test "parse config - full production-like config" {
         \\handshake_timeout_sec = 15
         \\backlog = 8192
         \\log_level = "info"
-        \\rate_limit_per_subnet = 8
+        \\rate_limit_per_subnet = 30
         \\
         \\[censorship]
         \\tls_domain = "wb.ru"
@@ -633,7 +633,7 @@ test "parse config - full production-like config" {
     try std.testing.expectEqual(@as(u32, 15), cfg.handshake_timeout_sec);
     try std.testing.expectEqual(@as(u32, 8192), cfg.backlog);
     try std.testing.expectEqual(std.log.Level.info, cfg.log_level);
-    try std.testing.expectEqual(@as(u8, 8), cfg.rate_limit_per_subnet);
+    try std.testing.expectEqual(@as(u8, 30), cfg.rate_limit_per_subnet);
     try std.testing.expect(!cfg.unsafe_override_limits);
     try std.testing.expectEqualStrings("wb.ru", cfg.tls_domain);
     try std.testing.expect(cfg.mask);
@@ -684,7 +684,7 @@ test "parse config - invalid rate_limit keeps default" {
     var cfg = try Config.parse(std.testing.allocator, content);
     defer cfg.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(u8, 8), cfg.rate_limit_per_subnet);
+    try std.testing.expectEqual(@as(u8, 30), cfg.rate_limit_per_subnet);
 }
 
 test "parse config - censorship section booleans" {


### PR DESCRIPTION
## Summary

Raises the default `rate_limit_per_subnet` from **8** to **30** connections/sec per /24 subnet.

## Motivation

The previous default of 8 was overly aggressive for legitimate Telegram clients on shared networks (offices, campuses, mobile carrier CGNAT pools where many users share a /24). Raising to 30 prevents false-positive drops while still effectively blocking scanner/DPI-probe floods (ТСПУ Revisor, etc.).

## Changes

- **`src/config.zig`** — struct default `8 → 30`, updated 3 test assertions (`missing fields defaults`, `full production-like config`, `invalid rate_limit keeps default`)
- **`config.toml.example`** — comment updated: "Default of 8" → "Default of 30"
- **`README.md`** — operational note updated: "8/sec" → "30/sec"

## Testing

`zig build test` — all tests pass.