### PR TITLE
fix(bootstrap): download mtbuddy binary instead of mtproto-proxy

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,12 +35,27 @@ jobs:
         include:
           - target: x86_64-linux
             artifact_name: mtproto-proxy-linux-x86_64
+            binary: mtproto-proxy
             cpu: ""
           - target: x86_64-linux
             artifact_name: mtproto-proxy-linux-x86_64_v3
+            binary: mtproto-proxy
             cpu: x86_64_v3
           - target: aarch64-linux
             artifact_name: mtproto-proxy-linux-aarch64
+            binary: mtproto-proxy
+            cpu: ""
+          - target: x86_64-linux
+            artifact_name: mtbuddy-linux-x86_64
+            binary: mtbuddy
+            cpu: ""
+          - target: x86_64-linux
+            artifact_name: mtbuddy-linux-x86_64_v3
+            binary: mtbuddy
+            cpu: x86_64_v3
+          - target: aarch64-linux
+            artifact_name: mtbuddy-linux-aarch64
+            binary: mtbuddy
             cpu: ""
 
     steps:
@@ -65,7 +80,7 @@ jobs:
       - name: Package artifact
         run: |
           mkdir -p dist
-          cp zig-out/bin/mtproto-proxy dist/${{ matrix.artifact_name }}
+          cp zig-out/bin/${{ matrix.binary }} dist/${{ matrix.artifact_name }}
           chmod +x dist/${{ matrix.artifact_name }}
           tar -C dist -czf dist/${{ matrix.artifact_name }}.tar.gz ${{ matrix.artifact_name }}
 

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -16,7 +16,7 @@ TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
 # ── colour helpers ────────────────────────────────────────────────
-Y='\033[0;33m'; G='\033[0;32m'; R='\033[0;31m'; D='\033[2m'; N='\033[0m'
+Y='\033[0;33m'; G='\033[0;32m'; R='\033[0;31m'; N='\033[0m'
 ok()   { printf "  ${G}✔${N} %s\n" "$*"; }
 fail() { printf "  ${R}✖${N} %s\n" "$*" >&2; exit 1; }
 step() { printf "  ${Y}●${N} %s...\n" "$*"; }
@@ -27,50 +27,50 @@ step() { printf "  ${Y}●${N} %s...\n" "$*"; }
 ARCH="$(uname -m)"
 case "$ARCH" in
   x86_64)
-    # try v3 first (AVX2/BMI2 etc); runtime validation will fall back if unsupported
+    # try v3 first (requires AVX2/BMI2); fall back at runtime if unsupported
     if grep -q 'avx2' /proc/cpuinfo 2>/dev/null; then
-      ARTIFACT="mtproto-proxy-linux-x86_64_v3"
-      ARTIFACT_FALLBACK="mtproto-proxy-linux-x86_64"
+      ARTIFACT="mtbuddy-linux-x86_64_v3"
+      ARTIFACT_FALLBACK="mtbuddy-linux-x86_64"
     else
-      ARTIFACT="mtproto-proxy-linux-x86_64"
+      ARTIFACT="mtbuddy-linux-x86_64"
       ARTIFACT_FALLBACK=""
     fi
     ;;
   aarch64)
-    ARTIFACT="mtproto-proxy-linux-aarch64"
+    ARTIFACT="mtbuddy-linux-aarch64"
     ARTIFACT_FALLBACK=""
     ;;
   *) fail "Unsupported architecture: $ARCH" ;;
 esac
 
 # ── resolve latest tag ────────────────────────────────────────────
-step "Fetching latest mtbuddy release"
+step "Fetching latest release"
 TAG="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
   | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": "\(.*\)".*/\1/')"
 [ -n "$TAG" ] || fail "Could not resolve latest release tag"
 ok "Latest release: $TAG"
 
