### PR TITLE
fix(uninstall): remove dashboard service during full cleanup

### DIFF
--- a/src/ctl/uninstall.zig
+++ b/src/ctl/uninstall.zig
@@ -8,20 +8,20 @@ const Color = tui_mod.Color;
 
 pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
     ui.section(ui.str(.uninstall_header));
-    
+
     // Warn the user and ask for confirmation
     const proceed = try ui.confirm(ui.str(.uninstall_warning), false);
     if (!proceed) {
         ui.print("  {s}{s}{s}\n", .{ Color.dim, ui.str(.aborting), Color.reset });
         return;
     }
-    
+
     try execute(ui, allocator);
 }
 
 pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.ArgIterator) void {
     var yes_flag = false;
-    
+
     while (args.next()) |arg| {
         if (std.mem.eql(u8, arg, "--yes") or std.mem.eql(u8, arg, "-y")) {
             yes_flag = true;
@@ -30,12 +30,12 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.ArgIterato
             return;
         }
     }
-    
+
     if (!yes_flag) {
         ui.fail("Uninstall is a destructive action. Pass --yes to confirm non-interactively.");
         return;
     }
-    
+
     ui.section(ui.str(.uninstall_header));
     execute(ui, allocator) catch {};
 }
@@ -46,16 +46,17 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
         ui.fail(ui.str(.error_not_root));
         return;
     }
-    
+
     ui.writeRaw("\n");
     ui.rule();
-    
+
     var sp = ui.spinner(ui.str(.uninstall_in_progress));
     sp.start();
 
     // 1. Stop and disable all associated systemd services
     const services = &[_][]const u8{
         "mtproto-proxy",
+        "proxy-monitor",
         "nfqws-mtproto",
         "mtproto-mask-health.timer",
         "mtproto-mask-health.service",
@@ -86,17 +87,15 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
     _ = sys.execForward(&.{ "rm", "-f", "/etc/nginx/sites-enabled/mtproto-mask" }) catch {};
     _ = sys.execForward(&.{ "rm", "-f", "/etc/nginx/sites-available/mtproto-mask" }) catch {};
     _ = sys.execForward(&.{ "rm", "-rf", "/etc/nginx/ssl/mtproto" }) catch {};
-    
+
     // Attempt Nginx reload if active, to flush deleted configs
     if (sys.isServiceActive("nginx")) {
         _ = sys.execForward(&.{ "systemctl", "try-reload-or-restart", "nginx" }) catch {};
     }
 
     // 6. Attempt to clear TCPMSS iptables rules specifically set by install
-    _ = sys.execForward(&.{ "bash", "-c", 
-        "while iptables -t mangle -D OUTPUT -p tcp --tcp-flags SYN,ACK SYN,ACK -j TCPMSS --set-mss 88 2>/dev/null; do true; done"
-    }) catch {};
-    
+    _ = sys.execForward(&.{ "bash", "-c", "while iptables -t mangle -D OUTPUT -p tcp --tcp-flags SYN,ACK SYN,ACK -j TCPMSS --set-mss 88 2>/dev/null; do true; done" }) catch {};
+
     // Note: Self-removal: The mtbuddy binary is running right now. Removing it while running usually works on Linux.
     _ = sys.execForward(&.{ "rm", "-f", "/usr/local/bin/mtbuddy" }) catch {};
 


### PR DESCRIPTION
## Summary
- include `proxy-monitor` in the service teardown list for `mtbuddy uninstall --yes`
- this ensures full uninstall also stops/disables the monitoring dashboard service and removes its systemd unit

## Testing
- `zig build`
- `zig build test`