### PR TITLE
fix(deploy): honor configured server port in helper scripts

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -10,7 +10,7 @@
 #   2. Clones and builds the proxy
 #   3. Generates a random user secret
 #   4. Creates a systemd service
-#   5. Opens port 443 in ufw (if active)
+#   5. Opens configured proxy port in ufw (if active)
 #   6. Applies TCPMSS clamping (DPI bypass: splits ClientHello into tiny packets)
 #   7. Installs IPv6 address hopping script + cron job (optional, requires CF_TOKEN + CF_ZONE)
 #   8. Prints the ready-to-use tg:// link
@@ -33,6 +33,28 @@ info()  { echo -e "${CYAN}▸${RESET} $*"; }
 ok()    { echo -e "${GREEN}✓${RESET} $*"; }
 warn()  { echo -e "${RED}⚠${RESET} $*"; }
 fail()  { echo -e "${RED}✗${RESET} $*" >&2; exit 1; }
+
+get_server_port() {
+    local cfg="$1"
+    awk '
+        BEGIN { in_server = 0 }
+        /^[[:space:]]*\[server\][[:space:]]*$/ { in_server = 1; next }
+        /^[[:space:]]*\[[^]]+\][[:space:]]*$/ { in_server = 0; next }
+        in_server {
+            line = $0
+            sub(/#.*/, "", line)
+            if (line ~ /^[[:space:]]*port[[:space:]]*=/) {
+                split(line, parts, "=")
+                value = parts[2]
+                gsub(/[^0-9]/, "", value)
+                if (value != "") {
+                    print value
+                    exit
+                }
+            }
+        }
+    ' "$cfg" 2>/dev/null
+}
 
 # ── Check root ──────────────────────────────────────────────
 [[ $EUID -eq 0 ]] || fail "Run as root: sudo bash install.sh"
@@ -132,15 +154,18 @@ systemctl restart "$SERVICE_NAME"
 ok "Systemd service installed and started"
 
 # ── Firewall & DPI bypass ───────────────────────────────────
+PORT="$(get_server_port "$INSTALL_DIR/config.toml")"
+PORT="${PORT:-443}"
+
 if command -v ufw &>/dev/null && ufw status | grep -q "active"; then
-    ufw allow 443/tcp >/dev/null 2>&1
-    ok "Opened port 443 in ufw"
+    ufw allow "$PORT"/tcp >/dev/null 2>&1
+    ok "Opened port $PORT in ufw"
 fi
 
 # TCPMSS clamping: force ClientHello fragmentation to bypass passive DPI
 if command -v iptables &>/dev/null; then
-    iptables -t mangle -D OUTPUT -p tcp --sport 443 --tcp-flags SYN,ACK SYN,ACK -j TCPMSS --set-mss 88 2>/dev/null || true
-    iptables -t mangle -A OUTPUT -p tcp --sport 443 --tcp-flags SYN,ACK SYN,ACK -j TCPMSS --set-mss 88
+    iptables -t mangle -D OUTPUT -p tcp --sport "$PORT" --tcp-flags SYN,ACK SYN,ACK -j TCPMSS --set-mss 88 2>/dev/null || true
+    iptables -t mangle -A OUTPUT -p tcp --sport "$PORT" --tcp-flags SYN,ACK SYN,ACK -j TCPMSS --set-mss 88
     mkdir -p /etc/iptables
     iptables-save > /etc/iptables/rules.v4 2>/dev/null || true
     ok "TCPMSS=88 clamping applied to IPv4 (passive DPI bypass)"
@@ -149,8 +174,8 @@ else
 fi
 
 if command -v ip6tables &>/dev/null; then
-    ip6tables -t mangle -D OUTPUT -p tcp --sport 443 --tcp-flags SYN,ACK SYN,ACK -j TCPMSS --set-mss 88 2>/dev/null || true
-    if ip6tables -t mangle -A OUTPUT -p tcp --sport 443 --tcp-flags SYN,ACK SYN,ACK -j TCPMSS --set-mss 88 2>/dev/null; then
+    ip6tables -t mangle -D OUTPUT -p tcp --sport "$PORT" --tcp-flags SYN,ACK SYN,ACK -j TCPMSS --set-mss 88 2>/dev/null || true
+    if ip6tables -t mangle -A OUTPUT -p tcp --sport "$PORT" --tcp-flags SYN,ACK SYN,ACK -j TCPMSS --set-mss 88 2>/dev/null; then
         mkdir -p /etc/iptables
         ip6tables-save > /etc/iptables/rules.v6 2>/dev/null || true
         ok "TCPMSS=88 clamping applied to IPv6 (passive DPI bypass)"
