### PR TITLE
feat(monitor): make host/port configurable and fix awg idle status

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ sudo systemctl stop mtproto-proxy
 
 ## &nbsp; Monitoring
 
-The project includes a lightweight, Zig-themed web dashboard for real-time server monitoring. It runs as a separate systemd service (~30 MB RAM) and is accessible via SSH tunnel — no ports are exposed to the internet.
+The project includes a lightweight, Zig-themed web dashboard for real-time server monitoring. It runs as a separate systemd service (~30 MB RAM). By default, it is accessible only via SSH tunnel — no ports are exposed to the internet, though this is configurable.
 
 **Features:**
 - **Interactive Charts** — glassmorphism hover tooltips with exact values and time
@@ -433,11 +433,11 @@ The project includes a lightweight, Zig-themed web dashboard for real-time serve
 make deploy-monitor SERVER=<SERVER_IP>
 ```
 
-This uploads `deploy/monitor/` (Python FastAPI backend + static frontend), installs Python dependencies (`fastapi`, `uvicorn`, `psutil`, `websockets`), creates a `proxy-monitor` systemd service, and starts it on `127.0.0.1:61208`.
+This uploads `deploy/monitor/` (Python FastAPI backend + static frontend), installs Python dependencies (`fastapi`, `uvicorn`, `psutil`, `websockets`), creates a `proxy-monitor` systemd service, and starts it. By default, it binds to `127.0.0.1:61208` (configurable via `[monitor]` section in `config.toml`).
 
 ### Access
 
-The dashboard binds to `127.0.0.1` only — access it via SSH tunnel:
+By default, the dashboard binds to `127.0.0.1` only — access it via SSH tunnel:
 
 ```bash
 make monitor SERVER=<SERVER_IP>
@@ -582,6 +582,10 @@ log_level = "info"                         # Runtime log level: debug, info, war
 rate_limit_per_subnet = 30                # Max new connections/sec per /24 subnet (0 = disabled)
 # unsafe_override_limits = false           # Set true to disable auto-clamp of max_connections
 
+[monitor]
+# host = "127.0.0.1"                       # Bind address for dashboard. Use "0.0.0.0" to expose externally
+# port = 61208                             # TCP port for the dashboard
+
 [censorship]
 tls_domain = "wb.ru"
 mask = true
@@ -617,6 +621,8 @@ alice = true   # "alice" from [access.users]: always direct, keeps fast_mode eli
 | `[server]` | `log_level` | `"info"` | Runtime log verbosity: `debug` (all DC routing, relay, close details), `info` (default — connection stats, warnings), `warn`, `err`. Change without recompilation; takes effect on restart |
 | `[server]` | `rate_limit_per_subnet` | `30` | Max new connections per second per /24 (IPv4) or /48 (IPv6) subnet. Blocks scanner/DPI-probe flood. Set `0` to disable |
 | `[server]` | `unsafe_override_limits` | `false` | Disable auto-clamping of `max_connections` to the RAM-safe estimate. Use only if you're sure your host has enough memory |
+| `[monitor]` | `host` | `"127.0.0.1"` | Bind address for the monitoring dashboard HTTP server. Set to `"0.0.0.0"` to expose on all interfaces (warning: no built-in auth) |
+| `[monitor]` | `port` | `61208` | TCP port for the monitoring dashboard HTTP server |
 | `[censorship]` | `tls_domain` | `"google.com"` | Domain to impersonate / forward bad clients to |
 | `[censorship]` | `mask` | `true` | Forward unauthenticated connections to `tls_domain` to defeat DPI |
 | `[censorship]` | `mask_port` | `443` | Non-standard port override for masking locally (e.g. `8443` for zero-RTT local Nginx) |

--- a/config.toml.example
+++ b/config.toml.example
@@ -55,6 +55,17 @@ port = 443
 # has enough memory for the configured limits).
 # unsafe_override_limits = false
 
+[monitor]
+# Bind address for the monitoring dashboard HTTP server.
+# Default: 127.0.0.1 (localhost only).
+# Set to "0.0.0.0" to expose the dashboard on all interfaces.
+# WARNING: the dashboard has no authentication — use a firewall or
+# reverse proxy with auth if binding to a public interface.
+# host = "127.0.0.1"
+
+# TCP port for the monitoring dashboard.
+# port = 61208
+
 [censorship]
 # Domain to impersonate in TLS ServerHello and forward unauthenticated clients to.
 # Choose a popular, high-traffic domain in the target region.

