### PR TITLE
feat: SOCKS5 & HTTP CONNECT upstream proxies, generic tunnel type

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ It also ships more evasion techniques than any of the above:
 | **TCPMSS=88** | Fragments ClientHello across 6 TCP packets, breaking DPI reassembly |
 | **nfqws TCP desync** | Sends fake packets + TTL-limited splits to confuse stateful DPI |
 | **Split-TLS** | 1-byte Application records to defeat passive signatures |
-| **AmneziaWG tunnel** | Routes through WG in an isolated network namespace when Telegram DCs are blocked |
+| **VPN tunnel** | Routes through WireGuard/AmneziaWG in an isolated network namespace when DCs are blocked |
 | **IPv6 hopping** | Auto-rotates IPv6 address from /64 on ban detection via Cloudflare API |
 | **Anti-replay** | Rejects replayed handshakes + detects ТСПУ Revisor active probes |
 | **Multi-user** | Independent per-user secrets |
@@ -154,7 +154,7 @@ sudo mtbuddy setup recovery
 # Install web monitoring dashboard
 sudo mtbuddy setup dashboard
 
-# AmneziaWG tunnel (for servers where Telegram DCs are blocked)
+# VPN tunnel (for servers where Telegram DCs are blocked)
 sudo mtbuddy setup tunnel /path/to/awg0.conf --mode direct
 
 # IPv6 hopping
@@ -180,9 +180,27 @@ sudo systemctl restart mtproto-proxy
 
 ---
 
-## AmneziaWG tunnel
+## Upstream Routing
 
