### PR TITLE
feat: generic Tunnel interface with AmneziaWG as first implementation

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -57,10 +57,19 @@ pub fn build(b: *std.Build) void {
     soak_step.dependOn(&run_soak_cmd.step);
 
     // ── mtbuddy (installer & control panel) ──
+    const tunnel_mod = b.createModule(.{
+        .root_source_file = b.path("src/tunnel.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
     const ctl_mod = b.createModule(.{
         .root_source_file = b.path("src/ctl/main.zig"),
         .target = target,
         .optimize = optimize,
+        .imports = &.{
+            .{ .name = "tunnel", .module = tunnel_mod },
+        },
     });
 
     const ctl_exe = b.addExecutable(.{

--- a/config.toml.example
+++ b/config.toml.example
@@ -66,6 +66,16 @@ port = 443
 # TCP port for the monitoring dashboard.
 # port = 61208
 
+[tunnel]
+# Active tunnel type for outgoing connections.
+# "none"       — direct TCP (default, auto-detected at runtime)
+# "amnezia_wg" — AmneziaWG via Linux network namespace
+#
+# When set to "none", the proxy auto-detects if it's running inside
+# the tg_proxy_ns network namespace and activates AmneziaWG mode
+# automatically. Set explicitly to override auto-detection.
+# type = "none"
+
 [censorship]
 # Domain to impersonate in TLS ServerHello and forward unauthenticated clients to.
 # Choose a popular, high-traffic domain in the target region.

--- a/src/config.zig
+++ b/src/config.zig
@@ -4,6 +4,7 @@
 //! Format is compatible with the Rust telemt config.toml.
 
 const std = @import("std");
+const Tunnel = @import("tunnel.zig").Tunnel;
 
 pub const Config = struct {
     pub const UserSecret = struct { name: []const u8, secret: [16]u8 };
@@ -63,6 +64,9 @@ pub const Config = struct {
     unsafe_override_limits: bool = false,
     /// Test-only hook to redirect upstream connections locally
     datacenter_override: ?std.net.Address = null,
+    /// Active tunnel type: "none" (default, auto-detect), "amnezia_wg".
+    /// Parsed from the [tunnel] section.
+    tunnel_type: Tunnel.Tag = .none,
 
     pub fn middleProxyBufferBytes(self: *const Config) usize {
         return @as(usize, self.middleproxy_buffer_kb) * 1024;
@@ -128,6 +132,7 @@ pub const Config = struct {
         var in_censorship_section = false;
         var in_server_section = false;
         var in_general_section = false;
+        var in_tunnel_section = false;
         var server_tag_set = false;
 
         while (lines.next()) |raw_line| {
@@ -143,6 +148,7 @@ pub const Config = struct {
                 in_censorship_section = std.mem.eql(u8, line, "[censorship]");
                 in_server_section = std.mem.eql(u8, line, "[server]");
                 in_general_section = std.mem.eql(u8, line, "[general]");
+                in_tunnel_section = std.mem.eql(u8, line, "[tunnel]");
                 continue;
             }
 
@@ -247,6 +253,10 @@ pub const Config = struct {
                         cfg.drs = std.mem.eql(u8, value, "true");
                     } else if (std.mem.eql(u8, key, "fast_mode")) {
                         cfg.fast_mode = std.mem.eql(u8, value, "true");
+                    }
+                } else if (in_tunnel_section) {
+                    if (std.mem.eql(u8, key, "type")) {
+                        cfg.tunnel_type = Tunnel.fromString(value);
                     }
                 }
             }
@@ -809,4 +819,58 @@ test "parse config - multiple users" {
     const alice_secret = cfg.users.get("alice").?;
     try std.testing.expectEqual(@as(u8, 0x00), alice_secret[0]);
     try std.testing.expectEqual(@as(u8, 0xff), alice_secret[15]);
+}
+
+test "parse config - tunnel type amnezia_wg" {
+    const content =
+        \\[tunnel]
+        \\type = "amnezia_wg"
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(Tunnel.Tag.amnezia_wg, cfg.tunnel_type);
+}
+
+test "parse config - tunnel type default none" {
+    const content =
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(Tunnel.Tag.none, cfg.tunnel_type);
+}
+
+test "parse config - tunnel type none explicit" {
+    const content =
+        \\[tunnel]
+        \\type = "none"
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(Tunnel.Tag.none, cfg.tunnel_type);
+}
+
+test "parse config - tunnel type invalid falls back to none" {
+    const content =
+        \\[tunnel]
+        \\type = "banana"
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(Tunnel.Tag.none, cfg.tunnel_type);
 }

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -9,6 +9,7 @@ const tui_mod = @import("tui.zig");
 const i18n = @import("i18n.zig");
 const sys = @import("sys.zig");
 const toml = @import("toml.zig");
+const Tunnel = @import("tunnel").Tunnel;
 
 const Tui = tui_mod.Tui;
 const Color = tui_mod.Color;
@@ -411,4 +412,18 @@ fn stripAwgDnsLines(allocator: std.mem.Allocator, path: []const u8) !bool {
 
     try sys.writeFileMode(path, sanitized, 0o600);
     return true;
+}
+
+/// Detect the currently active tunnel by inspecting runtime state.
+/// Returns the `Tunnel.Tag` corresponding to the detected tunnel,
+/// or `.none` if no known tunnel is active.
+pub fn detectActiveTunnel(allocator: std.mem.Allocator) Tunnel.Tag {
+    // Check if AmneziaWG interface is up inside the network namespace
+    const result = sys.exec(allocator, &.{
+        "ip", "netns", "exec", NS_NAME, "awg", "show", "awg0",
+    }) catch return .none;
+    defer result.deinit();
+
+    if (result.exit_code == 0) return .amnezia_wg;
+    return .none;
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -423,4 +423,5 @@ test {
     _ = tls;
     _ = config;
     _ = proxy;
+    _ = @import("tunnel.zig");
 }

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -16,6 +16,7 @@ const middleproxy = @import("../protocol/middleproxy.zig");
 const tls = @import("../protocol/tls.zig");
 const Config = @import("../config.zig").Config;
 const upstream_mod = @import("upstream.zig");
+const tunnel_mod = @import("../tunnel.zig");
 
 const log = std.log.scoped(.proxy);
 
@@ -825,6 +826,7 @@ pub const ProxyState = struct {
     middle_proxy_secret_len: usize,
     middle_proxy_nat_ip4: ?[4]u8,
     upstream: upstream_mod.Upstream,
+    tunnel_info: tunnel_mod.Tunnel,
 
     pub fn init(allocator: std.mem.Allocator, cfg: Config) ProxyState {
         var secrets: std.ArrayList(obfuscation.UserSecret) = .empty;
@@ -934,6 +936,21 @@ pub const ProxyState = struct {
             .middle_proxy_secret_len = middleproxy.proxy_secret.len,
             .middle_proxy_nat_ip4 = detected_nat_ip4,
             .upstream = upstream_mod.Upstream.initDirect(),
+            .tunnel_info = blk: {
+                // Explicit config takes priority
+                if (cfg.tunnel_type != .none) {
+                    const t = tunnel_mod.Tunnel{ .tag = cfg.tunnel_type };
+                    log.info("Tunnel: {s} (from config)", .{t.name()});
+                    break :blk t;
+                }
+                // Auto-detect: if we're in a non-init netns, assume AmneziaWG
+                if (isRunningInNonInitNetns()) {
+                    const t = tunnel_mod.Tunnel{ .tag = .amnezia_wg };
+                    log.info("Tunnel: {s} (auto-detected from network namespace)", .{t.name()});
+                    break :blk t;
+                }
+                break :blk tunnel_mod.Tunnel{ .tag = .none };
+            },
         };
     }
 

--- a/src/proxy/upstream.zig
+++ b/src/proxy/upstream.zig
@@ -4,10 +4,19 @@
 //! when creating upstream sockets. Today it only provides a direct TCP
 //! connector, but new variants (SOCKS5, HTTP CONNECT, custom tunnels)
 //! can be added without changing the event loop call sites.
+//!
+//! The `tunnel_info` field carries metadata about the active tunnel
+//! (see `tunnel.zig`). For namespace-based tunnels like AmneziaWG,
+//! the connect variant stays `direct` because the proxy process itself
+//! runs inside the namespace — so all TCP connects implicitly traverse
+//! the tunnel without socket-level wrapping.
 
 const std = @import("std");
 const net = std.net;
 const posix = std.posix;
+const tunnel_mod = @import("../tunnel.zig");
+
+pub const Tunnel = tunnel_mod.Tunnel;
 
 pub const ConnectResult = struct {
     fd: posix.fd_t,

--- a/src/tunnel.zig
+++ b/src/tunnel.zig
@@ -1,0 +1,98 @@
+//! Generic tunnel abstraction for proxy transport.
+//!
+//! Defines the `Tunnel` metadata type that describes which tunnel
+//! (if any) is active for outgoing proxy connections. This is a
+//! capability/metadata struct — not a socket connector — because
+//! some tunnels (e.g. AmneziaWG) work by running the proxy inside
+//! a network namespace rather than wrapping individual connect() calls.
+//!
+//! New tunnel types (SOCKS5, HTTP CONNECT, etc.) can be added by
+//! extending the `Tag` enum and implementing type-specific behavior.
+
+const std = @import("std");
+
+pub const Tunnel = struct {
+    pub const Tag = enum {
+        /// Direct connection — no tunnel active.
+        none,
+        /// AmneziaWG tunnel via Linux network namespace.
+        /// The proxy process runs inside `tg_proxy_ns` and all
+        /// outgoing TCP connects traverse the AWG interface.
+        amnezia_wg,
+        // Future variants:
+        // socks5,
+        // http_connect,
+    };
+
+    tag: Tag = .none,
+
+    /// Human-readable name for logging and status display.
+    pub fn name(self: *const Tunnel) []const u8 {
+        return switch (self.tag) {
+            .none => "direct",
+            .amnezia_wg => "AmneziaWG",
+        };
+    }
+
+    /// Whether this tunnel type requires running inside a network namespace.
+    pub fn requiresNetns(self: *const Tunnel) bool {
+        return switch (self.tag) {
+            .none => false,
+            .amnezia_wg => true,
+        };
+    }
+
+    /// The network namespace name, if applicable.
+    pub fn netnsName(self: *const Tunnel) ?[]const u8 {
+        return switch (self.tag) {
+            .none => null,
+            .amnezia_wg => "tg_proxy_ns",
+        };
+    }
+
+    /// Parse a tunnel type string from configuration.
+    /// Returns `.none` for unrecognized values.
+    pub fn fromString(s: []const u8) Tag {
+        if (std.mem.eql(u8, s, "amnezia_wg") or std.mem.eql(u8, s, "amneziawg")) {
+            return .amnezia_wg;
+        }
+        if (std.mem.eql(u8, s, "none") or std.mem.eql(u8, s, "direct")) {
+            return .none;
+        }
+        return .none;
+    }
+};
+
+// ============= Tests =============
+
+test "tunnel - name returns human-readable string" {
+    const direct = Tunnel{ .tag = .none };
+    try std.testing.expectEqualStrings("direct", direct.name());
+
+    const awg = Tunnel{ .tag = .amnezia_wg };
+    try std.testing.expectEqualStrings("AmneziaWG", awg.name());
+}
+
+test "tunnel - requiresNetns" {
+    const direct = Tunnel{ .tag = .none };
+    try std.testing.expect(!direct.requiresNetns());
+
+    const awg = Tunnel{ .tag = .amnezia_wg };
+    try std.testing.expect(awg.requiresNetns());
+}
+
+test "tunnel - netnsName" {
+    const direct = Tunnel{ .tag = .none };
+    try std.testing.expect(direct.netnsName() == null);
+
+    const awg = Tunnel{ .tag = .amnezia_wg };
+    try std.testing.expectEqualStrings("tg_proxy_ns", awg.netnsName().?);
+}
+
+test "tunnel - fromString parsing" {
+    try std.testing.expectEqual(Tunnel.Tag.amnezia_wg, Tunnel.fromString("amnezia_wg"));
+    try std.testing.expectEqual(Tunnel.Tag.amnezia_wg, Tunnel.fromString("amneziawg"));
+    try std.testing.expectEqual(Tunnel.Tag.none, Tunnel.fromString("none"));
+    try std.testing.expectEqual(Tunnel.Tag.none, Tunnel.fromString("direct"));
+    try std.testing.expectEqual(Tunnel.Tag.none, Tunnel.fromString("unknown_value"));
+}


### PR DESCRIPTION
Introduce a Tunnel abstraction that separates tunnel metadata from the upstream transport layer, making the system extensible for future transport types (SOCKS5, HTTP CONNECT, etc.).

Changes:
- New src/tunnel.zig: Tunnel type with Tag enum (none, amnezia_wg), metadata methods (name, requiresNetns, netnsName), and config parsing
- config.zig: parse [tunnel] section with type field
- proxy.zig: ProxyState stores tunnel_info with auto-detection of AmneziaWG namespace at startup
- upstream.zig: re-exports Tunnel, updated documentation
- ctl/tunnel.zig: imports Tunnel.Tag, adds detectActiveTunnel()
- build.zig: tunnel registered as shared module for mtbuddy
- config.toml.example: document [tunnel] section

Fully backward compatible — existing deployments without [tunnel] section continue to work with auto-detection.

Closes #140
Closes #143