### PR TITLE
fix(ctl): keep configured public_ip in tunnel and install links

### DIFF
--- a/src/ctl/install.zig
+++ b/src/ctl/install.zig
@@ -474,22 +474,62 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
     const public_ip = sys.detectPublicIp(allocator) orelse "<SERVER_IP>";
     sp.stop(true, public_ip);
 
-    // Read secret from generated config
+    // Read summary values from active config
+    var summary_server: []const u8 = public_ip;
+    var summary_server_buf: [256]u8 = undefined;
+    var summary_port: u16 = opts.port;
+    var summary_tls_domain: []const u8 = opts.tls_domain;
+    var summary_tls_domain_buf: [256]u8 = undefined;
     var secret_from_cfg: []const u8 = "unknown";
+    var secret_buf: [128]u8 = undefined;
+
     {
         var cfg_doc = toml.TomlDoc.load(allocator, config_path_buf) catch {
-            printSummary(ui, allocator, public_ip, opts.port, secret_from_cfg, opts, config_path_buf);
+            printSummary(ui, allocator, public_ip, opts.port, secret_from_cfg, opts.tls_domain, opts, config_path_buf);
             return;
         };
         defer cfg_doc.deinit();
 
+        if (cfg_doc.get("server", "public_ip")) |configured_server| {
+            const trimmed = std.mem.trim(u8, configured_server, &[_]u8{ ' ', '\t' });
+            if (trimmed.len > 0) {
+                const copy_len = @min(trimmed.len, summary_server_buf.len);
+                @memcpy(summary_server_buf[0..copy_len], trimmed[0..copy_len]);
+                summary_server = summary_server_buf[0..copy_len];
+            }
+        }
+
+        if (cfg_doc.get("server", "port")) |configured_port| {
+            summary_port = std.fmt.parseInt(u16, configured_port, 10) catch summary_port;
+        }
+
+        if (cfg_doc.get("censorship", "tls_domain")) |configured_domain| {
+            const trimmed = std.mem.trim(u8, configured_domain, &[_]u8{ ' ', '\t' });
+            if (trimmed.len > 0) {
+                const copy_len = @min(trimmed.len, summary_tls_domain_buf.len);
+                @memcpy(summary_tls_domain_buf[0..copy_len], trimmed[0..copy_len]);
+                summary_tls_domain = summary_tls_domain_buf[0..copy_len];
+            }
+        }
+
         const user_name = opts.user orelse "user";
-        secret_from_cfg = cfg_doc.get("access.users", user_name) orelse
-            cfg_doc.get("access.users", "user") orelse
-            "unknown";
+        if (cfg_doc.get("access.users", user_name) orelse cfg_doc.get("access.users", "user")) |configured_secret| {
+            const copy_len = @min(configured_secret.len, secret_buf.len);
+            @memcpy(secret_buf[0..copy_len], configured_secret[0..copy_len]);
+            secret_from_cfg = secret_buf[0..copy_len];
+        }
     }
 
-    printSummary(ui, allocator, public_ip, opts.port, secret_from_cfg, opts, config_path_buf);
+    printSummary(
+        ui,
+        allocator,
+        summary_server,
+        summary_port,
+        secret_from_cfg,
+        summary_tls_domain,
+        opts,
+        config_path_buf,
+    );
 }
 
 fn buildEeSecret(secret: []const u8, tls_domain: []const u8, ee_buf: *[512]u8) []const u8 {
@@ -610,6 +650,7 @@ fn printSummary(
     public_ip: []const u8,
     port: u16,
     secret: []const u8,
+    tls_domain: []const u8,
     opts: InstallOpts,
     config_path: []const u8,
 ) void {
@@ -649,9 +690,9 @@ fn printSummary(
     ui.writeRaw("\n");
     ui.print("  {s}╭─ {s}{s}\n", .{ tui_mod.Color.gray, tui_mod.Color.bold, ui.str(.install_connection_link) });
 
-    if (!printLinksFromConfig(ui, allocator, public_ip, port, opts.tls_domain, config_path)) {
+    if (!printLinksFromConfig(ui, allocator, public_ip, port, tls_domain, config_path)) {
         var ee_buf: [512]u8 = undefined;
-        const ee_secret = buildEeSecret(secret, opts.tls_domain, &ee_buf);
+        const ee_secret = buildEeSecret(secret, tls_domain, &ee_buf);
 
         var link_buf: [512]u8 = undefined;
         const link = std.fmt.bufPrint(&link_buf, "tg://proxy?server={s}&port={d}&secret={s}", .{

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -249,20 +249,32 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
     };
     ui.ok(mode_label);
 
-    // ── Inject public IP ──
-    const public_ip = sys.detectPublicIp(allocator) orelse "";
-    if (public_ip.len > 0) {
-        var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch null;
-        if (doc) |*d| {
-            defer d.deinit();
-            var quoted_buf: [64]u8 = undefined;
-            const quoted = std.fmt.bufPrint(&quoted_buf, "\"{s}\"", .{public_ip}) catch "";
-            if (quoted.len > 0) {
-                d.set("server", "public_ip", quoted) catch {};
-                d.save(INSTALL_DIR ++ "/config.toml") catch {};
+    // ── Inject public IP (preserve existing custom value) ──
+    var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch null;
+    if (doc) |*d| {
+        defer d.deinit();
+
+        var should_inject = true;
+        if (d.get("server", "public_ip")) |configured_public_ip| {
+            const configured = std.mem.trim(u8, configured_public_ip, &[_]u8{ ' ', '\t' });
+            if (configured.len > 0 and !std.mem.eql(u8, configured, "<SERVER_IP>")) {
+                should_inject = false;
+                ui.stepOk("Keeping configured public IP", configured);
             }
         }
-        ui.stepOk("Injected public IP", public_ip);
+
+        if (should_inject) {
+            const public_ip = sys.detectPublicIp(allocator) orelse "";
+            if (public_ip.len > 0) {
+                var quoted_buf: [64]u8 = undefined;
+                const quoted = std.fmt.bufPrint(&quoted_buf, "\"{s}\"", .{public_ip}) catch "";
+                if (quoted.len > 0) {
+                    d.set("server", "public_ip", quoted) catch {};
+                    d.save(INSTALL_DIR ++ "/config.toml") catch {};
+                    ui.stepOk("Injected public IP", public_ip);
+                }
+            }
+        }
     }
 
     // ── Preserve promotion tag from env.sh ──


### PR DESCRIPTION
## Summary
- preserve custom `server.public_ip` during `mtbuddy setup tunnel` instead of always overwriting it with detected host IP
- make install summary/link rendering read `server.public_ip`, `server.port`, and `censorship.tls_domain` from the active config so generated links match runtime settings
- avoid stale pointer usage when reading user secret for install summary fallback link generation

## Testing
- `zig build`
- `zig build test`
- validated on a live host: dashboard `/api/stats` now reports `users.server=proxy.sleep3r.ru` and startup links use the configured hostname after restart