### PR TITLE
fix(bootstrap): redirect ok/step to stderr to fix subshell capture

### DIFF
--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -17,9 +17,9 @@ trap 'rm -rf "$TMP"' EXIT
 
 # ── colour helpers ────────────────────────────────────────────────
 Y='\033[0;33m'; G='\033[0;32m'; R='\033[0;31m'; N='\033[0m'
-ok()   { printf "  ${G}✔${N} %s\n" "$*"; }
+ok()   { printf "  ${G}✔${N} %s\n" "$*" >&2; }
 fail() { printf "  ${R}✖${N} %s\n" "$*" >&2; exit 1; }
-step() { printf "  ${Y}●${N} %s...\n" "$*"; }
+step() { printf "  ${Y}●${N} %s...\n" "$*" >&2; }
 
 [ "$(id -u)" = "0" ] || fail "Run as root: sudo bash bootstrap.sh"
 


### PR DESCRIPTION
## Bug

\`ok()\` and \`step()\` wrote to stdout. The \`download_artifact\` function is called in a subshell via \`BUDDY_BIN=\"\$(download_artifact ...)\"\`, which captures all stdout — so \`BUDDY_BIN\` ended up containing the step message prepended to the path:

```
  ● Downloading mtbuddy-linux-x86_64_v3...
/tmp/xyz/mtbuddy-linux-x86_64_v3
```

\`[ -f \"\$BUDDY_BIN\" ]\` then failed because that string is not a valid path, producing:

```
✖ Binary not found in archive: mtbuddy-linux-x86_64_v3
```

The archive and binary were correct — \`fail()\` already wrote to stderr, \`ok()\` and \`step()\` didn't.

## Fix

Add \`>&2\` to \`ok()\` and \`step()\` so subshell capture only receives the \`echo\` return value.