-If your VPS is in a region where Telegram DCs are blocked at the network level (e.g. Russia), you can route proxy traffic through an AmneziaWG tunnel in an isolated network namespace. The host is completely unaffected — only the proxy process runs inside the namespace.
+The proxy supports multiple ways to route outgoing connections to Telegram DC servers.
+
+### Routing modes
+
+| `[upstream].type` | How it works | When to use |
+|---|---|---|
+| `auto` (default) | Auto-detect: if running in a network namespace → tunnel, otherwise → direct | Most deployments |
+| `direct` | Connect to Telegram DCs directly from the host | DCs reachable from the server |
+| `tunnel` | Direct connect inside an isolated network namespace with a VPN tunnel | DCs blocked by the ISP |
+| `socks5` | Route through an external SOCKS5 proxy with optional auth | Existing proxy infrastructure |
+| `http` | Route through an HTTP CONNECT proxy with optional auth | Corporate proxy environments |
+
+### VPN tunnel
+
+If your VPS is in a region where Telegram DCs are blocked at the network level, you can route proxy traffic through a VPN tunnel in an isolated network namespace. The host is completely unaffected — only the proxy process runs inside the namespace.
+
+Currently supported VPN types:
+- **AmneziaWG** — DPI-resistant WireGuard fork (recommended for Russia/Iran)
+- **WireGuard** — standard WireGuard (planned)
 
 ```
 Client → VPS:443 → [DNAT] → tg_proxy_ns:443
@@ -205,7 +223,37 @@ sudo mtbuddy setup tunnel /path/to/awg0.conf --mode direct
 
 After setup, `mtbuddy` validates connectivity to all 5 Telegram DCs through the tunnel and prints the link.
 
-It also sets `[upstream].type = "amnezia_wg"` in `config.toml`, so tunnel intent is explicit in config (not only in systemd/netns wiring).
+### SOCKS5 proxy
+
+Route DC connections through an external SOCKS5 proxy. Supports RFC 1928 auth.
+
+```toml
+[upstream]
+type = "socks5"
+
+[upstream.socks5]
+host = "127.0.0.1"
+port = 1080
+username = "admin"    # optional, omit for no-auth
+password = "secret"
+```
+
+### HTTP CONNECT proxy
+
+Route DC connections through an HTTP CONNECT proxy. Supports Basic auth.
+
+```toml
+[upstream]
+type = "http"
+
+[upstream.http]
+host = "127.0.0.1"
+port = 8080
+username = "admin"    # optional, omit for no-auth
+password = "secret"
+```
+
+> **Note:** Only DC-bound traffic is routed through the configured upstream. Mask (camouflage) connections always go direct.
 
 ---
 
@@ -218,11 +266,11 @@ Config lives at `/opt/mtproto-proxy/config.toml`. MTBuddy generates it on instal
 use_middle_proxy = true   # ME mode for promo-channel parity
 
 [upstream]
-type = "auto"            # auto | direct | amnezia_wg
+type = "auto"            # auto | direct | tunnel | socks5 | http
 
 [server]
 port = 443
-# public_ip = "proxy.example.com"   # Override auto-detected IP (recommended with amnezia_wg)
+# public_ip = "proxy.example.com"   # Override auto-detected IP (recommended with tunnel)
 max_connections = 512
 idle_timeout_sec = 120
 handshake_timeout_sec = 15
@@ -250,11 +298,19 @@ alice = true   # bypass MiddleProxy for this user
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `[upstream].type` | `auto` | Egress mode: `auto` (detect netns), `direct`, or `amnezia_wg` (requires proxy in tunnel netns) |
+| `[upstream].type` | `auto` | Egress mode: `auto` (detect netns), `direct`, `tunnel` (VPN via netns), `socks5`, or `http` |
+| `[upstream.socks5] host` | — | SOCKS5 proxy address |
+| `[upstream.socks5] port` | — | SOCKS5 proxy port |
+| `[upstream.socks5] username` | — | SOCKS5 username (empty = no auth) |
+| `[upstream.socks5] password` | — | SOCKS5 password |
+| `[upstream.http] host` | — | HTTP CONNECT proxy address |
+| `[upstream.http] port` | — | HTTP CONNECT proxy port |
+| `[upstream.http] username` | — | HTTP proxy username (empty = no auth) |
+| `[upstream.http] password` | — | HTTP proxy password |
 | `[general] use_middle_proxy` | `false` | Telemt-compatible ME mode for DC1..5 (recommended for promo parity) |
 | `[general] ad_tag` | — | Alias for `[server].tag` (telemt compat) |
 | `[server] port` | `443` | TCP listen port |
-| `[server] public_ip` | auto | Override auto-detected IP/domain. Required with AmneziaWG tunnel |
+| `[server] public_ip` | auto | Override auto-detected IP/domain. Required with VPN tunnel |
 | `[server] backlog` | `4096` | TCP listen queue depth |
 | `[server] max_connections` | `512` | Concurrent connection cap, auto-clamped by RAM and `RLIMIT_NOFILE` |
 | `[server] idle_timeout_sec` | `120` | Connection idle timeout |
@@ -285,7 +341,7 @@ alice = true   # bypass MiddleProxy for this user
 
 ## Monitoring dashboard
 
-A lightweight web dashboard (FastAPI + WebSocket, ~30 MB RAM) shows live connections, CPU/memory, network throughput, proxy stats, AmneziaWG tunnel metrics, user management, and streaming logs.
+A lightweight web dashboard (FastAPI + WebSocket, ~30 MB RAM) shows live connections, CPU/memory, network throughput, proxy stats, tunnel metrics, user management, and streaming logs.
 
 The dashboard is **embedded directly into the `mtbuddy` binary** — no extra files needed.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ It also ships more evasion techniques than any of the above:
 | **IPv6 hopping** | Auto-rotates IPv6 address from /64 on ban detection via Cloudflare API |
 | **Anti-replay** | Rejects replayed handshakes + detects ТСПУ Revisor active probes |
 | **Multi-user** | Independent per-user secrets |
-| **MiddleProxy** | Telemt-compatible ME transport with auto-refreshed Telegram metadata |
+| **MiddleProxy** | ME transport with auto-refreshed Telegram metadata |
 
 ---
 
@@ -307,8 +307,8 @@ alice = true   # bypass MiddleProxy for this user
 | `[upstream.http] port` | — | HTTP CONNECT proxy port |
 | `[upstream.http] username` | — | HTTP proxy username (empty = no auth) |
 | `[upstream.http] password` | — | HTTP proxy password |
-| `[general] use_middle_proxy` | `false` | Telemt-compatible ME mode for DC1..5 (recommended for promo parity) |
-| `[general] ad_tag` | — | Alias for `[server].tag` (telemt compat) |
+| `[general] use_middle_proxy` | `false` | ME mode for DC1..5 (recommended for promo parity) |
+| `[general] ad_tag` | — | Alias for `[server].tag` |
 | `[server] port` | `443` | TCP listen port |
 | `[server] public_ip` | auto | Override auto-detected IP/domain. Required with VPN tunnel |
 | `[server] backlog` | `4096` | TCP listen queue depth |
@@ -334,8 +334,6 @@ alice = true   # bypass MiddleProxy for this user
 </details>
 
 > Generate a secret: `openssl rand -hex 16`
->
-> Config format is compatible with [telemt](https://github.com/telemt/telemt).
 
 ---
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -70,8 +70,34 @@ port = 443
 # Upstream egress mode for outgoing DC connections.
 # "auto"       — detect by runtime namespace (default)
 # "direct"     — direct TCP from current namespace
-# "amnezia_wg" — require running proxy inside tunnel namespace
+# "tunnel"     — VPN tunnel via network namespace (AmneziaWG, WireGuard, ...)
+# "socks5"     — route via SOCKS5 proxy
+# "http"       — route via HTTP CONNECT proxy
 # type = "auto"
+
+# ── VPN tunnel configuration ──
+# Activate with: type = "tunnel"
+# The interface name determines which VPN type is used:
+#   awg0 — AmneziaWG (default, via mtbuddy setup tunnel)
+#   wg0  — WireGuard
+# [upstream.tunnel]
+# interface = "awg0"
+
+# ── SOCKS5 upstream proxy configuration ──
+# Activate with: type = "socks5"
+# [upstream.socks5]
+# host = "127.0.0.1"
+# port = 1080
+# username = ""
+# password = ""
+
+# ── HTTP CONNECT upstream proxy configuration ──
+# Activate with: type = "http"
+# [upstream.http]
+# host = "127.0.0.1"
+# port = 8080
+# username = ""
+# password = ""
 
 [censorship]
 # Domain to impersonate in TLS ServerHello and forward unauthenticated clients to.

--- a/src/config.zig
+++ b/src/config.zig
@@ -7,18 +7,29 @@ const std = @import("std");
 
 pub const UpstreamMode = enum {
     /// Infer egress mode from runtime environment (default).
-    /// If proxy runs in non-init netns, treat as AmneziaWG; otherwise direct.
+    /// If proxy runs in non-init netns, treat as tunnel; otherwise direct.
     auto,
     /// Explicit direct egress.
     direct,
-    /// Explicit AmneziaWG egress (requires running inside tunnel netns).
-    amnezia_wg,
+    /// VPN tunnel egress (AmneziaWG, WireGuard, etc.) — requires running
+    /// inside tunnel network namespace. The specific VPN type is an
+    /// mtbuddy/installer concern; for runtime proxy they are identical.
+    tunnel,
+    /// SOCKS5 proxy upstream.
+    socks5,
+    /// HTTP CONNECT proxy upstream.
+    http,
 };
 
 fn parseUpstreamMode(value: []const u8) ?UpstreamMode {
     if (std.mem.eql(u8, value, "auto")) return .auto;
     if (std.mem.eql(u8, value, "direct") or std.mem.eql(u8, value, "none")) return .direct;
-    if (std.mem.eql(u8, value, "amnezia_wg") or std.mem.eql(u8, value, "amneziawg")) return .amnezia_wg;
+    if (std.mem.eql(u8, value, "tunnel")) return .tunnel;
+    // Backward compatibility: old config values map to .tunnel
+    if (std.mem.eql(u8, value, "amnezia_wg") or std.mem.eql(u8, value, "amneziawg")) return .tunnel;
+    if (std.mem.eql(u8, value, "wireguard") or std.mem.eql(u8, value, "wg")) return .tunnel;
+    if (std.mem.eql(u8, value, "socks5") or std.mem.eql(u8, value, "socks")) return .socks5;
+    if (std.mem.eql(u8, value, "http") or std.mem.eql(u8, value, "http_connect")) return .http;
     return null;
 }
 
@@ -112,8 +123,20 @@ pub const Config = struct {
     /// Test-only hook to redirect upstream connections locally
     datacenter_override: ?std.net.Address = null,
     /// Upstream egress mode. Parsed from [upstream].type.
-    /// Supported values: auto | direct | amnezia_wg.
+    /// Supported values: auto | direct | tunnel | socks5 | http.
     upstream_mode: UpstreamMode = .auto,
+    /// Proxy server host for socks5/http upstream modes.
+    /// Parsed from [upstream.socks5].host or [upstream.http].host.
+    upstream_proxy_host: ?[]const u8 = null,
+    /// Proxy server port for socks5/http upstream modes.
+    upstream_proxy_port: u16 = 0,
+    /// Proxy authentication username (empty string = no auth).
+    upstream_proxy_username: ?[]const u8 = null,
+    /// Proxy authentication password.
+    upstream_proxy_password: ?[]const u8 = null,
+    /// VPN tunnel interface name (e.g. "awg0", "wg0").
+    /// Parsed from [upstream.tunnel].interface.
+    upstream_tunnel_interface: ?[]const u8 = null,
 
     pub fn middleProxyBufferBytes(self: *const Config) usize {
         return @as(usize, self.middleproxy_buffer_kb) * 1024;
@@ -180,6 +203,9 @@ pub const Config = struct {
         var in_server_section = false;
         var in_general_section = false;
         var in_upstream_section = false;
+        var in_upstream_socks5_section = false;
+        var in_upstream_http_section = false;
+        var in_upstream_tunnel_section = false;
         var server_tag_set = false;
 
         while (lines.next()) |raw_line| {
@@ -196,6 +222,14 @@ pub const Config = struct {
                 in_server_section = std.mem.eql(u8, line, "[server]");
                 in_general_section = std.mem.eql(u8, line, "[general]");
                 in_upstream_section = std.mem.eql(u8, line, "[upstream]");
+                in_upstream_socks5_section = std.mem.eql(u8, line, "[upstream.socks5]");
+                in_upstream_http_section = std.mem.eql(u8, line, "[upstream.http]");
+                in_upstream_tunnel_section = std.mem.eql(u8, line, "[upstream.tunnel]");
+                // Sub-sections are also part of the upstream family;
+                // entering a sub-section should not reset the parent.
+                if (in_upstream_socks5_section or in_upstream_http_section or in_upstream_tunnel_section) {
+                    in_upstream_section = false;
+                }
                 continue;
             }
 
@@ -309,6 +343,20 @@ pub const Config = struct {
                             cfg.upstream_mode = mode;
                         }
                     }
+                } else if (in_upstream_socks5_section or in_upstream_http_section) {
+                    if (std.mem.eql(u8, key, "host")) {
+                        cfg.upstream_proxy_host = try allocator.dupe(u8, value);
+                    } else if (std.mem.eql(u8, key, "port")) {
+                        cfg.upstream_proxy_port = std.fmt.parseInt(u16, value, 10) catch 0;
+                    } else if (std.mem.eql(u8, key, "username")) {
+                        cfg.upstream_proxy_username = try allocator.dupe(u8, value);
+                    } else if (std.mem.eql(u8, key, "password")) {
+                        cfg.upstream_proxy_password = try allocator.dupe(u8, value);
+                    }
+                } else if (in_upstream_tunnel_section) {
+                    if (std.mem.eql(u8, key, "interface")) {
+                        cfg.upstream_tunnel_interface = try allocator.dupe(u8, value);
+                    }
                 }
             }
         }
@@ -340,6 +388,18 @@ pub const Config = struct {
         }
         if (self.middle_proxy_nat_ip) |ip| {
             allocator.free(ip);
+        }
+        if (self.upstream_proxy_host) |h| {
+            allocator.free(h);
+        }
+        if (self.upstream_proxy_username) |u| {
+            allocator.free(u);
+        }
+        if (self.upstream_proxy_password) |p| {
+            allocator.free(p);
+        }
+        if (self.upstream_tunnel_interface) |iface| {
+            allocator.free(iface);
         }
     }
 
@@ -902,7 +962,7 @@ test "parse config - multiple users" {
     try std.testing.expectEqual(@as(u8, 0xff), alice_secret[15]);
 }
 
-test "parse config - upstream type amnezia_wg" {
+test "parse config - upstream type amnezia_wg backward compat" {
     const content =
         \\[upstream]
         \\type = "amnezia_wg"
@@ -913,7 +973,22 @@ test "parse config - upstream type amnezia_wg" {
     var cfg = try Config.parse(std.testing.allocator, content);
     defer cfg.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(UpstreamMode.amnezia_wg, cfg.upstream_mode);
+    // amnezia_wg maps to .tunnel for backward compatibility
+    try std.testing.expectEqual(UpstreamMode.tunnel, cfg.upstream_mode);
+}
+
+test "parse config - upstream type tunnel explicit" {
+    const content =
+        \\[upstream]
+        \\type = "tunnel"
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(UpstreamMode.tunnel, cfg.upstream_mode);
 }
 
 test "parse config - upstream type default auto" {
@@ -968,4 +1043,116 @@ test "parse config - legacy tunnel section ignored" {
     defer cfg.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(UpstreamMode.auto, cfg.upstream_mode);
+}
+
+test "parse config - upstream type wireguard backward compat" {
+    const content =
+        \\[upstream]
+        \\type = "wireguard"
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(UpstreamMode.tunnel, cfg.upstream_mode);
+}
+
+test "parse config - upstream socks5 with credentials" {
+    const content =
+        \\[upstream]
+        \\type = "socks5"
+        \\[upstream.socks5]
+        \\host = "38.180.236.207"
+        \\port = 1080
+        \\username = "admin"
+        \\password = "fr6CgjUvxFEAn5vs"
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(UpstreamMode.socks5, cfg.upstream_mode);
+    try std.testing.expectEqualStrings("38.180.236.207", cfg.upstream_proxy_host.?);
+    try std.testing.expectEqual(@as(u16, 1080), cfg.upstream_proxy_port);
+    try std.testing.expectEqualStrings("admin", cfg.upstream_proxy_username.?);
+    try std.testing.expectEqualStrings("fr6CgjUvxFEAn5vs", cfg.upstream_proxy_password.?);
+}
+
+test "parse config - upstream http with credentials" {
+    const content =
+        \\[upstream]
+        \\type = "http"
+        \\[upstream.http]
+        \\host = "38.180.236.207"
+        \\port = 8080
+        \\username = "admin"
+        \\password = "secret123"
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(UpstreamMode.http, cfg.upstream_mode);
+    try std.testing.expectEqualStrings("38.180.236.207", cfg.upstream_proxy_host.?);
+    try std.testing.expectEqual(@as(u16, 8080), cfg.upstream_proxy_port);
+    try std.testing.expectEqualStrings("admin", cfg.upstream_proxy_username.?);
+    try std.testing.expectEqualStrings("secret123", cfg.upstream_proxy_password.?);
+}
+
+test "parse config - upstream socks5 no credentials" {
+    const content =
+        \\[upstream]
+        \\type = "socks5"
+        \\[upstream.socks5]
+        \\host = "127.0.0.1"
+        \\port = 1080
+        \\username = ""
+        \\password = ""
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(UpstreamMode.socks5, cfg.upstream_mode);
+    try std.testing.expectEqualStrings("127.0.0.1", cfg.upstream_proxy_host.?);
+    try std.testing.expectEqual(@as(u16, 1080), cfg.upstream_proxy_port);
+    // Empty string credentials are preserved
+    try std.testing.expectEqualStrings("", cfg.upstream_proxy_username.?);
+    try std.testing.expectEqualStrings("", cfg.upstream_proxy_password.?);
+}
+
+test "parse config - upstream http_connect alias" {
+    const content =
+        \\[upstream]
+        \\type = "http_connect"
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(UpstreamMode.http, cfg.upstream_mode);
+}
+
+test "parse config - upstream socks alias" {
+    const content =
+        \\[upstream]
+        \\type = "socks"
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(UpstreamMode.socks5, cfg.upstream_mode);
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -345,12 +345,15 @@ pub const Config = struct {
                     }
                 } else if (in_upstream_socks5_section or in_upstream_http_section) {
                     if (std.mem.eql(u8, key, "host")) {
+                        if (cfg.upstream_proxy_host) |h| allocator.free(h);
                         cfg.upstream_proxy_host = try allocator.dupe(u8, value);
                     } else if (std.mem.eql(u8, key, "port")) {
                         cfg.upstream_proxy_port = std.fmt.parseInt(u16, value, 10) catch 0;
                     } else if (std.mem.eql(u8, key, "username")) {
+                        if (cfg.upstream_proxy_username) |u| allocator.free(u);
                         cfg.upstream_proxy_username = try allocator.dupe(u8, value);
                     } else if (std.mem.eql(u8, key, "password")) {
+                        if (cfg.upstream_proxy_password) |p| allocator.free(p);
                         cfg.upstream_proxy_password = try allocator.dupe(u8, value);
                     }
                 } else if (in_upstream_tunnel_section) {
@@ -1155,4 +1158,28 @@ test "parse config - upstream socks alias" {
     defer cfg.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(UpstreamMode.socks5, cfg.upstream_mode);
+}
+
+test "parse config - duplicate upstream proxy fields" {
+    const content =
+        \\[upstream]
+        \\type = "socks5"
+        \\[upstream.socks5]
+        \\host = "10.0.0.1"
+        \\host = "10.0.0.2"
+        \\port = 1080
+        \\username = "first"
+        \\username = "second"
+        \\password = "one"
+        \\password = "two"
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings("10.0.0.2", cfg.upstream_proxy_host.?);
+    try std.testing.expectEqualStrings("second", cfg.upstream_proxy_username.?);
+    try std.testing.expectEqualStrings("two", cfg.upstream_proxy_password.?);
 }

--- a/src/ctl/i18n.zig
+++ b/src/ctl/i18n.zig
@@ -176,7 +176,7 @@ const en_strings = [_][]const u8{
     // menu_setup_masking
     "\xF0\x9F\x9B\xA1\xEF\xB8\x8F  Setup DPI evasion",
     // menu_setup_tunnel
-    "\xF0\x9F\x94\x97  Setup AmneziaWG tunnel",
+    "\xF0\x9F\x94\x97  Setup tunnel",
     // menu_setup_recovery
     "🚑  Setup auto-recovery",
     // menu_setup_dashboard
@@ -230,9 +230,9 @@ const en_strings = [_][]const u8{
 
     // ── Tunnel ──
     // tunnel_conf_prompt
-    "AmneziaWG config file path",
+    "VPN config file path",
     // tunnel_conf_help
-    "Path to your .conf file from AmneziaVPN app or provider.",
+    "Path to your .conf file from VPN app or provider.",
 
     // ── Install ──
     // install_header
@@ -401,7 +401,7 @@ const ru_strings = [_][]const u8{
     // menu_setup_masking
     "\xF0\x9F\x9B\xA1\xEF\xB8\x8F  Настроить обход DPI",
     // menu_setup_tunnel
-    "\xF0\x9F\x94\x97  Настроить AmneziaWG туннель",
+    "\xF0\x9F\x94\x97  Настроить туннель",
     // menu_setup_recovery
     "🚑  Настроить авто-восстановление",
     // menu_setup_dashboard
@@ -455,7 +455,7 @@ const ru_strings = [_][]const u8{
 
     // ── Tunnel ──
     // tunnel_conf_prompt
-    "Путь к конфигурации AmneziaWG",
+    "Путь к конфигурации VPN",
     // tunnel_conf_help
     "Путь к .conf файлу от VPN-приложения или провайдера.",
 

--- a/src/ctl/main.zig
+++ b/src/ctl/main.zig
@@ -319,7 +319,7 @@ fn printHelp() void {
     printCmd(&ui, "update", "Update to latest GitHub release");
     printCmd(&ui, "setup masking", "Setup local Nginx DPI masking");
     printCmd(&ui, "setup nfqws", "Setup nfqws TCP desync (Zapret)");
-    printCmd(&ui, "setup tunnel <conf>", "Setup AmneziaWG tunnel");
+    printCmd(&ui, "setup tunnel <conf>", "Setup VPN tunnel (AmneziaWG, WireGuard, ...)");
     printCmd(&ui, "setup dashboard",     "Install web monitoring dashboard");
     printCmd(&ui, "setup recovery",      "Install DPI auto-recovery");
     printCmd(&ui, "ipv6-hop", "IPv6 address rotation");

--- a/src/ctl/masking.zig
+++ b/src/ctl/masking.zig
@@ -239,7 +239,7 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: MaskingOpts) !void 
     // ── Install masking monitor ──
     if (!opts.skip_monitor) {
         const recovery = @import("recovery.zig");
-        recovery.execute(ui, allocator, .{}) catch |err| {
+        recovery.execute(ui, allocator, .{ .quiet = true }) catch |err| {
             ui.warn("Failed to install auto-recovery module");
             std.log.debug("Recovery install error: {any}", .{err});
         };

--- a/src/ctl/recovery.zig
+++ b/src/ctl/recovery.zig
@@ -48,8 +48,6 @@ pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
 }
 
 pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: RecoveryOpts) !void {
-    _ = opts;
-
     if (!sys.isRoot()) {
         ui.fail(i18n.get(ui.lang, .error_not_root));
         return;
@@ -58,13 +56,9 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: RecoveryOpts) !void
     // ── Create drop-in for nginx auto-restart ──
     _ = sys.exec(allocator, &.{ "mkdir", "-p", NGINX_DROPIN_DIR, PROXY_DROPIN_DIR }) catch {};
 
-    sys.writeFile(NGINX_DROPIN_DIR ++ "/restart.conf",
-        "[Service]\nRestart=on-failure\nRestartSec=2s\n"
-    ) catch {};
+    sys.writeFile(NGINX_DROPIN_DIR ++ "/restart.conf", "[Service]\nRestart=on-failure\nRestartSec=2s\n") catch {};
 
-    sys.writeFile(PROXY_DROPIN_DIR ++ "/10-nginx.conf",
-        "[Unit]\nWants=nginx.service\nAfter=nginx.service\n"
-    ) catch {};
+    sys.writeFile(PROXY_DROPIN_DIR ++ "/10-nginx.conf", "[Unit]\nWants=nginx.service\nAfter=nginx.service\n") catch {};
 
     // ── Create health check script ──
     const health_script =
@@ -152,17 +146,13 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: RecoveryOpts) !void
         };
     }
 
-    sys.writeFile(MASK_HEALTH_SERVICE,
-        "[Unit]\nDescription=MTProto masking endpoint health check\n\n" ++
-        "[Service]\nType=oneshot\nExecStart=" ++ MASK_HEALTH_SCRIPT ++ "\n"
-    ) catch {};
+    sys.writeFile(MASK_HEALTH_SERVICE, "[Unit]\nDescription=MTProto masking endpoint health check\n\n" ++
+        "[Service]\nType=oneshot\nExecStart=" ++ MASK_HEALTH_SCRIPT ++ "\n") catch {};
 
     // ── Create timer unit ──
-    sys.writeFile(MASK_HEALTH_TIMER,
-        "[Unit]\nDescription=Run MTProto masking health check every minute\n\n" ++
+    sys.writeFile(MASK_HEALTH_TIMER, "[Unit]\nDescription=Run MTProto masking health check every minute\n\n" ++
         "[Timer]\nOnBootSec=2min\nOnUnitActiveSec=1min\nRandomizedDelaySec=10s\nPersistent=true\n\n" ++
-        "[Install]\nWantedBy=timers.target\n"
-    ) catch {};
+        "[Install]\nWantedBy=timers.target\n") catch {};
 
     // ── Enable and start ──
     _ = sys.execForward(&.{ "systemctl", "daemon-reload" }) catch {};
@@ -174,26 +164,28 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: RecoveryOpts) !void
     }
     _ = sys.exec(allocator, &.{ "systemctl", "start", "mtproto-mask-health.service" }) catch {};
 
-    // ── Report status ──
-    if (sys.isServiceActive("mtproto-mask-health.timer")) {
-        ui.ok("Masking health timer is active");
-    } else {
-        ui.warn("Masking health timer is not active");
-    }
+    if (!opts.quiet) {
+        // ── Report status ──
+        if (sys.isServiceActive("mtproto-mask-health.timer")) {
+            ui.ok("Masking health timer is active");
+        } else {
+            ui.warn("Masking health timer is not active");
+        }
 
-    if (sys.isServiceActive("nginx")) {
-        ui.ok("Nginx service is active");
-    } else {
-        ui.warn("Nginx service is not active");
-    }
+        if (sys.isServiceActive("nginx")) {
+            ui.ok("Nginx service is active");
+        } else {
+            ui.warn("Nginx service is not active");
+        }
 
-    ui.summaryBox("DPI Auto-Recovery (Health Check) Activated", &.{
-        .{ .label = "Health script:", .value = MASK_HEALTH_SCRIPT },
-        .{ .label = "Timer:", .value = "systemctl status mtproto-mask-health.timer" },
-        .{ .label = "Logs:", .value = "journalctl -t mtproto-mask-health -n 50" },
-        .{ .label = "", .style = .blank },
-        .{ .label = "Auto-restart nginx on failure", .style = .success },
-        .{ .label = "Auto-restart mtproto-proxy if nginx recovery insufficient", .style = .success },
-        .{ .label = "Checks every 60 seconds", .style = .success },
-    });
+        ui.summaryBox("DPI Auto-Recovery (Health Check) Activated", &.{
+            .{ .label = "Health script:", .value = MASK_HEALTH_SCRIPT },
+            .{ .label = "Timer:", .value = "systemctl status mtproto-mask-health.timer" },
+            .{ .label = "Logs:", .value = "journalctl -t mtproto-mask-health -n 50" },
+            .{ .label = "", .style = .blank },
+            .{ .label = "Auto-restart nginx on failure", .style = .success },
+            .{ .label = "Auto-restart mtproto-proxy if nginx recovery insufficient", .style = .success },
+            .{ .label = "Checks every 60 seconds", .style = .success },
+        });
+    }
 }

--- a/src/ctl/toml.zig
+++ b/src/ctl/toml.zig
@@ -182,6 +182,8 @@ fn sectionHeader(name: []const u8) []const u8 {
     if (std.mem.eql(u8, name, "server")) return "[server]";
     if (std.mem.eql(u8, name, "censorship")) return "[censorship]";
     if (std.mem.eql(u8, name, "general")) return "[general]";
+    if (std.mem.eql(u8, name, "upstream")) return "[upstream]";
+    if (std.mem.eql(u8, name, "upstream.tunnel")) return "[upstream.tunnel]";
     if (std.mem.eql(u8, name, "access.users")) return "[access.users]";
     if (std.mem.eql(u8, name, "access.direct_users")) return "[access.direct_users]";
     // Fallback: just return the name (caller is responsible for brackets)

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -327,7 +327,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
     // ── Apply masking monitor (if recovery is already installed) ──
     if (sys.isServiceActive("mtproto-mask-health.timer") or sys.fileExists("/usr/local/bin/mtproto-mask-health.sh")) {
         const recovery = @import("recovery.zig");
-        recovery.execute(ui, allocator, .{}) catch {};
+        recovery.execute(ui, allocator, .{ .quiet = true }) catch {};
     }
 
     // ── Restart proxy ──
@@ -388,10 +388,10 @@ fn setUpstreamType(allocator: std.mem.Allocator, value: []const u8) void {
     var quoted_buf: [64]u8 = undefined;
     const quoted = std.fmt.bufPrint(&quoted_buf, "\"{s}\"", .{value}) catch return;
     doc.set("upstream", "type", quoted) catch return;
-    
+
     // Default to AmneziaWG interface when setting up tunnel via this script
     doc.set("upstream.tunnel", "interface", "\"awg0\"") catch return;
-    
+
     doc.save(INSTALL_DIR ++ "/config.toml") catch {};
 }
 

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -1,8 +1,9 @@
 //! Setup tunnel command for mtbuddy.
 //!
 //! Ports setup_tunnel.sh (400 lines bash) — creates an isolated network
-//! namespace with AmneziaWG tunnel so Telegram DCs become reachable
+//! namespace with a VPN tunnel so Telegram DCs become reachable
 //! while the host keeps normal connectivity.
+//! Currently supports AmneziaWG; other VPN types will be added.
 
 const std = @import("std");
 const tui_mod = @import("tui.zig");
@@ -47,7 +48,7 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.ArgIterato
     }
 
     if (opts.awg_conf.len == 0) {
-        ui.fail("Usage: mtbuddy setup tunnel <awg-config.conf> [--mode direct|preserve|middleproxy]");
+        ui.fail("Usage: mtbuddy setup tunnel <vpn-config.conf> [--mode direct|preserve|middleproxy]");
         return;
     }
 
@@ -250,8 +251,8 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
     };
     ui.ok(mode_label);
 
-    setUpstreamType(allocator, "amnezia_wg");
-    ui.stepOk("Set [upstream].type", "amnezia_wg");
+    setUpstreamType(allocator, "tunnel");
+    ui.stepOk("Set [upstream].type", "tunnel");
 
     // ── Inject public IP (preserve existing custom value) ──
     var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch null;
@@ -333,7 +334,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
     _ = sys.execForward(&.{ "systemctl", "restart", "mtproto-proxy" }) catch {};
 
     if (sys.isServiceActive("mtproto-proxy")) {
-        ui.ok("Proxy running inside AmneziaWG tunnel");
+        ui.ok("Proxy running inside VPN tunnel");
     } else {
         ui.fail("Proxy failed to start. Check: journalctl -u mtproto-proxy -n 30");
         return;
@@ -360,14 +361,14 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
     }
 
     // ── Summary ──
-    ui.summaryBox("AmneziaWG Tunnel Configured", &.{
+    ui.summaryBox("VPN Tunnel Configured", &.{
         .{ .label = "Status:", .value = "systemctl status mtproto-proxy" },
         .{ .label = "Logs:", .value = "journalctl -u mtproto-proxy -f" },
         .{ .label = "Tunnel:", .value = "ip netns exec " ++ NS_NAME ++ " awg show" },
         .{ .label = "Mode:", .value = mode_label },
         .{ .label = "", .style = .blank },
         .{ .label = "Proxy runs inside isolated network namespace", .style = .success },
-        .{ .label = "AmneziaWG tunnel active (host network untouched)", .style = .success },
+        .{ .label = "VPN tunnel active (host network untouched)", .style = .success },
         .{ .label = "SSH and host services unaffected", .style = .success },
     });
 }
@@ -386,6 +387,10 @@ fn setUpstreamType(allocator: std.mem.Allocator, value: []const u8) void {
     var quoted_buf: [64]u8 = undefined;
     const quoted = std.fmt.bufPrint(&quoted_buf, "\"{s}\"", .{value}) catch return;
     doc.set("upstream", "type", quoted) catch return;
+    
+    // Default to AmneziaWG interface when setting up tunnel via this script
+    doc.set("upstream.tunnel", "interface", "\"awg0\"") catch return;
+    
     doc.save(INSTALL_DIR ++ "/config.toml") catch {};
 }
 
@@ -440,11 +445,22 @@ fn stripAwgDnsLines(allocator: std.mem.Allocator, path: []const u8) !bool {
 /// or `.none` if no known tunnel is active.
 pub fn detectActiveTunnel(allocator: std.mem.Allocator) Tunnel.Tag {
     // Check if AmneziaWG interface is up inside the network namespace
-    const result = sys.exec(allocator, &.{
+    const awg_result = sys.exec(allocator, &.{
         "ip", "netns", "exec", NS_NAME, "awg", "show", "awg0",
-    }) catch return .none;
-    defer result.deinit();
+    }) catch null;
+    if (awg_result) |r| {
+        defer r.deinit();
+        if (r.exit_code == 0) return .tunnel;
+    }
 
-    if (result.exit_code == 0) return .amnezia_wg;
+    // Check if WireGuard interface is up inside the network namespace
+    const wg_result = sys.exec(allocator, &.{
+        "ip", "netns", "exec", NS_NAME, "wg", "show", "wg0",
+    }) catch null;
+    if (wg_result) |r| {
+        defer r.deinit();
+        if (r.exit_code == 0) return .tunnel;
+    }
+
     return .none;
 }

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -253,6 +253,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
 
     setUpstreamType(allocator, "tunnel");
     ui.stepOk("Set [upstream].type", "tunnel");
+    ui.stepOk("Set [upstream.tunnel].interface", "awg0");
 
     // ── Inject public IP (preserve existing custom value) ──
     var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch null;

--- a/src/ctl/update.zig
+++ b/src/ctl/update.zig
@@ -173,7 +173,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: UpdateOpts) !void {
 
     // ── Apply masking monitor (if recovery is already installed) ──
     if (sys.isServiceActive("mtproto-mask-health.timer") or sys.fileExists("/usr/local/bin/mtproto-mask-health.sh")) {
-        recovery.execute(ui, allocator, .{}) catch {};
+        recovery.execute(ui, allocator, .{ .quiet = true }) catch {};
     }
 
     // ── Summary ──

--- a/src/proxy/http_connect.zig
+++ b/src/proxy/http_connect.zig
@@ -1,0 +1,248 @@
+//! HTTP CONNECT proxy protocol helpers.
+//!
+//! Pure message serialization and parsing — no socket I/O.
+//! Used by the upstream transport layer to drive the HTTP CONNECT
+//! handshake through the non-blocking epoll event loop.
+
+const std = @import("std");
+const net = std.net;
+
+// ─── Request Building ────────────────────────────────────────
+
+/// Build an HTTP CONNECT request.
+///
+/// Format:
+///   CONNECT host:port HTTP/1.1\r\n
+///   Host: host:port\r\n
+///   [Proxy-Authorization: Basic base64(user:pass)\r\n]
+///   \r\n
+///
+/// Returns the slice of `buf` used, or empty on overflow.
+pub fn buildConnectRequest(
+    buf: []u8,
+    addr: net.Address,
+    username: ?[]const u8,
+    password: ?[]const u8,
+) []u8 {
+    var pos: usize = 0;
+
+    // Format the address as host:port
+    var addr_buf: [64]u8 = undefined;
+    const addr_str = formatAddress(addr, &addr_buf);
+
+    // CONNECT host:port HTTP/1.1\r\n
+    pos += copyInto(buf[pos..], "CONNECT ") orelse return buf[0..0];
+    pos += copyInto(buf[pos..], addr_str) orelse return buf[0..0];
+    pos += copyInto(buf[pos..], " HTTP/1.1\r\n") orelse return buf[0..0];
+
+    // Host: host:port\r\n
+    pos += copyInto(buf[pos..], "Host: ") orelse return buf[0..0];
+    pos += copyInto(buf[pos..], addr_str) orelse return buf[0..0];
+    pos += copyInto(buf[pos..], "\r\n") orelse return buf[0..0];
+
+    // Proxy-Authorization: Basic base64(user:pass)\r\n
+    if (username) |user| {
+        if (user.len > 0) {
+            const pass = password orelse "";
+
+            // Encode user:pass as base64
+            // Max input: 255 + 1 + 255 = 511 bytes → base64 ≤ 684 chars
+            var cred_buf: [512]u8 = undefined;
+            if (user.len + 1 + pass.len > cred_buf.len) return buf[0..0];
+
+            @memcpy(cred_buf[0..user.len], user);
+            cred_buf[user.len] = ':';
+            @memcpy(cred_buf[user.len + 1 .. user.len + 1 + pass.len], pass);
+            const cred_slice = cred_buf[0 .. user.len + 1 + pass.len];
+
+            var b64_buf: [700]u8 = undefined;
+            const encoded = std.base64.standard.Encoder.encode(&b64_buf, cred_slice);
+
+            pos += copyInto(buf[pos..], "Proxy-Authorization: Basic ") orelse return buf[0..0];
+            pos += copyInto(buf[pos..], encoded) orelse return buf[0..0];
+            pos += copyInto(buf[pos..], "\r\n") orelse return buf[0..0];
+        }
+    }
+
+    // Final \r\n
+    pos += copyInto(buf[pos..], "\r\n") orelse return buf[0..0];
+
+    return buf[0..pos];
+}
+
+// ─── Response Parsing ────────────────────────────────────────
+
+pub const ParseResult = struct {
+    status: u16,
+    header_end: usize, // offset past the final \r\n\r\n
+};
+
+/// Parse an HTTP CONNECT response.
+/// Looks for `HTTP/1.x NNN` status line and `\r\n\r\n` terminator.
+/// Returns null if not enough data has been received yet.
+pub fn parseResponse(data: []const u8) ?ParseResult {
+    // Find the end of headers
+    const header_end = findHeaderEnd(data) orelse return null;
+
+    // Parse status line: "HTTP/1.x NNN ..."
+    const status = parseStatusCode(data) orelse return null;
+
+    return .{
+        .status = status,
+        .header_end = header_end,
+    };
+}
+
+/// Check if we have received the complete header block.
+/// Returns the offset past `\r\n\r\n`, or null.
+fn findHeaderEnd(data: []const u8) ?usize {
+    if (data.len < 4) return null;
+
+    var i: usize = 0;
+    while (i + 3 < data.len) : (i += 1) {
+        if (data[i] == '\r' and data[i + 1] == '\n' and
+            data[i + 2] == '\r' and data[i + 3] == '\n')
+        {
+            return i + 4;
+        }
+    }
+    return null;
+}
+
+/// Extract HTTP status code from the first line.
+/// Expects "HTTP/1.x NNN" format.
+fn parseStatusCode(data: []const u8) ?u16 {
+    // Find end of first line
+    var line_end: usize = 0;
+    while (line_end < data.len) : (line_end += 1) {
+        if (data[line_end] == '\r' or data[line_end] == '\n') break;
+    }
+    if (line_end < 12) return null; // "HTTP/1.x NNN" minimum
+
+    const line = data[0..line_end];
+
+    // Must start with "HTTP/"
+    if (!std.mem.startsWith(u8, line, "HTTP/")) return null;
+
+    // Find space after version
+    const space_idx = std.mem.indexOfScalar(u8, line, ' ') orelse return null;
+    if (space_idx + 4 > line.len) return null;
+
+    // Parse 3-digit status code
+    const code_str = line[space_idx + 1 .. space_idx + 4];
+    return std.fmt.parseInt(u16, code_str, 10) catch null;
+}
+
+/// Maximum response size we'll buffer before giving up.
+/// HTTP CONNECT responses are typically < 200 bytes.
+pub const max_response_size: usize = 4096;
+
+// ─── Internal Helpers ────────────────────────────────────────
+
+fn copyInto(dst: []u8, src: []const u8) ?usize {
+    if (src.len > dst.len) return null;
+    @memcpy(dst[0..src.len], src);
+    return src.len;
+}
+
+fn formatAddress(addr: net.Address, buf: []u8) []const u8 {
+    if (addr.any.family == std.posix.AF.INET) {
+        const ip = std.mem.asBytes(&addr.in.sa.addr);
+        const port = std.mem.bigToNative(u16, addr.in.sa.port);
+        const str = std.fmt.bufPrint(buf, "{d}.{d}.{d}.{d}:{d}", .{
+            ip[0], ip[1], ip[2], ip[3], port,
+        }) catch return "";
+        return str;
+    } else if (addr.any.family == std.posix.AF.INET6) {
+        const port = std.mem.bigToNative(u16, addr.in6.sa.port);
+        // For IPv6, use bracket notation
+        var ip_buf: [46]u8 = undefined;
+        var ip_len: usize = 0;
+        const ip6 = &addr.in6.sa.addr;
+
+        // Simple hex format for IPv6
+        var i: usize = 0;
+        while (i < 16) : (i += 2) {
+            if (i > 0) {
+                ip_buf[ip_len] = ':';
+                ip_len += 1;
+            }
+            const word = @as(u16, ip6[i]) << 8 | @as(u16, ip6[i + 1]);
+            const hex = std.fmt.bufPrint(ip_buf[ip_len..], "{x}", .{word}) catch return "";
+            ip_len += hex.len;
+        }
+
+        const str = std.fmt.bufPrint(buf, "[{s}]:{d}", .{
+            ip_buf[0..ip_len], port,
+        }) catch return "";
+        return str;
+    }
+    return "";
+}
+
+// ─── Tests ───────────────────────────────────────────────────
+
+test "http_connect - build request without auth" {
+    var buf: [1024]u8 = undefined;
+    const addr = net.Address.initIp4(.{ 149, 154, 167, 51 }, 443);
+    const msg = buildConnectRequest(&buf, addr, null, null);
+
+    try std.testing.expect(msg.len > 0);
+    try std.testing.expect(std.mem.startsWith(u8, msg, "CONNECT 149.154.167.51:443 HTTP/1.1\r\n"));
+    try std.testing.expect(std.mem.endsWith(u8, msg, "\r\n\r\n"));
+    // No auth header
+    try std.testing.expect(std.mem.indexOf(u8, msg, "Proxy-Authorization") == null);
+}
+
+test "http_connect - build request with auth" {
+    var buf: [1024]u8 = undefined;
+    const addr = net.Address.initIp4(.{ 149, 154, 167, 51 }, 443);
+    const msg = buildConnectRequest(&buf, addr, "admin", "fr6CgjUvxFEAn5vs");
+
+    try std.testing.expect(msg.len > 0);
+    try std.testing.expect(std.mem.startsWith(u8, msg, "CONNECT 149.154.167.51:443 HTTP/1.1\r\n"));
+    try std.testing.expect(std.mem.indexOf(u8, msg, "Proxy-Authorization: Basic ") != null);
+    try std.testing.expect(std.mem.endsWith(u8, msg, "\r\n\r\n"));
+}
+
+test "http_connect - build request with empty username skips auth" {
+    var buf: [1024]u8 = undefined;
+    const addr = net.Address.initIp4(.{ 149, 154, 167, 51 }, 443);
+    const msg = buildConnectRequest(&buf, addr, "", "");
+
+    try std.testing.expect(std.mem.indexOf(u8, msg, "Proxy-Authorization") == null);
+}
+
+test "http_connect - parse response success" {
+    const data = "HTTP/1.1 200 Connection Established\r\n\r\n";
+    const result = parseResponse(data);
+    try std.testing.expect(result != null);
+    try std.testing.expectEqual(@as(u16, 200), result.?.status);
+    try std.testing.expectEqual(data.len, result.?.header_end);
+}
+
+test "http_connect - parse response 407 proxy auth required" {
+    const data = "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic\r\n\r\n";
+    const result = parseResponse(data);
+    try std.testing.expect(result != null);
+    try std.testing.expectEqual(@as(u16, 407), result.?.status);
+}
+
+test "http_connect - parse response incomplete" {
+    const data = "HTTP/1.1 200 Connection";
+    const result = parseResponse(data);
+    try std.testing.expect(result == null);
+}
+
+test "http_connect - parse response no terminator yet" {
+    const data = "HTTP/1.1 200 Connection Established\r\n";
+    const result = parseResponse(data);
+    try std.testing.expect(result == null);
+}
+
+test "http_connect - address formatting ipv4" {
+    var buf: [64]u8 = undefined;
+    const addr = net.Address.initIp4(.{ 10, 0, 0, 1 }, 8080);
+    const str = formatAddress(addr, &buf);
+    try std.testing.expectEqualStrings("10.0.0.1:8080", str);
+}

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -626,7 +626,7 @@ const ConnectionSlot = struct {
     mp_frame_first_decrypted: bool = false,
 
     // Non-blocking proxy handshake state (SOCKS5 / HTTP CONNECT)
-    proxy_handshake_buf: [512]u8 = undefined,
+    proxy_handshake_buf: [1024]u8 = undefined,
     proxy_handshake_pos: u16 = 0,
     proxy_handshake_len: u16 = 0,
     proxy_target_addr: ?net.Address = null,
@@ -1780,38 +1780,25 @@ const EventLoop = struct {
             .proxy_http_connect,
             => {
                 // Proxy handshake phases: flush pending writes.
-                const had_pending = slot.hasUpstreamPending();
-                if (flushUpstreamPending(slot, self.state.allocator)) |_| {} else |err| {
-                    log.debug("[{d}] proxy handshake flush error: {any}", .{ slot.conn_id, err });
-                    self.closeSlot(slot, "proxy handshake flush error");
-                    return;
+                if (slot.hasUpstreamPending()) {
+                    if (flushUpstreamPending(slot, self.state.allocator)) |_| {} else |err| {
+                        log.debug("[{d}] proxy handshake flush error: {any}", .{ slot.conn_id, err });
+                        self.closeSlot(slot, "proxy handshake flush error");
+                        return;
+                    }
                 }
-                if (had_pending and !slot.hasUpstreamPending()) {
+
+                if (!slot.hasUpstreamPending()) {
                     slot.last_activity_ms = std.time.milliTimestamp();
                     // Write complete, switch to reading response
                     switch (slot.phase) {
-                        .proxy_socks5_greeting => {
-                            slot.phase = .proxy_socks5_greeting_resp;
-                            slot.proxy_handshake_pos = 0;
-                            self.modFd(slot.upstream_fd, true, false) catch {};
-                        },
-                        .proxy_socks5_auth => {
-                            slot.phase = .proxy_socks5_auth_resp;
-                            slot.proxy_handshake_pos = 0;
-                            self.modFd(slot.upstream_fd, true, false) catch {};
-                        },
-                        .proxy_socks5_connect => {
-                            slot.phase = .proxy_socks5_connect_resp;
-                            slot.proxy_handshake_pos = 0;
-                            self.modFd(slot.upstream_fd, true, false) catch {};
-                        },
-                        .proxy_http_connect => {
-                            slot.phase = .proxy_http_connect_resp;
-                            slot.proxy_handshake_pos = 0;
-                            self.modFd(slot.upstream_fd, true, false) catch {};
-                        },
+                        .proxy_socks5_greeting => slot.phase = .proxy_socks5_greeting_resp,
+                        .proxy_socks5_auth => slot.phase = .proxy_socks5_auth_resp,
+                        .proxy_socks5_connect => slot.phase = .proxy_socks5_connect_resp,
+                        .proxy_http_connect => slot.phase = .proxy_http_connect_resp,
                         else => {},
                     }
+                    slot.proxy_handshake_pos = 0;
                 }
             },
             .writing_dc_nonce, .relaying, .mask_relaying, .middle_proxy_handshake => {
@@ -2238,7 +2225,10 @@ const EventLoop = struct {
     }
 
     fn startConnectUpstream(self: *EventLoop, slot: *ConnectionSlot, addr: net.Address, kind: UpstreamKind) !void {
-        const connect_result = try self.state.upstream.connect(addr);
+        const connect_result = if (kind == .mask) blk: {
+            const direct = upstream_mod.Upstream.initDirect();
+            break :blk try direct.connect(addr);
+        } else try self.state.upstream.connect(addr);
         const fd = connect_result.fd;
         errdefer posix.close(fd);
 
@@ -2347,11 +2337,11 @@ const EventLoop = struct {
             return;
         }
 
-        slot.phase = .proxy_socks5_greeting;
+        slot.phase = if (slot.hasUpstreamPending())
+            .proxy_socks5_greeting
+        else
+            .proxy_socks5_greeting_resp;
         slot.proxy_handshake_pos = 0;
-        self.modFd(slot.upstream_fd, false, true) catch {
-            self.closeSlot(slot, "socks5 modfd failed");
-        };
     }
 
     fn onProxySocks5Readable(self: *EventLoop, slot: *ConnectionSlot) void {
@@ -2450,11 +2440,11 @@ const EventLoop = struct {
             return;
         }
 
-        slot.phase = .proxy_socks5_auth;
+        slot.phase = if (slot.hasUpstreamPending())
+            .proxy_socks5_auth
+        else
+            .proxy_socks5_auth_resp;
         slot.proxy_handshake_pos = 0;
-        self.modFd(slot.upstream_fd, false, true) catch {
-            self.closeSlot(slot, "socks5 auth modfd failed");
-        };
     }
 
     fn socks5SendConnect(self: *EventLoop, slot: *ConnectionSlot) void {
@@ -2475,11 +2465,11 @@ const EventLoop = struct {
             return;
         }
 
-        slot.phase = .proxy_socks5_connect;
+        slot.phase = if (slot.hasUpstreamPending())
+            .proxy_socks5_connect
+        else
+            .proxy_socks5_connect_resp;
         slot.proxy_handshake_pos = 0;
-        self.modFd(slot.upstream_fd, false, true) catch {
-            self.closeSlot(slot, "socks5 connect modfd failed");
-        };
     }
 
     // ─── HTTP CONNECT Proxy Handshake ───────────────────────────
@@ -2510,11 +2500,11 @@ const EventLoop = struct {
             return;
         }
 
-        slot.phase = .proxy_http_connect;
+        slot.phase = if (slot.hasUpstreamPending())
+            .proxy_http_connect
+        else
+            .proxy_http_connect_resp;
         slot.proxy_handshake_pos = 0;
-        self.modFd(slot.upstream_fd, false, true) catch {
-            self.closeSlot(slot, "http connect modfd failed");
-        };
     }
 
     fn onProxyHttpConnectReadable(self: *EventLoop, slot: *ConnectionSlot) void {
@@ -2558,12 +2548,6 @@ const EventLoop = struct {
         slot.proxy_target_addr = null;
 
         log.debug("[{d}] proxy handshake complete, proceeding to DC path", .{slot.conn_id});
-
-        // Switch upstream fd to write interest for DC nonce / middle-proxy
-        self.modFd(slot.upstream_fd, true, true) catch {
-            self.closeSlot(slot, "proxy->dc modfd failed");
-            return;
-        };
 
         if (slot.use_middle_proxy) {
             self.middleProxyBegin(slot);
@@ -3450,6 +3434,24 @@ const EventLoop = struct {
             .connecting_upstream => {
                 want_client_in = false;
                 want_upstream_out = true;
+            },
+
+            .proxy_socks5_greeting,
+            .proxy_socks5_auth,
+            .proxy_socks5_connect,
+            .proxy_http_connect,
+            => {
+                want_client_in = false;
+                want_upstream_out = true;
+            },
+
+            .proxy_socks5_greeting_resp,
+            .proxy_socks5_auth_resp,
+            .proxy_socks5_connect_resp,
+            .proxy_http_connect_resp,
+            => {
+                want_client_in = false;
+                want_upstream_in = true;
             },
 
             .writing_dc_nonce => {

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -17,6 +17,8 @@ const tls = @import("../protocol/tls.zig");
 const Config = @import("../config.zig").Config;
 const upstream_mod = @import("upstream.zig");
 const tunnel_mod = @import("../tunnel.zig");
+const socks5 = @import("socks5.zig");
+const http_connect = @import("http_connect.zig");
 
 const log = std.log.scoped(.proxy);
 
@@ -334,6 +336,16 @@ const ConnectionPhase = enum {
     reading_mtproto_tls_header,
     reading_mtproto_tls_body,
     connecting_upstream,
+    // SOCKS5 proxy handshake sub-phases
+    proxy_socks5_greeting,
+    proxy_socks5_greeting_resp,
+    proxy_socks5_auth,
+    proxy_socks5_auth_resp,
+    proxy_socks5_connect,
+    proxy_socks5_connect_resp,
+    // HTTP CONNECT proxy handshake sub-phases
+    proxy_http_connect,
+    proxy_http_connect_resp,
     writing_dc_nonce,
     middle_proxy_handshake,
     relaying,
@@ -346,7 +358,29 @@ fn shouldCloseOnFatalHangup(phase: ConnectionPhase, event_fd: posix.fd_t, upstre
 
     // During connecting_upstream, EPOLLERR on upstream fd is expected and
     // handled via onUpstreamWritable -> onUpstreamConnectComplete.
-    return !(phase == .connecting_upstream and event_fd == upstream_fd);
+    if (phase == .connecting_upstream and event_fd == upstream_fd) return false;
+
+    // During proxy handshake phases, upstream hangup is a proxy
+    // connect failure — let the handler deal with it.
+    if (isProxyHandshakePhase(phase) and event_fd == upstream_fd) return false;
+
+    return true;
+}
+
+/// Check if a phase is one of the proxy handshake sub-phases.
+fn isProxyHandshakePhase(phase: ConnectionPhase) bool {
+    return switch (phase) {
+        .proxy_socks5_greeting,
+        .proxy_socks5_greeting_resp,
+        .proxy_socks5_auth,
+        .proxy_socks5_auth_resp,
+        .proxy_socks5_connect,
+        .proxy_socks5_connect_resp,
+        .proxy_http_connect,
+        .proxy_http_connect_resp,
+        => true,
+        else => false,
+    };
 }
 
 const MiddleProxyHandshakeStep = enum {
@@ -591,6 +625,12 @@ const ConnectionSlot = struct {
     mp_frame_encrypted: bool = false,
     mp_frame_first_decrypted: bool = false,
 
+    // Non-blocking proxy handshake state (SOCKS5 / HTTP CONNECT)
+    proxy_handshake_buf: [512]u8 = undefined,
+    proxy_handshake_pos: u16 = 0,
+    proxy_handshake_len: u16 = 0,
+    proxy_target_addr: ?net.Address = null,
+
     // Current epoll interests
     client_interest_in: bool = false,
     client_interest_out: bool = false,
@@ -616,6 +656,14 @@ const ConnectionSlot = struct {
             .reading_mtproto_tls_header,
             .reading_mtproto_tls_body,
             .connecting_upstream,
+            .proxy_socks5_greeting,
+            .proxy_socks5_greeting_resp,
+            .proxy_socks5_auth,
+            .proxy_socks5_auth_resp,
+            .proxy_socks5_connect,
+            .proxy_socks5_connect_resp,
+            .proxy_http_connect,
+            .proxy_http_connect_resp,
             .writing_dc_nonce,
             .middle_proxy_handshake,
             => true,
@@ -959,7 +1007,53 @@ pub const ProxyState = struct {
             .middle_proxy_secret = default_middle_proxy_secret,
             .middle_proxy_secret_len = middleproxy.proxy_secret.len,
             .middle_proxy_nat_ip4 = detected_nat_ip4,
-            .upstream = upstream_mod.Upstream.initDirect(),
+            .upstream = upblk: {
+                switch (cfg.upstream_mode) {
+                    .socks5 => {
+                        if (cfg.upstream_proxy_host) |host| {
+                            if (cfg.upstream_proxy_port > 0) {
+                                const proxy_list = net.getAddressList(allocator, host, cfg.upstream_proxy_port) catch |err| {
+                                    log.err("Failed to resolve SOCKS5 proxy host '{s}:{d}': {any}", .{ host, cfg.upstream_proxy_port, err });
+                                    break :upblk upstream_mod.Upstream.initDirect();
+                                };
+                                defer proxy_list.deinit();
+                                if (proxy_list.addrs.len > 0) {
+                                    log.info("Upstream mode: SOCKS5 via {s}:{d}", .{ host, cfg.upstream_proxy_port });
+                                    break :upblk upstream_mod.Upstream.initSocks5(
+                                        proxy_list.addrs[0],
+                                        cfg.upstream_proxy_username,
+                                        cfg.upstream_proxy_password,
+                                    );
+                                }
+                            }
+                        }
+                        log.warn("upstream.type=socks5 but proxy host/port not configured; falling back to direct", .{});
+                        break :upblk upstream_mod.Upstream.initDirect();
+                    },
+                    .http => {
+                        if (cfg.upstream_proxy_host) |host| {
+                            if (cfg.upstream_proxy_port > 0) {
+                                const proxy_list = net.getAddressList(allocator, host, cfg.upstream_proxy_port) catch |err| {
+                                    log.err("Failed to resolve HTTP proxy host '{s}:{d}': {any}", .{ host, cfg.upstream_proxy_port, err });
+                                    break :upblk upstream_mod.Upstream.initDirect();
+                                };
+                                defer proxy_list.deinit();
+                                if (proxy_list.addrs.len > 0) {
+                                    log.info("Upstream mode: HTTP CONNECT via {s}:{d}", .{ host, cfg.upstream_proxy_port });
+                                    break :upblk upstream_mod.Upstream.initHttpConnect(
+                                        proxy_list.addrs[0],
+                                        cfg.upstream_proxy_username,
+                                        cfg.upstream_proxy_password,
+                                    );
+                                }
+                            }
+                        }
+                        log.warn("upstream.type=http but proxy host/port not configured; falling back to direct", .{});
+                        break :upblk upstream_mod.Upstream.initDirect();
+                    },
+                    else => break :upblk upstream_mod.Upstream.initDirect(),
+                }
+            },
             .tunnel_info = blk: {
                 const in_non_init_netns = isRunningInNonInitNetns();
                 switch (cfg.upstream_mode) {
@@ -970,18 +1064,24 @@ pub const ProxyState = struct {
                         log.info("Upstream mode: direct (configured)", .{});
                         break :blk tunnel_mod.Tunnel{ .tag = .none };
                     },
-                    .amnezia_wg => {
-                        const t = tunnel_mod.Tunnel{ .tag = .amnezia_wg };
+                    .tunnel => {
+                        const t = tunnel_mod.Tunnel{ .tag = .tunnel };
                         if (in_non_init_netns) {
                             log.info("Upstream mode: {s} (configured)", .{t.name()});
                         } else {
-                            log.warn("upstream.type=amnezia_wg configured, but proxy is not running in tunnel netns", .{});
+                            log.warn("upstream.type=tunnel configured, but proxy is not running in tunnel netns", .{});
                         }
                         break :blk t;
                     },
+                    .socks5 => {
+                        break :blk tunnel_mod.Tunnel{ .tag = .socks5 };
+                    },
+                    .http => {
+                        break :blk tunnel_mod.Tunnel{ .tag = .http_connect };
+                    },
                     .auto => {
                         if (in_non_init_netns) {
-                            const t = tunnel_mod.Tunnel{ .tag = .amnezia_wg };
+                            const t = tunnel_mod.Tunnel{ .tag = .tunnel };
                             log.info("Upstream mode: {s} (auto-detected from network namespace)", .{t.name()});
                             break :blk t;
                         }
@@ -1000,9 +1100,9 @@ pub const ProxyState = struct {
     pub fn run(self: *ProxyState) !void {
         if (builtin.os.tag != .linux) return error.UnsupportedOperatingSystem;
 
-        if (self.config.upstream_mode == .amnezia_wg and !isRunningInNonInitNetns()) {
+        if (self.config.upstream_mode == .tunnel and !isRunningInNonInitNetns()) {
             log.err(
-                "upstream.type=amnezia_wg requires running proxy inside tunnel netns (expected via `mtbuddy setup tunnel`)",
+                "upstream.type=tunnel requires running proxy inside tunnel netns (expected via `mtbuddy setup tunnel`)",
                 .{},
             );
             return error.UpstreamTunnelNotActive;
@@ -1659,6 +1759,11 @@ const EventLoop = struct {
         slot.last_activity_ms = std.time.milliTimestamp();
 
         switch (slot.phase) {
+            .proxy_socks5_greeting_resp,
+            .proxy_socks5_auth_resp,
+            .proxy_socks5_connect_resp,
+            => self.onProxySocks5Readable(slot),
+            .proxy_http_connect_resp => self.onProxyHttpConnectReadable(slot),
             .middle_proxy_handshake => self.middleProxyOnReadable(slot),
             .relaying => self.relayUpstreamToClient(slot),
             .mask_relaying => self.relayRawUpstreamToClient(slot),
@@ -1669,6 +1774,46 @@ const EventLoop = struct {
     fn onUpstreamWritable(self: *EventLoop, slot: *ConnectionSlot) void {
         switch (slot.phase) {
             .connecting_upstream => self.onUpstreamConnectComplete(slot),
+            .proxy_socks5_greeting,
+            .proxy_socks5_auth,
+            .proxy_socks5_connect,
+            .proxy_http_connect,
+            => {
+                // Proxy handshake phases: flush pending writes.
+                const had_pending = slot.hasUpstreamPending();
+                if (flushUpstreamPending(slot, self.state.allocator)) |_| {} else |err| {
+                    log.debug("[{d}] proxy handshake flush error: {any}", .{ slot.conn_id, err });
+                    self.closeSlot(slot, "proxy handshake flush error");
+                    return;
+                }
+                if (had_pending and !slot.hasUpstreamPending()) {
+                    slot.last_activity_ms = std.time.milliTimestamp();
+                    // Write complete, switch to reading response
+                    switch (slot.phase) {
+                        .proxy_socks5_greeting => {
+                            slot.phase = .proxy_socks5_greeting_resp;
+                            slot.proxy_handshake_pos = 0;
+                            self.modFd(slot.upstream_fd, true, false) catch {};
+                        },
+                        .proxy_socks5_auth => {
+                            slot.phase = .proxy_socks5_auth_resp;
+                            slot.proxy_handshake_pos = 0;
+                            self.modFd(slot.upstream_fd, true, false) catch {};
+                        },
+                        .proxy_socks5_connect => {
+                            slot.phase = .proxy_socks5_connect_resp;
+                            slot.proxy_handshake_pos = 0;
+                            self.modFd(slot.upstream_fd, true, false) catch {};
+                        },
+                        .proxy_http_connect => {
+                            slot.phase = .proxy_http_connect_resp;
+                            slot.proxy_handshake_pos = 0;
+                            self.modFd(slot.upstream_fd, true, false) catch {};
+                        },
+                        else => {},
+                    }
+                }
+            },
             .writing_dc_nonce, .relaying, .mask_relaying, .middle_proxy_handshake => {
                 const had_pending = slot.hasUpstreamPending();
                 if (flushUpstreamPending(slot, self.state.allocator)) |_| {} else |err| {
@@ -2107,10 +2252,17 @@ const EventLoop = struct {
         slot.upstream_kind = kind;
         slot.current_upstream_addr = addr;
         slot.phase = .connecting_upstream;
+
+        // For proxy upstreams, stash the real target address for the proxy handshake.
+        if (connect_result.proxy_handshake != .none) {
+            slot.proxy_target_addr = addr;
+        }
+
         errdefer {
             slot.upstream_fd = -1;
             slot.upstream_kind = .none;
             slot.current_upstream_addr = null;
+            slot.proxy_target_addr = null;
         }
 
         if (!connect_result.pending) {
@@ -2155,6 +2307,263 @@ const EventLoop = struct {
             slot.phase = .mask_relaying;
             return;
         }
+
+        // Check if we need a proxy handshake before proceeding to DC.
+        if (slot.proxy_target_addr != null) {
+            switch (self.state.upstream) {
+                .socks5 => {
+                    self.startSocks5Handshake(slot);
+                    return;
+                },
+                .http_connect => {
+                    self.startHttpConnectHandshake(slot);
+                    return;
+                },
+                .direct => {},
+            }
+        }
+
+        if (slot.use_middle_proxy) {
+            self.middleProxyBegin(slot);
+            return;
+        }
+
+        self.sendDcNonce(slot);
+    }
+
+    // ─── SOCKS5 Proxy Handshake ─────────────────────────────────
+
+    fn startSocks5Handshake(self: *EventLoop, slot: *ConnectionSlot) void {
+        const needs_auth = self.state.upstream.socks5.needsAuth();
+        const msg = socks5.buildGreeting(&slot.proxy_handshake_buf, needs_auth);
+        if (msg.len == 0) {
+            self.closeSlot(slot, "socks5 greeting build failed");
+            return;
+        }
+
+        if (queueUpstream(slot, self.state.allocator, msg)) |_| {} else |err| {
+            log.debug("[{d}] socks5 greeting queue error: {any}", .{ slot.conn_id, err });
+            self.closeSlot(slot, "socks5 greeting queue failed");
+            return;
+        }
+
+        slot.phase = .proxy_socks5_greeting;
+        slot.proxy_handshake_pos = 0;
+        self.modFd(slot.upstream_fd, false, true) catch {
+            self.closeSlot(slot, "socks5 modfd failed");
+        };
+    }
+
+    fn onProxySocks5Readable(self: *EventLoop, slot: *ConnectionSlot) void {
+        // Read into proxy_handshake_buf at current pos
+        const pos: usize = slot.proxy_handshake_pos;
+        const space = slot.proxy_handshake_buf[pos..];
+        if (space.len == 0) {
+            self.closeSlot(slot, "socks5 response buffer overflow");
+            return;
+        }
+
+        const n = posix.read(slot.upstream_fd, space) catch |err| {
+            log.debug("[{d}] socks5 read error: {any}", .{ slot.conn_id, err });
+            if (err == error.WouldBlock) return;
+            self.closeSlot(slot, "socks5 read failed");
+            return;
+        };
+
+        if (n == 0) {
+            self.closeSlot(slot, "socks5 proxy closed connection");
+            return;
+        }
+
+        slot.proxy_handshake_pos += @intCast(n);
+        const have = slot.proxy_handshake_buf[0..slot.proxy_handshake_pos];
+
+        switch (slot.phase) {
+            .proxy_socks5_greeting_resp => {
+                if (have.len < socks5.greeting_response_len) return; // need more
+
+                const method = socks5.parseGreetingResponse(have) orelse {
+                    self.closeSlot(slot, "socks5 invalid greeting response");
+                    return;
+                };
+
+                switch (method) {
+                    .no_auth => {
+                        self.socks5SendConnect(slot);
+                    },
+                    .username_password => {
+                        self.socks5SendAuth(slot);
+                    },
+                    .no_acceptable => {
+                        log.debug("[{d}] socks5 proxy rejected all auth methods", .{slot.conn_id});
+                        self.closeSlot(slot, "socks5 no acceptable auth");
+                    },
+                }
+            },
+            .proxy_socks5_auth_resp => {
+                if (have.len < socks5.auth_response_len) return; // need more
+
+                const ok = socks5.parseAuthResponse(have) orelse {
+                    self.closeSlot(slot, "socks5 invalid auth response");
+                    return;
+                };
+
+                if (!ok) {
+                    log.debug("[{d}] socks5 authentication failed", .{slot.conn_id});
+                    self.closeSlot(slot, "socks5 auth rejected");
+                    return;
+                }
+
+                self.socks5SendConnect(slot);
+            },
+            .proxy_socks5_connect_resp => {
+                const result = socks5.parseConnectResponse(have) orelse return; // need more
+
+                if (result.reply != .succeeded) {
+                    log.debug("[{d}] socks5 CONNECT failed: reply={d}", .{
+                        slot.conn_id, @intFromEnum(result.reply),
+                    });
+                    self.closeSlot(slot, "socks5 connect rejected");
+                    return;
+                }
+
+                // SOCKS5 handshake complete — proceed to DC path
+                self.proxyHandshakeComplete(slot);
+            },
+            else => {},
+        }
+    }
+
+    fn socks5SendAuth(self: *EventLoop, slot: *ConnectionSlot) void {
+        const username = self.state.upstream.proxyUsername() orelse "";
+        const password = self.state.upstream.proxyPassword() orelse "";
+
+        const msg = socks5.buildAuthRequest(&slot.proxy_handshake_buf, username, password);
+        if (msg.len == 0) {
+            self.closeSlot(slot, "socks5 auth request build failed");
+            return;
+        }
+
+        if (queueUpstream(slot, self.state.allocator, msg)) |_| {} else |err| {
+            log.debug("[{d}] socks5 auth queue error: {any}", .{ slot.conn_id, err });
+            self.closeSlot(slot, "socks5 auth queue failed");
+            return;
+        }
+
+        slot.phase = .proxy_socks5_auth;
+        slot.proxy_handshake_pos = 0;
+        self.modFd(slot.upstream_fd, false, true) catch {
+            self.closeSlot(slot, "socks5 auth modfd failed");
+        };
+    }
+
+    fn socks5SendConnect(self: *EventLoop, slot: *ConnectionSlot) void {
+        const target = slot.proxy_target_addr orelse {
+            self.closeSlot(slot, "socks5 no target addr");
+            return;
+        };
+
+        const msg = socks5.buildConnectRequest(&slot.proxy_handshake_buf, target);
+        if (msg.len == 0) {
+            self.closeSlot(slot, "socks5 connect request build failed");
+            return;
+        }
+
+        if (queueUpstream(slot, self.state.allocator, msg)) |_| {} else |err| {
+            log.debug("[{d}] socks5 connect queue error: {any}", .{ slot.conn_id, err });
+            self.closeSlot(slot, "socks5 connect queue failed");
+            return;
+        }
+
+        slot.phase = .proxy_socks5_connect;
+        slot.proxy_handshake_pos = 0;
+        self.modFd(slot.upstream_fd, false, true) catch {
+            self.closeSlot(slot, "socks5 connect modfd failed");
+        };
+    }
+
+    // ─── HTTP CONNECT Proxy Handshake ───────────────────────────
+
+    fn startHttpConnectHandshake(self: *EventLoop, slot: *ConnectionSlot) void {
+        const target = slot.proxy_target_addr orelse {
+            self.closeSlot(slot, "http proxy no target addr");
+            return;
+        };
+
+        const username = self.state.upstream.proxyUsername();
+        const password = self.state.upstream.proxyPassword();
+
+        const msg = http_connect.buildConnectRequest(
+            &slot.proxy_handshake_buf,
+            target,
+            username,
+            password,
+        );
+        if (msg.len == 0) {
+            self.closeSlot(slot, "http connect request build failed");
+            return;
+        }
+
+        if (queueUpstream(slot, self.state.allocator, msg)) |_| {} else |err| {
+            log.debug("[{d}] http connect queue error: {any}", .{ slot.conn_id, err });
+            self.closeSlot(slot, "http connect queue failed");
+            return;
+        }
+
+        slot.phase = .proxy_http_connect;
+        slot.proxy_handshake_pos = 0;
+        self.modFd(slot.upstream_fd, false, true) catch {
+            self.closeSlot(slot, "http connect modfd failed");
+        };
+    }
+
+    fn onProxyHttpConnectReadable(self: *EventLoop, slot: *ConnectionSlot) void {
+        const pos: usize = slot.proxy_handshake_pos;
+        const space = slot.proxy_handshake_buf[pos..];
+        if (space.len == 0) {
+            self.closeSlot(slot, "http connect response buffer overflow");
+            return;
+        }
+
+        const n = posix.read(slot.upstream_fd, space) catch |err| {
+            log.debug("[{d}] http connect read error: {any}", .{ slot.conn_id, err });
+            if (err == error.WouldBlock) return;
+            self.closeSlot(slot, "http connect read failed");
+            return;
+        };
+
+        if (n == 0) {
+            self.closeSlot(slot, "http proxy closed connection");
+            return;
+        }
+
+        slot.proxy_handshake_pos += @intCast(n);
+        const have = slot.proxy_handshake_buf[0..slot.proxy_handshake_pos];
+
+        const result = http_connect.parseResponse(have) orelse return; // need more
+
+        if (result.status < 200 or result.status >= 300) {
+            log.debug("[{d}] HTTP CONNECT failed: status={d}", .{ slot.conn_id, result.status });
+            self.closeSlot(slot, "http connect rejected");
+            return;
+        }
+
+        // HTTP CONNECT handshake complete — proceed to DC path
+        self.proxyHandshakeComplete(slot);
+    }
+
+    // ─── Common: proxy handshake → DC path transition ───────────
+
+    fn proxyHandshakeComplete(self: *EventLoop, slot: *ConnectionSlot) void {
+        slot.proxy_target_addr = null;
+
+        log.debug("[{d}] proxy handshake complete, proceeding to DC path", .{slot.conn_id});
+
+        // Switch upstream fd to write interest for DC nonce / middle-proxy
+        self.modFd(slot.upstream_fd, true, true) catch {
+            self.closeSlot(slot, "proxy->dc modfd failed");
+            return;
+        };
 
         if (slot.use_middle_proxy) {
             self.middleProxyBegin(slot);

--- a/src/proxy/socks5.zig
+++ b/src/proxy/socks5.zig
@@ -1,0 +1,288 @@
+//! SOCKS5 protocol helpers (RFC 1928 / RFC 1929).
+//!
+//! Pure message serialization and parsing — no socket I/O.
+//! Used by the upstream transport layer to drive the SOCKS5
+//! handshake through the non-blocking epoll event loop.
+
+const std = @import("std");
+const net = std.net;
+
+// ─── Constants ───────────────────────────────────────────────
+
+pub const version: u8 = 0x05;
+pub const auth_version: u8 = 0x01; // RFC 1929
+
+pub const Method = enum(u8) {
+    no_auth = 0x00,
+    username_password = 0x02,
+    no_acceptable = 0xFF,
+};
+
+pub const Command = enum(u8) {
+    connect = 0x01,
+    bind = 0x02,
+    udp_associate = 0x03,
+};
+
+pub const AddressType = enum(u8) {
+    ipv4 = 0x01,
+    domain = 0x03,
+    ipv6 = 0x04,
+};
+
+pub const Reply = enum(u8) {
+    succeeded = 0x00,
+    general_failure = 0x01,
+    connection_not_allowed = 0x02,
+    network_unreachable = 0x03,
+    host_unreachable = 0x04,
+    connection_refused = 0x05,
+    ttl_expired = 0x06,
+    command_not_supported = 0x07,
+    address_type_not_supported = 0x08,
+    _,
+};
+
+// ─── Greeting ────────────────────────────────────────────────
+
+/// Build a SOCKS5 greeting message.
+/// If `use_auth` is true, offers both no-auth and username/password.
+/// Otherwise offers only no-auth.
+pub fn buildGreeting(buf: []u8, use_auth: bool) []u8 {
+    if (use_auth) {
+        if (buf.len < 4) return buf[0..0];
+        buf[0] = version;
+        buf[1] = 2; // 2 methods
+        buf[2] = @intFromEnum(Method.no_auth);
+        buf[3] = @intFromEnum(Method.username_password);
+        return buf[0..4];
+    } else {
+        if (buf.len < 3) return buf[0..0];
+        buf[0] = version;
+        buf[1] = 1; // 1 method
+        buf[2] = @intFromEnum(Method.no_auth);
+        return buf[0..3];
+    }
+}
+
+/// Parse a SOCKS5 greeting response (2 bytes: version + method).
+/// Returns the selected method or null on invalid data.
+pub fn parseGreetingResponse(data: []const u8) ?Method {
+    if (data.len < 2) return null;
+    if (data[0] != version) return null;
+    return std.meta.intToEnum(Method, data[1]) catch .no_acceptable;
+}
+
+/// Minimum bytes needed for greeting response.
+pub const greeting_response_len: usize = 2;
+
+// ─── Username/Password Auth (RFC 1929) ───────────────────────
+
+/// Build a username/password authentication request.
+/// Returns the slice of `buf` that was written, or empty on overflow.
+pub fn buildAuthRequest(buf: []u8, username: []const u8, password: []const u8) []u8 {
+    const ulen = username.len;
+    const plen = password.len;
+
+    // VER(1) + ULEN(1) + UNAME(ulen) + PLEN(1) + PASSWD(plen)
+    const total = 1 + 1 + ulen + 1 + plen;
+    if (total > buf.len or ulen > 255 or plen > 255) return buf[0..0];
+
+    buf[0] = auth_version;
+    buf[1] = @intCast(ulen);
+    @memcpy(buf[2 .. 2 + ulen], username);
+    buf[2 + ulen] = @intCast(plen);
+    @memcpy(buf[3 + ulen .. 3 + ulen + plen], password);
+    return buf[0..total];
+}
+
+/// Parse an auth response (2 bytes: version + status).
+/// Returns true if authentication succeeded.
+pub fn parseAuthResponse(data: []const u8) ?bool {
+    if (data.len < 2) return null;
+    if (data[0] != auth_version) return null;
+    return data[1] == 0x00;
+}
+
+/// Minimum bytes needed for auth response.
+pub const auth_response_len: usize = 2;
+
+// ─── CONNECT Command ─────────────────────────────────────────
+
+/// Build a SOCKS5 CONNECT request to the given target address.
+/// Returns the slice of `buf` that was written, or empty on overflow.
+pub fn buildConnectRequest(buf: []u8, addr: net.Address) []u8 {
+    if (addr.any.family == std.posix.AF.INET) {
+        // VER(1) + CMD(1) + RSV(1) + ATYP(1) + IPv4(4) + PORT(2) = 10
+        const total: usize = 10;
+        if (buf.len < total) return buf[0..0];
+
+        buf[0] = version;
+        buf[1] = @intFromEnum(Command.connect);
+        buf[2] = 0x00; // reserved
+        buf[3] = @intFromEnum(AddressType.ipv4);
+
+        const ip_bytes = std.mem.asBytes(&addr.in.sa.addr);
+        @memcpy(buf[4..8], ip_bytes);
+
+        const port = addr.in.sa.port; // network byte order already
+        const port_bytes = std.mem.asBytes(&port);
+        buf[8] = port_bytes[0];
+        buf[9] = port_bytes[1];
+
+        return buf[0..total];
+    } else if (addr.any.family == std.posix.AF.INET6) {
+        // VER(1) + CMD(1) + RSV(1) + ATYP(1) + IPv6(16) + PORT(2) = 22
+        const total: usize = 22;
+        if (buf.len < total) return buf[0..0];
+
+        buf[0] = version;
+        buf[1] = @intFromEnum(Command.connect);
+        buf[2] = 0x00; // reserved
+        buf[3] = @intFromEnum(AddressType.ipv6);
+
+        @memcpy(buf[4..20], &addr.in6.sa.addr);
+
+        const port = addr.in6.sa.port;
+        const port_bytes = std.mem.asBytes(&port);
+        buf[20] = port_bytes[0];
+        buf[21] = port_bytes[1];
+
+        return buf[0..total];
+    }
+    return buf[0..0];
+}
+
+/// Parse a SOCKS5 CONNECT response.
+/// Returns the reply code, or null if not enough data.
+/// The minimum response is 10 bytes (IPv4) but we only need the
+/// first 4 to determine success/failure. We read the full response
+/// to consume it from the stream.
+pub fn parseConnectResponse(data: []const u8) ?struct { reply: Reply, consumed: usize } {
+    if (data.len < 4) return null;
+    if (data[0] != version) return .{ .reply = .general_failure, .consumed = data.len };
+
+    const reply: Reply = @enumFromInt(data[1]);
+    // data[2] is reserved
+    const atyp = data[3];
+
+    // Calculate total response length based on address type
+    const total: usize = switch (atyp) {
+        @intFromEnum(AddressType.ipv4) => 10, // 4 + 4 + 2
+        @intFromEnum(AddressType.ipv6) => 22, // 4 + 16 + 2
+        @intFromEnum(AddressType.domain) => blk: {
+            if (data.len < 5) return null;
+            const dlen: usize = data[4];
+            break :blk 4 + 1 + dlen + 2;
+        },
+        else => return .{ .reply = .general_failure, .consumed = data.len },
+    };
+
+    if (data.len < total) return null;
+    return .{ .reply = reply, .consumed = total };
+}
+
+/// Minimum bytes needed to start parsing a connect response
+/// (enough to read version + reply + reserved + atyp).
+pub const connect_response_min_len: usize = 4;
+
+// ─── Tests ───────────────────────────────────────────────────
+
+test "socks5 - greeting with auth" {
+    var buf: [16]u8 = undefined;
+    const msg = buildGreeting(&buf, true);
+    try std.testing.expectEqual(@as(usize, 4), msg.len);
+    try std.testing.expectEqual(version, msg[0]);
+    try std.testing.expectEqual(@as(u8, 2), msg[1]);
+    try std.testing.expectEqual(@as(u8, 0x00), msg[2]);
+    try std.testing.expectEqual(@as(u8, 0x02), msg[3]);
+}
+
+test "socks5 - greeting without auth" {
+    var buf: [16]u8 = undefined;
+    const msg = buildGreeting(&buf, false);
+    try std.testing.expectEqual(@as(usize, 3), msg.len);
+    try std.testing.expectEqual(version, msg[0]);
+    try std.testing.expectEqual(@as(u8, 1), msg[1]);
+    try std.testing.expectEqual(@as(u8, 0x00), msg[2]);
+}
+
+test "socks5 - parse greeting response" {
+    const ok = parseGreetingResponse(&[_]u8{ 0x05, 0x02 });
+    try std.testing.expectEqual(Method.username_password, ok.?);
+
+    const no_auth = parseGreetingResponse(&[_]u8{ 0x05, 0x00 });
+    try std.testing.expectEqual(Method.no_auth, no_auth.?);
+
+    const rejected = parseGreetingResponse(&[_]u8{ 0x05, 0xFF });
+    try std.testing.expectEqual(Method.no_acceptable, rejected.?);
+
+    const too_short = parseGreetingResponse(&[_]u8{0x05});
+    try std.testing.expect(too_short == null);
+
+    const bad_ver = parseGreetingResponse(&[_]u8{ 0x04, 0x00 });
+    try std.testing.expect(bad_ver == null);
+}
+
+test "socks5 - auth request" {
+    var buf: [512]u8 = undefined;
+    const msg = buildAuthRequest(&buf, "admin", "fr6CgjUvxFEAn5vs");
+
+    try std.testing.expectEqual(auth_version, msg[0]);
+    try std.testing.expectEqual(@as(u8, 5), msg[1]); // username len
+    try std.testing.expectEqualStrings("admin", msg[2..7]);
+    try std.testing.expectEqual(@as(u8, 16), msg[7]); // password len
+    try std.testing.expectEqualStrings("fr6CgjUvxFEAn5vs", msg[8..24]);
+}
+
+test "socks5 - parse auth response" {
+    const ok = parseAuthResponse(&[_]u8{ 0x01, 0x00 });
+    try std.testing.expect(ok.? == true);
+
+    const fail = parseAuthResponse(&[_]u8{ 0x01, 0x01 });
+    try std.testing.expect(fail.? == false);
+
+    const short = parseAuthResponse(&[_]u8{0x01});
+    try std.testing.expect(short == null);
+}
+
+test "socks5 - connect request ipv4" {
+    var buf: [64]u8 = undefined;
+    // Construct an IPv4 address: 149.154.167.51:443
+    const addr = net.Address.initIp4(.{ 149, 154, 167, 51 }, 443);
+    const msg = buildConnectRequest(&buf, addr);
+
+    try std.testing.expectEqual(@as(usize, 10), msg.len);
+    try std.testing.expectEqual(version, msg[0]);
+    try std.testing.expectEqual(@as(u8, 0x01), msg[1]); // CONNECT
+    try std.testing.expectEqual(@as(u8, 0x00), msg[2]); // RSV
+    try std.testing.expectEqual(@as(u8, 0x01), msg[3]); // IPv4
+
+    // IP bytes
+    try std.testing.expectEqual(@as(u8, 149), msg[4]);
+    try std.testing.expectEqual(@as(u8, 154), msg[5]);
+    try std.testing.expectEqual(@as(u8, 167), msg[6]);
+    try std.testing.expectEqual(@as(u8, 51), msg[7]);
+}
+
+test "socks5 - parse connect response success ipv4" {
+    // Typical success response: ver=5, rep=0, rsv=0, atyp=1, ip=0.0.0.0, port=0
+    const resp = [_]u8{ 0x05, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    const result = parseConnectResponse(&resp);
+    try std.testing.expect(result != null);
+    try std.testing.expectEqual(Reply.succeeded, result.?.reply);
+    try std.testing.expectEqual(@as(usize, 10), result.?.consumed);
+}
+
+test "socks5 - parse connect response failure" {
+    const resp = [_]u8{ 0x05, 0x05, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    const result = parseConnectResponse(&resp);
+    try std.testing.expect(result != null);
+    try std.testing.expectEqual(Reply.connection_refused, result.?.reply);
+}
+
+test "socks5 - parse connect response too short" {
+    const resp = [_]u8{ 0x05, 0x00, 0x00 };
+    const result = parseConnectResponse(&resp);
+    try std.testing.expect(result == null);
+}

--- a/src/proxy/upstream.zig
+++ b/src/proxy/upstream.zig
@@ -1,9 +1,15 @@
 //! Upstream transport abstraction for proxy egress connections.
 //!
 //! This tagged union defines the transport interface used by the proxy
-//! when creating upstream sockets. Today it only provides a direct TCP
-//! connector, but new variants (SOCKS5, HTTP CONNECT, custom tunnels)
-//! can be added without changing the event loop call sites.
+//! when creating upstream sockets. Today it provides:
+//!   - direct: plain TCP connect (namespace-level tunnels like AmneziaWG)
+//!   - socks5: SOCKS5 proxy with optional username/password auth
+//!   - http_connect: HTTP CONNECT proxy with optional Basic auth
+//!
+//! For SOCKS5 and HTTP CONNECT, the initial `connect()` creates a TCP
+//! socket to the *proxy server*. The actual proxy protocol handshake
+//! (SOCKS5 greeting→auth→connect, or HTTP CONNECT request→response)
+//! is driven by the event loop as non-blocking state machine phases.
 //!
 //! The `tunnel_info` field carries metadata about the active tunnel
 //! (see `tunnel.zig`). For namespace-based tunnels like AmneziaWG,
@@ -18,25 +24,99 @@ const tunnel_mod = @import("../tunnel.zig");
 
 pub const Tunnel = tunnel_mod.Tunnel;
 
+/// What proxy-level handshake (if any) must be completed after TCP connect.
+pub const ProxyHandshake = enum {
+    /// Direct connection — no proxy handshake needed.
+    none,
+    /// SOCKS5 handshake required (greeting → auth → CONNECT).
+    socks5,
+    /// HTTP CONNECT handshake required (CONNECT request → response).
+    http_connect,
+};
+
 pub const ConnectResult = struct {
     fd: posix.fd_t,
     pending: bool,
+    /// What proxy handshake to run after TCP connect completes.
+    proxy_handshake: ProxyHandshake = .none,
 };
 
 pub const Tag = enum {
     direct,
+    socks5,
+    http_connect,
 };
 
 pub const Upstream = union(Tag) {
     direct: Direct,
+    socks5: Socks5,
+    http_connect: HttpConnect,
 
     pub fn initDirect() Upstream {
         return .{ .direct = .{} };
     }
 
+    pub fn initSocks5(
+        proxy_addr: net.Address,
+        username: ?[]const u8,
+        password: ?[]const u8,
+    ) Upstream {
+        return .{ .socks5 = .{
+            .proxy_addr = proxy_addr,
+            .username = username,
+            .password = password,
+        } };
+    }
+
+    pub fn initHttpConnect(
+        proxy_addr: net.Address,
+        username: ?[]const u8,
+        password: ?[]const u8,
+    ) Upstream {
+        return .{ .http_connect = .{
+            .proxy_addr = proxy_addr,
+            .username = username,
+            .password = password,
+        } };
+    }
+
+    /// Create a non-blocking upstream socket.
+    ///
+    /// For `direct`, connects to `addr` directly.
+    /// For proxy variants, connects to the proxy server; the caller
+    /// must check `proxy_handshake` and run the appropriate handshake
+    /// before using the socket for DC traffic.
     pub fn connect(self: *const Upstream, addr: net.Address) !ConnectResult {
         return switch (self.*) {
             .direct => |connector| connector.connect(addr),
+            .socks5 => |connector| connector.connect(),
+            .http_connect => |connector| connector.connect(),
+        };
+    }
+
+    /// Get the proxy server address (for logging), or null for direct.
+    pub fn proxyAddr(self: *const Upstream) ?net.Address {
+        return switch (self.*) {
+            .direct => null,
+            .socks5 => |s| s.proxy_addr,
+            .http_connect => |h| h.proxy_addr,
+        };
+    }
+
+    /// Get proxy credentials for the handshake protocol modules.
+    pub fn proxyUsername(self: *const Upstream) ?[]const u8 {
+        return switch (self.*) {
+            .direct => null,
+            .socks5 => |s| s.username,
+            .http_connect => |h| h.username,
+        };
+    }
+
+    pub fn proxyPassword(self: *const Upstream) ?[]const u8 {
+        return switch (self.*) {
+            .direct => null,
+            .socks5 => |s| s.password,
+            .http_connect => |h| h.password,
         };
     }
 };
@@ -58,5 +138,63 @@ pub const Direct = struct {
         };
 
         return .{ .fd = fd, .pending = false };
+    }
+};
+
+pub const Socks5 = struct {
+    proxy_addr: net.Address,
+    username: ?[]const u8 = null,
+    password: ?[]const u8 = null,
+
+    /// Connect to the SOCKS5 proxy server (not the target DC).
+    /// Returns a result with `.proxy_handshake = .socks5`.
+    pub fn connect(self: Socks5) !ConnectResult {
+        const fd = try posix.socket(
+            self.proxy_addr.any.family,
+            posix.SOCK.STREAM | posix.SOCK.NONBLOCK | posix.SOCK.CLOEXEC,
+            posix.IPPROTO.TCP,
+        );
+        errdefer posix.close(fd);
+
+        posix.connect(fd, &self.proxy_addr.any, self.proxy_addr.getOsSockLen()) catch |err| switch (err) {
+            error.WouldBlock, error.ConnectionPending => {
+                return .{ .fd = fd, .pending = true, .proxy_handshake = .socks5 };
+            },
+            else => return err,
+        };
+
+        return .{ .fd = fd, .pending = false, .proxy_handshake = .socks5 };
+    }
+
+    /// Whether auth is needed (username is non-null and non-empty).
+    pub fn needsAuth(self: Socks5) bool {
+        if (self.username) |u| return u.len > 0;
+        return false;
+    }
+};
+
+pub const HttpConnect = struct {
+    proxy_addr: net.Address,
+    username: ?[]const u8 = null,
+    password: ?[]const u8 = null,
+
+    /// Connect to the HTTP proxy server (not the target DC).
+    /// Returns a result with `.proxy_handshake = .http_connect`.
+    pub fn connect(self: HttpConnect) !ConnectResult {
+        const fd = try posix.socket(
+            self.proxy_addr.any.family,
+            posix.SOCK.STREAM | posix.SOCK.NONBLOCK | posix.SOCK.CLOEXEC,
+            posix.IPPROTO.TCP,
+        );
+        errdefer posix.close(fd);
+
+        posix.connect(fd, &self.proxy_addr.any, self.proxy_addr.getOsSockLen()) catch |err| switch (err) {
+            error.WouldBlock, error.ConnectionPending => {
+                return .{ .fd = fd, .pending = true, .proxy_handshake = .http_connect };
+            },
+            else => return err,
+        };
+
+        return .{ .fd = fd, .pending = false, .proxy_handshake = .http_connect };
     }
 };

--- a/src/tunnel.zig
+++ b/src/tunnel.zig
@@ -3,11 +3,13 @@
 //! Defines the `Tunnel` metadata type that describes which tunnel
 //! (if any) is active for outgoing proxy connections. This is a
 //! capability/metadata struct — not a socket connector — because
-//! some tunnels (e.g. AmneziaWG) work by running the proxy inside
-//! a network namespace rather than wrapping individual connect() calls.
+//! network-level tunnels (AmneziaWG, WireGuard, ...) work by running
+//! the proxy inside a network namespace rather than wrapping individual
+//! connect() calls. The specific VPN type is an mtbuddy concern.
 //!
-//! New tunnel types (SOCKS5, HTTP CONNECT, etc.) can be added by
-//! extending the `Tag` enum and implementing type-specific behavior.
+//! Socket-level proxy types (SOCKS5, HTTP CONNECT) are also tracked
+//! here for logging and status display, even though their actual I/O
+//! is handled by the upstream transport layer.
 
 const std = @import("std");
 
@@ -15,13 +17,14 @@ pub const Tunnel = struct {
     pub const Tag = enum {
         /// Direct connection — no tunnel active.
         none,
-        /// AmneziaWG tunnel via Linux network namespace.
-        /// The proxy process runs inside `tg_proxy_ns` and all
-        /// outgoing TCP connects traverse the AWG interface.
-        amnezia_wg,
-        // Future variants:
-        // socks5,
-        // http_connect,
+        /// VPN tunnel via Linux network namespace. The proxy process
+        /// runs inside `tg_proxy_ns` and all outgoing TCP connects
+        /// traverse the VPN interface (AmneziaWG, WireGuard, etc.).
+        tunnel,
+        /// SOCKS5 proxy — socket-level upstream wrapping.
+        socks5,
+        /// HTTP CONNECT proxy — socket-level upstream wrapping.
+        http_connect,
     };
 
     tag: Tag = .none,
@@ -30,7 +33,9 @@ pub const Tunnel = struct {
     pub fn name(self: *const Tunnel) []const u8 {
         return switch (self.tag) {
             .none => "direct",
-            .amnezia_wg => "AmneziaWG",
+            .tunnel => "VPN tunnel",
+            .socks5 => "SOCKS5",
+            .http_connect => "HTTP CONNECT",
         };
     }
 
@@ -38,7 +43,9 @@ pub const Tunnel = struct {
     pub fn requiresNetns(self: *const Tunnel) bool {
         return switch (self.tag) {
             .none => false,
-            .amnezia_wg => true,
+            .tunnel => true,
+            .socks5 => false,
+            .http_connect => false,
         };
     }
 
@@ -46,15 +53,30 @@ pub const Tunnel = struct {
     pub fn netnsName(self: *const Tunnel) ?[]const u8 {
         return switch (self.tag) {
             .none => null,
-            .amnezia_wg => "tg_proxy_ns",
+            .tunnel => "tg_proxy_ns",
+            .socks5 => null,
+            .http_connect => null,
         };
     }
 
     /// Parse a tunnel type string from configuration.
     /// Returns `.none` for unrecognized values.
     pub fn fromString(s: []const u8) Tag {
+        if (std.mem.eql(u8, s, "tunnel")) {
+            return .tunnel;
+        }
+        // Backward compat: specific VPN names map to generic .tunnel
         if (std.mem.eql(u8, s, "amnezia_wg") or std.mem.eql(u8, s, "amneziawg")) {
-            return .amnezia_wg;
+            return .tunnel;
+        }
+        if (std.mem.eql(u8, s, "wireguard") or std.mem.eql(u8, s, "wg")) {
+            return .tunnel;
+        }
+        if (std.mem.eql(u8, s, "socks5")) {
+            return .socks5;
+        }
+        if (std.mem.eql(u8, s, "http") or std.mem.eql(u8, s, "http_connect")) {
+            return .http_connect;
         }
         if (std.mem.eql(u8, s, "none") or std.mem.eql(u8, s, "direct")) {
             return .none;
@@ -69,29 +91,53 @@ test "tunnel - name returns human-readable string" {
     const direct = Tunnel{ .tag = .none };
     try std.testing.expectEqualStrings("direct", direct.name());
 
-    const awg = Tunnel{ .tag = .amnezia_wg };
-    try std.testing.expectEqualStrings("AmneziaWG", awg.name());
+    const vpn = Tunnel{ .tag = .tunnel };
+    try std.testing.expectEqualStrings("VPN tunnel", vpn.name());
+
+    const socks = Tunnel{ .tag = .socks5 };
+    try std.testing.expectEqualStrings("SOCKS5", socks.name());
+
+    const http = Tunnel{ .tag = .http_connect };
+    try std.testing.expectEqualStrings("HTTP CONNECT", http.name());
 }
 
 test "tunnel - requiresNetns" {
     const direct = Tunnel{ .tag = .none };
     try std.testing.expect(!direct.requiresNetns());
 
-    const awg = Tunnel{ .tag = .amnezia_wg };
-    try std.testing.expect(awg.requiresNetns());
+    const vpn = Tunnel{ .tag = .tunnel };
+    try std.testing.expect(vpn.requiresNetns());
+
+    const socks = Tunnel{ .tag = .socks5 };
+    try std.testing.expect(!socks.requiresNetns());
+
+    const http = Tunnel{ .tag = .http_connect };
+    try std.testing.expect(!http.requiresNetns());
 }
 
 test "tunnel - netnsName" {
     const direct = Tunnel{ .tag = .none };
     try std.testing.expect(direct.netnsName() == null);
 
-    const awg = Tunnel{ .tag = .amnezia_wg };
-    try std.testing.expectEqualStrings("tg_proxy_ns", awg.netnsName().?);
+    const vpn = Tunnel{ .tag = .tunnel };
+    try std.testing.expectEqualStrings("tg_proxy_ns", vpn.netnsName().?);
+
+    const socks = Tunnel{ .tag = .socks5 };
+    try std.testing.expect(socks.netnsName() == null);
+
+    const http = Tunnel{ .tag = .http_connect };
+    try std.testing.expect(http.netnsName() == null);
 }
 
 test "tunnel - fromString parsing" {
-    try std.testing.expectEqual(Tunnel.Tag.amnezia_wg, Tunnel.fromString("amnezia_wg"));
-    try std.testing.expectEqual(Tunnel.Tag.amnezia_wg, Tunnel.fromString("amneziawg"));
+    try std.testing.expectEqual(Tunnel.Tag.tunnel, Tunnel.fromString("tunnel"));
+    try std.testing.expectEqual(Tunnel.Tag.tunnel, Tunnel.fromString("amnezia_wg"));
+    try std.testing.expectEqual(Tunnel.Tag.tunnel, Tunnel.fromString("amneziawg"));
+    try std.testing.expectEqual(Tunnel.Tag.tunnel, Tunnel.fromString("wireguard"));
+    try std.testing.expectEqual(Tunnel.Tag.tunnel, Tunnel.fromString("wg"));
+    try std.testing.expectEqual(Tunnel.Tag.socks5, Tunnel.fromString("socks5"));
+    try std.testing.expectEqual(Tunnel.Tag.http_connect, Tunnel.fromString("http"));
+    try std.testing.expectEqual(Tunnel.Tag.http_connect, Tunnel.fromString("http_connect"));
     try std.testing.expectEqual(Tunnel.Tag.none, Tunnel.fromString("none"));
     try std.testing.expectEqual(Tunnel.Tag.none, Tunnel.fromString("direct"));
     try std.testing.expectEqual(Tunnel.Tag.none, Tunnel.fromString("unknown_value"));


### PR DESCRIPTION
## Summary

Add SOCKS5 and HTTP CONNECT proxy providers as new upstream transport types, and rename `amnezia_wg` → generic `tunnel` type.

Closes #139

## What changed

### New upstream transports
The proxy can now route egress DC connections through an external proxy server with authentication. Both protocols use **non-blocking handshake state machines** integrated into the epoll event loop (same pattern as MiddleProxy handshake).

- **SOCKS5** (RFC 1928/1929) — greeting → auth → CONNECT (3 round trips)
- **HTTP CONNECT** — single request → response (1 round trip)

### Generic tunnel type
Renamed `amnezia_wg` to `tunnel` as a generic VPN upstream type. The specific VPN implementation (AmneziaWG, WireGuard, etc.) is now an **mtbuddy concern** — runtime proxy treats all namespace-based VPNs identically.

**Backward compatible**: old config values `amnezia_wg` / `wireguard` automatically map to `tunnel`.

## Config format

```toml
[upstream]
type = "socks5"  # auto | direct | tunnel | socks5 | http

