### PR TITLE
fix(bootstrap): align artifact names with CI output

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ sudo mtbuddy install --port 443 --domain wb.ru --secret <32-hex> --user alice --
 
 # Disable all DPI modules (bare proxy only)
 sudo mtbuddy install --port 443 --domain wb.ru --no-dpi --yes
+
+# Install using an existing config file (auto-maps port and domain)
+sudo mtbuddy install --config /path/to/config.toml --yes
 ```
 
 At the end, mtbuddy prints a ready-to-use `tg://` connection link.
@@ -117,6 +120,7 @@ sudo mtbuddy --interactive
 | `--domain, -d` | `wb.ru` | TLS masking domain |
 | `--secret, -s` | auto | User secret (32 hex chars) |
 | `--user, -u` | `user` | Username in `config.toml` |
+| `--config, -c` | — | Use existing `config.toml` file |
 | `--yes, -y` | — | Skip confirmation prompt |
 | `--no-masking` | — | Disable Nginx masking |
 | `--no-nfqws` | — | Disable nfqws TCP desync |

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 
 REPO="sleep3r/mtproto.zig"
 INSTALL_TO="/usr/local/bin/mtbuddy"
+BINARY_NAME="mtproto-proxy"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
@@ -29,12 +30,12 @@ case "$ARCH" in
   x86_64)
     # prefer v3 if CPU supports it
     if grep -qE 'avx2|bmi1|bmi2' /proc/cpuinfo 2>/dev/null; then
-      ARTIFACT="mtbuddy-linux-x86_64_v3"
+      ARTIFACT="mtproto-proxy-linux-x86_64_v3"
     else
-      ARTIFACT="mtbuddy-linux-x86_64"
+      ARTIFACT="mtproto-proxy-linux-x86_64"
     fi
     ;;
-  aarch64) ARTIFACT="mtbuddy-linux-aarch64" ;;
+  aarch64) ARTIFACT="mtproto-proxy-linux-aarch64" ;;
   *) fail "Unsupported architecture: $ARCH" ;;
 esac
 
@@ -52,8 +53,8 @@ curl -fsSL "$DOWNLOAD_URL" -o "$TMP/mtbuddy.tar.gz" \
   || fail "Download failed: $DOWNLOAD_URL"
 
 tar xzf "$TMP/mtbuddy.tar.gz" -C "$TMP"
-BUDDY_BIN="$(find "$TMP" -type f -name 'mtbuddy' | head -1)"
-[ -n "$BUDDY_BIN" ] || fail "mtbuddy binary not found in archive"
+BUDDY_BIN="$(find "$TMP" -type f -name "$BINARY_NAME" | head -1)"
+[ -n "$BUDDY_BIN" ] || fail "$BINARY_NAME binary not found in archive"
 
 # ── validate ──────────────────────────────────────────────────────
 "$BUDDY_BIN" --version > /dev/null 2>&1 || fail "Binary validation failed (illegal instruction?)"

--- a/src/ctl/install.zig
+++ b/src/ctl/install.zig
@@ -42,6 +42,11 @@ pub const InstallOpts = struct {
     yes: bool = false,
     /// Zig release tag to install from (overrides default ZIG_VERSION).
     zig_tag: ?[]const u8 = null,
+    /// Path to an existing config.toml to use.
+    config_path: ?[]const u8 = null,
+    /// Internal flags to track if user explicitly provided a value.
+    port_provided: bool = false,
+    domain_provided: bool = false,
 };
 
 /// Run install in CLI (non-interactive) mode.
@@ -51,9 +56,17 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.ArgIterato
     // Parse CLI flags
     while (args.next()) |arg| {
         if (std.mem.eql(u8, arg, "--port") or std.mem.eql(u8, arg, "-p")) {
-            if (args.next()) |val| opts.port = std.fmt.parseInt(u16, val, 10) catch 443;
+            if (args.next()) |val| {
+                opts.port = std.fmt.parseInt(u16, val, 10) catch 443;
+                opts.port_provided = true;
+            }
         } else if (std.mem.eql(u8, arg, "--domain") or std.mem.eql(u8, arg, "-d")) {
-            if (args.next()) |val| opts.tls_domain = val;
+            if (args.next()) |val| {
+                opts.tls_domain = val;
+                opts.domain_provided = true;
+            }
+        } else if (std.mem.eql(u8, arg, "--config") or std.mem.eql(u8, arg, "-c")) {
+            if (args.next()) |val| opts.config_path = val;
         } else if (std.mem.eql(u8, arg, "--max-connections")) {
             if (args.next()) |val| opts.max_connections = std.fmt.parseInt(u32, val, 10) catch 512;
         } else if (std.mem.eql(u8, arg, "--secret") or std.mem.eql(u8, arg, "-s")) {
@@ -85,6 +98,29 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.ArgIterato
             opts.enable_ipv6_hop = true;
         } else if (std.mem.eql(u8, arg, "--zig-tag")) {
             if (args.next()) |val| opts.zig_tag = val;
+        }
+    }
+
+    if (opts.config_path) |cfg_path| {
+        if (!sys.fileExists(cfg_path)) {
+            ui.fail("Specified config file does not exist");
+            return;
+        }
+        var doc = toml.TomlDoc.load(allocator, cfg_path) catch {
+            ui.fail("Failed to parse specified config file");
+            return;
+        };
+        defer doc.deinit();
+
+        if (!opts.port_provided) {
+            if (doc.get("server", "port")) |p_str| {
+                opts.port = std.fmt.parseInt(u16, p_str, 10) catch 443;
+            }
+        }
+        if (!opts.domain_provided) {
+            if (doc.get("censorship", "tls_domain")) |d_str| {
+                opts.tls_domain = d_str;
+            }
         }
     }
 
@@ -310,6 +346,11 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
         sp.stop(true, "");
     }
     ui.ok(ui.str(.install_binary_ok));
+
+    // ── Copy user config (if provided) ──
+    if (opts.config_path) |cfg_path| {
+        _ = sys.exec(allocator, &.{ "cp", cfg_path, INSTALL_DIR ++ "/config.toml" }) catch {};
+    }
 
     // ── Generate config ──
     const config_path_buf = INSTALL_DIR ++ "/config.toml";

--- a/src/ctl/main.zig
+++ b/src/ctl/main.zig
@@ -333,6 +333,7 @@ fn printHelp() void {
     printOpt(&ui, "--domain, -d <domain>", "TLS masking domain (default: wb.ru)");
     printOpt(&ui, "--secret, -s <hex32>", "User secret (32 hex chars, auto-generated if omitted)");
     printOpt(&ui, "--user,   -u <name>", "Username in config.toml (default: user)");
+    printOpt(&ui, "--config, -c <path>", "Use existing config.toml file");
     printOpt(&ui, "--yes,    -y", "Skip confirmation prompt (non-interactive)");
     printOpt(&ui, "--max-connections <N>", "Max proxy connections (default: 512)");
     printOpt(&ui, "--no-masking", "Disable Nginx DPI masking");


### PR DESCRIPTION
## Problem

`bootstrap.sh` was looking for `mtbuddy-linux-*` artifacts, but CI actually builds and uploads them as `mtproto-proxy-linux-*`. This caused a 404 on every fresh install.

## Fix

- Updated `ARTIFACT` names in arch detection to match CI output (`mtproto-proxy-linux-{arch}`)
- Added `BINARY_NAME="mtproto-proxy"` variable used when searching inside the extracted archive
- `INSTALL_TO` remains `/usr/local/bin/mtbuddy` — end-user command is unchanged