### PR TITLE
ci: add GHCR docker publish workflow, update README.md

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,148 @@
+name: Docker Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-arch:
+    name: Build & Push (${{ matrix.arch }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+          - arch: arm64
+            platform: linux/arm64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set image tags
+        id: vars
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          image="ghcr.io/${GITHUB_REPOSITORY,,}"
+          arch="${{ matrix.arch }}"
+          ref_name="${GITHUB_REF_NAME}"
+          safe_ref="${ref_name//\//-}"
+
+          if [[ ! "$safe_ref" =~ ^v([0-9]+(\.[0-9]+){0,2}([.-].+)?)$ ]]; then
+            echo "Tag must match v<semver>, got: $safe_ref" >&2
+            exit 1
+          fi
+          plain_ref="${BASH_REMATCH[1]}"
+
+          tags=(
+            "${image}:${safe_ref}-${arch}"
+            "${image}:${plain_ref}-${arch}"
+            "${image}:latest-${arch}"
+          )
+
+          echo "image=${image}" >> "$GITHUB_OUTPUT"
+          {
+            echo "tags<<EOF"
+            printf '%s\n' "${tags[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ${{ steps.vars.outputs.tags }}
+          labels: |
+            org.opencontainers.image.title=mtproto.zig
+            org.opencontainers.image.description=High-performance Telegram MTProto proxy written in Zig
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha,scope=docker-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=docker-${{ matrix.arch }}
+
+  publish-manifest:
+    name: Publish Multi-Arch Tags
+    runs-on: ubuntu-latest
+    needs: build-arch
+    steps:
+      - name: Set image tags
+        id: vars
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          image="ghcr.io/${GITHUB_REPOSITORY,,}"
+          ref_name="${GITHUB_REF_NAME}"
+          safe_ref="${ref_name//\//-}"
+
+          if [[ ! "$safe_ref" =~ ^v([0-9]+(\.[0-9]+){0,2}([.-].+)?)$ ]]; then
+            echo "Tag must match v<semver>, got: $safe_ref" >&2
+            exit 1
+          fi
+          plain_ref="${BASH_REMATCH[1]}"
+
+          tags=(
+            "${safe_ref}"
+            "${plain_ref}"
+            "latest"
+          )
+
+          echo "image=${image}" >> "$GITHUB_OUTPUT"
+          {
+            echo "tags<<EOF"
+            printf '%s\n' "${tags[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifests
+        shell: bash
+        env:
+          IMAGE: ${{ steps.vars.outputs.image }}
+          TAGS: ${{ steps.vars.outputs.tags }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r tag; do
+            [[ -z "$tag" ]] && continue
+            docker buildx imagetools create \
+              --tag "${IMAGE}:${tag}" \
+              "${IMAGE}:${tag}-amd64" \
+              "${IMAGE}:${tag}-arm64"
+          done <<< "$TAGS"

--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ curl -fsSL https://raw.githubusercontent.com/sleep3r/mtproto.zig/main/deploy/upd
 
 The repository includes a **multi-stage Dockerfile**: Zig is bootstrapped from the official tarball inside the build stage; the runtime image is Debian **bookworm-slim** with `curl` and CA certs (startup banner resolves the public IP via `curl`). The process runs as **root** inside the container (simple bind to port 443). The image ships `config.toml.example` as `/etc/mtproto-proxy/config.toml` for a quick start; mount your own file for real secrets and settings.
 
+Prebuilt multi-arch image is published to GitHub Container Registry from this repository, so you can use `latest` directly:
+
+```bash
+docker pull ghcr.io/sleep3r/mtproto.zig:latest
+```
+
 ### Build
 
 ```bash


### PR DESCRIPTION
## Summary
This PR adds automated Docker image publishing to GHCR for release tags.

## Changes
- Added GitHub Actions workflow: `.github/workflows/docker-publish.yml`
- Workflow now runs on `push` tags matching `v*`
- Builds and pushes architecture images for `linux/amd64` and `linux/arm64`
- Publishes multi-arch tags:
  - `vX.Y.Z`
  - `X.Y.Z`
  - `latest`
- Updated `README.md` with a short note about using the prebuilt `latest` image from GHCR

## Result
After pushing a release tag (for example `v1.0.0`), users can pull:
```bash
docker pull ghcr.io/sleep3r/mtproto.zig:latest
```