[upstream.socks5]
host = "127.0.0.1"
port = 1080
username = ""
password = ""
```

```toml
[upstream]
type = "http"

[upstream.http]
host = "127.0.0.1"
port = 8080
username = "admin"
password = "secret"
```

## Files changed

| File | Change |
|------|--------|
| `src/proxy/socks5.zig` | **NEW** — SOCKS5 protocol serialization/parsing (no I/O) |
| `src/proxy/http_connect.zig` | **NEW** — HTTP CONNECT request/response helpers (no I/O) |
| `src/proxy/upstream.zig` | Extended `Upstream` union with `Socks5` / `HttpConnect` variants |
| `src/proxy/proxy.zig` | 8 new `ConnectionPhase` values, handshake state machines, ProxyState init |
| `src/config.zig` | `UpstreamMode.tunnel`, `[upstream.socks5]` / `[upstream.http]` parsing |
| `src/tunnel.zig` | `Tunnel.Tag.tunnel` (generic VPN), backward compat `fromString` |
| `config.toml.example` | Documented new upstream options |
| `src/ctl/i18n.zig` | Menu: "Setup tunnel" / "Настроить туннель" |
| `src/ctl/main.zig` | Help: "Setup VPN tunnel (AmneziaWG, WireGuard, ...)" |
| `src/ctl/tunnel.zig` | Writes `type = "tunnel"`, detects both `awg0` and `wg0` |

## Design decisions

- **DC-only proxying** — mask connections stay direct
- **Auth-optional** — empty username = SOCKS5 no-auth / HTTP no Proxy-Authorization
- **Protocol modules are pure** — zero I/O, event loop drives the state machine
- **Graceful fallback** — missing host/port falls back to direct with warning

## Testing

- ✅ `zig build test` — all tests pass (config, socks5, http_connect, tunnel, proxy)
- ✅ `zig build -Dtarget=x86_64-linux -Doptimize=ReleaseFast` — cross-compile succeeds