@@ -226,7 +251,8 @@ rm -rf "$TMPBUILD"
 
 # ── Print connection info ───────────────────────────────────
 PUBLIC_IP=$(curl -s --max-time 5 https://ifconfig.me || echo "<SERVER_IP>")
-PORT=$(grep -oP 'port\s*=\s*\K[0-9]+' "$INSTALL_DIR/config.toml" || echo "443")
+PORT="$(get_server_port "$INSTALL_DIR/config.toml")"
+PORT="${PORT:-443}"
 
 # Build ee-secret: ee + hex(secret) + hex(tls_domain)
 DOMAIN_HEX=$(echo -n "$TLS_DOMAIN" | xxd -p | tr -d '\n')

--- a/deploy/setup_nfqws.sh
+++ b/deploy/setup_nfqws.sh
@@ -3,7 +3,7 @@
 # setup_nfqws.sh — Install zapret's nfqws for OS-level TCP desync.
 #
 # This complements the proxy's built-in Split-TLS desync (1-byte split in proxy.zig)
-# with OS-level packet manipulation that works on ALL outbound traffic from port 443.
+# with OS-level packet manipulation that works on ALL outbound traffic from the proxy port.
 #
 # nfqws uses NFQUEUE to intercept outbound TCP packets and applies:
 #   - Fake packets with low TTL (expires before reaching DPI but after the ISP router)
@@ -43,6 +43,45 @@ ok()    { echo -e "${GREEN}✓${RESET} $*"; }
 warn()  { echo -e "${RED}⚠${RESET} $*"; }
 fail()  { echo -e "${RED}✗${RESET} $*" >&2; exit 1; }
 
+get_server_port() {
+    local cfg="$1"
+    awk '
+        BEGIN { in_server = 0 }
+        /^[[:space:]]*\[server\][[:space:]]*$/ { in_server = 1; next }
+        /^[[:space:]]*\[[^]]+\][[:space:]]*$/ { in_server = 0; next }
+        in_server {
+            line = $0
+            sub(/#.*/, "", line)
+            if (line ~ /^[[:space:]]*port[[:space:]]*=/) {
+                split(line, parts, "=")
+                value = parts[2]
+                gsub(/[^0-9]/, "", value)
+                if (value != "") {
+                    print value
+                    exit
+                }
+            }
+        }
+    ' "$cfg" 2>/dev/null
+}
+
+remove_nfqws_rules() {
+    local ipt="$1"
+    command -v "$ipt" &>/dev/null || return 0
+
+    while IFS= read -r rule; do
+        rule="${rule/-A /-D }"
+        # shellcheck disable=SC2086
+        $ipt -t mangle $rule 2>/dev/null || true
+    done < <(
+        "$ipt" -t mangle -S OUTPUT 2>/dev/null | awk -v q="${NFQUEUE_NUM}" '
+            $1 == "-A" && $2 == "OUTPUT" && $0 ~ ("-j NFQUEUE --queue-num " q "($| )") {
+                print
+            }
+        '
+    )
+}
+
 [[ $EUID -eq 0 ]] || fail "Run as root: sudo bash setup_nfqws.sh"
 
 # ── Parse args ──────────────────────────────────────────────
@@ -63,6 +102,10 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# ── Parse config port ───────────────────────────────────────
+PORT="$(get_server_port "/opt/mtproto-proxy/config.toml")"
+PORT="${PORT:-443}"
+
 # ── Uninstall ───────────────────────────────────────────────
 if $REMOVE; then
     info "Removing nfqws-mtproto..."
@@ -72,8 +115,8 @@ if $REMOVE; then
     systemctl daemon-reload
 
     # Remove iptables rules
-    iptables -t mangle -D OUTPUT -p tcp --sport 443 -j NFQUEUE --queue-num "$NFQUEUE_NUM" 2>/dev/null || true
-    ip6tables -t mangle -D OUTPUT -p tcp --sport 443 -j NFQUEUE --queue-num "$NFQUEUE_NUM" 2>/dev/null || true
+    remove_nfqws_rules iptables
+    remove_nfqws_rules ip6tables
     iptables-save > /etc/iptables/rules.v4 2>/dev/null || true
     ip6tables-save > /etc/iptables/rules.v6 2>/dev/null || true
 
@@ -108,12 +151,12 @@ fi
 info "Setting up NFQUEUE rules..."
 
 # Remove old rules (idempotent)
-iptables -t mangle -D OUTPUT -p tcp --sport 443 -j NFQUEUE --queue-num "$NFQUEUE_NUM" 2>/dev/null || true
-ip6tables -t mangle -D OUTPUT -p tcp --sport 443 -j NFQUEUE --queue-num "$NFQUEUE_NUM" 2>/dev/null || true
+remove_nfqws_rules iptables
+remove_nfqws_rules ip6tables
 
-# Add NFQUEUE rules — intercept outbound TCP from port 443
-iptables -t mangle -A OUTPUT -p tcp --sport 443 -j NFQUEUE --queue-num "$NFQUEUE_NUM"
-ip6tables -t mangle -A OUTPUT -p tcp --sport 443 -j NFQUEUE --queue-num "$NFQUEUE_NUM"
+# Add NFQUEUE rules — intercept outbound TCP from port
+iptables -t mangle -A OUTPUT -p tcp --sport "$PORT" -j NFQUEUE --queue-num "$NFQUEUE_NUM"
+ip6tables -t mangle -A OUTPUT -p tcp --sport "$PORT" -j NFQUEUE --queue-num "$NFQUEUE_NUM"
 
 # Persist rules
 mkdir -p /etc/iptables

--- a/deploy/setup_tunnel.sh
+++ b/deploy/setup_tunnel.sh
@@ -57,6 +57,28 @@ ok()    { echo -e "${GREEN}✓${RESET} $*"; }
 warn()  { echo -e "${RED}⚠${RESET} $*"; }
 fail()  { echo -e "${RED}✗${RESET} $*" >&2; exit 1; }
 
+get_server_port() {
+    local cfg="$1"
+    awk '
+        BEGIN { in_server = 0 }
+        /^[[:space:]]*\[server\][[:space:]]*$/ { in_server = 1; next }
+        /^[[:space:]]*\[[^]]+\][[:space:]]*$/ { in_server = 0; next }
+        in_server {
+            line = $0
+            sub(/#.*/, "", line)
+            if (line ~ /^[[:space:]]*port[[:space:]]*=/) {
+                split(line, parts, "=")
+                value = parts[2]
+                gsub(/[^0-9]/, "", value)
+                if (value != "") {
+                    print value
+                    exit
+                }
+            }
+        }
+    ' "$cfg" 2>/dev/null
+}
+
 # ── Argument parsing ────────────────────────────────────────
 AWG_CONF="${1:-}"
 TUNNEL_MODE="${2:-direct}"
@@ -98,6 +120,9 @@ set_use_middle_proxy() {
 # ── Validate proxy is installed ─────────────────────────────
 [[ -f "$INSTALL_DIR/mtproto-proxy" ]] || fail "mtproto-proxy not found at $INSTALL_DIR. Run install.sh first."
 [[ -f "$INSTALL_DIR/config.toml" ]] || fail "config.toml not found at $INSTALL_DIR."
+
+PORT="$(get_server_port "$INSTALL_DIR/config.toml")"
+PORT="${PORT:-443}"
 
 # ── Step 1: Install AmneziaWG ───────────────────────────────
 info "Installing AmneziaWG..."
@@ -182,6 +207,8 @@ iptables -A FORWARD -i veth_main -o $MAIN_IF -j ACCEPT
 
 echo "Network namespace $NS_NAME ready, awg0 tunnel active inside namespace"
 NETNS_EOF
+sed -i "s/--dport 443/--dport $PORT/g" "$NETNS_SCRIPT"
+sed -i "s/10.200.200.2:443/10.200.200.2:$PORT/g" "$NETNS_SCRIPT"
 chmod +x "$NETNS_SCRIPT"
 ok "Created $NETNS_SCRIPT"
 
@@ -286,14 +313,6 @@ if [[ $FAIL -eq 1 ]]; then
 fi
 
 # ── Print result ────────────────────────────────────────────
-PORT=$(awk '
-    BEGIN { in_server = 0 }
-    /^\[server\]/ { in_server = 1; next }
-    /^\[/ { in_server = 0; next }
-    in_server && /^port/ { split($0, a, "="); gsub(/[^0-9]/, "", a[2]); print a[2] }
-' "$INSTALL_DIR/config.toml" | head -1)
-PORT="${PORT:-443}"
-
 # Extract first user secret
 SECRET=$(grep -oP '=\s*"\K[0-9a-f]{32}' "$INSTALL_DIR/config.toml" | head -1)
 TLS_DOMAIN=$(grep -oP 'tls_domain\s*=\s*"\K[^"]+' "$INSTALL_DIR/config.toml" || echo "wb.ru")


### PR DESCRIPTION
## Summary
- parse the listen port strictly from `[server].port` in `install.sh`, `setup_nfqws.sh`, and `setup_tunnel.sh` to avoid matching `mask_port`
- apply the parsed port to ufw/TCPMSS/NFQUEUE/netns DNAT paths so deploy helpers follow non-443 configs
- make NFQUEUE cleanup remove previous queue rules before adding new ones, preventing stale mixed-port rules after port changes

## Testing
- `bash -n deploy/install.sh deploy/setup_nfqws.sh deploy/setup_tunnel.sh`
- remote smoke test on `38.180.236.207`: switched `server.port` to `8443` with `mask_port=7443`, ran `setup_nfqws.sh`, verified NFQUEUE rules use only `--sport 8443`, then restored config and verified rules return to `--sport 443`

Closes #101