### PR TITLE
fix(ctl): unify install to use release artifacts instead of building from source

### DIFF
--- a/src/ctl/i18n.zig
+++ b/src/ctl/i18n.zig
@@ -92,10 +92,10 @@ pub const S = enum(u16) {
     install_dpi_drs,
     install_dpi_drs_help,
     install_checking_deps,
-    install_installing_zig,
-    install_zig_ok,
-    install_cloning,
-    install_building,
+    install_resolving_tag,
+    install_download_ok,
+    install_downloading,
+    install_validating,
     install_binary_ok,
     install_config_generated,
     install_config_exists,
@@ -279,14 +279,14 @@ const en_strings = [_][]const u8{
     "Ramp TLS records 1369→16384 bytes to mimic browser behavior, evade traffic analysis.",
     // install_checking_deps
     "Installing system dependencies...",
-    // install_installing_zig
-    "Installing Zig",
-    // install_zig_ok
-    "Zig installed",
-    // install_cloning
-    "Cloning repository...",
-    // install_building
-    "Building mtproto-proxy...",
+    // install_resolving_tag
+    "Resolving latest release...",
+    // install_download_ok
+    "Binary downloaded",
+    // install_downloading
+    "Downloading proxy binary...",
+    // install_validating
+    "Validating binary compatibility...",
     // install_binary_ok
     "Binary installed",
     // install_config_generated
@@ -504,14 +504,14 @@ const ru_strings = [_][]const u8{
     "Наращивание TLS записей 1369→16384 байт, имитируя браузер, обход анализа трафика.",
     // install_checking_deps
     "Установка системных зависимостей...",
-    // install_installing_zig
-    "Установка Zig",
-    // install_zig_ok
-    "Zig установлен",
-    // install_cloning
-    "Клонирование репозитория...",
-    // install_building
-    "Сборка mtproto-proxy...",
+    // install_resolving_tag
+    "Определение последней версии...",
+    // install_download_ok
+    "Бинарник скачан",
+    // install_downloading
+    "Скачивание бинарника прокси...",
+    // install_validating
+    "Проверка совместимости бинарника...",
     // install_binary_ok
     "Бинарник установлен",
     // install_config_generated

--- a/src/ctl/install.zig
+++ b/src/ctl/install.zig
@@ -279,6 +279,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
 
     // ── Download + validate proxy binary ──
     var artifact = release.Artifact{};
+    defer release.cleanup(allocator, &artifact);
     {
         var sp = ui.spinner(ui.str(.install_downloading));
         sp.start();
@@ -298,8 +299,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
             artifact.binaryPath(),
             INSTALL_DIR ++ "/mtproto-proxy",
         }) catch {};
-        release.downloadServiceFile(allocator, tag.slice());
-        release.cleanup(allocator, &artifact);
+        release.writeServiceFile();
     }
     ui.ok(ui.str(.install_binary_ok));
 

--- a/src/ctl/install.zig
+++ b/src/ctl/install.zig
@@ -1,7 +1,7 @@
 //! Install command for mtbuddy.
 //!
-//! Ports install.sh (296 lines of bash) into structured Zig code.
 //! Supports both interactive TUI mode and non-interactive CLI mode.
+//! Downloads pre-built release artifacts from GitHub (same path as update).
 //!
 //! One-liner usage:
 //!   sudo mtbuddy install --port 443 --domain wb.ru --yes
@@ -11,6 +11,7 @@ const std = @import("std");
 const tui_mod = @import("tui.zig");
 const i18n = @import("i18n.zig");
 const sys = @import("sys.zig");
+const release = @import("release.zig");
 const toml = @import("toml.zig");
 const masking = @import("masking.zig");
 const nfqws = @import("nfqws.zig");
@@ -19,10 +20,8 @@ const Tui = tui_mod.Tui;
 const Color = tui_mod.Color;
 const SummaryLine = tui_mod.SummaryLine;
 
-const ZIG_VERSION = "0.15.2";
-const INSTALL_DIR = "/opt/mtproto-proxy";
-const REPO_URL = "https://github.com/sleep3r/mtproto.zig.git";
-const SERVICE_NAME = "mtproto-proxy";
+const INSTALL_DIR = release.INSTALL_DIR;
+const SERVICE_NAME = release.SERVICE_NAME;
 
 pub const InstallOpts = struct {
     port: u16 = 443,
@@ -40,8 +39,8 @@ pub const InstallOpts = struct {
     user: ?[]const u8 = null,
     /// Skip confirmation prompt (non-interactive / one-liner mode).
     yes: bool = false,
-    /// Zig release tag to install from (overrides default ZIG_VERSION).
-    zig_tag: ?[]const u8 = null,
+    /// Release version to install (e.g. "v0.12.0"). If null, uses latest.
+    version: ?[]const u8 = null,
     /// Path to an existing config.toml to use.
     config_path: ?[]const u8 = null,
     /// Internal flags to track if user explicitly provided a value.
@@ -96,8 +95,8 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.ArgIterato
             opts.enable_tcpmss = false;
         } else if (std.mem.eql(u8, arg, "--ipv6-hop")) {
             opts.enable_ipv6_hop = true;
-        } else if (std.mem.eql(u8, arg, "--zig-tag")) {
-            if (args.next()) |val| opts.zig_tag = val;
+        } else if (std.mem.eql(u8, arg, "--version") or std.mem.eql(u8, arg, "-v")) {
+            opts.version = args.next();
         }
     }
 
@@ -258,92 +257,49 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
         sp.start();
         _ = sys.exec(allocator, &.{ "apt-get", "update", "-qq" }) catch {};
         _ = sys.exec(allocator, &.{
-            "apt-get",  "install", "-y",
-            "iptables", "xxd",     "git",
-            "curl",     "openssl", "tar",
-            "xz-utils",
+            "apt-get", "install", "-y",
+            "iptables", "xxd",    "curl",
+            "openssl",  "tar",
         }) catch {};
         sp.stop(true, "");
     }
 
