### PR TITLE
feat(config): add per-user MiddleProxy direct bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,10 @@ fast_mode = true
 [access.users]
 alice = "00112233445566778899aabbccddeeff"
 bob   = "ffeeddccbbaa99887766554433221100"
+
+[access.direct_users]
+alice = true   # "alice" from [access.users]: always direct, keeps fast_mode eligible
+# bob = true   # optional
 ```
 
 <details>
@@ -618,6 +622,7 @@ bob   = "ffeeddccbbaa99887766554433221100"
 | `[censorship]` | `drs` | `false` | Dynamic Record Sizing: ramp TLS records from 1369→16384 bytes after warmup (mimics Chrome/Firefox) |
 | `[censorship]` | `fast_mode` | `false` | **Recommended**. Drastically reduces RAM/CPU usage by natively delegating S2C AES encryption to the Telegram DC |
 | `[access.users]` | `<name>` | -- | 32 hex-char secret (16 bytes) per user |
+| `[access.direct_users]` | `<name> = true` | _(none)_ | Optional per-user MiddleProxy bypass. `<name>` must match a user from `[access.users]`; such users always connect directly to Telegram DCs (including media paths). Alias section: `[access.admins]` |
 
 </details>
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -84,3 +84,10 @@ fast_mode = true
 # Generate with: openssl rand -hex 16
 user1 = "00112233445566778899aabbccddeeff"
 user2 = "ffeeddccbbaa99887766554433221100"
+
+[access.direct_users]
+# Optional: users that always bypass MiddleProxy (direct DC path).
+# Useful for admin/service accounts that should always use fast mode.
+# Names here must match keys from [access.users].
+# Value must be true/1/yes to enable.
+# user1 = true

--- a/src/config.zig
+++ b/src/config.zig
@@ -33,6 +33,9 @@ pub const Config = struct {
     tag: ?[16]u8 = null,
     tls_domain: []const u8 = "google.com",
     users: std.StringHashMap([16]u8),
+    /// Users that always bypass MiddleProxy and connect to DC directly.
+    /// Section: [access.direct_users] (alias: [access.admins])
+    direct_users: std.StringHashMap(void),
     /// Whether to mask bad clients (forward to tls_domain)
     mask: bool = true,
     /// Test-only hook to override the mask port
@@ -65,6 +68,10 @@ pub const Config = struct {
         return @as(usize, self.middleproxy_buffer_kb) * 1024;
     }
 
+    pub fn userBypassesMiddleProxy(self: *const Config, user_name: []const u8) bool {
+        return self.direct_users.contains(user_name);
+    }
+
     /// Emit startup warnings for configuration values known to cause issues.
     pub fn emitWarnings(self: *const Config) void {
         if (self.use_middle_proxy and self.middleproxy_buffer_kb < 1024) {
@@ -86,6 +93,19 @@ pub const Config = struct {
                 .{ self.max_connections, self.middleproxy_buffer_kb, mem_per_conn_mb * self.max_connections, shared_mb },
             );
         }
+
+        if (self.direct_users.count() > 0) {
+            const log = std.log.scoped(.config);
+            var it = @constCast(&self.direct_users).iterator();
+            while (it.next()) |entry| {
+                if (!self.users.contains(entry.key_ptr.*)) {
+                    log.warn(
+                        "access.direct_users contains unknown user '{s}' (missing in [access.users]); entry will be ignored",
+                        .{entry.key_ptr.*},
+                    );
+                }
+            }
+        }
     }
 
     pub fn loadFromFile(allocator: std.mem.Allocator, path: []const u8) !Config {
@@ -99,10 +119,12 @@ pub const Config = struct {
     pub fn parse(allocator: std.mem.Allocator, content: []const u8) !Config {
         var cfg = Config{
             .users = std.StringHashMap([16]u8).init(allocator),
+            .direct_users = std.StringHashMap(void).init(allocator),
         };
 
         var lines = std.mem.splitScalar(u8, content, '\n');
         var in_users_section = false;
+        var in_direct_users_section = false;
         var in_censorship_section = false;
         var in_server_section = false;
         var in_general_section = false;
@@ -117,6 +139,7 @@ pub const Config = struct {
             // Section headers
             if (line[0] == '[') {
                 in_users_section = std.mem.eql(u8, line, "[access.users]");
+                in_direct_users_section = std.mem.eql(u8, line, "[access.direct_users]") or std.mem.eql(u8, line, "[access.admins]");
                 in_censorship_section = std.mem.eql(u8, line, "[censorship]");
                 in_server_section = std.mem.eql(u8, line, "[server]");
                 in_general_section = std.mem.eql(u8, line, "[general]");
@@ -140,6 +163,13 @@ pub const Config = struct {
                     _ = std.fmt.hexToBytes(&secret, value) catch continue;
                     const name = try allocator.dupe(u8, key);
                     try cfg.users.put(name, secret);
+                } else if (in_direct_users_section) {
+                    const enabled = std.mem.eql(u8, value, "true") or
+                        std.mem.eql(u8, value, "1") or
+                        std.mem.eql(u8, value, "yes");
+                    if (!enabled) continue;
+                    const name = try allocator.dupe(u8, key);
+                    try cfg.direct_users.put(name, {});
                 } else if (in_general_section) {
                     if (std.mem.eql(u8, key, "use_middle_proxy")) {
                         cfg.use_middle_proxy = std.mem.eql(u8, value, "true");
@@ -232,6 +262,14 @@ pub const Config = struct {
             allocator.free(entry.key_ptr.*);
         }
         users.deinit();
+
+        var direct_users = @constCast(&self.direct_users);
+        var direct_it = direct_users.iterator();
+        while (direct_it.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+        }
+        direct_users.deinit();
+
         // Free tls_domain if it was allocated (not the default)
         if (!std.mem.eql(u8, self.tls_domain, "google.com")) {
             allocator.free(self.tls_domain);
@@ -326,6 +364,41 @@ test "parse config - missing fields defaults" {
     try std.testing.expectEqual(@as(u8, 30), cfg.rate_limit_per_subnet);
     try std.testing.expect(!cfg.unsafe_override_limits);
     try std.testing.expectEqual(@as(usize, 1), cfg.users.count());
+    try std.testing.expectEqual(@as(usize, 0), cfg.direct_users.count());
+}
+
+test "parse config - direct users allowlist" {
+    const content =
+        \\[access.users]
+        \\admin = "00112233445566778899aabbccddeeff"
+        \\regular = "aabbccddeeff00112233445566778899"
+        \\[access.direct_users]
+        \\admin = true
+        \\regular = false
+        \\ghost = true
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), cfg.direct_users.count());
+    try std.testing.expect(cfg.userBypassesMiddleProxy("admin"));
+    try std.testing.expect(!cfg.userBypassesMiddleProxy("regular"));
+    try std.testing.expect(cfg.userBypassesMiddleProxy("ghost"));
+}
+
+test "parse config - access admins alias" {
+    const content =
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+        \\[access.admins]
+        \\alice = true
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expect(cfg.userBypassesMiddleProxy("alice"));
 }
 
 test "parse config - middleproxy buffer size" {

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -1890,7 +1890,7 @@ const EventLoop = struct {
         else
             null;
 
-        const plan = buildDcConnectPlan(&self.state.config, dc_abs, slot.dc_idx, if (snapshot) |*s| s else null);
+        const plan = buildDcConnectPlan(&self.state.config, dc_abs, slot.dc_idx, if (snapshot) |*s| s else null, result.user);
         if (plan.count == 0) {
             self.closeSlot(slot, "no upstream candidates");
             return;
@@ -3526,12 +3526,21 @@ fn buildDcConnectPlan(
     dc_abs: usize,
     dc_idx: i16,
     snapshot: ?*const ProxyState.MiddleProxySnapshot,
+    user_name: []const u8,
 ) DcConnectPlan {
     var plan = DcConnectPlan{};
     plan.is_media_path = (dc_idx < 0) or (dc_abs == 203);
 
     if (cfg.datacenter_override) |override| {
         plan.candidates[0] = override;
+        plan.count = 1;
+        plan.use_middle_proxy = false;
+        plan.direct_fallback = null;
+        return plan;
+    }
+
+    if (cfg.userBypassesMiddleProxy(user_name)) {
+        plan.candidates[0] = constants.getDcAddressV4(dc_abs);
         plan.count = 1;
         plan.use_middle_proxy = false;
         plan.direct_fallback = null;
@@ -3869,6 +3878,58 @@ test "parse middle proxy address for dc203" {
     const addr = parseMiddleProxyAddressForDc(cfg, 203) orelse return error.TestExpectedEqual;
     try std.testing.expect(addr.any.family == posix.AF.INET);
     try std.testing.expectEqual(@as(u16, 443), std.mem.bigToNative(u16, addr.in.sa.port));
+}
+
+test "direct users bypass middle-proxy routing" {
+    const cfg_text =
+        \\[general]
+        \\use_middle_proxy = true
+        \\[access.users]
+        \\admin = "00112233445566778899aabbccddeeff"
+        \\regular = "ffeeddccbbaa99887766554433221100"
+        \\[access.direct_users]
+        \\admin = true
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, cfg_text);
+    defer cfg.deinit(std.testing.allocator);
+
+    const mp_dc4 = net.Address.initIp4(.{ 11, 11, 11, 11 }, 443);
+    const mp_dc203 = net.Address.initIp4(.{ 12, 12, 12, 12 }, 443);
+    const snapshot = ProxyState.MiddleProxySnapshot{
+        .addrs_primary = .{
+            constants.tg_middle_proxies_v4[0],
+            constants.tg_middle_proxies_v4[1],
+            constants.tg_middle_proxies_v4[2],
+            mp_dc4,
+            constants.tg_middle_proxies_v4[4],
+        },
+        .addr_203 = mp_dc203,
+        .addrs_dc4 = [_]net.Address{mp_dc4} ++ ([_]net.Address{mp_dc4} ** 15),
+        .addrs_dc4_len = 1,
+        .addrs_203 = [_]net.Address{mp_dc203} ++ ([_]net.Address{mp_dc203} ** 7),
+        .addrs_203_len = 1,
+        .secret = [_]u8{0} ** 256,
+        .secret_len = 16,
+    };
+
+    const regular_plan = buildDcConnectPlan(&cfg, 4, 4, &snapshot, "regular");
+    try std.testing.expect(regular_plan.use_middle_proxy);
+    try std.testing.expect(regular_plan.direct_fallback != null);
+    try std.testing.expect(regular_plan.candidates[0].eql(mp_dc4));
+
+    const admin_plan = buildDcConnectPlan(&cfg, 4, 4, &snapshot, "admin");
+    try std.testing.expect(!admin_plan.use_middle_proxy);
+    try std.testing.expect(admin_plan.direct_fallback == null);
+    try std.testing.expect(admin_plan.candidates[0].eql(constants.getDcAddressV4(4)));
+
+    const regular_media = buildDcConnectPlan(&cfg, 203, -203, &snapshot, "regular");
+    try std.testing.expect(regular_media.use_middle_proxy);
+    try std.testing.expect(regular_media.candidates[0].eql(mp_dc203));
+
+    const admin_media = buildDcConnectPlan(&cfg, 203, -203, &snapshot, "admin");
+    try std.testing.expect(!admin_media.use_middle_proxy);
+    try std.testing.expect(admin_media.candidates[0].eql(constants.getDcAddressV4(203)));
 }
 
 test "DRS disabled fixed size" {


### PR DESCRIPTION
## Summary
- add `[access.direct_users]` (alias `[access.admins]`) in config parsing and runtime lookups
- bypass MiddleProxy per validated user secret, including media/DC203 paths
- add parser/routing tests and update docs/examples for direct-user mapping behavior

## Testing
- zig build test