### PR TITLE
refactor(proxy): harden handshake path and finalize upstream config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,12 @@ jobs:
       - name: Run microbenchmark
         run: zig build -Doptimize=ReleaseFast bench 2>&1 | tee bench-output.txt
 
+      - name: Run handshake-path benchmark (inline candidates)
+        run: zig build -Doptimize=ReleaseFast bench -- handshake-path --iterations=500000 --candidate-count=4 2>&1 | tee handshake-path-inline-output.txt
+
+      - name: Run handshake-path benchmark (heap fallback)
+        run: zig build -Doptimize=ReleaseFast bench -- handshake-path --iterations=200000 --candidate-count=8 2>&1 | tee handshake-path-heap-output.txt
+
       - name: Run soak test
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -67,5 +73,7 @@ jobs:
           name: bench-soak-results
           path: |
             bench-output.txt
+            handshake-path-inline-output.txt
+            handshake-path-heap-output.txt
             soak-output.txt
           retention-days: 90

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Disguises Telegram traffic as standard TLS 1.3 HTTPS to bypass network censorshi
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Zig](https://img.shields.io/badge/zig-0.15.2-f7a41d.svg?logo=zig&logoColor=white)](https://ziglang.org)
 [![Platform](https://img.shields.io/badge/platform-linux-blueviolet.svg?logo=linux&logoColor=white)](#install)
-[![LOC](https://img.shields.io/badge/lines_of_code-5.5k-informational)](src/)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ sudo mtbuddy setup tunnel /path/to/awg0.conf --mode direct
 
 After setup, `mtbuddy` validates connectivity to all 5 Telegram DCs through the tunnel and prints the link.
 
+It also sets `[upstream].type = "amnezia_wg"` in `config.toml`, so tunnel intent is explicit in config (not only in systemd/netns wiring).
+
 ---
 
 ## Configuration
@@ -216,9 +218,12 @@ Config lives at `/opt/mtproto-proxy/config.toml`. MTBuddy generates it on instal
 [general]
 use_middle_proxy = true   # ME mode for promo-channel parity
 
+[upstream]
+type = "auto"            # auto | direct | amnezia_wg
+
 [server]
 port = 443
-# public_ip = "proxy.example.com"   # Override auto-detected IP (required with tunnel)
+# public_ip = "proxy.example.com"   # Override auto-detected IP (recommended with amnezia_wg)
 max_connections = 512
 idle_timeout_sec = 120
 handshake_timeout_sec = 15
@@ -246,6 +251,7 @@ alice = true   # bypass MiddleProxy for this user
 
 | Key | Default | Description |
 |-----|---------|-------------|
+| `[upstream] type` | `auto` | Egress mode: `auto` (detect netns), `direct`, or `amnezia_wg` (requires proxy in tunnel netns) |
 | `[general] use_middle_proxy` | `false` | Telemt-compatible ME mode for DC1..5 (recommended for promo parity) |
 | `[general] ad_tag` | — | Alias for `[server].tag` (telemt compat) |
 | `[server] port` | `443` | TCP listen port |
@@ -269,6 +275,8 @@ alice = true   # bypass MiddleProxy for this user
 | `[censorship] fast_mode` | `false` | Delegate S2C encryption to DC (recommended) |
 | `[access.users] <name>` | — | 32 hex-char secret per user |
 | `[access.direct_users] <name>` | — | Bypass ME for this user |
+
+[tunnel].type is deprecated and kept only for backward compatibility; use `[upstream].type`.
 
 </details>
 

--- a/build.zig
+++ b/build.zig
@@ -57,10 +57,19 @@ pub fn build(b: *std.Build) void {
     soak_step.dependOn(&run_soak_cmd.step);
 
     // ── mtbuddy (installer & control panel) ──
+    const tunnel_mod = b.createModule(.{
+        .root_source_file = b.path("src/tunnel.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
     const ctl_mod = b.createModule(.{
         .root_source_file = b.path("src/ctl/main.zig"),
         .target = target,
         .optimize = optimize,
+        .imports = &.{
+            .{ .name = "tunnel", .module = tunnel_mod },
+        },
     });
 
     const ctl_exe = b.addExecutable(.{

--- a/config.toml.example
+++ b/config.toml.example
@@ -66,6 +66,16 @@ port = 443
 # TCP port for the monitoring dashboard.
 # port = 61208
 
+[tunnel]
+# Active tunnel type for outgoing connections.
+# "none"       — direct TCP (default, auto-detected at runtime)
+# "amnezia_wg" — AmneziaWG via Linux network namespace
+#
+# When set to "none", the proxy auto-detects if it's running inside
+# the tg_proxy_ns network namespace and activates AmneziaWG mode
+# automatically. Set explicitly to override auto-detection.
+# type = "none"
+
 [censorship]
 # Domain to impersonate in TLS ServerHello and forward unauthenticated clients to.
 # Choose a popular, high-traffic domain in the target region.

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -3,9 +3,11 @@ const net = std.net;
 const crypto = @import("crypto/crypto.zig");
 const middleproxy = @import("protocol/middleproxy.zig");
 const constants = @import("protocol/constants.zig");
+const tls = @import("protocol/tls.zig");
 
 const Mode = enum {
     bench,
+    handshake,
     soak,
 };
 
@@ -44,6 +46,7 @@ pub fn main() !void {
 
     switch (opts.mode) {
         .bench => try runBench(allocator),
+        .handshake => try runHandshakeBench(allocator),
         .soak => try runSoak(allocator, opts),
     }
 }
@@ -99,6 +102,53 @@ fn runBench(allocator: std.mem.Allocator) !void {
             bytesPerSecToMiB(produced_out_bytes, elapsed_ns),
         });
     }
+}
+
+fn runHandshakeBench(allocator: std.mem.Allocator) !void {
+    const bench_secret = [_]u8{0x42} ** 16;
+    const user_secrets = [_]tls.UserSecret{.{ .name = "bench", .secret = bench_secret }};
+    const iterations: usize = 1_000_000;
+
+    var handshake = [_]u8{0} ** 96;
+    handshake[constants.tls_digest_pos + constants.tls_digest_len] = 32;
+    @memset(handshake[44..76], 0xaa);
+
+    var canonical_input = handshake;
+    @memset(canonical_input[constants.tls_digest_pos..][0..constants.tls_digest_len], 0);
+    const canonical = crypto.sha256Hmac(&bench_secret, &canonical_input);
+
+    @memcpy(handshake[constants.tls_digest_pos..][0..28], canonical[0..28]);
+    const ts: u32 = 0x11223344;
+    const ts_bytes = std.mem.toBytes(ts);
+    handshake[constants.tls_digest_pos + 28] = canonical[28] ^ ts_bytes[0];
+    handshake[constants.tls_digest_pos + 29] = canonical[29] ^ ts_bytes[1];
+    handshake[constants.tls_digest_pos + 30] = canonical[30] ^ ts_bytes[2];
+    handshake[constants.tls_digest_pos + 31] = canonical[31] ^ ts_bytes[3];
+
+    var warmup: usize = 0;
+    while (warmup < 1000) : (warmup += 1) {
+        const ok = try tls.validateTlsHandshake(allocator, &handshake, &user_secrets, true);
+        if (ok == null) return error.BenchmarkValidationFailed;
+    }
+
+    var timer = try std.time.Timer.start();
+    var matched: usize = 0;
+    var i: usize = 0;
+    while (i < iterations) : (i += 1) {
+        const ok = try tls.validateTlsHandshake(allocator, &handshake, &user_secrets, true);
+        if (ok != null) matched += 1;
+    }
+
+    const elapsed_ns = timer.read();
+    const ns_per_op = elapsedNsPerOp(elapsed_ns, iterations);
+    const ops_per_sec = if (elapsed_ns == 0)
+        0
+    else
+        @as(u64, @intCast((@as(u128, iterations) * std.time.ns_per_s) / elapsed_ns));
+
+    std.debug.print("benchmark: validateTlsHandshake\n", .{});
+    std.debug.print("iterations matched ns_per_op ops_per_sec\n", .{});
+    std.debug.print("{d} {d} {d} {d}\n", .{ iterations, matched, ns_per_op, ops_per_sec });
 }
 
 fn runSoak(allocator: std.mem.Allocator, opts: Options) !void {
@@ -229,6 +279,10 @@ fn parseArgs(allocator: std.mem.Allocator) !Options {
             opts.mode = .bench;
             continue;
         }
+        if (std.mem.eql(u8, arg, "handshake")) {
+            opts.mode = .handshake;
+            continue;
+        }
         if (std.mem.eql(u8, arg, "soak")) {
             opts.mode = .soak;
             continue;
@@ -283,6 +337,7 @@ fn printUsage() void {
         \\
         \\Modes:
         \\  bench (default): microbenchmark for C2S encapsulation
+        \\  handshake: microbenchmark for TLS handshake validation
         \\  soak: multithreaded crash/stability stress test
         \\
     , .{});
@@ -335,10 +390,15 @@ fn nextPayloadLen(state: *u64, max_payload: usize) usize {
     const pick_hot = (nextRand(state) % 10) < 7;
     if (pick_hot) {
         const idx: usize = @intCast(nextRand(state) % hot_sizes.len);
-        const capped = @min(hot_sizes[idx], max_payload);
-        return if (capped == 0) 1 else capped;
+        return normalizePayloadLen(hot_sizes[idx], max_payload);
     }
 
     const max_u64 = @as(u64, @intCast(@max(@as(usize, 1), max_payload)));
-    return 1 + @as(usize, @intCast(nextRand(state) % max_u64));
+    const random_len = 1 + @as(usize, @intCast(nextRand(state) % max_u64));
+    return normalizePayloadLen(random_len, max_payload);
+}
+
+fn normalizePayloadLen(payload_len: usize, max_payload: usize) usize {
+    const capped = @max(@as(usize, 4), @min(payload_len, max_payload));
+    return capped - @mod(capped, 4);
 }

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -2,12 +2,15 @@ const std = @import("std");
 const net = std.net;
 const crypto = @import("crypto/crypto.zig");
 const middleproxy = @import("protocol/middleproxy.zig");
+const obfuscation = @import("protocol/obfuscation.zig");
 const constants = @import("protocol/constants.zig");
 const tls = @import("protocol/tls.zig");
+const proxy = @import("proxy/proxy.zig");
 
 const Mode = enum {
     bench,
     handshake,
+    handshake_path,
     soak,
 };
 
@@ -16,6 +19,8 @@ const Options = struct {
     seconds: u32 = 30,
     threads: usize = 0,
     max_payload: usize = 128 * 1024,
+    iterations: usize = 1_000_000,
+    candidate_count: usize = 4,
 };
 
 const SoakShared = struct {
@@ -46,7 +51,8 @@ pub fn main() !void {
 
     switch (opts.mode) {
         .bench => try runBench(allocator),
-        .handshake => try runHandshakeBench(allocator),
+        .handshake => try runHandshakeBench(allocator, opts.iterations),
+        .handshake_path => try runHandshakePathBench(allocator, opts),
         .soak => try runSoak(allocator, opts),
     }
 }
@@ -104,10 +110,9 @@ fn runBench(allocator: std.mem.Allocator) !void {
     }
 }
 
-fn runHandshakeBench(allocator: std.mem.Allocator) !void {
+fn runHandshakeBench(allocator: std.mem.Allocator, iterations: usize) !void {
     const bench_secret = [_]u8{0x42} ** 16;
     const user_secrets = [_]tls.UserSecret{.{ .name = "bench", .secret = bench_secret }};
-    const iterations: usize = 1_000_000;
 
     var handshake = [_]u8{0} ** 96;
     handshake[constants.tls_digest_pos + constants.tls_digest_len] = 32;
@@ -149,6 +154,78 @@ fn runHandshakeBench(allocator: std.mem.Allocator) !void {
     std.debug.print("benchmark: validateTlsHandshake\n", .{});
     std.debug.print("iterations matched ns_per_op ops_per_sec\n", .{});
     std.debug.print("{d} {d} {d} {d}\n", .{ iterations, matched, ns_per_op, ops_per_sec });
+}
+
+fn runHandshakePathBench(allocator: std.mem.Allocator, opts: Options) !void {
+    if (opts.candidate_count == 0 or opts.candidate_count > 16) return error.InvalidArgument;
+
+    const bench_secret = [_]u8{0x33} ** 16;
+    const user_secrets = [_]obfuscation.UserSecret{.{ .name = "bench", .secret = bench_secret }};
+
+    var handshakes: [8][constants.handshake_len]u8 = undefined;
+    for (&handshakes, 0..) |*handshake, idx| {
+        const dc_idx: i16 = @intCast(idx + 1);
+        const nonce_seed: u8 = @intCast(23 + idx * 11);
+        handshake.* = buildObfuscationHandshake(&bench_secret, .intermediate, dc_idx, nonce_seed);
+    }
+
+    var candidates: [16]net.Address = undefined;
+    fillBenchmarkCandidates(&candidates);
+    const windows = candidates.len - opts.candidate_count + 1;
+
+    var candidate_state = proxy.BenchCandidatePath{};
+    defer candidate_state.deinit(allocator);
+
+    const warmup_iters = @min(opts.iterations, @as(usize, 2000));
+    var warmup: usize = 0;
+    while (warmup < warmup_iters) : (warmup += 1) {
+        const handshake_idx = warmup % handshakes.len;
+        const parsed = obfuscation.ObfuscationParams.fromHandshake(&handshakes[handshake_idx], &user_secrets) orelse {
+            return error.BenchmarkValidationFailed;
+        };
+        _ = parsed;
+
+        const base = if (windows > 1) warmup % windows else 0;
+        _ = try candidate_state.apply(allocator, candidates[base .. base + opts.candidate_count]);
+    }
+
+    var timer = try std.time.Timer.start();
+    var matched: usize = 0;
+    var checksum: u64 = 0;
+    var i: usize = 0;
+    while (i < opts.iterations) : (i += 1) {
+        const handshake_idx = i % handshakes.len;
+        const parsed = obfuscation.ObfuscationParams.fromHandshake(&handshakes[handshake_idx], &user_secrets) orelse {
+            return error.BenchmarkValidationFailed;
+        };
+        matched += 1;
+
+        const base = if (windows > 1) i % windows else 0;
+        const candidate_slice = candidates[base .. base + opts.candidate_count];
+        const candidate_len = try candidate_state.apply(allocator, candidate_slice);
+
+        checksum +%= @as(u64, @intCast(candidate_len));
+        checksum +%= @as(u64, @intCast(@abs(parsed.params.dc_idx)));
+        checksum +%= std.mem.bigToNative(u16, candidate_slice[0].in.sa.port);
+    }
+
+    const elapsed_ns = timer.read();
+    const ns_per_op = elapsedNsPerOp(elapsed_ns, opts.iterations);
+    const ops_per_sec = if (elapsed_ns == 0)
+        0
+    else
+        @as(u64, @intCast((@as(u128, opts.iterations) * std.time.ns_per_s) / elapsed_ns));
+
+    std.debug.print("benchmark: finishClientHandshake candidate-path\n", .{});
+    std.debug.print("iterations candidate_count matched ns_per_op ops_per_sec checksum\n", .{});
+    std.debug.print("{d} {d} {d} {d} {d} {d}\n", .{
+        opts.iterations,
+        opts.candidate_count,
+        matched,
+        ns_per_op,
+        ops_per_sec,
+        checksum,
+    });
 }
 
 fn runSoak(allocator: std.mem.Allocator, opts: Options) !void {
@@ -267,6 +344,44 @@ fn fillPayload(buf: []u8) void {
     }
 }
 
+fn buildObfuscationHandshake(secret: *const [16]u8, proto_tag: constants.ProtoTag, dc_idx: i16, nonce_seed: u8) [constants.handshake_len]u8 {
+    var nonce = [_]u8{0} ** constants.handshake_len;
+    for (&nonce, 0..) |*byte, idx| {
+        byte.* = @truncate((idx * 29 + nonce_seed) % 251);
+    }
+
+    const tag_bytes = proto_tag.toBytes();
+    @memcpy(nonce[constants.proto_tag_pos..][0..4], &tag_bytes);
+    std.mem.writeInt(i16, nonce[constants.dc_idx_pos..][0..2], dc_idx, .little);
+
+    var key_input: [constants.prekey_len + 16]u8 = undefined;
+    @memcpy(key_input[0..constants.prekey_len], nonce[constants.skip_len .. constants.skip_len + constants.prekey_len]);
+    @memcpy(key_input[constants.prekey_len..], secret);
+    const decrypt_key = crypto.sha256(&key_input);
+    const decrypt_iv = std.mem.readInt(
+        u128,
+        nonce[constants.skip_len + constants.prekey_len ..][0..constants.iv_len],
+        .big,
+    );
+
+    var encrypted = nonce;
+    var encryptor = crypto.AesCtr.init(&decrypt_key, decrypt_iv);
+    defer encryptor.wipe();
+    encryptor.apply(&encrypted);
+
+    var handshake = nonce;
+    @memcpy(handshake[constants.proto_tag_pos..], encrypted[constants.proto_tag_pos..]);
+    return handshake;
+}
+
+fn fillBenchmarkCandidates(out: *[16]net.Address) void {
+    for (out, 0..) |*addr, idx| {
+        const octet: u8 = @intCast(100 + idx);
+        const port = constants.tg_datacenter_port + @as(u16, @intCast(idx));
+        addr.* = net.Address.initIp4(.{ 149, 154, 167, octet }, port);
+    }
+}
+
 fn parseArgs(allocator: std.mem.Allocator) !Options {
     var opts = Options{};
 
@@ -281,6 +396,10 @@ fn parseArgs(allocator: std.mem.Allocator) !Options {
         }
         if (std.mem.eql(u8, arg, "handshake")) {
             opts.mode = .handshake;
+            continue;
+        }
+        if (std.mem.eql(u8, arg, "handshake-path")) {
+            opts.mode = .handshake_path;
             continue;
         }
         if (std.mem.eql(u8, arg, "soak")) {
@@ -302,6 +421,14 @@ fn parseArgs(allocator: std.mem.Allocator) !Options {
             opts.max_payload = try parsePositiveUsize(arg["--max-payload=".len..]);
             continue;
         }
+        if (std.mem.startsWith(u8, arg, "--iterations=")) {
+            opts.iterations = try parsePositiveUsize(arg["--iterations=".len..]);
+            continue;
+        }
+        if (std.mem.startsWith(u8, arg, "--candidate-count=")) {
+            opts.candidate_count = try parsePositiveUsize(arg["--candidate-count=".len..]);
+            continue;
+        }
 
         return error.InvalidArgument;
     }
@@ -312,6 +439,7 @@ fn parseArgs(allocator: std.mem.Allocator) !Options {
     }
 
     if (opts.max_payload < 64) return error.InvalidArgument;
+    if (opts.candidate_count == 0 or opts.candidate_count > 16) return error.InvalidArgument;
 
     return opts;
 }
@@ -333,12 +461,18 @@ fn printUsage() void {
         \\Usage:
         \\  zig build bench
         \\  zig build bench -- --help
+        \\  zig build bench -- handshake --iterations=1000000
+        \\  zig build bench -- handshake-path --iterations=1000000 --candidate-count=4
         \\  zig build soak -- --seconds=30 --threads=8 --max-payload=131072
         \\
         \\Modes:
         \\  bench (default): microbenchmark for C2S encapsulation
         \\  handshake: microbenchmark for TLS handshake validation
+        \\  handshake-path: microbenchmark for MTProto handshake + candidate staging
         \\  soak: multithreaded crash/stability stress test
+        \\Flags:
+        \\  --iterations=N       iterations for handshake and handshake-path
+        \\  --candidate-count=N  candidate list size for handshake-path (1..16)
         \\
     , .{});
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -6,6 +6,37 @@
 const std = @import("std");
 const Tunnel = @import("tunnel.zig").Tunnel;
 
+fn stripInlineComment(value: []const u8) []const u8 {
+    var in_quotes = false;
+    var escaped = false;
+    var i: usize = 0;
+
+    while (i < value.len) : (i += 1) {
+        const ch = value[i];
+
+        if (escaped) {
+            escaped = false;
+            continue;
+        }
+
+        if (in_quotes and ch == '\\') {
+            escaped = true;
+            continue;
+        }
+
+        if (ch == '"') {
+            in_quotes = !in_quotes;
+            continue;
+        }
+
+        if (!in_quotes and (ch == '#' or ch == ';')) {
+            return std.mem.trimRight(u8, value[0..i], &[_]u8{ ' ', '\t' });
+        }
+    }
+
+    return std.mem.trimRight(u8, value, &[_]u8{ ' ', '\t' });
+}
+
 pub const Config = struct {
     pub const UserSecret = struct { name: []const u8, secret: [16]u8 };
 
@@ -156,6 +187,8 @@ pub const Config = struct {
             if (std.mem.indexOfScalar(u8, line, '=')) |eq_pos| {
                 const key = std.mem.trim(u8, line[0..eq_pos], &[_]u8{ ' ', '\t' });
                 var value = std.mem.trim(u8, line[eq_pos + 1 ..], &[_]u8{ ' ', '\t' });
+                value = stripInlineComment(value);
+                if (value.len == 0) continue;
 
                 // Strip quotes from value
                 if (value.len >= 2 and value[0] == '"' and value[value.len - 1] == '"') {
@@ -562,6 +595,36 @@ test "parse config - tag parsing" {
     try std.testing.expect(cfg.tag != null);
     const expected_tag = [_]u8{ 0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef, 0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef };
     try std.testing.expectEqual(expected_tag, cfg.tag.?);
+}
+
+test "parse config - inline comment after tag" {
+    const content =
+        \\[server]
+        \\tag = "1234567890abcdef1234567890abcdef" # production tag
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expect(cfg.tag != null);
+    const expected_tag = [_]u8{ 0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef, 0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef };
+    try std.testing.expectEqual(expected_tag, cfg.tag.?);
+}
+
+test "parse config - quoted hash preserved" {
+    const content =
+        \\[censorship]
+        \\tls_domain = "exa#mple.com" # inline comment
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings("exa#mple.com", cfg.tls_domain);
 }
 
 test "parse config - tag default null" {

--- a/src/config.zig
+++ b/src/config.zig
@@ -4,6 +4,7 @@
 //! Format is compatible with the Rust telemt config.toml.
 
 const std = @import("std");
+const Tunnel = @import("tunnel.zig").Tunnel;
 
 pub const Config = struct {
     pub const UserSecret = struct { name: []const u8, secret: [16]u8 };
@@ -63,6 +64,9 @@ pub const Config = struct {
     unsafe_override_limits: bool = false,
     /// Test-only hook to redirect upstream connections locally
     datacenter_override: ?std.net.Address = null,
+    /// Active tunnel type: "none" (default, auto-detect), "amnezia_wg".
+    /// Parsed from the [tunnel] section.
+    tunnel_type: Tunnel.Tag = .none,
 
     pub fn middleProxyBufferBytes(self: *const Config) usize {
         return @as(usize, self.middleproxy_buffer_kb) * 1024;
@@ -128,6 +132,7 @@ pub const Config = struct {
         var in_censorship_section = false;
         var in_server_section = false;
         var in_general_section = false;
+        var in_tunnel_section = false;
         var server_tag_set = false;
 
         while (lines.next()) |raw_line| {
@@ -143,6 +148,7 @@ pub const Config = struct {
                 in_censorship_section = std.mem.eql(u8, line, "[censorship]");
                 in_server_section = std.mem.eql(u8, line, "[server]");
                 in_general_section = std.mem.eql(u8, line, "[general]");
+                in_tunnel_section = std.mem.eql(u8, line, "[tunnel]");
                 continue;
             }
 
@@ -247,6 +253,10 @@ pub const Config = struct {
                         cfg.drs = std.mem.eql(u8, value, "true");
                     } else if (std.mem.eql(u8, key, "fast_mode")) {
                         cfg.fast_mode = std.mem.eql(u8, value, "true");
+                    }
+                } else if (in_tunnel_section) {
+                    if (std.mem.eql(u8, key, "type")) {
+                        cfg.tunnel_type = Tunnel.fromString(value);
                     }
                 }
             }
@@ -809,4 +819,58 @@ test "parse config - multiple users" {
     const alice_secret = cfg.users.get("alice").?;
     try std.testing.expectEqual(@as(u8, 0x00), alice_secret[0]);
     try std.testing.expectEqual(@as(u8, 0xff), alice_secret[15]);
+}
+
+test "parse config - tunnel type amnezia_wg" {
+    const content =
+        \\[tunnel]
+        \\type = "amnezia_wg"
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(Tunnel.Tag.amnezia_wg, cfg.tunnel_type);
+}
+
+test "parse config - tunnel type default none" {
+    const content =
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(Tunnel.Tag.none, cfg.tunnel_type);
+}
+
+test "parse config - tunnel type none explicit" {
+    const content =
+        \\[tunnel]
+        \\type = "none"
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(Tunnel.Tag.none, cfg.tunnel_type);
+}
+
+test "parse config - tunnel type invalid falls back to none" {
+    const content =
+        \\[tunnel]
+        \\type = "banana"
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(Tunnel.Tag.none, cfg.tunnel_type);
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -6,6 +6,30 @@
 const std = @import("std");
 const Tunnel = @import("tunnel.zig").Tunnel;
 
+pub const UpstreamMode = enum {
+    /// Infer egress mode from runtime environment (default).
+    /// If proxy runs in non-init netns, treat as AmneziaWG; otherwise direct.
+    auto,
+    /// Explicit direct egress.
+    direct,
+    /// Explicit AmneziaWG egress (requires running inside tunnel netns).
+    amnezia_wg,
+};
+
+fn parseUpstreamMode(value: []const u8) ?UpstreamMode {
+    if (std.mem.eql(u8, value, "auto")) return .auto;
+    if (std.mem.eql(u8, value, "direct") or std.mem.eql(u8, value, "none")) return .direct;
+    if (std.mem.eql(u8, value, "amnezia_wg") or std.mem.eql(u8, value, "amneziawg")) return .amnezia_wg;
+    return null;
+}
+
+fn parseLegacyTunnelMode(value: []const u8) UpstreamMode {
+    return switch (Tunnel.fromString(value)) {
+        .none => .direct,
+        .amnezia_wg => .amnezia_wg,
+    };
+}
+
 fn stripInlineComment(value: []const u8) []const u8 {
     var in_quotes = false;
     var escaped = false;
@@ -95,9 +119,11 @@ pub const Config = struct {
     unsafe_override_limits: bool = false,
     /// Test-only hook to redirect upstream connections locally
     datacenter_override: ?std.net.Address = null,
-    /// Active tunnel type: "none" (default, auto-detect), "amnezia_wg".
-    /// Parsed from the [tunnel] section.
-    tunnel_type: Tunnel.Tag = .none,
+    /// Upstream egress mode. Parsed from [upstream].type.
+    /// Supported values: auto | direct | amnezia_wg.
+    upstream_mode: UpstreamMode = .auto,
+    /// Backward-compatibility marker: config used deprecated [tunnel] section.
+    uses_legacy_tunnel_section: bool = false,
 
     pub fn middleProxyBufferBytes(self: *const Config) usize {
         return @as(usize, self.middleproxy_buffer_kb) * 1024;
@@ -141,6 +167,11 @@ pub const Config = struct {
                 }
             }
         }
+
+        if (self.uses_legacy_tunnel_section) {
+            const log = std.log.scoped(.config);
+            log.warn("[tunnel] section is deprecated; use [upstream] type = \"direct|amnezia_wg|auto\"", .{});
+        }
     }
 
     pub fn loadFromFile(allocator: std.mem.Allocator, path: []const u8) !Config {
@@ -163,8 +194,10 @@ pub const Config = struct {
         var in_censorship_section = false;
         var in_server_section = false;
         var in_general_section = false;
+        var in_upstream_section = false;
         var in_tunnel_section = false;
         var server_tag_set = false;
+        var upstream_set = false;
 
         while (lines.next()) |raw_line| {
             const line = std.mem.trim(u8, raw_line, &[_]u8{ ' ', '\t', '\r' });
@@ -179,6 +212,7 @@ pub const Config = struct {
                 in_censorship_section = std.mem.eql(u8, line, "[censorship]");
                 in_server_section = std.mem.eql(u8, line, "[server]");
                 in_general_section = std.mem.eql(u8, line, "[general]");
+                in_upstream_section = std.mem.eql(u8, line, "[upstream]");
                 in_tunnel_section = std.mem.eql(u8, line, "[tunnel]");
                 continue;
             }
@@ -287,9 +321,19 @@ pub const Config = struct {
                     } else if (std.mem.eql(u8, key, "fast_mode")) {
                         cfg.fast_mode = std.mem.eql(u8, value, "true");
                     }
+                } else if (in_upstream_section) {
+                    if (std.mem.eql(u8, key, "type")) {
+                        if (parseUpstreamMode(value)) |mode| {
+                            cfg.upstream_mode = mode;
+                            upstream_set = true;
+                        }
+                    }
                 } else if (in_tunnel_section) {
                     if (std.mem.eql(u8, key, "type")) {
-                        cfg.tunnel_type = Tunnel.fromString(value);
+                        cfg.uses_legacy_tunnel_section = true;
+                        if (!upstream_set) {
+                            cfg.upstream_mode = parseLegacyTunnelMode(value);
+                        }
                     }
                 }
             }
@@ -884,7 +928,61 @@ test "parse config - multiple users" {
     try std.testing.expectEqual(@as(u8, 0xff), alice_secret[15]);
 }
 
-test "parse config - tunnel type amnezia_wg" {
+test "parse config - upstream type amnezia_wg" {
+    const content =
+        \\[upstream]
+        \\type = "amnezia_wg"
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(UpstreamMode.amnezia_wg, cfg.upstream_mode);
+}
+
+test "parse config - upstream type default auto" {
+    const content =
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(UpstreamMode.auto, cfg.upstream_mode);
+}
+
+test "parse config - upstream type direct explicit" {
+    const content =
+        \\[upstream]
+        \\type = "direct"
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(UpstreamMode.direct, cfg.upstream_mode);
+}
+
+test "parse config - upstream type invalid keeps default auto" {
+    const content =
+        \\[upstream]
+        \\type = "banana"
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(UpstreamMode.auto, cfg.upstream_mode);
+}
+
+test "parse config - legacy tunnel maps to upstream" {
     const content =
         \\[tunnel]
         \\type = "amnezia_wg"
@@ -895,25 +993,16 @@ test "parse config - tunnel type amnezia_wg" {
     var cfg = try Config.parse(std.testing.allocator, content);
     defer cfg.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(Tunnel.Tag.amnezia_wg, cfg.tunnel_type);
+    try std.testing.expect(cfg.uses_legacy_tunnel_section);
+    try std.testing.expectEqual(UpstreamMode.amnezia_wg, cfg.upstream_mode);
 }
 
-test "parse config - tunnel type default none" {
-    const content =
-        \\[access.users]
-        \\alice = "00112233445566778899aabbccddeeff"
-    ;
-
-    var cfg = try Config.parse(std.testing.allocator, content);
-    defer cfg.deinit(std.testing.allocator);
-
-    try std.testing.expectEqual(Tunnel.Tag.none, cfg.tunnel_type);
-}
-
-test "parse config - tunnel type none explicit" {
+test "parse config - upstream overrides legacy tunnel" {
     const content =
         \\[tunnel]
-        \\type = "none"
+        \\type = "amnezia_wg"
+        \\[upstream]
+        \\type = "direct"
         \\[access.users]
         \\alice = "00112233445566778899aabbccddeeff"
     ;
@@ -921,19 +1010,6 @@ test "parse config - tunnel type none explicit" {
     var cfg = try Config.parse(std.testing.allocator, content);
     defer cfg.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(Tunnel.Tag.none, cfg.tunnel_type);
-}
-
-test "parse config - tunnel type invalid falls back to none" {
-    const content =
-        \\[tunnel]
-        \\type = "banana"
-        \\[access.users]
-        \\alice = "00112233445566778899aabbccddeeff"
-    ;
-
-    var cfg = try Config.parse(std.testing.allocator, content);
-    defer cfg.deinit(std.testing.allocator);
-
-    try std.testing.expectEqual(Tunnel.Tag.none, cfg.tunnel_type);
+    try std.testing.expect(cfg.uses_legacy_tunnel_section);
+    try std.testing.expectEqual(UpstreamMode.direct, cfg.upstream_mode);
 }

--- a/src/crypto/crypto.zig
+++ b/src/crypto/crypto.zig
@@ -112,12 +112,12 @@ pub const AesCbc = struct {
         };
     }
 
-    fn xorBlocks(a: *const [16]u8, b: *const [16]u8) [16]u8 {
-        var result: [16]u8 = undefined;
-        for (0..16) |i| {
-            result[i] = a[i] ^ b[i];
-        }
-        return result;
+    fn xorBlockInPlace(dst: *[16]u8, mask: *const [16]u8) void {
+        const BlockVec = @Vector(16, u8);
+        const a: BlockVec = @bitCast(dst.*);
+        const b: BlockVec = @bitCast(mask.*);
+        const mixed: BlockVec = a ^ b;
+        dst.* = @bitCast(mixed);
     }
 
     /// Encrypt data in-place. Data length must be a multiple of 16.
@@ -132,9 +132,7 @@ pub const AesCbc = struct {
         while (offset < data.len) : (offset += block_size) {
             const block: *[16]u8 = data[offset..][0..16];
             // XOR plaintext with previous ciphertext
-            for (0..16) |j| {
-                block[j] ^= prev[j];
-            }
+            xorBlockInPlace(block, &prev);
             // Encrypt
             var encrypted: [16]u8 = undefined;
             self.enc_ctx.encrypt(&encrypted, block);
@@ -163,9 +161,7 @@ pub const AesCbc = struct {
             self.dec_ctx.decrypt(&decrypted, block);
             block.* = decrypted;
             // XOR with previous ciphertext
-            for (0..16) |j| {
-                block[j] ^= prev[j];
-            }
+            xorBlockInPlace(block, &prev);
             prev = saved;
         }
 

--- a/src/ctl/install.zig
+++ b/src/ctl/install.zig
@@ -375,6 +375,9 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
         try doc.addKv("idle_timeout_sec", "120");
         try doc.addKv("handshake_timeout_sec", "15");
 
+        try doc.addSection("upstream");
+        try doc.addKvStr("type", "direct");
+
         try doc.addSection("censorship");
         try doc.addKvStr("tls_domain", opts.tls_domain);
         try doc.addKv("mask", "true");

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -9,6 +9,7 @@ const tui_mod = @import("tui.zig");
 const i18n = @import("i18n.zig");
 const sys = @import("sys.zig");
 const toml = @import("toml.zig");
+const Tunnel = @import("tunnel").Tunnel;
 
 const Tui = tui_mod.Tui;
 const Color = tui_mod.Color;
@@ -411,4 +412,18 @@ fn stripAwgDnsLines(allocator: std.mem.Allocator, path: []const u8) !bool {
 
     try sys.writeFileMode(path, sanitized, 0o600);
     return true;
+}
+
+/// Detect the currently active tunnel by inspecting runtime state.
+/// Returns the `Tunnel.Tag` corresponding to the detected tunnel,
+/// or `.none` if no known tunnel is active.
+pub fn detectActiveTunnel(allocator: std.mem.Allocator) Tunnel.Tag {
+    // Check if AmneziaWG interface is up inside the network namespace
+    const result = sys.exec(allocator, &.{
+        "ip", "netns", "exec", NS_NAME, "awg", "show", "awg0",
+    }) catch return .none;
+    defer result.deinit();
+
+    if (result.exit_code == 0) return .amnezia_wg;
+    return .none;
 }

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -250,6 +250,9 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
     };
     ui.ok(mode_label);
 
+    setUpstreamType(allocator, "amnezia_wg");
+    ui.stepOk("Set [upstream].type", "amnezia_wg");
+
     // ── Inject public IP (preserve existing custom value) ──
     var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch null;
     if (doc) |*d| {
@@ -372,6 +375,16 @@ fn setUseMiddleProxy(allocator: std.mem.Allocator, value: []const u8) void {
     var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch return;
     defer doc.deinit();
     doc.set("general", "use_middle_proxy", value) catch return;
+    doc.save(INSTALL_DIR ++ "/config.toml") catch {};
+}
+
+fn setUpstreamType(allocator: std.mem.Allocator, value: []const u8) void {
+    var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch return;
+    defer doc.deinit();
+
+    var quoted_buf: [64]u8 = undefined;
+    const quoted = std.fmt.bufPrint(&quoted_buf, "\"{s}\"", .{value}) catch return;
+    doc.set("upstream", "type", quoted) catch return;
     doc.save(INSTALL_DIR ++ "/config.toml") catch {};
 }
 

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -302,13 +302,20 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
         ui.ok("Nginx masking patched for tunnel netns");
     }
 
-    // ── Firewall: allow namespace → host veth traffic ──
+    // ── Firewall rules for namespace ──
     if (sys.commandExists("ufw")) {
         var ufw_buf: [128]u8 = undefined;
         const ufw_rule = std.fmt.bufPrint(&ufw_buf, "ufw allow from 10.200.200.0/24 to 10.200.200.1 port {s}", .{port}) catch "";
         if (ufw_rule.len > 0) {
             _ = sys.exec(allocator, &.{ "bash", "-c", ufw_rule }) catch {};
             ui.ok("Firewall: allowed namespace traffic to host veth");
+        }
+
+        var route_buf: [128]u8 = undefined;
+        const route_rule = std.fmt.bufPrint(&route_buf, "ufw route allow proto tcp to 10.200.200.2 port {s}", .{port}) catch "";
+        if (route_rule.len > 0) {
+            _ = sys.exec(allocator, &.{ "bash", "-c", route_rule }) catch {};
+            ui.ok("Firewall: allowed external client traffic forwarding");
         }
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -423,4 +423,5 @@ test {
     _ = tls;
     _ = config;
     _ = proxy;
+    _ = @import("tunnel.zig");
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -326,7 +326,7 @@ fn printBanner(allocator: std.mem.Allocator, cfg: config.Config) void {
 }
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.GeneralPurposeAllocator(.{ .thread_safe = false }){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -326,10 +326,9 @@ fn printBanner(allocator: std.mem.Allocator, cfg: config.Config) void {
 }
 
 pub fn main() !void {
-    // Use page_allocator instead of GeneralPurposeAllocator for production.
-    // GPA has an internal mutex that causes deadlocks under heavy thread contention
-    // (1000+ simultaneous connections all doing TLS validation allocations).
-    const allocator = std.heap.page_allocator;
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
 
     // Parse config path from args
     var args = try std.process.argsWithAllocator(allocator);

--- a/src/protocol/tls.zig
+++ b/src/protocol/tls.zig
@@ -38,6 +38,8 @@ pub fn validateTlsHandshake(
     secrets: []const UserSecret,
     ignore_time_skew: bool,
 ) !?TlsValidation {
+    _ = allocator;
+
     const min_len = constants.tls_digest_pos + constants.tls_digest_len + 1;
     if (handshake.len < min_len) return null;
 
@@ -48,16 +50,13 @@ pub fn validateTlsHandshake(
     const session_id_len_pos = constants.tls_digest_pos + constants.tls_digest_len;
     if (session_id_len_pos >= handshake.len) return null;
     const session_id_len: usize = handshake[session_id_len_pos];
-    if (session_id_len > 32) return null;
+    if (session_id_len != 32) return null;
 
     const session_id_start = session_id_len_pos + 1;
     if (handshake.len < session_id_start + session_id_len) return null;
 
-    // Build message with zeroed digest for HMAC
-    const msg = try allocator.alloc(u8, handshake.len);
-    defer allocator.free(msg);
-    @memcpy(msg, handshake);
-    @memset(msg[constants.tls_digest_pos..][0..constants.tls_digest_len], 0);
+    const HmacSha256 = std.crypto.auth.hmac.sha2.HmacSha256;
+    const zero_digest = [_]u8{0} ** constants.tls_digest_len;
 
     const now: i64 = if (!ignore_time_skew)
         @intCast(std.time.timestamp())
@@ -65,7 +64,12 @@ pub fn validateTlsHandshake(
         0;
 
     for (secrets) |entry| {
-        const computed = crypto.sha256Hmac(&entry.secret, msg);
+        var hmac = HmacSha256.init(&entry.secret);
+        hmac.update(handshake[0..constants.tls_digest_pos]);
+        hmac.update(&zero_digest);
+        hmac.update(handshake[constants.tls_digest_pos + constants.tls_digest_len ..]);
+        var computed: [constants.tls_digest_len]u8 = undefined;
+        hmac.final(&computed);
 
         // Constant-time comparison of first 28 bytes using stdlib
         if (!std.crypto.timing_safe.eql([28]u8, digest[0..28].*, computed[0..28].*)) continue;
@@ -148,14 +152,9 @@ pub fn buildServerHelloWithTemplate(
     errdefer allocator.free(response);
     @memcpy(response, template);
 
-    // 2. Patch Session ID (echo from client). Template assumes 32-byte session ID.
-    if (session_id.len == 32) {
-        @memcpy(response[tmpl_session_id_offset..][0..32], session_id);
-    } else if (session_id.len <= 32) {
-        // Non-standard length: patch the length byte and copy what we have
-        response[tmpl_session_id_offset - 1] = @intCast(session_id.len);
-        @memcpy(response[tmpl_session_id_offset..][0..session_id.len], session_id);
-    }
+    // 2. Patch Session ID (echo from client). Template is fixed for 32-byte session IDs.
+    if (session_id.len != 32) return error.BadSessionIdLength;
+    @memcpy(response[tmpl_session_id_offset..][0..32], session_id);
 
     // 3. Patch X25519 public key with fresh random bytes
     var x25519_key: [32]u8 = undefined;
@@ -519,6 +518,17 @@ test "buildServerHello deterministic AppData (no random size fingerprint)" {
     try std.testing.expectEqualSlices(u8, r1[app_offset..], r2[app_offset..]);
 }
 
+test "buildServerHello rejects non-32-byte session id" {
+    const allocator = std.testing.allocator;
+    var digest = [_]u8{0xAA} ** 32;
+    const session_id = [_]u8{0xBB} ** 16;
+
+    try std.testing.expectError(
+        error.BadSessionIdLength,
+        buildServerHello(allocator, &digest, &digest, &session_id),
+    );
+}
+
 test "buildServerHelloTemplate depends on seed" {
     const t1 = buildServerHelloTemplate(0x1111_2222_3333_4444);
     const t2 = buildServerHelloTemplate(0x5555_6666_7777_8888);
@@ -538,16 +548,16 @@ test "validateTlsHandshake - valid handshake" {
 
     // Client hello mock
     // min_len = 11 + 32 + 1 = 44 bytes minimum
-    var handshake = [_]u8{0x00} ** 64;
+    var handshake = [_]u8{0x00} ** 96;
     // Set timestamp (say 123456789 = 0x075BCD15)
     // Wait, the client sends digest WITH timestamp XOR'd in the last 4 bytes.
     // If ignore_time_skew = true, the proxy doesn't care what timestamp is.
     // Proxy calculates HMAC on handshake with zeroed digest, then expects it to match (up to 28 bytes) the given digest.
 
-    var hmac_input = std.mem.zeroes([64]u8);
+    var hmac_input = std.mem.zeroes([96]u8);
     // Add session id len
-    hmac_input[43] = 4; // session_id len
-    hmac_input[44] = 0xaa; // session ID
+    hmac_input[43] = 32; // session_id len
+    @memset(hmac_input[44..76], 0xaa);
 
     // Compute HMAC
     const computed_mac = crypto.sha256Hmac(&secrets[1].secret, &hmac_input);
@@ -579,6 +589,30 @@ test "validateTlsHandshake - invalid user" {
     try std.testing.expect(result == null);
 }
 
+test "validateTlsHandshake - rejects non-32 session id" {
+    const allocator = std.testing.allocator;
+    var secrets = [_]UserSecret{.{ .name = "alice", .secret = [_]u8{0x1A} ** 16 }};
+    var handshake = [_]u8{0x00} ** 80;
+
+    var hmac_input = std.mem.zeroes([80]u8);
+    hmac_input[43] = 16;
+    @memset(hmac_input[44..60], 0xaa);
+
+    const computed_mac = crypto.sha256Hmac(&secrets[0].secret, &hmac_input);
+    @memcpy(&handshake, &hmac_input);
+    @memcpy(handshake[constants.tls_digest_pos..][0..28], computed_mac[0..28]);
+
+    const timestamp: u32 = 0x01020304;
+    const ts_bytes = std.mem.toBytes(timestamp);
+    handshake[constants.tls_digest_pos + 28] = computed_mac[28] ^ ts_bytes[0];
+    handshake[constants.tls_digest_pos + 29] = computed_mac[29] ^ ts_bytes[1];
+    handshake[constants.tls_digest_pos + 30] = computed_mac[30] ^ ts_bytes[2];
+    handshake[constants.tls_digest_pos + 31] = computed_mac[31] ^ ts_bytes[3];
+
+    const result = try validateTlsHandshake(allocator, &handshake, &secrets, true);
+    try std.testing.expect(result == null);
+}
+
 test "extractSni - malformed returns null" {
     // Too short
     try std.testing.expect(extractSni(&[_]u8{ 0x16, 0x03, 0x01, 0x00 }) == null);
@@ -590,11 +624,11 @@ test "validateTlsHandshake returns canonical_hmac" {
     const allocator = std.testing.allocator;
 
     var secrets = [_]UserSecret{.{ .name = "alice", .secret = [_]u8{0x1A} ** 16 }};
-    var handshake = [_]u8{0x00} ** 64;
+    var handshake = [_]u8{0x00} ** 96;
 
-    var hmac_input = std.mem.zeroes([64]u8);
-    hmac_input[43] = 4;
-    hmac_input[44] = 0xaa;
+    var hmac_input = std.mem.zeroes([96]u8);
+    hmac_input[43] = 32;
+    @memset(hmac_input[44..76], 0xaa);
 
     const computed_mac = crypto.sha256Hmac(&secrets[0].secret, &hmac_input);
     @memcpy(&handshake, &hmac_input);

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -895,19 +895,34 @@ pub const ProxyState = struct {
             .middle_proxy_nat_ip4 = detected_nat_ip4,
             .upstream = upstream_mod.Upstream.initDirect(),
             .tunnel_info = blk: {
-                // Explicit config takes priority
-                if (cfg.tunnel_type != .none) {
-                    const t = tunnel_mod.Tunnel{ .tag = cfg.tunnel_type };
-                    log.info("Tunnel: {s} (from config)", .{t.name()});
-                    break :blk t;
+                const in_non_init_netns = isRunningInNonInitNetns();
+                switch (cfg.upstream_mode) {
+                    .direct => {
+                        if (in_non_init_netns) {
+                            log.warn("upstream.type=direct but proxy runs in non-init netns; egress still follows namespace routing", .{});
+                        }
+                        log.info("Upstream mode: direct (configured)", .{});
+                        break :blk tunnel_mod.Tunnel{ .tag = .none };
+                    },
+                    .amnezia_wg => {
+                        const t = tunnel_mod.Tunnel{ .tag = .amnezia_wg };
+                        if (in_non_init_netns) {
+                            log.info("Upstream mode: {s} (configured)", .{t.name()});
+                        } else {
+                            log.warn("upstream.type=amnezia_wg configured, but proxy is not running in tunnel netns", .{});
+                        }
+                        break :blk t;
+                    },
+                    .auto => {
+                        if (in_non_init_netns) {
+                            const t = tunnel_mod.Tunnel{ .tag = .amnezia_wg };
+                            log.info("Upstream mode: {s} (auto-detected from network namespace)", .{t.name()});
+                            break :blk t;
+                        }
+                        log.info("Upstream mode: direct (auto)", .{});
+                        break :blk tunnel_mod.Tunnel{ .tag = .none };
+                    },
                 }
-                // Auto-detect: if we're in a non-init netns, assume AmneziaWG
-                if (isRunningInNonInitNetns()) {
-                    const t = tunnel_mod.Tunnel{ .tag = .amnezia_wg };
-                    log.info("Tunnel: {s} (auto-detected from network namespace)", .{t.name()});
-                    break :blk t;
-                }
-                break :blk tunnel_mod.Tunnel{ .tag = .none };
             },
         };
     }
@@ -918,6 +933,14 @@ pub const ProxyState = struct {
 
     pub fn run(self: *ProxyState) !void {
         if (builtin.os.tag != .linux) return error.UnsupportedOperatingSystem;
+
+        if (self.config.upstream_mode == .amnezia_wg and !isRunningInNonInitNetns()) {
+            log.err(
+                "upstream.type=amnezia_wg requires running proxy inside tunnel netns (expected via `mtbuddy setup tunnel`)",
+                .{},
+            );
+            return error.UpstreamTunnelNotActive;
+        }
 
         const address = net.Address.initIp6(
             .{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -36,7 +36,7 @@ const tunnel_mask_gateway_ip = "10.200.200.1";
 const min_nofile_soft: usize = 65535;
 const client_hello_inline_size: usize = 512;
 const mp_handshake_frame_buf_size: usize = 2048;
-const read_buf_size: usize = 4096;
+const read_buf_size: usize = 32 * 1024;
 
 /// Per-/24 (IPv4) or /48 (IPv6) subnet rate limiter.
 /// Fixed-size open-addressed hash table — zero heap allocation.
@@ -151,46 +151,22 @@ const SubnetRateLimit = struct {
     }
 };
 
-const MsgBlockClass = enum(u2) {
-    tiny = 0,
-    small = 1,
-    standard = 2,
-};
-
 const MsgBlock = struct {
-    class: MsgBlockClass,
     len: usize,
-    data: [standard_block_size]u8,
+    data: [msg_block_size]u8,
 };
 
-const tiny_block_size: usize = 64;
-const small_block_size: usize = 512;
-const standard_block_size: usize = 2048;
+const msg_block_size: usize = 2048;
+const msg_free_cap_per_queue: usize = 4;
 const max_scatter_parts: usize = 64;
 
 fn hasFatalEpollHangup(events: u32) bool {
     return (events & (linux.EPOLL.ERR | linux.EPOLL.HUP | linux.EPOLL.RDHUP)) != 0;
 }
 
-fn classCapacity(class: MsgBlockClass) usize {
-    return switch (class) {
-        .tiny => tiny_block_size,
-        .small => small_block_size,
-        .standard => standard_block_size,
-    };
-}
-
-fn chooseClass(size: usize) MsgBlockClass {
-    if (size <= tiny_block_size) return .tiny;
-    if (size <= small_block_size) return .small;
-    return .standard;
-}
-
 const MessageQueue = struct {
     allocator: std.mem.Allocator,
-    tiny_free: std.ArrayListUnmanaged(*MsgBlock) = .{},
-    small_free: std.ArrayListUnmanaged(*MsgBlock) = .{},
-    std_free: std.ArrayListUnmanaged(*MsgBlock) = .{},
+    free: std.ArrayListUnmanaged(*MsgBlock) = .{},
     blocks: std.ArrayListUnmanaged(*MsgBlock) = .{},
     head_idx: usize = 0,
     offset: usize = 0,
@@ -199,21 +175,15 @@ const MessageQueue = struct {
     fn deinit(self: *MessageQueue) void {
         self.clear();
 
-        for (self.tiny_free.items) |blk| self.allocator.destroy(blk);
-        for (self.small_free.items) |blk| self.allocator.destroy(blk);
-        for (self.std_free.items) |blk| self.allocator.destroy(blk);
+        for (self.free.items) |blk| self.allocator.destroy(blk);
 
-        self.tiny_free.deinit(self.allocator);
-        self.small_free.deinit(self.allocator);
-        self.std_free.deinit(self.allocator);
+        self.free.deinit(self.allocator);
         self.blocks.deinit(self.allocator);
     }
 
     fn clear(self: *MessageQueue) void {
         for (self.blocks.items[self.head_idx..]) |blk| {
-            self.recycleBlock(blk) catch {
-                self.allocator.destroy(blk);
-            };
+            self.recycleBlock(blk);
         }
         self.blocks.clearRetainingCapacity();
         self.head_idx = 0;
@@ -231,11 +201,10 @@ const MessageQueue = struct {
         var off: usize = 0;
         while (off < data.len) {
             const rem = data.len - off;
-            const class = chooseClass(rem);
-            const cap = classCapacity(class);
+            const cap = msg_block_size;
             const take = @min(rem, cap);
 
-            var blk = try self.acquireBlock(class);
+            const blk = try self.acquireBlock();
             blk.len = take;
             @memcpy(blk.data[0..take], data[off .. off + take]);
             try self.blocks.append(self.allocator, blk);
@@ -288,9 +257,7 @@ const MessageQueue = struct {
             remaining -= blk_left;
             self.offset = 0;
             self.head_idx += 1;
-            self.recycleBlock(blk) catch {
-                self.allocator.destroy(blk);
-            };
+            self.recycleBlock(blk);
         }
 
         if (self.head_idx > 0 and (self.head_idx >= self.blocks.items.len or self.head_idx >= 64)) {
@@ -308,34 +275,29 @@ const MessageQueue = struct {
         }
     }
 
-    fn acquireBlock(self: *MessageQueue, class: MsgBlockClass) !*MsgBlock {
-        const list = switch (class) {
-            .tiny => &self.tiny_free,
-            .small => &self.small_free,
-            .standard => &self.std_free,
-        };
-
-        if (list.items.len > 0) {
-            return list.pop().?;
+    fn acquireBlock(self: *MessageQueue) !*MsgBlock {
+        if (self.free.items.len > 0) {
+            return self.free.pop().?;
         }
 
         const blk = try self.allocator.create(MsgBlock);
         blk.* = .{
-            .class = class,
             .len = 0,
             .data = undefined,
         };
         return blk;
     }
 
-    fn recycleBlock(self: *MessageQueue, blk: *MsgBlock) !void {
+    fn recycleBlock(self: *MessageQueue, blk: *MsgBlock) void {
         blk.len = 0;
-        const list = switch (blk.class) {
-            .tiny => &self.tiny_free,
-            .small => &self.small_free,
-            .standard => &self.std_free,
+        if (self.free.items.len >= msg_free_cap_per_queue) {
+            self.allocator.destroy(blk);
+            return;
+        }
+
+        self.free.append(self.allocator, blk) catch {
+            self.allocator.destroy(blk);
         };
-        try list.append(self.allocator, blk);
     }
 };
 
@@ -586,8 +548,6 @@ const ConnectionSlot = struct {
     c2s_bytes: u64 = 0,
     s2c_bytes: u64 = 0,
 
-    read_buf: ?[]u8 = null,
-
     // Non-blocking write queues (slab-like chain buffers)
     client_queue: MessageQueue = .{ .allocator = std.heap.page_allocator },
     upstream_queue: MessageQueue = .{ .allocator = std.heap.page_allocator },
@@ -617,6 +577,7 @@ const ConnectionSlot = struct {
     client_interest_out: bool = false,
     upstream_interest_in: bool = false,
     upstream_interest_out: bool = false,
+    desync_wait_enqueued: bool = false,
 
     fn hasClientPending(self: *const ConnectionSlot) bool {
         return !self.client_queue.isEmpty();
@@ -673,9 +634,6 @@ const ConnectionSlot = struct {
         self.current_upstream_addr = null;
         self.dc_abs = 0;
         self.is_media_path = false;
-
-        if (self.read_buf) |buf| allocator.free(buf);
-        self.read_buf = null;
 
         if (self.mp_frame_buf) |buf| allocator.free(buf);
         self.mp_frame_buf = null;
@@ -1198,6 +1156,8 @@ const EventLoop = struct {
     prev_dropped_hs_budget: u64,
     prev_hs_timeout: u64,
     prev_mp_fallback: u64,
+    shared_read_buf: [read_buf_size]u8,
+    desync_wait_slots: std.ArrayListUnmanaged(u32),
     mp_c2s_scratch: ?[]u8,
     mp_s2c_scratch: ?[]u8,
 
@@ -1224,6 +1184,8 @@ const EventLoop = struct {
             .prev_dropped_hs_budget = 0,
             .prev_hs_timeout = 0,
             .prev_mp_fallback = 0,
+            .shared_read_buf = undefined,
+            .desync_wait_slots = .{},
             .mp_c2s_scratch = null,
             .mp_s2c_scratch = null,
         };
@@ -1244,6 +1206,7 @@ const EventLoop = struct {
 
         if (self.mp_c2s_scratch) |buf| self.state.allocator.free(buf);
         if (self.mp_s2c_scratch) |buf| self.state.allocator.free(buf);
+        self.desync_wait_slots.deinit(self.state.allocator);
 
         self.pool.deinit();
         posix.close(self.epoll_fd);
@@ -1276,6 +1239,8 @@ const EventLoop = struct {
                 const slot = self.pool.getByFd(fd) orelse continue;
                 self.processSlotEvent(slot, fd, ev_flags);
             }
+
+            self.processDesyncWaits();
 
             const now_ns = std.time.nanoTimestamp();
             if (self.accept_paused and now_ns >= self.accept_resume_ns) {
@@ -1363,6 +1328,9 @@ const EventLoop = struct {
                 }
             };
             accepted_this_round += 1;
+
+            // Ensure desync byte-splitting is not coalesced by Nagle during early handshake.
+            setTcpNoDelay(cfd);
 
             // Per-/24 subnet rate limit (before we allocate any slot)
             if (!self.subnet_limiter.check(client_addr, self.state.config.rate_limit_per_subnet)) {
@@ -1569,6 +1537,10 @@ const EventLoop = struct {
                 if (!slot.hasClientPending()) {
                     slot.phase = .desync_wait;
                     slot.desync_deadline_ns = std.time.nanoTimestamp() + (3 * std.time.ns_per_ms);
+                    self.enqueueDesyncWait(slot) catch {
+                        self.closeSlot(slot, "desync wait queue failed");
+                        return;
+                    };
                 }
             },
             .writing_server_hello_rest => {
@@ -1646,6 +1618,57 @@ const EventLoop = struct {
         if (!slot.hasUpstreamPending() and slot.dc_initial_tail == null) {
             self.startRelay(slot);
         }
+    }
+
+    fn enqueueDesyncWait(self: *EventLoop, slot: *ConnectionSlot) !void {
+        if (slot.desync_wait_enqueued) return;
+        try self.desync_wait_slots.append(self.state.allocator, slot.index);
+        slot.desync_wait_enqueued = true;
+    }
+
+    fn processDesyncWaits(self: *EventLoop) void {
+        if (self.desync_wait_slots.items.len == 0) return;
+
+        const now_ns = std.time.nanoTimestamp();
+        var write_idx: usize = 0;
+        var read_idx: usize = 0;
+
+        while (read_idx < self.desync_wait_slots.items.len) : (read_idx += 1) {
+            const slot_idx = self.desync_wait_slots.items[read_idx];
+            const slot = self.pool.slots[slot_idx] orelse continue;
+
+            if (slot.phase != .desync_wait) {
+                slot.desync_wait_enqueued = false;
+                continue;
+            }
+
+            if (now_ns < slot.desync_deadline_ns) {
+                self.desync_wait_slots.items[write_idx] = slot_idx;
+                write_idx += 1;
+                continue;
+            }
+
+            slot.desync_wait_enqueued = false;
+            slot.phase = .writing_server_hello_rest;
+
+            if (slot.server_hello) |sh| {
+                if (slot.server_hello_off < sh.len) {
+                    if (queueClient(slot, self.state.allocator, sh[slot.server_hello_off..])) |_| {
+                        slot.server_hello_off = sh.len;
+                    } else |_| {
+                        self.closeSlot(slot, "desync rest write failed");
+                        continue;
+                    }
+                }
+            }
+
+            self.syncInterests(slot) catch |err| {
+                log.debug("[{d}] desync syncInterests error: {any}", .{ slot.conn_id, err });
+                self.closeSlot(slot, "desync sync interests failed");
+            };
+        }
+
+        self.desync_wait_slots.shrinkRetainingCapacity(write_idx);
     }
 
     fn readTlsHeader(self: *EventLoop, slot: *ConnectionSlot) void {
@@ -1846,10 +1869,7 @@ const EventLoop = struct {
                 continue;
             }
 
-            const read_buf = ensureReadBuf(slot, self.state.allocator) catch {
-                self.closeSlot(slot, "alloc read buffer failed");
-                return;
-            };
+            const read_buf = self.shared_read_buf[0..];
             const want = @min(remaining, read_buf.len);
             const n = posix.read(slot.client_fd, read_buf[0..want]) catch |err| {
                 if (err == error.WouldBlock) return;
@@ -2274,7 +2294,7 @@ const EventLoop = struct {
         else
             null;
 
-        const progress = relayClientToUpstreamStep(slot, self.state.allocator, mp_c2s_scratch) catch |err| {
+        const progress = relayClientToUpstreamStep(slot, self.state.allocator, mp_c2s_scratch, self.shared_read_buf[0..]) catch |err| {
             if (slot.is_media_path) {
                 log.debug("[{d}] relay c2s error: dc_idx={d} err={any} c2s={d} s2c={d}", .{
                     slot.conn_id, slot.dc_idx, err, slot.c2s_bytes, slot.s2c_bytes,
@@ -2299,7 +2319,7 @@ const EventLoop = struct {
         else
             null;
 
-        const progress = relayUpstreamToClientStep(slot, self.state.allocator, mp_s2c_scratch) catch |err| {
+        const progress = relayUpstreamToClientStep(slot, self.state.allocator, mp_s2c_scratch, self.shared_read_buf[0..]) catch |err| {
             if (slot.is_media_path) {
                 log.debug("[{d}] relay s2c error: dc_idx={d} err={any} c2s={d} s2c={d}", .{
                     slot.conn_id, slot.dc_idx, err, slot.c2s_bytes, slot.s2c_bytes,
@@ -2316,49 +2336,45 @@ const EventLoop = struct {
     fn relayRawClientToUpstream(self: *EventLoop, slot: *ConnectionSlot) void {
         if (slot.hasUpstreamPending()) return;
 
-        const read_buf = ensureReadBuf(slot, self.state.allocator) catch {
-            slot.phase = .closing;
-            return;
-        };
+        const read_buf = self.shared_read_buf[0..];
 
         const n = posix.read(slot.client_fd, read_buf) catch |err| {
             if (err == error.WouldBlock) return;
-            slot.phase = .closing;
+            self.closeSlot(slot, "mask relay c2s read error");
             return;
         };
         if (n == 0) {
-            slot.phase = .closing;
+            self.closeSlot(slot, "mask relay c2s eof");
             return;
         }
 
         _ = queueUpstream(slot, self.state.allocator, read_buf[0..n]) catch {
-            slot.phase = .closing;
+            self.closeSlot(slot, "mask relay c2s queue error");
             return;
         };
+        slot.last_activity_ms = std.time.milliTimestamp();
     }
 
     fn relayRawUpstreamToClient(self: *EventLoop, slot: *ConnectionSlot) void {
         if (slot.hasClientPending()) return;
 
-        const read_buf = ensureReadBuf(slot, self.state.allocator) catch {
-            slot.phase = .closing;
-            return;
-        };
+        const read_buf = self.shared_read_buf[0..];
 
         const n = posix.read(slot.upstream_fd, read_buf) catch |err| {
             if (err == error.WouldBlock) return;
-            slot.phase = .closing;
+            self.closeSlot(slot, "mask relay s2c read error");
             return;
         };
         if (n == 0) {
-            slot.phase = .closing;
+            self.closeSlot(slot, "mask relay s2c eof");
             return;
         }
 
         _ = queueClient(slot, self.state.allocator, read_buf[0..n]) catch {
-            slot.phase = .closing;
+            self.closeSlot(slot, "mask relay s2c queue error");
             return;
         };
+        slot.last_activity_ms = std.time.milliTimestamp();
     }
 
     fn middleProxyBegin(self: *EventLoop, slot: *ConnectionSlot) void {
@@ -2867,7 +2883,6 @@ const EventLoop = struct {
 
     fn runTimers(self: *EventLoop) void {
         const now_ms = std.time.milliTimestamp();
-        const now_ns = std.time.nanoTimestamp();
 
         const hi: usize = @intCast(self.pool.allocated_hi);
         if (hi == 0) return;
@@ -2884,19 +2899,6 @@ const EventLoop = struct {
 
             const slot = slot_opt orelse continue;
             if (slot.phase == .idle) continue;
-
-            if (slot.phase == .desync_wait and now_ns >= slot.desync_deadline_ns) {
-                slot.phase = .writing_server_hello_rest;
-                if (slot.server_hello) |sh| {
-                    if (slot.server_hello_off < sh.len) {
-                        if (queueClient(slot, self.state.allocator, sh[slot.server_hello_off..])) |_| {} else |_| {
-                            self.closeSlot(slot, "desync rest write failed");
-                            continue;
-                        }
-                        slot.server_hello_off = sh.len;
-                    }
-                }
-            }
 
             if (slot.phase == .closing) {
                 self.closeSlot(slot, "closing phase");
@@ -3056,6 +3058,7 @@ const EventLoop = struct {
             self.closed_since_log += 1;
         }
 
+        slot.desync_wait_enqueued = false;
         slot.phase = .idle;
         self.pool.release(slot);
     }
@@ -3112,8 +3115,7 @@ const EventLoop = struct {
     }
 };
 
-fn relayClientToUpstreamStep(slot: *ConnectionSlot, allocator: std.mem.Allocator, mp_c2s_scratch: ?[]u8) !RelayProgress {
-    const read_buf = try ensureReadBuf(slot, allocator);
+fn relayClientToUpstreamStep(slot: *ConnectionSlot, allocator: std.mem.Allocator, mp_c2s_scratch: ?[]u8, read_buf: []u8) !RelayProgress {
     var consumed_any = false;
 
     while (true) {
@@ -3198,8 +3200,7 @@ fn relayClientToUpstreamStep(slot: *ConnectionSlot, allocator: std.mem.Allocator
     }
 }
 
-fn relayUpstreamToClientStep(slot: *ConnectionSlot, allocator: std.mem.Allocator, mp_s2c_scratch: ?[]u8) !RelayProgress {
-    const read_buf = try ensureReadBuf(slot, allocator);
+fn relayUpstreamToClientStep(slot: *ConnectionSlot, allocator: std.mem.Allocator, mp_s2c_scratch: ?[]u8, read_buf: []u8) !RelayProgress {
     const n = posix.read(slot.upstream_fd, read_buf) catch |err| {
         if (err == error.WouldBlock) return .none;
         return err;
@@ -3357,13 +3358,6 @@ fn formatAddress(addr: net.Address, buf: *[64]u8) []const u8 {
         },
         else => return "?",
     }
-}
-
-fn ensureReadBuf(slot: *ConnectionSlot, allocator: std.mem.Allocator) ![]u8 {
-    if (slot.read_buf) |buf| return buf;
-    const buf = try allocator.alloc(u8, read_buf_size);
-    slot.read_buf = buf;
-    return buf;
 }
 
 fn ensureMpFrameBuf(slot: *ConnectionSlot, allocator: std.mem.Allocator) ![]u8 {

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -21,7 +21,8 @@ const tunnel_mod = @import("../tunnel.zig");
 const log = std.log.scoped(.proxy);
 
 const tls_header_len = 5;
-const event_loop_wait_ms = 37;
+const event_loop_wait_ms: i32 = 37;
+const desync_wait_poll_ms: i32 = 3;
 const accept_backoff_ms: i64 = 500;
 const accept_backoff_ns: i128 = @as(i128, accept_backoff_ms) * std.time.ns_per_ms;
 const accept_batch_limit: usize = 256;
@@ -37,6 +38,7 @@ const min_nofile_soft: usize = 65535;
 const client_hello_inline_size: usize = 512;
 const mp_handshake_frame_buf_size: usize = 2048;
 const read_buf_size: usize = 32 * 1024;
+const max_pipelined_handshake_bytes: usize = 128 * 1024;
 
 /// Per-/24 (IPv4) or /48 (IPv6) subnet rate limiter.
 /// Fixed-size open-addressed hash table — zero heap allocation.
@@ -159,6 +161,7 @@ const MsgBlock = struct {
 const msg_block_size: usize = 2048;
 const msg_free_cap_per_queue: usize = 4;
 const max_scatter_parts: usize = 64;
+const upstream_candidates_inline_cap: usize = 4;
 
 fn hasFatalEpollHangup(events: u32) bool {
     return (events & (linux.EPOLL.ERR | linux.EPOLL.HUP | linux.EPOLL.RDHUP)) != 0;
@@ -199,12 +202,26 @@ const MessageQueue = struct {
         if (data.len == 0) return;
 
         var off: usize = 0;
+
+        if (self.blocks.items.len > 0) {
+            const last_blk = self.blocks.items[self.blocks.items.len - 1];
+            if (last_blk.len < msg_block_size) {
+                const space = msg_block_size - last_blk.len;
+                const take = @min(space, data.len);
+                @memcpy(last_blk.data[last_blk.len .. last_blk.len + take], data[off .. off + take]);
+                last_blk.len += take;
+                self.total_len += take;
+                off += take;
+            }
+        }
+
         while (off < data.len) {
             const rem = data.len - off;
-            const cap = msg_block_size;
-            const take = @min(rem, cap);
+            const take = @min(rem, msg_block_size);
 
             const blk = try self.acquireBlock();
+            errdefer self.recycleBlock(blk);
+
             blk.len = take;
             @memcpy(blk.data[0..take], data[off .. off + take]);
             try self.blocks.append(self.allocator, blk);
@@ -523,7 +540,9 @@ const ConnectionSlot = struct {
     use_middle_proxy: bool = false,
     is_media_path: bool = false,
 
-    upstream_candidates: ?[]net.Address = null,
+    upstream_candidates_inline: [upstream_candidates_inline_cap]net.Address = undefined,
+    upstream_candidates_heap: ?[]net.Address = null,
+    upstream_candidate_count: u8 = 0,
     upstream_candidate_next: u8 = 0,
     direct_fallback_addr: ?net.Address = null,
     direct_fallback_used: bool = false,
@@ -626,8 +645,9 @@ const ConnectionSlot = struct {
         if (self.middle_ctx) |*mp| mp.deinit(allocator);
         self.middle_ctx = null;
 
-        if (self.upstream_candidates) |buf| allocator.free(buf);
-        self.upstream_candidates = null;
+        if (self.upstream_candidates_heap) |buf| allocator.free(buf);
+        self.upstream_candidates_heap = null;
+        self.upstream_candidate_count = 0;
         self.upstream_candidate_next = 0;
         self.direct_fallback_addr = null;
         self.direct_fallback_used = false;
@@ -655,6 +675,57 @@ const ConnectionSlot = struct {
     fn clientHelloBuf(self: *ConnectionSlot) []u8 {
         if (self.client_hello_heap) |buf| return buf;
         return self.client_hello_inline[0..self.client_hello_len];
+    }
+
+    fn upstreamCandidates(self: *const ConnectionSlot) []const net.Address {
+        const count: usize = self.upstream_candidate_count;
+        if (count == 0) return &.{};
+        if (self.upstream_candidates_heap) |buf| return buf[0..count];
+        return self.upstream_candidates_inline[0..count];
+    }
+
+    fn setUpstreamCandidates(self: *ConnectionSlot, allocator: std.mem.Allocator, candidates: []const net.Address) !void {
+        if (self.upstream_candidates_heap) |buf| {
+            allocator.free(buf);
+            self.upstream_candidates_heap = null;
+        }
+
+        if (candidates.len == 0) {
+            self.upstream_candidate_count = 0;
+            return;
+        }
+
+        if (candidates.len <= self.upstream_candidates_inline.len) {
+            @memcpy(self.upstream_candidates_inline[0..candidates.len], candidates);
+            self.upstream_candidate_count = @intCast(candidates.len);
+            return;
+        }
+
+        const heap = try allocator.alloc(net.Address, candidates.len);
+        errdefer allocator.free(heap);
+
+        @memcpy(heap, candidates);
+        self.upstream_candidates_heap = heap;
+        self.upstream_candidate_count = @intCast(candidates.len);
+    }
+};
+
+pub const BenchCandidatePath = struct {
+    slot: ConnectionSlot = .{},
+
+    pub fn deinit(self: *BenchCandidatePath, allocator: std.mem.Allocator) void {
+        self.slot.resetOwnedBuffers(allocator);
+    }
+
+    pub fn apply(self: *BenchCandidatePath, allocator: std.mem.Allocator, candidates: []const net.Address) !usize {
+        if (candidates.len == 0) return error.BenchEmptyCandidates;
+
+        try self.slot.setUpstreamCandidates(allocator, candidates);
+
+        const prepared = self.slot.upstreamCandidates();
+        self.slot.upstream_candidate_next = 1;
+        self.slot.current_upstream_addr = prepared[0];
+        return prepared.len;
     }
 };
 
@@ -748,11 +819,6 @@ const ConnectionPool = struct {
         return self.slots[idx];
     }
 };
-
-fn slotCandidateCount(slot: *const ConnectionSlot) usize {
-    if (slot.upstream_candidates) |c| return c.len;
-    return 0;
-}
 
 pub const ProxyState = struct {
     allocator: std.mem.Allocator,
@@ -1055,8 +1121,11 @@ pub const ProxyState = struct {
     }
 
     fn refreshMiddleProxyInfo(self: *ProxyState) !void {
-        const cfg_bytes = try fetchUrlBytes(self.allocator, middle_proxy_config_url);
-        defer self.allocator.free(cfg_bytes);
+        var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+        defer arena.deinit();
+        const temp_alloc = arena.allocator();
+
+        const cfg_bytes = try fetchUrlBytes(temp_alloc, middle_proxy_config_url);
 
         var next_primary: [5]?net.Address = [_]?net.Address{null} ** 5;
         var next_dc4_candidates: [16]net.Address = undefined;
@@ -1092,8 +1161,7 @@ pub const ProxyState = struct {
         }
         const next_addr_203 = if (count_203 == 0) null else candidates_203[0];
 
-        const next_secret = try fetchUrlBytes(self.allocator, middle_proxy_secret_url);
-        defer self.allocator.free(next_secret);
+        const next_secret = try fetchUrlBytes(temp_alloc, middle_proxy_secret_url);
 
         if (next_secret.len < 16 or next_secret.len > self.middle_proxy_secret.len) {
             return error.BadMiddleProxySecret;
@@ -1241,7 +1309,12 @@ const EventLoop = struct {
         var next_timer_tick_ns: i128 = std.time.nanoTimestamp();
 
         while (true) {
-            const rc = linux.epoll_wait(self.epoll_fd, events[0..].ptr, @intCast(events.len), event_loop_wait_ms);
+            var current_wait_ms: i32 = event_loop_wait_ms;
+            if (self.desync_wait_slots.items.len > 0) {
+                current_wait_ms = @min(current_wait_ms, desync_wait_poll_ms);
+            }
+
+            const rc = linux.epoll_wait(self.epoll_fd, events[0..].ptr, @intCast(events.len), current_wait_ms);
             switch (posix.errno(rc)) {
                 .SUCCESS => {},
                 .INTR => continue,
@@ -1994,20 +2067,12 @@ const EventLoop = struct {
             });
         }
 
-        if (slot.upstream_candidates) |old| {
-            self.state.allocator.free(old);
-            slot.upstream_candidates = null;
-        }
-
-        slot.upstream_candidates = self.state.allocator.alloc(net.Address, plan.count) catch {
+        slot.setUpstreamCandidates(self.state.allocator, plan.candidates[0..plan.count]) catch {
             self.closeSlot(slot, "alloc upstream candidate list failed");
             return;
         };
-        const candidates = slot.upstream_candidates.?;
-        var idx: usize = 0;
-        while (idx < candidates.len) : (idx += 1) {
-            candidates[idx] = plan.candidates[idx];
-        }
+
+        const candidates = slot.upstreamCandidates();
         slot.upstream_candidate_next = 1;
         slot.current_upstream_addr = candidates[0];
 
@@ -2114,11 +2179,13 @@ const EventLoop = struct {
 
     fn tryNextDcEndpoint(self: *EventLoop, slot: *ConnectionSlot, err: anyerror) bool {
         const attempt_addr = slot.current_upstream_addr;
-        const candidates = slot.upstream_candidates orelse return false;
-        const candidate_count = slotCandidateCount(slot);
+        const candidates = slot.upstreamCandidates();
+        if (candidates.len == 0) return false;
+        const candidate_count = candidates.len;
 
-        if (slot.upstream_candidate_next < candidates.len) {
-            const next_idx = slot.upstream_candidate_next;
+        const next_u: usize = slot.upstream_candidate_next;
+        if (next_u < candidates.len) {
+            const next_idx = next_u;
             const next_addr = candidates[next_idx];
             slot.upstream_candidate_next += 1;
             self.startConnectUpstream(slot, next_addr, .dc) catch |next_err| {
@@ -2151,15 +2218,10 @@ const EventLoop = struct {
             const fallback = slot.direct_fallback_addr.?;
             slot.upstream_candidate_next = 1;
 
-            if (slot.upstream_candidates) |old| {
-                self.state.allocator.free(old);
-                slot.upstream_candidates = null;
-            }
-            const one = self.state.allocator.alloc(net.Address, 1) catch {
+            var one = [_]net.Address{fallback};
+            slot.setUpstreamCandidates(self.state.allocator, one[0..]) catch {
                 return false;
             };
-            one[0] = fallback;
-            slot.upstream_candidates = one;
 
             self.startConnectUpstream(slot, fallback, .dc) catch |fallback_err| {
                 log.warn("[{d}] direct fallback connect failed: {any}", .{ slot.conn_id, fallback_err });
@@ -2717,15 +2779,10 @@ const EventLoop = struct {
         self.cleanupFailedUpstreamConnect(slot);
         slot.upstream_candidate_next = 1;
 
-        if (slot.upstream_candidates) |old| {
-            self.state.allocator.free(old);
-            slot.upstream_candidates = null;
-        }
-        const one = self.state.allocator.alloc(net.Address, 1) catch {
+        var one = [_]net.Address{fallback};
+        slot.setUpstreamCandidates(self.state.allocator, one[0..]) catch {
             return false;
         };
-        one[0] = fallback;
-        slot.upstream_candidates = one;
 
         self.startConnectUpstream(slot, fallback, .dc) catch |err| {
             log.warn("[{d}] direct fallback connect start failed: {any}", .{ slot.conn_id, err });
@@ -3122,15 +3179,24 @@ const EventLoop = struct {
 
     fn appendPipelined(self: *EventLoop, slot: *ConnectionSlot, extra: []const u8) !void {
         if (extra.len == 0) return;
+
+        const current_len: usize = if (slot.pipelined_data) |p| p.len else 0;
+        const next_len = std.math.add(usize, current_len, extra.len) catch {
+            return error.PipelinedDataTooLarge;
+        };
+        if (next_len > max_pipelined_handshake_bytes) {
+            return error.PipelinedDataTooLarge;
+        }
+
         if (slot.pipelined_data == null) {
-            const buf = try self.state.allocator.alloc(u8, extra.len);
+            const buf = try self.state.allocator.alloc(u8, next_len);
             @memcpy(buf, extra);
             slot.pipelined_data = buf;
             return;
         }
 
         const prev = slot.pipelined_data.?;
-        const next = try self.state.allocator.alloc(u8, prev.len + extra.len);
+        const next = try self.state.allocator.alloc(u8, next_len);
         @memcpy(next[0..prev.len], prev);
         @memcpy(next[prev.len..], extra);
         self.state.allocator.free(prev);
@@ -3847,6 +3913,9 @@ fn flushQueue(fd: posix.fd_t, queue: *MessageQueue) !bool {
         const n_iov = queue.prepareIovecs(iovecs[0..]);
         if (n_iov == 0) return true;
 
+        var total_req: usize = 0;
+        for (iovecs[0..n_iov]) |iov| total_req += iov.len;
+
         const n = posix.writev(fd, iovecs[0..n_iov]) catch |err| {
             if (err == error.WouldBlock) return false;
             return err;
@@ -3855,7 +3924,7 @@ fn flushQueue(fd: posix.fd_t, queue: *MessageQueue) !bool {
         if (n == 0) return error.ConnectionReset;
         try queue.consume(n);
 
-        if (n < iovecs[0].len) return false;
+        if (n < total_req) return false;
     }
 
     return true;
@@ -4023,6 +4092,18 @@ test "message queue consume is stable" {
     try std.testing.expect(q.isEmpty());
     try std.testing.expectEqual(@as(usize, 0), q.offset);
     try std.testing.expectEqual(@as(usize, 0), q.head_idx);
+}
+
+test "message queue append fills tail block" {
+    var q = MessageQueue{ .allocator = std.testing.allocator };
+    defer q.deinit();
+
+    try q.appendCopy("abcde");
+    try q.appendCopy("fghij");
+
+    try std.testing.expectEqual(@as(usize, 10), q.total_len);
+    try std.testing.expectEqual(@as(usize, 1), q.blocks.items.len);
+    try std.testing.expectEqual(@as(usize, 10), q.blocks.items[0].len);
 }
 
 test "epoll hangup helper" {

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -16,6 +16,7 @@ const middleproxy = @import("../protocol/middleproxy.zig");
 const tls = @import("../protocol/tls.zig");
 const Config = @import("../config.zig").Config;
 const upstream_mod = @import("upstream.zig");
+const tunnel_mod = @import("../tunnel.zig");
 
 const log = std.log.scoped(.proxy);
 
@@ -825,6 +826,7 @@ pub const ProxyState = struct {
     middle_proxy_secret_len: usize,
     middle_proxy_nat_ip4: ?[4]u8,
     upstream: upstream_mod.Upstream,
+    tunnel_info: tunnel_mod.Tunnel,
 
     pub fn init(allocator: std.mem.Allocator, cfg: Config) ProxyState {
         var secrets: std.ArrayList(obfuscation.UserSecret) = .empty;
@@ -934,6 +936,21 @@ pub const ProxyState = struct {
             .middle_proxy_secret_len = middleproxy.proxy_secret.len,
             .middle_proxy_nat_ip4 = detected_nat_ip4,
             .upstream = upstream_mod.Upstream.initDirect(),
+            .tunnel_info = blk: {
+                // Explicit config takes priority
+                if (cfg.tunnel_type != .none) {
+                    const t = tunnel_mod.Tunnel{ .tag = cfg.tunnel_type };
+                    log.info("Tunnel: {s} (from config)", .{t.name()});
+                    break :blk t;
+                }
+                // Auto-detect: if we're in a non-init netns, assume AmneziaWG
+                if (isRunningInNonInitNetns()) {
+                    const t = tunnel_mod.Tunnel{ .tag = .amnezia_wg };
+                    log.info("Tunnel: {s} (auto-detected from network namespace)", .{t.name()});
+                    break :blk t;
+                }
+                break :blk tunnel_mod.Tunnel{ .tag = .none };
+            },
         };
     }
 

--- a/src/proxy/upstream.zig
+++ b/src/proxy/upstream.zig
@@ -4,10 +4,19 @@
 //! when creating upstream sockets. Today it only provides a direct TCP
 //! connector, but new variants (SOCKS5, HTTP CONNECT, custom tunnels)
 //! can be added without changing the event loop call sites.
+//!
+//! The `tunnel_info` field carries metadata about the active tunnel
+//! (see `tunnel.zig`). For namespace-based tunnels like AmneziaWG,
+//! the connect variant stays `direct` because the proxy process itself
+//! runs inside the namespace — so all TCP connects implicitly traverse
+//! the tunnel without socket-level wrapping.
 
 const std = @import("std");
 const net = std.net;
 const posix = std.posix;
+const tunnel_mod = @import("../tunnel.zig");
+
+pub const Tunnel = tunnel_mod.Tunnel;
 
 pub const ConnectResult = struct {
     fd: posix.fd_t,

--- a/src/tunnel.zig
+++ b/src/tunnel.zig
@@ -1,0 +1,98 @@
+//! Generic tunnel abstraction for proxy transport.
+//!
+//! Defines the `Tunnel` metadata type that describes which tunnel
+//! (if any) is active for outgoing proxy connections. This is a
+//! capability/metadata struct — not a socket connector — because
+//! some tunnels (e.g. AmneziaWG) work by running the proxy inside
+//! a network namespace rather than wrapping individual connect() calls.
+//!
+//! New tunnel types (SOCKS5, HTTP CONNECT, etc.) can be added by
+//! extending the `Tag` enum and implementing type-specific behavior.
+
+const std = @import("std");
+
+pub const Tunnel = struct {
+    pub const Tag = enum {
+        /// Direct connection — no tunnel active.
+        none,
+        /// AmneziaWG tunnel via Linux network namespace.
+        /// The proxy process runs inside `tg_proxy_ns` and all
+        /// outgoing TCP connects traverse the AWG interface.
+        amnezia_wg,
+        // Future variants:
+        // socks5,
+        // http_connect,
+    };
+
+    tag: Tag = .none,
+
+    /// Human-readable name for logging and status display.
+    pub fn name(self: *const Tunnel) []const u8 {
+        return switch (self.tag) {
+            .none => "direct",
+            .amnezia_wg => "AmneziaWG",
+        };
+    }
+
+    /// Whether this tunnel type requires running inside a network namespace.
+    pub fn requiresNetns(self: *const Tunnel) bool {
+        return switch (self.tag) {
+            .none => false,
+            .amnezia_wg => true,
+        };
+    }
+
+    /// The network namespace name, if applicable.
+    pub fn netnsName(self: *const Tunnel) ?[]const u8 {
+        return switch (self.tag) {
+            .none => null,
+            .amnezia_wg => "tg_proxy_ns",
+        };
+    }
+
+    /// Parse a tunnel type string from configuration.
+    /// Returns `.none` for unrecognized values.
+    pub fn fromString(s: []const u8) Tag {
+        if (std.mem.eql(u8, s, "amnezia_wg") or std.mem.eql(u8, s, "amneziawg")) {
+            return .amnezia_wg;
+        }
+        if (std.mem.eql(u8, s, "none") or std.mem.eql(u8, s, "direct")) {
+            return .none;
+        }
+        return .none;
+    }
+};
+
+// ============= Tests =============
+
+test "tunnel - name returns human-readable string" {
+    const direct = Tunnel{ .tag = .none };
+    try std.testing.expectEqualStrings("direct", direct.name());
+
+    const awg = Tunnel{ .tag = .amnezia_wg };
+    try std.testing.expectEqualStrings("AmneziaWG", awg.name());
+}
+
+test "tunnel - requiresNetns" {
+    const direct = Tunnel{ .tag = .none };
+    try std.testing.expect(!direct.requiresNetns());
+
+    const awg = Tunnel{ .tag = .amnezia_wg };
+    try std.testing.expect(awg.requiresNetns());
+}
+
+test "tunnel - netnsName" {
+    const direct = Tunnel{ .tag = .none };
+    try std.testing.expect(direct.netnsName() == null);
+
+    const awg = Tunnel{ .tag = .amnezia_wg };
+    try std.testing.expectEqualStrings("tg_proxy_ns", awg.netnsName().?);
+}
+
+test "tunnel - fromString parsing" {
+    try std.testing.expectEqual(Tunnel.Tag.amnezia_wg, Tunnel.fromString("amnezia_wg"));
+    try std.testing.expectEqual(Tunnel.Tag.amnezia_wg, Tunnel.fromString("amneziawg"));
+    try std.testing.expectEqual(Tunnel.Tag.none, Tunnel.fromString("none"));
+    try std.testing.expectEqual(Tunnel.Tag.none, Tunnel.fromString("direct"));
+    try std.testing.expectEqual(Tunnel.Tag.none, Tunnel.fromString("unknown_value"));
+}


### PR DESCRIPTION
## Summary
- Introduce and standardize explicit upstream routing config via `[upstream].type` (`auto|direct|amnezia_wg`) across runtime config, docs, examples, and mtbuddy tunnel setup flow.
- Harden hot proxy paths after validator review: dynamic desync poll wake-up, correct partial `writev` handling, `MessageQueue` tail-fill + OOM-safe block recycling, pipelined handshake cap, and middle-proxy updater temporary allocations moved to arena.
- Reduce handshake-path allocation pressure with inline upstream-candidate staging plus heap fallback, and switch main GPA to non-thread-safe mode (safe after isolating updater temporaries).
- Add dedicated `handshake-path` benchmark mode and CI coverage for both inline and heap-fallback candidate paths, with artifacts uploaded for trend tracking.

## Config decision (final)
- Removed legacy `[tunnel].type` parsing path from config loader.
- `[upstream].type` is now the only supported config key for egress mode.
- Updated `config.toml.example` and README reference to match this single source of truth.

## Validator-driven fixes in this session
- `epoll_wait` timeout now shrinks when desync wait slots exist (avoids 37ms jitter for delayed `ServerHello` rest).
- `flushQueue` now compares bytes written against total iovec request (prevents extra `writev` when socket buffer is already full).
- `MessageQueue.appendCopy` now reuses tail space and uses `errdefer` to avoid OOM leak window.
- Added hard cap for pre-upstream pipelined bytes to protect against handshake-stage memory abuse.
- Middle-proxy refresh now uses arena-backed temp allocator; no long-lived heap pressure in that path.
- Upstream candidate staging now uses inline storage first (`cap=4`) with heap fallback only when needed.

## Validation
- `zig build test`
- `zig build`
- `zig build -Doptimize=ReleaseFast bench -- handshake-path --iterations=50000 --candidate-count=4`
- `zig build -Doptimize=ReleaseFast bench -- handshake-path --iterations=50000 --candidate-count=8`

## Notes
- The `candidate-count=8` benchmark is intentionally slower because it exercises heap fallback path; production default remains inline-first (`cap=4`), so typical handshakes stay in the fast path.

Closes #140
Closes #143