+# ── download helper ───────────────────────────────────────────────
+download_artifact() {
+  local artifact="$1"
+  local url="https://github.com/${REPO}/releases/download/${TAG}/${artifact}.tar.gz"
+  step "Downloading $artifact"
+  curl -fsSL "$url" -o "$TMP/mtbuddy.tar.gz" || fail "Download failed: $url"
+  tar xzf "$TMP/mtbuddy.tar.gz" -C "$TMP"
+  echo "$TMP/$artifact"
+}
+
 # ── download ──────────────────────────────────────────────────────
-DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${TAG}/${ARTIFACT}.tar.gz"
-step "Downloading $ARTIFACT"
-curl -fsSL "$DOWNLOAD_URL" -o "$TMP/mtbuddy.tar.gz" \
-  || fail "Download failed: $DOWNLOAD_URL"
+BUDDY_BIN="$(download_artifact "$ARTIFACT")"
+[ -f "$BUDDY_BIN" ] || fail "Binary not found in archive: $ARTIFACT"
 
-tar xzf "$TMP/mtbuddy.tar.gz" -C "$TMP"
-BUDDY_BIN="$TMP/$ARTIFACT"
-[ -f "$BUDDY_BIN" ] || fail "binary not found in archive: $ARTIFACT"
-
-# ── validate (fallback to base if v3 causes illegal instruction) ──
+# ── validate; fall back to base build if v3 illegal-instructions ─
 if ! "$BUDDY_BIN" --version > /dev/null 2>&1; then
   if [ -n "$ARTIFACT_FALLBACK" ]; then
-    step "v3 binary unsupported by CPU, retrying with $ARTIFACT_FALLBACK"
+    step "CPU does not support v3 build, falling back to $ARTIFACT_FALLBACK"
     ARTIFACT="$ARTIFACT_FALLBACK"
-    DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${TAG}/${ARTIFACT}.tar.gz"
-    curl -fsSL "$DOWNLOAD_URL" -o "$TMP/mtbuddy.tar.gz" \
-      || fail "Download failed: $DOWNLOAD_URL"
-    tar xzf "$TMP/mtbuddy.tar.gz" -C "$TMP"
-    BUDDY_BIN="$TMP/$ARTIFACT"
-    [ -f "$BUDDY_BIN" ] || fail "binary not found in archive: $ARTIFACT"
+    BUDDY_BIN="$(download_artifact "$ARTIFACT")"
+    [ -f "$BUDDY_BIN" ] || fail "Binary not found in archive: $ARTIFACT"
     "$BUDDY_BIN" --version > /dev/null 2>&1 || fail "Binary validation failed"
   else
     fail "Binary validation failed"


### PR DESCRIPTION
## Root cause

Bootstrap has been installing the wrong binary since the beginning.

CI builds and publishes **only** `mtproto-proxy` (the proxy server). `mtbuddy` (the CLI installer/control panel) was never published to releases. Bootstrap downloaded `mtproto-proxy`, renamed it to `mtbuddy`, and placed it at `/usr/local/bin/mtbuddy` — so every user was running the proxy binary when calling `mtbuddy`, which has no flag parsing and treats every argument as a config file path:

```
root@host:~# sudo mtbuddy --interactive
✗ Failed to load config '--interactive': error.FileNotFound
  Usage: mtproto-proxy [config.toml]
```

## Fix

**CI (`release-please.yml`):** added 3 new matrix entries that build and publish `mtbuddy-linux-{x86_64,x86_64_v3,aarch64}` artifacts alongside the existing `mtproto-proxy-*` ones.

**`bootstrap.sh`:** changed artifact names from `mtproto-proxy-linux-*` to `mtbuddy-linux-*`. Also cleaned up the script — extracted a `download_artifact` helper to avoid duplicating curl/tar logic in the v3 fallback path.

## Testing

Verified locally that the correct binaries respond correctly:
```
$ mtbuddy --help        # shows full CLI help
$ mtbuddy --version     # mtbuddy v0.14.0
$ mtbuddy               # shows help (no args)
$ mtbuddy --interactive # launches TUI wizard
$ mtproto-proxy --help  # shows proxy usage
$ mtproto-proxy --version # mtproto-proxy v0.14.0
```