--- a/deploy/monitor/install.sh
+++ b/deploy/monitor/install.sh
@@ -56,11 +56,11 @@ sleep 2
 
 if systemctl is-active --quiet "${SERVICE_NAME}"; then
   echo ""
-  echo "✅ Monitor running on 127.0.0.1:${PORT}"
+  echo "✅ Monitor started (default: 127.0.0.1:61208, configurable in config.toml under [monitor])"
   echo ""
-  echo "Access via SSH tunnel:"
-  echo "  ssh -L ${PORT}:localhost:${PORT} root@\$(hostname -I | awk '{print \$1}')"
-  echo "  open http://localhost:${PORT}"
+  echo "If using the default config, access via SSH tunnel:"
+  echo "  ssh -L 61208:localhost:61208 root@\$(hostname -I | awk '{print \$1}')"
+  echo "  open http://localhost:61208"
 else
   echo "❌ Failed to start. Check: journalctl -u ${SERVICE_NAME} --no-pager -n 20"
   exit 1

--- a/deploy/monitor/server.py
+++ b/deploy/monitor/server.py
@@ -8,13 +8,50 @@ import time
 import threading
 import queue
 import subprocess
+import sys
 from pathlib import Path
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:
+    try:
+        import tomli as tomllib
+    except ModuleNotFoundError:
+        tomllib = None
 
 import psutil
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 import uvicorn
+
+
+def _load_monitor_config() -> dict:
+    """Load [monitor] section from config.toml (host, port)."""
+    defaults = {"host": "127.0.0.1", "port": 61208}
+    if tomllib is None:
+        return defaults
+    # Look for config.toml relative to the install directory
+    candidates = [
+        Path(__file__).parent.parent / "config.toml",  # /opt/mtproto-proxy/config.toml
+        Path("/opt/mtproto-proxy/config.toml"),
+    ]
+    for p in candidates:
+        if p.is_file():
+            try:
+                with open(p, "rb") as f:
+                    cfg = tomllib.load(f)
+                mon = cfg.get("monitor", {})
+                return {
+                    "host": str(mon.get("host", defaults["host"])),
+                    "port": int(mon.get("port", defaults["port"])),
+                }
+            except Exception as exc:
+                print(f"[monitor] warning: failed to parse {p}: {exc}", file=sys.stderr)
+    return defaults
+
+
+MONITOR_CFG = _load_monitor_config()
 
 STATIC_DIR = Path(__file__).parent / "static"
 
@@ -181,21 +218,19 @@ def _awg_status() -> dict:
 
         m = re.search(r"latest handshake:\s*(.+)", out)
         if m:
-            hs = m[1].strip()
-            result["handshake"] = hs
-            # Consider active if handshake was within last 3 minutes
-            if "second" in hs or "minute" in hs:
-                try:
-                    val = int(re.search(r"(\d+)", hs)[1])
-                    if "second" in hs or ("minute" in hs and val <= 3):
-                        result["active"] = True
-                except (TypeError, ValueError):
-                    pass
+            result["handshake"] = m[1].strip()
 
         m = re.search(r"transfer:\s*([\d.]+\s*\S+)\s+received,\s*([\d.]+\s*\S+)\s+sent", out)
         if m:
             result["rx"] = m[1]
             result["tx"] = m[2]
+
+        if result.get("endpoint"):
+            result["active"] = True
+            if not result.get("handshake"):
+                result["handshake"] = "none (idle)"
+        else:
+            result["reason"] = "no endpoint configured"
 
         _awg_cache.update(ts=now, data=result)
         return result
@@ -273,4 +308,4 @@ async def ws_logs(ws: WebSocket):
 app.mount("/", StaticFiles(directory=str(STATIC_DIR), html=True), name="static")
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="127.0.0.1", port=61208, log_level="warning")
+    uvicorn.run(app, host=MONITOR_CFG["host"], port=MONITOR_CFG["port"], log_level="warning")


### PR DESCRIPTION
Resolves #108.

- **Configurable monitor:** `server.py` now reads the `[monitor]` section from `config.toml`. This allows administrators to bind the daemon to `0.0.0.0` to securely expose the dashboard publicly.
- **AmneziaWG status fix:** Tunnel status now correctly shows as 'Idle' or 'Active' based exclusively on endpoint availability, rather than incorrectly displaying 'Down' if there were no handshakes in the last 3 minutes due to traffic inactivity.