### PR TITLE
fix(docs): use absolute URLs for README video embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ sudo mtbuddy --interactive
 <summary>Demo: interactive installer</summary>
 <br>
 
-<video src="assets/buddy.mp4" autoplay loop muted playsinline width="100%"></video>
+<video src="https://github.com/sleep3r/mtproto.zig/raw/main/assets/buddy.mp4" autoplay loop muted playsinline width="100%"></video>
 
 </details>
 
@@ -293,7 +293,7 @@ Alternatively, expose the dashboard port via `[monitor]` config section and acce
 <summary>Demo: monitoring dashboard</summary>
 <br>
 
-<video src="assets/dashboard.mp4" autoplay loop muted playsinline width="100%"></video>
+<video src="https://github.com/sleep3r/mtproto.zig/raw/main/assets/dashboard.mp4" autoplay loop muted playsinline width="100%"></video>
 
 </details>
 


### PR DESCRIPTION
GitHub strips <video> tags with relative src paths, so the demo videos were not playable. Switched to absolute raw.githubusercontent.com URLs.