-    // ── Install Zig ──
-    const zig_ver = opts.zig_tag orelse ZIG_VERSION;
-    const has_zig = blk: {
-        const result = sys.exec(allocator, &.{ "zig", "version" }) catch break :blk false;
-        defer result.deinit();
-        const trimmed = std.mem.trim(u8, result.stdout, &[_]u8{ ' ', '\t', '\r', '\n' });
-        break :blk std.mem.startsWith(u8, trimmed, zig_ver);
-    };
-
-    if (has_zig) {
-        ui.stepOk(ui.str(.install_zig_ok), zig_ver);
-    } else {
-        var sp = ui.spinner(ui.str(.install_installing_zig));
+    // ── Resolve release tag ──
+    var tag = release.Tag{};
+    {
+        var sp = ui.spinner(ui.str(.install_resolving_tag));
         sp.start();
-
-        const arch = sys.getArch() catch {
+        if (!release.resolveTag(allocator, opts.version, &tag)) {
             sp.stop(false, "");
-            ui.fail(ui.str(.error_arch_unsupported));
-            return;
-        };
-
-        var zig_cmd_buf: [512]u8 = undefined;
-        const zig_cmd = std.fmt.bufPrint(&zig_cmd_buf,
-            \\cd /tmp && curl -sSfL -o zig.tar.xz https://ziglang.org/download/{[a]s}/zig-{[b]s}-linux-{[c]s}.tar.xz && tar xf zig.tar.xz && rm -rf /usr/local/zig && mv zig-{[b]s}-linux-{[c]s} /usr/local/zig && ln -sf /usr/local/zig/zig /usr/local/bin/zig && rm -f zig.tar.xz
-        , .{ .a = zig_ver, .b = arch.toStr(), .c = zig_ver }) catch {
-            sp.stop(false, "");
-            return;
-        };
-
-        const dl_result = sys.exec(allocator, &.{ "bash", "-c", zig_cmd }) catch {
-            sp.stop(false, "");
-            return;
-        };
-
-        if (dl_result.exit_code != 0) {
-            sp.stop(false, "");
-            if (dl_result.stderr.len > 0) {
-                ui.hint(dl_result.stderr[0..@min(dl_result.stderr.len, 200)]);
-            }
+            ui.fail(ui.str(.error_no_release));
             return;
         }
-        sp.stop(true, zig_ver);
+        sp.stop(true, tag.slice());
     }
 
-    // ── Clone & build ──
+    // ── Download + validate proxy binary ──
+    var artifact = release.Artifact{};
     {
-        var sp = ui.spinner(ui.str(.install_building));
+        var sp = ui.spinner(ui.str(.install_downloading));
         sp.start();
-        var cmd_buf: [1024]u8 = undefined;
-        const build_cmd = std.fmt.bufPrint(
-            &cmd_buf,
-            "TMPDIR=$(mktemp -d) && git clone --depth 1 {s} $TMPDIR 2>&1 && " ++
-                "cd $TMPDIR && zig build -Doptimize=ReleaseFast 2>&1 && " ++
-                "mkdir -p {s} && cp zig-out/bin/mtproto-proxy {s}/mtproto-proxy && " ++
-                "chmod +x {s}/mtproto-proxy && " ++
-                "cp $TMPDIR/deploy/*.sh {s}/ 2>/dev/null || true && " ++
-                "cp $TMPDIR/deploy/mtproto-proxy.service /etc/systemd/system/ && " ++
-                "chmod +x {s}/*.sh 2>/dev/null || true && rm -rf $TMPDIR",
-            .{ REPO_URL, INSTALL_DIR, INSTALL_DIR, INSTALL_DIR, INSTALL_DIR, INSTALL_DIR },
-        ) catch {
+        if (!release.downloadProxyArtifact(allocator, tag.slice(), "install", &artifact)) {
             sp.stop(false, "");
-            return;
-        };
-
-        const build_result = sys.exec(allocator, &.{ "bash", "-c", build_cmd }) catch {
-            sp.stop(false, "");
-            return;
-        };
-        defer build_result.deinit();
-
-        if (build_result.exit_code != 0) {
-            sp.stop(false, "");
-            if (build_result.stderr.len > 0) {
-                ui.hint(build_result.stderr[0..@min(build_result.stderr.len, 200)]);
-            }
+            ui.fail(ui.str(.error_download_failed));
             return;
         }
-        sp.stop(true, "");
+        sp.stop(true, artifact.asset_name);
+    }
+
+    // ── Install binary + service file ──
+    {
+        _ = sys.exec(allocator, &.{ "mkdir", "-p", INSTALL_DIR }) catch {};
+        _ = sys.execForward(&.{
+            "install", "-m", "0755",
+            artifact.binaryPath(),
+            INSTALL_DIR ++ "/mtproto-proxy",
+        }) catch {};
+        release.downloadServiceFile(allocator, tag.slice());
+        release.cleanup(allocator, &artifact);
     }
     ui.ok(ui.str(.install_binary_ok));
 

--- a/src/ctl/main.zig
+++ b/src/ctl/main.zig
@@ -314,7 +314,7 @@ fn printHelp() void {
 
     // ── Commands ──
     ui.print("  {s}Commands:{s}\n\n", .{ Color.accent, Color.reset });
-    printCmd(&ui, "install", "Install mtproto-proxy from source");
+    printCmd(&ui, "install", "Install mtproto-proxy from release");
     printCmd(&ui, "uninstall", "Uninstall mtproto-proxy completely");
     printCmd(&ui, "update", "Update to latest GitHub release");
     printCmd(&ui, "setup masking", "Setup local Nginx DPI masking");
@@ -341,7 +341,7 @@ fn printHelp() void {
     printOpt(&ui, "--no-tcpmss", "Disable TCPMSS=88 clamping");
     printOpt(&ui, "--no-dpi", "Disable all DPI bypass modules");
     printOpt(&ui, "--ipv6-hop", "Enable IPv6 auto-hopping");
-    printOpt(&ui, "--zig-tag <ver>", "Override Zig version to install");
+    printOpt(&ui, "--version, -v <tag>", "Release version to install (default: latest)");
     ui.writeRaw("\n");
 
     // ── Update options ──

--- a/src/ctl/masking.zig
+++ b/src/ctl/masking.zig
@@ -238,9 +238,11 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: MaskingOpts) !void 
 
     // ── Install masking monitor ──
     if (!opts.skip_monitor) {
-        if (sys.fileExists(INSTALL_DIR ++ "/setup_mask_monitor.sh")) {
-            _ = sys.execForward(&.{ "bash", INSTALL_DIR ++ "/setup_mask_monitor.sh", "--quiet" }) catch {};
-        }
+        const recovery = @import("recovery.zig");
+        recovery.execute(ui, allocator, .{}) catch |err| {
+            ui.warn("Failed to install auto-recovery module");
+            std.log.debug("Recovery install error: {any}", .{err});
+        };
     }
 
     // ── Summary ──

--- a/src/ctl/recovery.zig
+++ b/src/ctl/recovery.zig
@@ -47,7 +47,7 @@ pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
     try execute(ui, allocator, .{});
 }
 
-fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: RecoveryOpts) !void {
+pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: RecoveryOpts) !void {
     _ = opts;
 
     if (!sys.isRoot()) {

--- a/src/ctl/release.zig
+++ b/src/ctl/release.zig
@@ -1,0 +1,265 @@
+//! Shared GitHub Releases helpers for install and update commands.
+//!
+//! Centralises tag resolution, artifact download with architecture-aware
+//! candidate selection, binary validation, and temp-directory cleanup.
+//! Used by both install.zig and update.zig to avoid duplication.
+
+const std = @import("std");
+const sys = @import("sys.zig");
+
+// ── Shared constants ────────────────────────────────────────────
+
+pub const REPO_OWNER = "sleep3r";
+pub const REPO_NAME = "mtproto.zig";
+pub const INSTALL_DIR = "/opt/mtproto-proxy";
+pub const SERVICE_NAME = "mtproto-proxy";
+pub const SERVICE_FILE = "/etc/systemd/system/mtproto-proxy.service";
+
+const RELEASES_API = "https://api.github.com/repos/" ++ REPO_OWNER ++ "/" ++ REPO_NAME ++ "/releases/latest";
+const RAW_BASE = "https://raw.githubusercontent.com/" ++ REPO_OWNER ++ "/" ++ REPO_NAME ++ "/";
+
+// ── Result types ────────────────────────────────────────────────
+
+/// Storage for a resolved release tag (e.g. "v0.12.0").
+pub const Tag = struct {
+    buf: [64]u8 = undefined,
+    len: usize = 0,
+
+    pub fn slice(self: *const Tag) []const u8 {
+        return self.buf[0..self.len];
+    }
+};
+
+/// Paths produced during artifact download. Owns all buffer storage.
+pub const Artifact = struct {
+    /// Temp extraction directory (e.g. "/tmp/mtproto-install-v0.12.0").
+    extract_dir_buf: [128]u8 = undefined,
+    extract_dir_len: usize = 0,
+    /// Full path to the validated binary inside extract_dir.
+    binary_path_buf: [256]u8 = undefined,
+    binary_path_len: usize = 0,
+    /// Path to the downloaded .tar.gz file.
+    dl_path_buf: [256]u8 = undefined,
+    dl_path_len: usize = 0,
+    /// Name of the selected release asset (comptime-known string literal).
+    asset_name: []const u8 = "",
+
+    pub fn extractDir(self: *const Artifact) []const u8 {
+        return self.extract_dir_buf[0..self.extract_dir_len];
+    }
+
+    pub fn binaryPath(self: *const Artifact) []const u8 {
+        return self.binary_path_buf[0..self.binary_path_len];
+    }
+
+    pub fn dlPath(self: *const Artifact) []const u8 {
+        return self.dl_path_buf[0..self.dl_path_len];
+    }
+};
+
+// ── Public API ──────────────────────────────────────────────────
+
+/// Resolve a release tag: normalise provided version or fetch latest.
+/// Returns true on success (tag is populated), false on failure.
+pub fn resolveTag(
+    allocator: std.mem.Allocator,
+    version: ?[]const u8,
+    tag: *Tag,
+) bool {
+    if (version) |v| {
+        if (v.len == 0) return resolveLatest(allocator, tag);
+        if (v[0] != 'v') {
+            tag.buf[0] = 'v';
+            const n = @min(v.len, tag.buf.len - 1);
+            @memcpy(tag.buf[1..][0..n], v[0..n]);
+            tag.len = n + 1;
+        } else {
+            const n = @min(v.len, tag.buf.len);
+            @memcpy(tag.buf[0..n], v[0..n]);
+            tag.len = n;
+        }
+        return true;
+    }
+    return resolveLatest(allocator, tag);
+}
+
+/// Download, extract, and validate a proxy binary from GitHub Releases.
+///
+/// Detects CPU architecture and tries optimised builds first (x86_64_v3),
+/// falling back to the base build. Validates the downloaded binary can
+/// execute on this CPU (catches SIGILL from unsupported instructions).
+///
+/// `label` is used in the temp directory name (e.g. "install", "update").
+/// Returns true on success (artifact is populated), false on failure.
+pub fn downloadProxyArtifact(
+    allocator: std.mem.Allocator,
+    tag: []const u8,
+    label: []const u8,
+    artifact: *Artifact,
+) bool {
+    // ── Detect architecture ──
+    const arch = sys.getArch() catch return false;
+    const supports_v3 = if (arch == .x86_64) sys.supportsV3(allocator) else false;
+
+    // ── Build candidate list ──
+    const candidates: []const []const u8 = if (supports_v3)
+        &[_][]const u8{ "mtproto-proxy-linux-x86_64_v3", "mtproto-proxy-linux-x86_64" }
+    else if (arch == .aarch64)
+        &[_][]const u8{"mtproto-proxy-linux-aarch64"}
+    else
+        &[_][]const u8{"mtproto-proxy-linux-x86_64"};
+
+    // ── Prepare extraction directory ──
+    const extract_dir = std.fmt.bufPrint(
+        &artifact.extract_dir_buf,
+        "/tmp/mtproto-{s}-{s}",
+        .{ label, tag },
+    ) catch return false;
+    artifact.extract_dir_len = extract_dir.len;
+
+    _ = sys.exec(allocator, &.{ "rm", "-rf", extract_dir }) catch {};
+    _ = sys.exec(allocator, &.{ "mkdir", "-p", extract_dir }) catch {};
+
+    // ── Try each candidate ──
+    for (candidates) |candidate| {
+        var url_buf: [512]u8 = undefined;
+        const url = std.fmt.bufPrint(
+            &url_buf,
+            "https://github.com/{s}/{s}/releases/download/{s}/{s}.tar.gz",
+            .{ REPO_OWNER, REPO_NAME, tag, candidate },
+        ) catch continue;
+
+        const dl_path = std.fmt.bufPrint(
+            &artifact.dl_path_buf,
+            "/tmp/{s}.tar.gz",
+            .{candidate},
+        ) catch continue;
+        artifact.dl_path_len = dl_path.len;
+
+        // Download
+        const dl = sys.exec(allocator, &.{ "curl", "-fsSL", url, "-o", dl_path }) catch continue;
+        defer dl.deinit();
+        if (dl.exit_code != 0) continue;
+
+        // Extract
+        const tar_exit = sys.execForward(&.{ "tar", "-xzf", dl_path, "-C", extract_dir }) catch continue;
+        if (tar_exit != 0) continue;
+
+        // Locate binary
+        const bin_path = std.fmt.bufPrint(
+            &artifact.binary_path_buf,
+            "{s}/{s}",
+            .{ extract_dir, candidate },
+        ) catch continue;
+        artifact.binary_path_len = bin_path.len;
+
+        if (!sys.fileExists(bin_path)) continue;
+
+        // Validate — run with a nonexistent config to check for SIGILL (exit 132)
+        const check = sys.exec(allocator, &.{
+            bin_path,
+            "/tmp/.mtproto-release-check-nonexistent.toml",
+        }) catch continue;
+        defer check.deinit();
+
+        if (check.exit_code == 132) continue;
+
+        // ── Success ──
+        artifact.asset_name = candidate;
+        return true;
+    }
+
+    return false;
+}
+
+/// Download the mtbuddy binary for the same platform as a proxy artifact.
+/// Returns the path to the extracted buddy binary, or null if unavailable.
+pub fn downloadBuddyArtifact(
+    allocator: std.mem.Allocator,
+    tag: []const u8,
+    proxy_asset: []const u8,
+    extract_dir: []const u8,
+    out_buf: *[256]u8,
+) ?[]const u8 {
+    // Derive buddy name: "mtproto-proxy-linux-x86_64_v3" → "mtbuddy-linux-x86_64_v3"
+    const prefix = "mtproto-proxy";
+    const idx = std.mem.indexOf(u8, proxy_asset, prefix) orelse return null;
+    const suffix = proxy_asset[idx + prefix.len ..];
+
+    var name_buf: [128]u8 = undefined;
+    const buddy_name = std.fmt.bufPrint(&name_buf, "mtbuddy{s}", .{suffix}) catch return null;
+
+    var url_buf: [512]u8 = undefined;
+    const url = std.fmt.bufPrint(
+        &url_buf,
+        "https://github.com/{s}/{s}/releases/download/{s}/{s}.tar.gz",
+        .{ REPO_OWNER, REPO_NAME, tag, buddy_name },
+    ) catch return null;
+
+    const dl = sys.exec(allocator, &.{ "curl", "-fsSL", url, "-o", "/tmp/mtbuddy.tar.gz" }) catch return null;
+    defer dl.deinit();
+    if (dl.exit_code != 0) return null;
+
+    const tar_exit = sys.execForward(&.{ "tar", "-xzf", "/tmp/mtbuddy.tar.gz", "-C", extract_dir }) catch return null;
+    if (tar_exit != 0) return null;
+
+    const bin_path = std.fmt.bufPrint(out_buf, "{s}/{s}", .{ extract_dir, buddy_name }) catch return null;
+    if (!sys.fileExists(bin_path)) return null;
+
+    return bin_path;
+}
+
+/// Download the systemd service file from the repository at the given tag.
+pub fn downloadServiceFile(allocator: std.mem.Allocator, tag: []const u8) void {
+    var url_buf: [512]u8 = undefined;
+    const url = std.fmt.bufPrint(
+        &url_buf,
+        "{s}{s}/deploy/mtproto-proxy.service",
+        .{ RAW_BASE, tag },
+    ) catch return;
+    _ = sys.exec(allocator, &.{ "curl", "-fsSL", url, "-o", SERVICE_FILE }) catch {};
+}
+
+/// Remove temporary files created during download.
+pub fn cleanup(allocator: std.mem.Allocator, artifact: *const Artifact) void {
+    if (artifact.extract_dir_len > 0) {
+        _ = sys.exec(allocator, &.{ "rm", "-rf", artifact.extractDir() }) catch {};
+    }
+    if (artifact.dl_path_len > 0) {
+        _ = sys.exec(allocator, &.{ "rm", "-f", artifact.dlPath() }) catch {};
+    }
+    // Clean up buddy tarball if it was downloaded
+    _ = sys.exec(allocator, &.{ "rm", "-f", "/tmp/mtbuddy.tar.gz" }) catch {};
+}
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+fn resolveLatest(allocator: std.mem.Allocator, tag: *Tag) bool {
+    const result = sys.exec(allocator, &.{ "curl", "-fsSL", RELEASES_API }) catch return false;
+    defer result.deinit();
+
+    const parsed = extractTagName(result.stdout) orelse return false;
+    const n = @min(parsed.len, tag.buf.len);
+    @memcpy(tag.buf[0..n], parsed[0..n]);
+    tag.len = n;
+    return true;
+}
+
+/// Extract "tag_name" value from a GitHub API JSON response.
+pub fn extractTagName(json: []const u8) ?[]const u8 {
+    const needle = "\"tag_name\"";
+    const idx = std.mem.indexOf(u8, json, needle) orelse return null;
+
+    // Skip to the opening quote of the value
+    var pos = idx + needle.len;
+    while (pos < json.len and json[pos] != '"') : (pos += 1) {}
+    if (pos >= json.len) return null;
+    pos += 1; // skip opening quote
+
+    // Read until closing quote
+    const start = pos;
+    while (pos < json.len and json[pos] != '"') : (pos += 1) {}
+    if (pos >= json.len) return null;
+
+    return json[start..pos];
+}

--- a/src/ctl/release.zig
+++ b/src/ctl/release.zig
@@ -16,7 +16,6 @@ pub const SERVICE_NAME = "mtproto-proxy";
 pub const SERVICE_FILE = "/etc/systemd/system/mtproto-proxy.service";
 
 const RELEASES_API = "https://api.github.com/repos/" ++ REPO_OWNER ++ "/" ++ REPO_NAME ++ "/releases/latest";
-const RAW_BASE = "https://raw.githubusercontent.com/" ++ REPO_OWNER ++ "/" ++ REPO_NAME ++ "/";
 
 // ── Result types ────────────────────────────────────────────────
 
@@ -67,7 +66,7 @@ pub fn resolveTag(
     tag: *Tag,
 ) bool {
     if (version) |v| {
-        if (v.len == 0) return resolveLatest(allocator, tag);
+        if (v.len == 0 or std.mem.eql(u8, v, "latest")) return resolveLatest(allocator, tag);
         if (v[0] != 'v') {
             tag.buf[0] = 'v';
             const n = @min(v.len, tag.buf.len - 1);
@@ -155,6 +154,9 @@ pub fn downloadProxyArtifact(
 
         if (!sys.fileExists(bin_path)) continue;
 
+        // Guarantee executable bit (paranoid umask can strip +x from tar)
+        _ = sys.exec(allocator, &.{ "chmod", "+x", bin_path }) catch {};
+
         // Validate — run with a nonexistent config to check for SIGILL (exit 132)
         const check = sys.exec(allocator, &.{
             bin_path,
@@ -209,15 +211,46 @@ pub fn downloadBuddyArtifact(
     return bin_path;
 }
 
-/// Download the systemd service file from the repository at the given tag.
-pub fn downloadServiceFile(allocator: std.mem.Allocator, tag: []const u8) void {
-    var url_buf: [512]u8 = undefined;
-    const url = std.fmt.bufPrint(
-        &url_buf,
-        "{s}{s}/deploy/mtproto-proxy.service",
-        .{ RAW_BASE, tag },
-    ) catch return;
-    _ = sys.exec(allocator, &.{ "curl", "-fsSL", url, "-o", SERVICE_FILE }) catch {};
+/// Write the systemd service file from embedded content.
+/// Avoids network dependency on raw.githubusercontent.com which may be
+/// throttled or blocked on some hosting providers.
+pub fn writeServiceFile() void {
+    const content =
+        \\[Unit]
+        \\Description=MTProto Proxy (Zig)
+        \\Documentation=https://github.com/sleep3r/mtproto.zig
+        \\After=network-online.target
+        \\Wants=network-online.target
+        \\
+        \\[Service]
+        \\Type=simple
+        \\User=mtproto
+        \\Group=mtproto
+        \\WorkingDirectory=/opt/mtproto-proxy
+        \\ExecStart=/opt/mtproto-proxy/mtproto-proxy /opt/mtproto-proxy/config.toml
+        \\Restart=always
+        \\RestartSec=3
+        \\
+        \\# Security hardening
+        \\NoNewPrivileges=yes
+        \\ProtectSystem=strict
+        \\ProtectHome=yes
+        \\PrivateTmp=yes
+        \\ReadOnlyPaths=/opt/mtproto-proxy
+        \\
+        \\# Allow binding to privileged ports (443)
+        \\AmbientCapabilities=CAP_NET_BIND_SERVICE
+        \\CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+        \\
+        \\# Limits
+        \\LimitNOFILE=131582
+        \\TasksMax=65535
+        \\
+        \\[Install]
+        \\WantedBy=multi-user.target
+        \\
+    ;
+    sys.writeFile(SERVICE_FILE, content) catch {};
 }
 
 /// Remove temporary files created during download.

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -322,9 +322,10 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
         }
     }
 
-    // ── Install masking monitor ──
-    if (sys.fileExists(INSTALL_DIR ++ "/setup_mask_monitor.sh")) {
-        _ = sys.execForward(&.{ "bash", INSTALL_DIR ++ "/setup_mask_monitor.sh", "--quiet" }) catch {};
+    // ── Apply masking monitor (if recovery is already installed) ──
+    if (sys.isServiceActive("mtproto-mask-health.timer") or sys.fileExists("/usr/local/bin/mtproto-mask-health.sh")) {
+        const recovery = @import("recovery.zig");
+        recovery.execute(ui, allocator, .{}) catch {};
     }
 
     // ── Restart proxy ──

--- a/src/ctl/update.zig
+++ b/src/ctl/update.zig
@@ -1,6 +1,5 @@
 //! Update command for mtbuddy.
 //!
-//! Ports update.sh (260 lines of bash) into structured Zig code.
 //! Downloads pre-built release artifacts from GitHub, validates
 //! compatibility, and performs safe binary swap with rollback.
 
@@ -8,16 +7,15 @@ const std = @import("std");
 const tui_mod = @import("tui.zig");
 const i18n = @import("i18n.zig");
 const sys = @import("sys.zig");
+const release = @import("release.zig");
 
 const Tui = tui_mod.Tui;
 const Color = tui_mod.Color;
 const SummaryLine = tui_mod.SummaryLine;
 
-const REPO_OWNER = "sleep3r";
-const REPO_NAME = "mtproto.zig";
-const INSTALL_DIR = "/opt/mtproto-proxy";
-const SERVICE_NAME = "mtproto-proxy";
-const SERVICE_FILE = "/etc/systemd/system/mtproto-proxy.service";
+const INSTALL_DIR = release.INSTALL_DIR;
+const SERVICE_NAME = release.SERVICE_NAME;
+const SERVICE_FILE = release.SERVICE_FILE;
 
 pub const UpdateOpts = struct {
     version: ?[]const u8 = null,
@@ -78,166 +76,39 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: UpdateOpts) !void {
         return;
     }
 
-    // ── Detect architecture ──
-    const arch_enum = sys.getArch() catch {
-        ui.fail(ui.str(.error_arch_unsupported));
-        return;
-    };
-    const arch = arch_enum.toStr();
-
-    // ── Build artifact candidates ──
-    const supports_v3 = if (arch_enum == .x86_64) sys.supportsV3(allocator) else false;
-
-    // ── Resolve version tag ──
-    var tag_storage: [64]u8 = undefined;
-    var tag: []const u8 = undefined;
-
-    if (opts.version) |v| {
-        if (v.len > 0 and v[0] != 'v') {
-            tag_storage[0] = 'v';
-            const copy_len = @min(v.len, tag_storage.len - 1);
-            @memcpy(tag_storage[1..][0..copy_len], v[0..copy_len]);
-            tag = tag_storage[0 .. copy_len + 1];
-        } else {
-            const copy_len = @min(v.len, tag_storage.len);
-            @memcpy(tag_storage[0..copy_len], v[0..copy_len]);
-            tag = tag_storage[0..copy_len];
-        }
-    } else {
-        ui.step(ui.str(.update_resolving_tag));
-
-        const result = sys.exec(allocator, &.{
-            "curl", "-fsSL",
-            "https://api.github.com/repos/" ++ REPO_OWNER ++ "/" ++ REPO_NAME ++ "/releases/latest",
-        }) catch {
-            ui.fail(ui.str(.error_no_release));
-            return;
-        };
-        defer result.deinit();
-
-        // Extract tag_name from JSON response (simple grep approach)
-        const tag_parsed = extractTagName(result.stdout);
-        if (tag_parsed) |t| {
-            const copy_len = @min(t.len, tag_storage.len);
-            @memcpy(tag_storage[0..copy_len], t[0..copy_len]);
-            tag = tag_storage[0..copy_len];
-            ui.stepOk(ui.str(.update_tag_resolved), tag);
-        } else {
-            ui.fail(ui.str(.error_no_release));
-            return;
-        }
-    }
-
-    // ── Download artifact ──
-    ui.step(ui.str(.update_downloading));
-
-    const candidates: []const []const u8 = if (supports_v3)
-        &[_][]const u8{
-            "mtproto-proxy-linux-x86_64_v3",
-            "mtproto-proxy-linux-x86_64",
-        }
-    else if (arch_enum == .aarch64)
-        &[_][]const u8{
-            "mtproto-proxy-linux-aarch64",
-        }
-    else
-        &[_][]const u8{
-            "mtproto-proxy-linux-x86_64",
-        };
-
-    // We can't concatenate runtime strings at comptime, so use bufPrint
-    var selected_asset: ?[]const u8 = null;
-    var dl_path_buf: [256]u8 = undefined;
-    var dl_path: []const u8 = undefined;
-
-    for (candidates) |candidate| {
-        var url_buf: [512]u8 = undefined;
-        const url = std.fmt.bufPrint(&url_buf, "https://github.com/{s}/{s}/releases/download/{s}/{s}.tar.gz", .{
-            REPO_OWNER, REPO_NAME, tag, candidate,
-        }) catch continue;
-
-        dl_path = std.fmt.bufPrint(&dl_path_buf, "/tmp/{s}.tar.gz", .{candidate}) catch continue;
-
-        const dl = sys.exec(allocator, &.{ "curl", "-fsSL", url, "-o", dl_path }) catch continue;
-        defer dl.deinit();
-
-        if (dl.exit_code == 0) {
-            selected_asset = candidate;
-            break;
-        }
-    }
-
-    if (selected_asset == null) {
-        ui.fail(ui.str(.error_download_failed));
-        return;
-    }
-    ui.stepOk(ui.str(.update_download_ok), selected_asset.?);
-
-    // ── Attempt to download mtbuddy ──
-    var buddy_candidate_buf: [256]u8 = undefined;
-    var buddy_candidate: []const u8 = "";
-    var has_mtbuddy = false;
-
-    if (std.mem.indexOf(u8, selected_asset.?, "mtproto-proxy")) |idx| {
-        const after = selected_asset.?[idx + "mtproto-proxy".len ..];
-        buddy_candidate = std.fmt.bufPrint(&buddy_candidate_buf, "mtbuddy{s}", .{after}) catch "";
-
-        if (buddy_candidate.len > 0) {
-            var url_buf: [512]u8 = undefined;
-            const url = std.fmt.bufPrint(&url_buf, "https://github.com/{s}/{s}/releases/download/{s}/{s}.tar.gz", .{
-                REPO_OWNER, REPO_NAME, tag, buddy_candidate,
-            }) catch "";
-
-            if (url.len > 0) {
-                const dl_buddy = sys.exec(allocator, &.{ "curl", "-fsSL", url, "-o", "/tmp/mtbuddy.tar.gz" }) catch null;
-                if (dl_buddy) |b| {
-                    if (b.exit_code == 0) has_mtbuddy = true;
-                    b.deinit();
-                }
-            }
-        }
-    }
-
-    // ── Extract ──
-    var extract_dir_buf: [128]u8 = undefined;
-    const extract_dir = std.fmt.bufPrint(&extract_dir_buf, "/tmp/mtproto-update-{s}", .{tag}) catch return;
-
-    _ = sys.exec(allocator, &.{ "rm", "-rf", extract_dir }) catch {};
-    _ = sys.exec(allocator, &.{ "mkdir", "-p", extract_dir }) catch {};
-    _ = sys.execForward(&.{ "tar", "-xzf", dl_path, "-C", extract_dir }) catch {
-        ui.fail(ui.str(.error_download_failed));
-        return;
-    };
-
-    if (has_mtbuddy) {
-        _ = sys.execForward(&.{ "tar", "-xzf", "/tmp/mtbuddy.tar.gz", "-C", extract_dir }) catch {};
-    }
-
-    var new_binary_buf: [256]u8 = undefined;
-    const new_binary = std.fmt.bufPrint(&new_binary_buf, "{s}/{s}", .{ extract_dir, selected_asset.? }) catch return;
-
-    if (!sys.fileExists(new_binary)) {
-        ui.fail(ui.str(.error_binary_not_found));
-        return;
-    }
-
-    // ── Validate binary ──
-    ui.step(ui.str(.update_validating));
+    // ── Resolve release tag ──
+    var tag = release.Tag{};
     {
-        const check = sys.exec(allocator, &.{ new_binary, "/tmp/mtproto-proxy-update-check-does-not-exist.toml" }) catch {
-            // If we can't even spawn the binary, it's incompatible (e.g. ExecFormatError)
-            ui.fail(ui.str(.update_validation_fail));
-            return;
-        };
-        defer check.deinit();
-
-        // Exit code 132 = SIGILL (illegal instruction) — CPU incompatible
-        if (check.exit_code == 132) {
-            ui.fail(ui.str(.update_validation_fail));
+        ui.step(ui.str(.update_resolving_tag));
+        if (!release.resolveTag(allocator, opts.version, &tag)) {
+            ui.fail(ui.str(.error_no_release));
             return;
         }
-        ui.ok(ui.str(.update_validation_ok));
+        ui.stepOk(ui.str(.update_tag_resolved), tag.slice());
     }
+
+    // ── Download + validate proxy binary ──
+    var artifact = release.Artifact{};
+    {
+        ui.step(ui.str(.update_downloading));
+        if (!release.downloadProxyArtifact(allocator, tag.slice(), "update", &artifact)) {
+            ui.fail(ui.str(.error_download_failed));
+            return;
+        }
+        ui.stepOk(ui.str(.update_download_ok), artifact.asset_name);
+    }
+
+    ui.ok(ui.str(.update_validation_ok));
+
+    // ── Download mtbuddy (optional) ──
+    var buddy_buf: [256]u8 = undefined;
+    const buddy_path = release.downloadBuddyArtifact(
+        allocator,
+        tag.slice(),
+        artifact.asset_name,
+        artifact.extractDir(),
+        &buddy_buf,
+    );
 
     // ── Backup current binary ──
     ui.step(ui.str(.update_backing_up));
@@ -266,14 +137,10 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: UpdateOpts) !void {
 
     // ── Install new binary ──
     ui.step(ui.str(.update_installing));
-    _ = sys.execForward(&.{ "install", "-m", "0755", new_binary, INSTALL_DIR ++ "/mtproto-proxy" }) catch {};
+    _ = sys.execForward(&.{ "install", "-m", "0755", artifact.binaryPath(), INSTALL_DIR ++ "/mtproto-proxy" }) catch {};
 
-    if (has_mtbuddy and buddy_candidate.len > 0) {
-        var buddy_bin_buf: [256]u8 = undefined;
-        const buddy_bin = std.fmt.bufPrint(&buddy_bin_buf, "{s}/{s}", .{ extract_dir, buddy_candidate }) catch "";
-        if (sys.fileExists(buddy_bin)) {
-            _ = sys.execForward(&.{ "install", "-m", "0755", buddy_bin, "/usr/local/bin/mtbuddy" }) catch {};
-        }
+    if (buddy_path) |bp| {
+        _ = sys.execForward(&.{ "install", "-m", "0755", bp, "/usr/local/bin/mtbuddy" }) catch {};
     }
 
     // Fix ownership
@@ -281,12 +148,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: UpdateOpts) !void {
 
     // ── Update service file (unless tunnel-aware) ──
     if (opts.force_service_update or !isTunnelServiceUnit()) {
-        const raw_base_buf = "https://raw.githubusercontent.com/" ++ REPO_OWNER ++ "/" ++ REPO_NAME ++ "/";
-        var svc_url_buf: [512]u8 = undefined;
-        const svc_url = std.fmt.bufPrint(&svc_url_buf, "{s}{s}/deploy/mtproto-proxy.service", .{ raw_base_buf, tag }) catch "";
-        if (svc_url.len > 0) {
-            _ = sys.exec(allocator, &.{ "curl", "-fsSL", svc_url, "-o", SERVICE_FILE }) catch {};
-        }
+        release.downloadServiceFile(allocator, tag.slice());
     }
     _ = sys.execForward(&.{ "systemctl", "daemon-reload" }) catch {};
 
@@ -313,14 +175,18 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: UpdateOpts) !void {
     }
 
     // ── Cleanup ──
-    _ = sys.exec(allocator, &.{ "rm", "-rf", extract_dir }) catch {};
-    _ = sys.exec(allocator, &.{ "rm", "-f", dl_path }) catch {};
+    release.cleanup(allocator, &artifact);
 
     // ── Summary ──
+    const arch_str = blk: {
+        const a = sys.getArch() catch break :blk "unknown";
+        break :blk a.toStr();
+    };
+
     ui.summaryBox(ui.str(.update_success_header), &.{
-        .{ .label = ui.str(.update_version_label), .value = tag },
-        .{ .label = ui.str(.update_arch_label), .value = arch },
-        .{ .label = ui.str(.update_artifact_label), .value = selected_asset.? },
+        .{ .label = ui.str(.update_version_label), .value = tag.slice() },
+        .{ .label = ui.str(.update_arch_label), .value = arch_str },
+        .{ .label = ui.str(.update_artifact_label), .value = artifact.asset_name },
         .{ .label = "Status:", .value = "systemctl status mtproto-proxy --no-pager" },
         .{ .label = "Logs:", .value = "journalctl -u mtproto-proxy -f" },
         .{ .label = ui.str(.update_backup_label), .value = backup_path orelse "none" },
@@ -337,24 +203,4 @@ fn isTunnelServiceUnit() bool {
     }) catch return false;
     defer result.deinit();
     return result.exit_code == 0;
-}
-
-/// Extract "tag_name" from GitHub API JSON response (simple string search).
-fn extractTagName(json: []const u8) ?[]const u8 {
-    // Look for "tag_name" : "vX.Y.Z"
-    const needle = "\"tag_name\"";
-    const idx = std.mem.indexOf(u8, json, needle) orelse return null;
-
-    // Find the opening quote of the value
-    var pos = idx + needle.len;
-    while (pos < json.len and json[pos] != '"') : (pos += 1) {}
-    if (pos >= json.len) return null;
-    pos += 1; // skip opening quote
-
-    // Find the closing quote
-    const start = pos;
-    while (pos < json.len and json[pos] != '"') : (pos += 1) {}
-    if (pos >= json.len) return null;
-
-    return json[start..pos];
 }

--- a/src/ctl/update.zig
+++ b/src/ctl/update.zig
@@ -8,6 +8,7 @@ const tui_mod = @import("tui.zig");
 const i18n = @import("i18n.zig");
 const sys = @import("sys.zig");
 const release = @import("release.zig");
+const recovery = @import("recovery.zig");
 
 const Tui = tui_mod.Tui;
 const Color = tui_mod.Color;
@@ -89,6 +90,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: UpdateOpts) !void {
 
     // ── Download + validate proxy binary ──
     var artifact = release.Artifact{};
+    defer release.cleanup(allocator, &artifact);
     {
         ui.step(ui.str(.update_downloading));
         if (!release.downloadProxyArtifact(allocator, tag.slice(), "update", &artifact)) {
@@ -148,7 +150,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: UpdateOpts) !void {
 
     // ── Update service file (unless tunnel-aware) ──
     if (opts.force_service_update or !isTunnelServiceUnit()) {
-        release.downloadServiceFile(allocator, tag.slice());
+        release.writeServiceFile();
     }
     _ = sys.execForward(&.{ "systemctl", "daemon-reload" }) catch {};
 
@@ -169,13 +171,10 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: UpdateOpts) !void {
 
     ui.ok(ui.str(.update_starting));
 
-    // ── Apply masking monitor ──
-    if (sys.fileExists(INSTALL_DIR ++ "/setup_mask_monitor.sh")) {
-        _ = sys.execForward(&.{ "bash", INSTALL_DIR ++ "/setup_mask_monitor.sh", "--quiet" }) catch {};
+    // ── Apply masking monitor (if recovery is already installed) ──
+    if (sys.isServiceActive("mtproto-mask-health.timer") or sys.fileExists("/usr/local/bin/mtproto-mask-health.sh")) {
+        recovery.execute(ui, allocator, .{}) catch {};
     }
-
-    // ── Cleanup ──
-    release.cleanup(allocator, &artifact);
 
     // ── Summary ──
     const arch_str = blk: {


### PR DESCRIPTION
## Summary

`mtbuddy install` собирал прокси из исходников на сервере (Zig + git clone + build), тогда как `mtbuddy update` скачивал готовый бинарник. Теперь обе команды используют **один путь** — pre-built release artifacts.

## Changes

### New: `src/ctl/release.zig`
Общий модуль для работы с GitHub Releases: tag resolution, artifact download (v3→base fallback), SIGILL validation, embedded systemd service file, cleanup.

### Modified: `src/ctl/install.zig`
- ❌ Removed: Zig compiler install, `git clone` + `zig build`, `git`/`xz-utils` deps, `--zig-tag` flag
- ✅ Added: `--version`/`-v`, `release.resolveTag()` → `downloadProxyArtifact()` → `writeServiceFile()`

### Modified: `src/ctl/update.zig`  
- Delegated to `release.zig`, replaced bash monitor with `recovery.zig` — **361→~190 lines**

### Modified: `masking.zig`, `tunnel.zig`, `recovery.zig`
- Replaced dead `setup_mask_monitor.sh` bash refs with native `recovery.execute()`

### Robustness fixes
1. Guard `--version latest` → resolves to latest instead of "vlatest" (404)
2. `defer release.cleanup()` — guaranteed temp file removal on any exit path
3. Embedded service file — no network dependency for static 30-line unit
4. `chmod +x` before SIGILL check — paranoid umask protection
5. Updated `--help` text

## Before / After
```
BEFORE:  apt → Zig (~400MB) → git clone → zig build → install  (~40s)
AFTER:   apt → curl artifact (~3MB) → validate → install       (~2s)
```

## Testing
- ✅ `zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux -Dcpu=x86_64_v3`
- ✅ `zig build test`