### PR TITLE
fix(proxy): decouple tunnel routing from netns and add dashboard controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Cross-compile for Linux x86_64
         run: zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux
 
+      - name: Cross-compile for Linux x86_64_v3+aes
+        run: zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux -Dcpu=x86_64_v3+aes
+
       - name: Verify binary exists
         run: |
           ls -lh zig-out/bin/mtproto-proxy

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,7 +40,7 @@ jobs:
           - target: x86_64-linux
             artifact_name: mtproto-proxy-linux-x86_64_v3
             binary: mtproto-proxy
-            cpu: x86_64_v3
+            cpu: x86_64_v3+aes
           - target: aarch64-linux
             artifact_name: mtproto-proxy-linux-aarch64
             binary: mtproto-proxy
@@ -52,7 +52,7 @@ jobs:
           - target: x86_64-linux
             artifact_name: mtbuddy-linux-x86_64_v3
             binary: mtbuddy
-            cpu: x86_64_v3
+            cpu: x86_64_v3+aes
           - target: aarch64-linux
             artifact_name: mtbuddy-linux-aarch64
             binary: mtbuddy
@@ -68,6 +68,22 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+
+      - name: Verify AES-enabled x86_64_v3 profile
+        if: contains(matrix.cpu, 'x86_64_v3')
+        run: |
+          cat > /tmp/check_aes_target.zig <<'EOF'
+          const std = @import("std");
+
+          comptime {
+              if (!std.crypto.core.aes.has_hardware_support) {
+                  @compileError("x86_64_v3 release artifacts must be built with +aes");
+              }
+          }
+
+          pub fn main() void {}
+          EOF
+          zig build-exe -target=${{ matrix.target }} -mcpu=${{ matrix.cpu }} /tmp/check_aes_target.zig
 
       - name: Build release binary
         run: |

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ help: ## Show this help message
 
 # ── local dev ─────────────────────────────────────────────────────────────────
 
-build: ## Cross-compile proxy + mtbuddy for Linux x86_64
-	zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux -Dcpu=x86_64_v3
+build: ## Cross-compile proxy + mtbuddy for Linux x86_64 (AES-enabled)
+	zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux -Dcpu=x86_64_v3+aes
 
 fmt: ## Format all Zig source files
 	zig fmt src/

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ deploy: build ## Build and push proxy + mtbuddy to server
 		rm .env.tmp; \
 	fi
 	ssh root@$(SERVER) 'chown -R mtproto:mtproto /opt/mtproto-proxy/ && systemctl start mtproto-proxy'
+	ssh root@$(SERVER) 'if [ -f /etc/systemd/system/proxy-monitor.service ]; then mtbuddy setup dashboard --quiet; fi'
 
 # ── dashboard ─────────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ It also ships more evasion techniques than any of the above:
 | **TCPMSS=88** | Fragments ClientHello across 6 TCP packets, breaking DPI reassembly |
 | **nfqws TCP desync** | Sends fake packets + TTL-limited splits to confuse stateful DPI |
 | **Split-TLS** | 1-byte Application records to defeat passive signatures |
-| **VPN tunnel** | Routes through WireGuard/AmneziaWG in an isolated network namespace when DCs are blocked |
+| **VPN tunnel** | Routes through WireGuard/AmneziaWG using explicit socket policy routing (SO_MARK) when DCs are blocked |
 | **IPv6 hopping** | Auto-rotates IPv6 address from /64 on ban detection via Cloudflare API |
 | **Anti-replay** | Rejects replayed handshakes + detects ТСПУ Revisor active probes |
 | **Multi-user** | Independent per-user secrets |
@@ -155,7 +155,7 @@ sudo mtbuddy setup recovery
 sudo mtbuddy setup dashboard
 
 # VPN tunnel (for servers where Telegram DCs are blocked)
-sudo mtbuddy setup tunnel /path/to/awg0.conf --mode direct
+sudo mtbuddy setup tunnel /path/to/awg0.conf
 
 # IPv6 hopping
 sudo mtbuddy ipv6-hop --check
@@ -188,40 +188,38 @@ The proxy supports multiple ways to route outgoing connections to Telegram DC se
 
 | `[upstream].type` | How it works | When to use |
 |---|---|---|
-| `auto` (default) | Auto-detect: if running in a network namespace → tunnel, otherwise → direct | Most deployments |
+| `auto` (default) | Direct egress without tunnel policy marks | Most deployments |
 | `direct` | Connect to Telegram DCs directly from the host | DCs reachable from the server |
-| `tunnel` | Direct connect inside an isolated network namespace with a VPN tunnel | DCs blocked by the ISP |
+| `tunnel` | Direct connect with `SO_MARK=200` policy-routed via VPN interface | DCs blocked by the ISP |
 | `socks5` | Route through an external SOCKS5 proxy with optional auth | Existing proxy infrastructure |
 | `http` | Route through an HTTP CONNECT proxy with optional auth | Corporate proxy environments |
 
 ### VPN tunnel
 
-If your VPS is in a region where Telegram DCs are blocked at the network level, you can route proxy traffic through a VPN tunnel in an isolated network namespace. The host is completely unaffected — only the proxy process runs inside the namespace.
+If your VPS is in a region where Telegram DCs are blocked at the network level, you can route proxy traffic through a VPN tunnel with explicit socket policy routing. The proxy runs in the host namespace; only sockets marked by the proxy (`SO_MARK=200`) are routed through the tunnel table.
 
 Currently supported VPN types:
 - **AmneziaWG** — DPI-resistant WireGuard fork (recommended for Russia/Iran)
 - **WireGuard** — standard WireGuard (planned)
 
 ```
-Client → VPS:443 → [DNAT] → tg_proxy_ns:443
-                                  │
-                             mtproto-proxy
-                                  │
-                             awg0 (tunnel)
-                                  │
-                          Telegram DC servers
+Client → mtproto-proxy (host namespace)
+                     │
+                SO_MARK=200
+                     │
+        Linux policy routing table 200
+                     │
+                 awg0 (tunnel)
+                     │
+             Telegram DC servers
 ```
 
 ```bash
-sudo mtbuddy setup tunnel /path/to/awg0.conf --mode direct
+sudo mtbuddy setup tunnel /path/to/awg0.conf
 ```
 
-**Modes:**
-- `direct` — sets `use_middle_proxy=false` (default, lower latency)
-- `middleproxy` — sets `use_middle_proxy=true` (required for promo tags)
-- `preserve` — keeps current config unchanged
-
-After setup, `mtbuddy` validates connectivity to all 5 Telegram DCs through the tunnel and prints the link.
+`mtbuddy` keeps `[general].use_middle_proxy` unchanged and only configures transport (`[upstream].type = "tunnel"`).
+After setup, it validates policy routes (`mark 200`) to Telegram DC ranges and prints operational commands.
 
 ### SOCKS5 proxy
 
@@ -298,7 +296,7 @@ alice = true   # bypass MiddleProxy for this user
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `[upstream].type` | `auto` | Egress mode: `auto` (detect netns), `direct`, `tunnel` (VPN via netns), `socks5`, or `http` |
+| `[upstream].type` | `auto` | Egress mode: `auto` (direct), `direct`, `tunnel` (VPN via socket policy routing), `socks5`, or `http` |
 | `[upstream.socks5] host` | — | SOCKS5 proxy address |
 | `[upstream.socks5] port` | — | SOCKS5 proxy port |
 | `[upstream.socks5] username` | — | SOCKS5 username (empty = no auth) |

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ make soak      # 30s multithreaded stability test
 Cross-compile for Linux from macOS:
 
 ```bash
-zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux -Dcpu=x86_64_v3
+zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux -Dcpu=x86_64_v3+aes
 scp zig-out/bin/mtproto-proxy root@<SERVER>:/opt/mtproto-proxy/
 ```
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -68,18 +68,17 @@ port = 443
 
 [upstream]
 # Upstream egress mode for outgoing DC connections.
-# "auto"       — detect by runtime namespace (default)
-# "direct"     — direct TCP from current namespace
-# "tunnel"     — VPN tunnel via network namespace (AmneziaWG, WireGuard, ...)
+# "auto"       — direct TCP from host routing (default)
+# "direct"     — force direct TCP egress
+# "tunnel"     — direct TCP with socket policy routing (SO_MARK)
 # "socks5"     — route via SOCKS5 proxy
 # "http"       — route via HTTP CONNECT proxy
 # type = "auto"
 
 # ── VPN tunnel configuration ──
 # Activate with: type = "tunnel"
-# The interface name determines which VPN type is used:
-#   awg0 — AmneziaWG (default, via mtbuddy setup tunnel)
-#   wg0  — WireGuard
+# Interface metadata for mtbuddy tooling/status.
+# Runtime proxy routing uses SO_MARK=200 and Linux policy routing.
 # [upstream.tunnel]
 # interface = "awg0"
 

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -24,11 +24,31 @@ step() { printf "  ${Y}●${N} %s...\n" "$*" >&2; }
 [ "$(id -u)" = "0" ] || fail "Run as root: sudo bash bootstrap.sh"
 
 # ── detect arch ───────────────────────────────────────────────────
+cpu_supports_x86_64_v3() {
+  local flags
+  flags="$(grep -m1 '^flags' /proc/cpuinfo 2>/dev/null || true)"
+  [ -n "$flags" ] || return 1
+
+  local required=(avx2 bmi1 bmi2 fma f16c movbe sse4_1 sse4_2 ssse3 popcnt aes)
+  local feat
+  for feat in "${required[@]}"; do
+    if ! grep -Eq "(^|[[:space:]:])${feat}([[:space:]]|$)" <<< "$flags"; then
+      return 1
+    fi
+  done
+
+  if ! grep -Eq "(^|[[:space:]:])(lzcnt|abm)([[:space:]]|$)" <<< "$flags"; then
+    return 1
+  fi
+
+  return 0
+}
+
 ARCH="$(uname -m)"
 case "$ARCH" in
   x86_64)
-    # try v3 first (requires AVX2/BMI2); fall back at runtime if unsupported
-    if grep -q 'avx2' /proc/cpuinfo 2>/dev/null; then
+    # try v3+aes first; fall back at runtime if unsupported
+    if cpu_supports_x86_64_v3; then
       ARTIFACT="mtbuddy-linux-x86_64_v3"
       ARTIFACT_FALLBACK="mtbuddy-linux-x86_64"
     else

--- a/src/config.zig
+++ b/src/config.zig
@@ -6,14 +6,13 @@
 const std = @import("std");
 
 pub const UpstreamMode = enum {
-    /// Infer egress mode from runtime environment (default).
-    /// If proxy runs in non-init netns, treat as tunnel; otherwise direct.
+    /// Automatic egress mode (default).
+    /// Uses direct routing without socket policy marks.
     auto,
     /// Explicit direct egress.
     direct,
-    /// VPN tunnel egress (AmneziaWG, WireGuard, etc.) — requires running
-    /// inside tunnel network namespace. The specific VPN type is an
-    /// mtbuddy/installer concern; for runtime proxy they are identical.
+    /// VPN tunnel egress via socket policy routing (SO_MARK/fwmask).
+    /// The specific VPN type is an mtbuddy/installer concern.
     tunnel,
     /// SOCKS5 proxy upstream.
     socks5,

--- a/src/ctl/dashboard_assets/server.py
+++ b/src/ctl/dashboard_assets/server.py
@@ -53,7 +53,9 @@ def _load_dashboard_config() -> dict:
                     "port": int(mon.get("port", defaults["port"])),
                 }
             except Exception as exc:
-                print(f"[dashboard] warning: failed to parse {p}: {exc}", file=sys.stderr)
+                print(
+                    f"[dashboard] warning: failed to parse {p}: {exc}", file=sys.stderr
+                )
     return defaults
 
 
@@ -222,7 +224,7 @@ AWG_CACHE_TTL = 10  # seconds
 
 
 def _awg_status() -> dict:
-    """Check AmneziaWG tunnel status. Returns None if not installed."""
+    """Check AmneziaWG tunnel status (host namespace)."""
     now = time.time()
     if now - _awg_cache["ts"] < AWG_CACHE_TTL:
         return _awg_cache["data"]
@@ -233,67 +235,20 @@ def _awg_status() -> dict:
         _awg_cache.update(ts=now, data=None)
         return None
 
-    # Check if namespace exists
-    try:
-        ns_out = subprocess.check_output(
-            ["ip", "netns", "list"], text=True, timeout=2, stderr=subprocess.DEVNULL
-        )
-        if "tg_proxy_ns" not in ns_out:
-            result = {
-                "installed": True,
-                "active": False,
-                "reason": "namespace not found",
-            }
-            _awg_cache.update(ts=now, data=result)
-            return result
-    except Exception:
-        _awg_cache.update(ts=now, data=None)
-        return None
+    tunnel = _detect_tunnel_interface("awg0", "awg")
+    result = {
+        "installed": True,
+        "active": bool(tunnel.get("active")),
+        "endpoint": tunnel.get("endpoint"),
+        "handshake": tunnel.get("handshake"),
+        "rx": tunnel.get("rx"),
+        "tx": tunnel.get("tx"),
+    }
+    if not result["active"]:
+        result["reason"] = tunnel.get("reason") or "awg0 not active"
 
-    try:
-        out = subprocess.check_output(
-            ["ip", "netns", "exec", "tg_proxy_ns", "awg", "show"],
-            text=True,
-            timeout=3,
-            stderr=subprocess.DEVNULL,
-        )
-        result = {
-            "installed": True,
-            "active": False,
-            "endpoint": None,
-            "handshake": None,
-            "rx": None,
-            "tx": None,
-        }
-
-        m = re.search(r"endpoint:\s*(\S+)", out)
-        if m:
-            result["endpoint"] = m[1]
-
-        m = re.search(r"latest handshake:\s*(.+)", out)
-        if m:
-            result["handshake"] = m[1].strip()
-
-        m = re.search(
-            r"transfer:\s*([\d.]+\s*\S+)\s+received,\s*([\d.]+\s*\S+)\s+sent", out
-        )
-        if m:
-            result["rx"] = m[1]
-            result["tx"] = m[2]
-
-        if result.get("endpoint"):
-            result["active"] = True
-            if not result.get("handshake"):
-                result["handshake"] = "none (idle)"
-        else:
-            result["reason"] = "no endpoint configured"
-
-        _awg_cache.update(ts=now, data=result)
-        return result
-    except Exception:
-        result = {"installed": True, "active": False, "reason": "awg show failed"}
-        _awg_cache.update(ts=now, data=result)
-        return result
+    _awg_cache.update(ts=now, data=result)
+    return result
 
 
 _mask_cache = {"ts": 0, "data": None}
@@ -320,6 +275,17 @@ def _load_proxy_runtime_config() -> dict:
         "mask": True,
         "mask_port": 443,
         "tls_domain": "google.com",
+        "use_middle_proxy": False,
+        "upstream_type": "auto",
+        "upstream_tunnel_interface": "awg0",
+        "upstream_socks5_host": "",
+        "upstream_socks5_port": 0,
+        "upstream_socks5_username": "",
+        "upstream_socks5_password": "",
+        "upstream_http_host": "",
+        "upstream_http_port": 0,
+        "upstream_http_username": "",
+        "upstream_http_password": "",
         "users": {},
         "direct_users": set(),
     }
@@ -339,6 +305,17 @@ def _load_proxy_runtime_config() -> dict:
         "mask": defaults["mask"],
         "mask_port": defaults["mask_port"],
         "tls_domain": defaults["tls_domain"],
+        "use_middle_proxy": defaults["use_middle_proxy"],
+        "upstream_type": defaults["upstream_type"],
+        "upstream_tunnel_interface": defaults["upstream_tunnel_interface"],
+        "upstream_socks5_host": defaults["upstream_socks5_host"],
+        "upstream_socks5_port": defaults["upstream_socks5_port"],
+        "upstream_socks5_username": defaults["upstream_socks5_username"],
+        "upstream_socks5_password": defaults["upstream_socks5_password"],
+        "upstream_http_host": defaults["upstream_http_host"],
+        "upstream_http_port": defaults["upstream_http_port"],
+        "upstream_http_username": defaults["upstream_http_username"],
+        "upstream_http_password": defaults["upstream_http_password"],
         "users": {},
         "direct_users": set(),
     }
@@ -378,6 +355,44 @@ def _load_proxy_runtime_config() -> dict:
                         if digits:
                             result["port"] = int(digits)
 
+                elif section == "[general]":
+                    if key == "use_middle_proxy":
+                        result["use_middle_proxy"] = _parse_bool(
+                            value, defaults["use_middle_proxy"]
+                        )
+
+                elif section == "[upstream]":
+                    if key == "type" and value:
+                        result["upstream_type"] = value.lower()
+
+                elif section == "[upstream.tunnel]":
+                    if key == "interface" and value:
+                        result["upstream_tunnel_interface"] = value
+
+                elif section == "[upstream.socks5]":
+                    if key == "host":
+                        result["upstream_socks5_host"] = value
+                    elif key == "port":
+                        digits = "".join(ch for ch in value if ch.isdigit())
+                        if digits:
+                            result["upstream_socks5_port"] = int(digits)
+                    elif key == "username":
+                        result["upstream_socks5_username"] = value
+                    elif key == "password":
+                        result["upstream_socks5_password"] = value
+
+                elif section == "[upstream.http]":
+                    if key == "host":
+                        result["upstream_http_host"] = value
+                    elif key == "port":
+                        digits = "".join(ch for ch in value if ch.isdigit())
+                        if digits:
+                            result["upstream_http_port"] = int(digits)
+                    elif key == "username":
+                        result["upstream_http_username"] = value
+                    elif key == "password":
+                        result["upstream_http_password"] = value
+
                 elif section == "[censorship]":
                     if key == "mask":
                         result["mask"] = _parse_bool(value, defaults["mask"])
@@ -412,6 +427,300 @@ def _load_censorship_config() -> dict:
     }
 
 
+_routing_cache = {"ts": 0, "data": None}
+ROUTING_CACHE_TTL = 8  # seconds
+
+
+def _detect_tunnel_interface(interface: str, tool_hint: str | None = None) -> dict:
+    result = {
+        "interface": interface,
+        "tool": tool_hint or "-",
+        "link_up": False,
+        "active": False,
+        "endpoint": None,
+        "handshake": None,
+        "rx": None,
+        "tx": None,
+        "reason": None,
+    }
+
+    try:
+        link_check = subprocess.run(
+            ["ip", "link", "show", "dev", interface],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=2,
+        )
+        result["link_up"] = link_check.returncode == 0
+    except Exception:
+        result["link_up"] = False
+
+    tools: list[str] = []
+    if tool_hint:
+        tools.append(tool_hint)
+    for name in ("awg", "wg"):
+        if name not in tools:
+            tools.append(name)
+
+    for tool in tools:
+        if not shutil.which(tool):
+            continue
+
+        try:
+            out = subprocess.check_output(
+                [tool, "show", interface],
+                text=True,
+                timeout=3,
+                stderr=subprocess.DEVNULL,
+            )
+        except Exception:
+            continue
+
+        result["tool"] = tool
+
+        m = re.search(r"endpoint:\s*(\S+)", out)
+        if m:
+            result["endpoint"] = m[1]
+
+        m = re.search(r"latest handshake:\s*(.+)", out)
+        if m:
+            result["handshake"] = m[1].strip()
+
+        m = re.search(
+            r"transfer:\s*([\d.]+\s*\S+)\s+received,\s*([\d.]+\s*\S+)\s+sent",
+            out,
+        )
+        if m:
+            result["rx"] = m[1]
+            result["tx"] = m[2]
+
+        if result.get("endpoint"):
+            result["active"] = True
+            if not result.get("handshake"):
+                result["handshake"] = "none (idle)"
+        elif result["link_up"]:
+            result["reason"] = "interface up, no endpoint"
+        else:
+            result["reason"] = "interface down"
+
+        return result
+
+    if result["link_up"]:
+        result["reason"] = "interface up, tool output unavailable"
+    else:
+        result["reason"] = "interface down"
+    return result
+
+
+def _policy_routing_status() -> dict:
+    result = {
+        "mark": 200,
+        "table": 200,
+        "rule_ok": False,
+        "route_ok": False,
+        "route_dev": None,
+    }
+
+    try:
+        rules = subprocess.check_output(
+            ["ip", "-4", "rule", "show"],
+            text=True,
+            timeout=2,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception:
+        rules = ""
+
+    for line in rules.splitlines():
+        low = line.lower()
+        has_mark = ("fwmark 200" in low) or ("fwmark 0xc8" in low)
+        has_table = ("lookup 200" in low) or ("table 200" in low)
+        if has_mark and has_table:
+            result["rule_ok"] = True
+            break
+
+    try:
+        routes = subprocess.check_output(
+            ["ip", "-4", "route", "show", "table", "200"],
+            text=True,
+            timeout=2,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception:
+        routes = ""
+
+    m = re.search(r"default\s+dev\s+(\S+)", routes)
+    if m:
+        result["route_ok"] = True
+        result["route_dev"] = m[1]
+
+    return result
+
+
+def _list_system_interfaces() -> list[str]:
+    names: list[str] = []
+    try:
+        out = subprocess.check_output(
+            ["ip", "-o", "link", "show"],
+            text=True,
+            timeout=2,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception:
+        return names
+
+    for line in out.splitlines():
+        m = re.match(r"\d+:\s*([^:]+):", line)
+        if not m:
+            continue
+
+        name = m.group(1).strip()
+        if "@" in name:
+            name = name.split("@", 1)[0]
+
+        if not name or name == "lo":
+            continue
+        if name not in names:
+            names.append(name)
+
+    return names
+
+
+def _upstream_target_from_cfg(cfg: dict, policy: dict) -> str:
+    upstream_type = str(cfg.get("upstream_type", "auto") or "auto").lower().strip()
+
+    if upstream_type == "socks5":
+        host = str(cfg.get("upstream_socks5_host", "") or "").strip()
+        port = int(cfg.get("upstream_socks5_port", 0) or 0)
+        return f"{host}:{port}" if host and port > 0 else "proxy host/port not set"
+
+    if upstream_type == "http":
+        host = str(cfg.get("upstream_http_host", "") or "").strip()
+        port = int(cfg.get("upstream_http_port", 0) or 0)
+        return f"{host}:{port}" if host and port > 0 else "proxy host/port not set"
+
+    if upstream_type == "tunnel":
+        iface = str(cfg.get("upstream_tunnel_interface", "awg0") or "awg0").strip()
+        route_dev = policy.get("route_dev")
+        if route_dev:
+            return f"mark 200 -> table 200 -> dev {route_dev}"
+        return f"mark 200 -> table 200 (iface {iface})"
+
+    if upstream_type == "direct":
+        return "direct host routing"
+
+    return "auto (direct unless tunnel mode is selected)"
+
+
+def _routing_status() -> dict:
+    now = time.time()
+    if now - _routing_cache["ts"] < ROUTING_CACHE_TTL:
+        return _routing_cache["data"]
+
+    cfg = _load_proxy_runtime_config()
+    upstream_type = str(cfg.get("upstream_type", "auto") or "auto").lower().strip()
+    selected_iface = str(cfg.get("upstream_tunnel_interface", "awg0") or "awg0").strip()
+
+    if not selected_iface:
+        selected_iface = "awg0"
+
+    system_ifaces = _list_system_interfaces()
+    available_tunnel_ifaces: list[str] = []
+    for iface in system_ifaces:
+        low = iface.lower()
+        if not (low.startswith(("awg", "wg", "tun", "tap")) or iface == selected_iface):
+            continue
+        if iface and iface not in available_tunnel_ifaces:
+            available_tunnel_ifaces.append(iface)
+
+    interfaces = list(available_tunnel_ifaces)
+    for iface in ("awg0", "wg0"):
+        if iface not in interfaces:
+            interfaces.append(iface)
+
+    tunnels = []
+    for iface in interfaces:
+        hint = None
+        if iface.startswith("awg"):
+            hint = "awg"
+        elif iface.startswith("wg"):
+            hint = "wg"
+
+        tunnel = _detect_tunnel_interface(iface, hint)
+        if (
+            iface == selected_iface
+            or tunnel.get("link_up")
+            or tunnel.get("active")
+            or tunnel.get("endpoint")
+        ):
+            tunnels.append(tunnel)
+
+    policy = _policy_routing_status()
+    target = _upstream_target_from_cfg(cfg, policy)
+
+    primary_tunnel = None
+    route_dev = policy.get("route_dev")
+    if route_dev:
+        primary_tunnel = next((t for t in tunnels if t["interface"] == route_dev), None)
+    if primary_tunnel is None:
+        primary_tunnel = next(
+            (t for t in tunnels if t["interface"] == selected_iface), None
+        )
+    if primary_tunnel is None and tunnels:
+        primary_tunnel = tunnels[0]
+
+    active_tunnels = sum(1 for t in tunnels if t.get("active"))
+
+    if upstream_type == "tunnel":
+        healthy = bool(
+            policy.get("rule_ok")
+            and policy.get("route_ok")
+            and primary_tunnel
+            and primary_tunnel.get("link_up")
+        )
+    elif upstream_type == "socks5":
+        healthy = bool(
+            str(cfg.get("upstream_socks5_host", "") or "").strip()
+            and int(cfg.get("upstream_socks5_port", 0) or 0) > 0
+        )
+    elif upstream_type == "http":
+        healthy = bool(
+            str(cfg.get("upstream_http_host", "") or "").strip()
+            and int(cfg.get("upstream_http_port", 0) or 0) > 0
+        )
+    else:
+        healthy = True
+
+    result = {
+        "middle_proxy_enabled": bool(cfg.get("use_middle_proxy", False)),
+        "upstream_type": upstream_type,
+        "upstream_target": target,
+        "selected_tunnel_interface": selected_iface,
+        "available_tunnel_interfaces": available_tunnel_ifaces,
+        "policy": policy,
+        "tunnels": tunnels,
+        "active_tunnels": active_tunnels,
+        "detected_tunnels": len(tunnels),
+        "primary_tunnel": primary_tunnel,
+        "upstream_socks5": {
+            "host": str(cfg.get("upstream_socks5_host", "") or ""),
+            "port": int(cfg.get("upstream_socks5_port", 0) or 0),
+            "username": str(cfg.get("upstream_socks5_username", "") or ""),
+            "password": str(cfg.get("upstream_socks5_password", "") or ""),
+        },
+        "upstream_http": {
+            "host": str(cfg.get("upstream_http_host", "") or ""),
+            "port": int(cfg.get("upstream_http_port", 0) or 0),
+            "username": str(cfg.get("upstream_http_username", "") or ""),
+            "password": str(cfg.get("upstream_http_password", "") or ""),
+        },
+        "healthy": healthy,
+    }
+
+    _routing_cache.update(ts=now, data=result)
+    return result
+
+
 def _unit_active(unit: str) -> bool:
     return (
         subprocess.run(
@@ -434,25 +743,12 @@ def _unit_enabled(unit: str) -> bool:
     )
 
 
-def _probe_mask_endpoint(target: str, port: int, use_netns: bool) -> bool:
+def _probe_mask_endpoint(target: str, port: int) -> bool:
     if not shutil.which("curl"):
         return False
 
     url = f"https://{target}:{port}/"
-    if use_netns:
-        cmd = [
-            "ip",
-            "netns",
-            "exec",
-            "tg_proxy_ns",
-            "curl",
-            "-sk",
-            "--max-time",
-            "2",
-            url,
-        ]
-    else:
-        cmd = ["curl", "-sk", "--max-time", "2", url]
+    cmd = ["curl", "-sk", "--max-time", "2", url]
 
     try:
         return (
@@ -478,30 +774,7 @@ def _masking_status() -> dict:
     mask_port = int(censorship["mask_port"])
     tls_domain = censorship["tls_domain"]
 
-    netns_present = False
-    host_veth_present = False
-    try:
-        ns_out = subprocess.check_output(
-            ["ip", "netns", "list"], text=True, timeout=2, stderr=subprocess.DEVNULL
-        )
-        netns_present = "tg_proxy_ns" in ns_out
-    except Exception:
-        netns_present = False
-
-    try:
-        addr_out = subprocess.check_output(
-            ["ip", "-4", "addr", "show"],
-            text=True,
-            timeout=2,
-            stderr=subprocess.DEVNULL,
-        )
-        host_veth_present = "10.200.200.1/" in addr_out
-    except Exception:
-        host_veth_present = False
-
-    using_netns_target = (
-        mask_enabled and mask_port != 443 and netns_present and host_veth_present
-    )
+    using_netns_target = False
 
     if not mask_enabled:
         mode = "disabled"
@@ -511,11 +784,11 @@ def _masking_status() -> dict:
         target_host = tls_domain
     else:
         mode = "local"
-        target_host = "10.200.200.1" if using_netns_target else "127.0.0.1"
+        target_host = "127.0.0.1"
 
     endpoint_ok = None
     if mode == "local":
-        endpoint_ok = _probe_mask_endpoint(target_host, mask_port, using_netns_target)
+        endpoint_ok = _probe_mask_endpoint(target_host, mask_port)
 
     nginx_active = _unit_active("nginx.service")
     nginx_enabled = _unit_enabled("nginx.service")
@@ -558,11 +831,17 @@ def _detect_public_ip() -> str:
     if now - _public_ip_cache["ts"] < PUBLIC_IP_TTL and _public_ip_cache["ip"]:
         return _public_ip_cache["ip"]
 
-    for url in ("https://ifconfig.me/ip", "https://api.ipify.org", "https://icanhazip.com"):
+    for url in (
+        "https://ifconfig.me/ip",
+        "https://api.ipify.org",
+        "https://icanhazip.com",
+    ):
         try:
             out = subprocess.check_output(
                 ["curl", "-s", "--max-time", "3", url],
-                text=True, timeout=5, stderr=subprocess.DEVNULL,
+                text=True,
+                timeout=5,
+                stderr=subprocess.DEVNULL,
             ).strip()
             if out and re.match(r"^[\d.]+$", out):
                 _public_ip_cache.update(ts=now, ip=out)
@@ -631,6 +910,7 @@ def _users_status() -> dict:
 
 # ── Config file manipulation helpers ──
 
+
 def _find_config_path() -> Path | None:
     for p in _proxy_config_candidates():
         if p.is_file():
@@ -652,6 +932,171 @@ def _restart_proxy():
     # Invalidate caches
     _users_cache["ts"] = 0
     _mask_cache["ts"] = 0
+    _routing_cache["ts"] = 0
+
+
+def _set_toml_key(
+    lines: list[str],
+    section_header: str,
+    key: str,
+    value_literal: str,
+) -> list[str]:
+    section_l = section_header.strip().lower()
+    key_l = key.strip().lower()
+
+    in_section = False
+    section_found = False
+    insert_idx = None
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            if in_section and insert_idx is None:
+                insert_idx = i
+            in_section = stripped.lower() == section_l
+            if in_section:
+                section_found = True
+                insert_idx = i + 1
+            continue
+
+        if not in_section:
+            continue
+
+        if not stripped or stripped.startswith("#") or stripped.startswith(";"):
+            continue
+
+        if "=" not in stripped:
+            continue
+
+        key_part = stripped.split("=", 1)[0].strip().lower()
+        if key_part != key_l:
+            continue
+
+        indent_len = len(line) - len(line.lstrip(" \t"))
+        indent = line[:indent_len]
+        lines[i] = f"{indent}{key} = {value_literal}\n"
+        return lines
+
+    if section_found:
+        if insert_idx is None:
+            insert_idx = len(lines)
+        lines.insert(insert_idx, f"{key} = {value_literal}\n")
+        return lines
+
+    if lines and not lines[-1].endswith("\n"):
+        lines[-1] += "\n"
+    if lines and lines[-1].strip():
+        lines.append("\n")
+
+    lines.append(f"{section_header}\n")
+    lines.append(f"{key} = {value_literal}\n")
+    return lines
+
+
+def _toml_string_literal(value: str) -> str:
+    return json.dumps(str(value), ensure_ascii=False)
+
+
+def _set_middle_proxy_enabled(enabled: bool) -> bool:
+    cfg_path = _find_config_path()
+    if cfg_path is None:
+        return False
+
+    lines = cfg_path.read_text(encoding="utf-8", errors="replace").splitlines(
+        keepends=True
+    )
+    value = "true" if enabled else "false"
+    lines = _set_toml_key(lines, "[general]", "use_middle_proxy", value)
+    cfg_path.write_text("".join(lines), encoding="utf-8")
+    return True
+
+
+def _set_upstream_type(upstream_type: str) -> bool:
+    cfg_path = _find_config_path()
+    if cfg_path is None:
+        return False
+
+    allowed = {"auto", "direct", "tunnel", "socks5", "http"}
+    if upstream_type not in allowed:
+        return False
+
+    lines = cfg_path.read_text(encoding="utf-8", errors="replace").splitlines(
+        keepends=True
+    )
+    lines = _set_toml_key(
+        lines, "[upstream]", "type", _toml_string_literal(upstream_type)
+    )
+
+    if upstream_type == "tunnel":
+        lines = _set_toml_key(lines, "[upstream.tunnel]", "interface", '"awg0"')
+
+    cfg_path.write_text("".join(lines), encoding="utf-8")
+    return True
+
+
+def _set_upstream_tunnel_interface(interface: str) -> bool:
+    cfg_path = _find_config_path()
+    if cfg_path is None:
+        return False
+
+    iface = str(interface or "").strip()
+    if not iface:
+        return False
+
+    if not re.fullmatch(r"[A-Za-z0-9_.:-]+", iface):
+        return False
+
+    lines = cfg_path.read_text(encoding="utf-8", errors="replace").splitlines(
+        keepends=True
+    )
+    lines = _set_toml_key(
+        lines, "[upstream.tunnel]", "interface", _toml_string_literal(iface)
+    )
+    cfg_path.write_text("".join(lines), encoding="utf-8")
+    return True
+
+
+def _set_upstream_proxy_target(
+    proxy_type: str,
+    host: str,
+    port: int,
+    username: str,
+    password: str,
+) -> bool:
+    cfg_path = _find_config_path()
+    if cfg_path is None:
+        return False
+
+    ptype = str(proxy_type or "").strip().lower()
+    if ptype not in {"socks5", "http"}:
+        return False
+
+    host_value = str(host or "").strip()
+    if not host_value or any(ch.isspace() for ch in host_value):
+        return False
+
+    if not isinstance(port, int) or port < 1 or port > 65535:
+        return False
+
+    user_value = str(username or "")
+    pass_value = str(password or "")
+
+    if "\n" in user_value or "\r" in user_value:
+        return False
+    if "\n" in pass_value or "\r" in pass_value:
+        return False
+
+    section = "[upstream.socks5]" if ptype == "socks5" else "[upstream.http]"
+
+    lines = cfg_path.read_text(encoding="utf-8", errors="replace").splitlines(
+        keepends=True
+    )
+    lines = _set_toml_key(lines, section, "host", _toml_string_literal(host_value))
+    lines = _set_toml_key(lines, section, "port", str(port))
+    lines = _set_toml_key(lines, section, "username", _toml_string_literal(user_value))
+    lines = _set_toml_key(lines, section, "password", _toml_string_literal(pass_value))
+    cfg_path.write_text("".join(lines), encoding="utf-8")
+    return True
 
 
 def _add_user_to_config(name: str, secret: str) -> bool:
@@ -660,7 +1105,9 @@ def _add_user_to_config(name: str, secret: str) -> bool:
     if cfg_path is None:
         return False
 
-    lines = cfg_path.read_text(encoding="utf-8", errors="replace").splitlines(keepends=True)
+    lines = cfg_path.read_text(encoding="utf-8", errors="replace").splitlines(
+        keepends=True
+    )
 
     # Find [access.users] section
     insert_idx = None
@@ -700,7 +1147,9 @@ def _remove_user_from_config(name: str) -> bool:
     if cfg_path is None:
         return False
 
-    lines = cfg_path.read_text(encoding="utf-8", errors="replace").splitlines(keepends=True)
+    lines = cfg_path.read_text(encoding="utf-8", errors="replace").splitlines(
+        keepends=True
+    )
     new_lines = []
     in_users = False
     in_direct = False
@@ -743,7 +1192,9 @@ def _set_user_direct(name: str, direct: bool) -> bool:
     if cfg_path is None:
         return False
 
-    lines = cfg_path.read_text(encoding="utf-8", errors="replace").splitlines(keepends=True)
+    lines = cfg_path.read_text(encoding="utf-8", errors="replace").splitlines(
+        keepends=True
+    )
     new_lines = []
     found_direct_section = False
     in_direct = False
@@ -838,13 +1289,180 @@ def api_stats():
             "proxy": _proxy_stats(),
             "proxy_info": _proxy_info(),
             "awg": _awg_status(),
+            "routing": _routing_status(),
             "masking": _masking_status(),
             "users": _users_status(),
         }
     )
 
 
+# ── Routing Management API ──
+
+
+@app.post("/api/routing/middle")
+async def api_routing_middle(request: Request):
+    """Set [general].use_middle_proxy. Body: { enabled: bool }"""
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"ok": False, "error": "invalid json"}, status_code=400)
+
+    raw_enabled = body.get("enabled", None)
+    if not isinstance(raw_enabled, bool):
+        return JSONResponse(
+            {"ok": False, "error": "enabled must be boolean"}, status_code=400
+        )
+
+    if not _set_middle_proxy_enabled(raw_enabled):
+        return JSONResponse(
+            {"ok": False, "error": "failed to update config"}, status_code=500
+        )
+
+    _restart_proxy()
+    return JSONResponse({"ok": True, "enabled": raw_enabled, "restarted": True})
+
+
+@app.post("/api/routing/upstream")
+async def api_routing_upstream(request: Request):
+    """Set [upstream].type. Body: { type: auto|direct|tunnel|socks5|http }"""
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"ok": False, "error": "invalid json"}, status_code=400)
+
+    upstream_type = str(body.get("type", "")).strip().lower()
+    if upstream_type not in {"auto", "direct", "tunnel", "socks5", "http"}:
+        return JSONResponse(
+            {
+                "ok": False,
+                "error": "type must be one of: auto, direct, tunnel, socks5, http",
+            },
+            status_code=400,
+        )
+
+    if not _set_upstream_type(upstream_type):
+        return JSONResponse(
+            {"ok": False, "error": "failed to update config"}, status_code=500
+        )
+
+    _restart_proxy()
+
+    cfg = _load_proxy_runtime_config()
+    warning = None
+    if upstream_type == "socks5":
+        host = str(cfg.get("upstream_socks5_host", "") or "").strip()
+        port = int(cfg.get("upstream_socks5_port", 0) or 0)
+        if not host or port <= 0:
+            warning = (
+                "socks5 selected but [upstream.socks5] host/port are not configured"
+            )
+    elif upstream_type == "http":
+        host = str(cfg.get("upstream_http_host", "") or "").strip()
+        port = int(cfg.get("upstream_http_port", 0) or 0)
+        if not host or port <= 0:
+            warning = "http selected but [upstream.http] host/port are not configured"
+
+    return JSONResponse(
+        {
+            "ok": True,
+            "type": upstream_type,
+            "restarted": True,
+            "warning": warning,
+        }
+    )
+
+
+@app.post("/api/routing/tunnel-interface")
+async def api_routing_tunnel_interface(request: Request):
+    """Set [upstream.tunnel].interface. Body: { interface: str }"""
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"ok": False, "error": "invalid json"}, status_code=400)
+
+    iface = str(body.get("interface", "")).strip()
+    if not iface:
+        return JSONResponse(
+            {"ok": False, "error": "interface is required"}, status_code=400
+        )
+
+    available = _list_system_interfaces()
+    if available and iface not in available:
+        return JSONResponse(
+            {"ok": False, "error": "interface is not present on host"},
+            status_code=400,
+        )
+
+    if not _set_upstream_tunnel_interface(iface):
+        return JSONResponse(
+            {"ok": False, "error": "failed to update config"}, status_code=500
+        )
+
+    _restart_proxy()
+    return JSONResponse({"ok": True, "interface": iface, "restarted": True})
+
+
+@app.post("/api/routing/proxy-target")
+async def api_routing_proxy_target(request: Request):
+    """Set [upstream.socks5]/[upstream.http] target + auth.
+    Body: { type: socks5|http, host: str, port: int, username?: str, password?: str }
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"ok": False, "error": "invalid json"}, status_code=400)
+
+    proxy_type = str(body.get("type", "")).strip().lower()
+    if proxy_type not in {"socks5", "http"}:
+        return JSONResponse(
+            {"ok": False, "error": "type must be socks5 or http"},
+            status_code=400,
+        )
+
+    host = str(body.get("host", "")).strip()
+    if not host:
+        return JSONResponse({"ok": False, "error": "host is required"}, status_code=400)
+
+    try:
+        port = int(body.get("port", 0))
+    except Exception:
+        port = 0
+
+    if port < 1 or port > 65535:
+        return JSONResponse(
+            {"ok": False, "error": "port must be 1..65535"}, status_code=400
+        )
+
+    username = str(body.get("username", "") or "")
+    password = str(body.get("password", "") or "")
+
+    if "\n" in username or "\r" in username or "\n" in password or "\r" in password:
+        return JSONResponse(
+            {"ok": False, "error": "username/password must not contain newlines"},
+            status_code=400,
+        )
+
+    if not _set_upstream_proxy_target(proxy_type, host, port, username, password):
+        return JSONResponse(
+            {"ok": False, "error": "failed to update config"}, status_code=500
+        )
+
+    _restart_proxy()
+    return JSONResponse(
+        {
+            "ok": True,
+            "type": proxy_type,
+            "host": host,
+            "port": port,
+            "username": username,
+            "password": password,
+            "restarted": True,
+        }
+    )
+
+
 # ── User Management API ──
+
 
 @app.post("/api/users/add")
 async def api_user_add(request: Request):
@@ -856,21 +1474,30 @@ async def api_user_add(request: Request):
 
     name = str(body.get("name", "")).strip()
     if not name or not re.match(r"^[a-zA-Z0-9_-]+$", name):
-        return JSONResponse({"ok": False, "error": "invalid name (use a-z, 0-9, _, -)"}, status_code=400)
+        return JSONResponse(
+            {"ok": False, "error": "invalid name (use a-z, 0-9, _, -)"}, status_code=400
+        )
 
     # Check if user already exists
     cfg = _load_proxy_runtime_config()
     if name in cfg.get("users", {}):
-        return JSONResponse({"ok": False, "error": "user already exists"}, status_code=409)
+        return JSONResponse(
+            {"ok": False, "error": "user already exists"}, status_code=409
+        )
 
     secret = str(body.get("secret", "")).strip().lower()
     if not secret:
         secret = secrets.token_hex(16)
     if not USER_SECRET_RE.fullmatch(secret):
-        return JSONResponse({"ok": False, "error": "invalid secret (must be 32 hex chars)"}, status_code=400)
+        return JSONResponse(
+            {"ok": False, "error": "invalid secret (must be 32 hex chars)"},
+            status_code=400,
+        )
 
     if not _add_user_to_config(name, secret):
-        return JSONResponse({"ok": False, "error": "failed to write config"}, status_code=500)
+        return JSONResponse(
+            {"ok": False, "error": "failed to write config"}, status_code=500
+        )
 
     _users_cache["ts"] = 0
     _restart_proxy()
@@ -917,7 +1544,9 @@ async def api_user_direct(request: Request):
         return JSONResponse({"ok": False, "error": "user not found"}, status_code=404)
 
     if not _set_user_direct(name, direct):
-        return JSONResponse({"ok": False, "error": "failed to write config"}, status_code=500)
+        return JSONResponse(
+            {"ok": False, "error": "failed to write config"}, status_code=500
+        )
 
     _users_cache["ts"] = 0
     _restart_proxy()

--- a/src/ctl/dashboard_assets/static/app.js
+++ b/src/ctl/dashboard_assets/static/app.js
@@ -12,6 +12,7 @@ let pollingPaused = false;
 let lastSuccessAt = 0;
 let hasPollError = false;
 let lastData = null; // store last API response for tooltips
+let currentRouting = null;
 
 const tt = $('chartTooltip');
 function showTooltip(e, canvas, padLeft, dataArr, formatCb) {
@@ -533,6 +534,316 @@ function renderUsers(users) {
   });
 }
 
+function setRoutingAction(msg, cls) {
+  const note = $('routingActionNote');
+  if (!note) return;
+  note.textContent = msg || '';
+  note.className = 'routing-action-note' + (cls ? (' ' + cls) : '');
+}
+
+function setupRoutingControls() {
+  const middleBtn = $('routingMiddleBtn');
+  const upstreamSelect = $('routingUpstreamSelect');
+  const upstreamApply = $('routingUpstreamApply');
+  const tunnelIfaceSelect = $('routingTunnelIfaceSelect');
+  const tunnelIfaceApply = $('routingTunnelIfaceApply');
+  const proxyHostInput = $('routingProxyHost');
+  const proxyPortInput = $('routingProxyPort');
+  const proxyUserInput = $('routingProxyUser');
+  const proxyPassInput = $('routingProxyPass');
+  const proxyApply = $('routingProxyApply');
+  if (!middleBtn || !upstreamSelect || !upstreamApply) return;
+
+  middleBtn.addEventListener('click', async () => {
+    if (!currentRouting) return;
+
+    const target = !Boolean(currentRouting.middle_proxy_enabled);
+    middleBtn.disabled = true;
+    setRoutingAction('Updating middle proxy mode…');
+
+    try {
+      const data = await apiCall('/api/routing/middle', { enabled: target });
+      setRoutingAction('MiddleProxy ' + (data.enabled ? 'enabled' : 'disabled') + '. Proxy restarted.', 'ok');
+      showToast('MiddleProxy ' + (data.enabled ? 'enabled' : 'disabled') + '. Proxy restarted.', 'success');
+      await runPoll();
+    } catch (e) {
+      setRoutingAction('Failed: ' + e.message, 'error');
+      showToast('Failed: ' + e.message, 'error');
+    } finally {
+      middleBtn.disabled = false;
+    }
+  });
+
+  upstreamApply.addEventListener('click', async () => {
+    if (!currentRouting) return;
+
+    const nextType = String(upstreamSelect.value || '').toLowerCase();
+    if (!nextType) return;
+
+    if (nextType === String(currentRouting.upstream_type || '').toLowerCase()) {
+      setRoutingAction('Upstream is already set to ' + nextType + '.');
+      return;
+    }
+
+    upstreamApply.disabled = true;
+    upstreamSelect.disabled = true;
+    setRoutingAction('Switching upstream to ' + nextType + '…');
+
+    try {
+      const data = await apiCall('/api/routing/upstream', { type: nextType });
+      const warn = data.warning ? (' Warning: ' + data.warning) : '';
+      setRoutingAction('Upstream switched to ' + data.type + '. Proxy restarted.' + warn, data.warning ? '' : 'ok');
+      showToast('Upstream switched to ' + data.type + '. Proxy restarted.', 'success');
+      await runPoll();
+    } catch (e) {
+      setRoutingAction('Failed: ' + e.message, 'error');
+      showToast('Failed: ' + e.message, 'error');
+    } finally {
+      upstreamApply.disabled = false;
+      upstreamSelect.disabled = false;
+    }
+  });
+
+  if (tunnelIfaceApply && tunnelIfaceSelect) {
+    tunnelIfaceApply.addEventListener('click', async () => {
+      if (!currentRouting) return;
+
+      const iface = String(tunnelIfaceSelect.value || '').trim();
+      if (!iface) {
+        setRoutingAction('Select tunnel interface first.', 'error');
+        return;
+      }
+
+      if (iface === String(currentRouting.selected_tunnel_interface || '')) {
+        setRoutingAction('Tunnel interface is already set to ' + iface + '.');
+        return;
+      }
+
+      tunnelIfaceApply.disabled = true;
+      tunnelIfaceSelect.disabled = true;
+      setRoutingAction('Switching tunnel interface to ' + iface + '…');
+
+      try {
+        const data = await apiCall('/api/routing/tunnel-interface', { interface: iface });
+        setRoutingAction('Tunnel interface set to ' + data.interface + '. Proxy restarted.', 'ok');
+        showToast('Tunnel interface set to ' + data.interface + '. Proxy restarted.', 'success');
+        await runPoll();
+      } catch (e) {
+        setRoutingAction('Failed: ' + e.message, 'error');
+        showToast('Failed: ' + e.message, 'error');
+      } finally {
+        tunnelIfaceApply.disabled = false;
+        tunnelIfaceSelect.disabled = false;
+      }
+    });
+  }
+
+  if (proxyApply && proxyHostInput && proxyPortInput && proxyUserInput && proxyPassInput) {
+    proxyApply.addEventListener('click', async () => {
+      if (!currentRouting) return;
+
+      const proxyType = String(currentRouting.upstream_type || '').toLowerCase();
+      if (proxyType !== 'socks5' && proxyType !== 'http') {
+        setRoutingAction('Proxy target can be set only for socks5/http upstream.', 'error');
+        return;
+      }
+
+      const host = String(proxyHostInput.value || '').trim();
+      const port = Number(proxyPortInput.value || 0);
+      const username = String(proxyUserInput.value || '');
+      const password = String(proxyPassInput.value || '');
+      if (!host) {
+        setRoutingAction('Proxy host is required.', 'error');
+        return;
+      }
+      if (!Number.isInteger(port) || port < 1 || port > 65535) {
+        setRoutingAction('Proxy port must be 1..65535.', 'error');
+        return;
+      }
+      if (username.includes('\n') || username.includes('\r') || password.includes('\n') || password.includes('\r')) {
+        setRoutingAction('Username/password must not contain newlines.', 'error');
+        return;
+      }
+
+      proxyApply.disabled = true;
+      proxyHostInput.disabled = true;
+      proxyPortInput.disabled = true;
+      proxyUserInput.disabled = true;
+      proxyPassInput.disabled = true;
+      setRoutingAction('Updating ' + proxyType + ' target…');
+
+      try {
+        const data = await apiCall('/api/routing/proxy-target', { type: proxyType, host, port, username, password });
+        setRoutingAction('Updated ' + data.type + ' target to ' + data.host + ':' + data.port + '. Proxy restarted.', 'ok');
+        showToast('Updated ' + data.type + ' target. Proxy restarted.', 'success');
+        await runPoll();
+      } catch (e) {
+        setRoutingAction('Failed: ' + e.message, 'error');
+        showToast('Failed: ' + e.message, 'error');
+      } finally {
+        proxyApply.disabled = false;
+        proxyHostInput.disabled = false;
+        proxyPortInput.disabled = false;
+        proxyUserInput.disabled = false;
+        proxyPassInput.disabled = false;
+      }
+    });
+  }
+}
+
+function renderRouting(routing) {
+  const card = $('routingCard');
+  if (!card) return;
+
+  if (!routing) {
+    currentRouting = null;
+    card.style.display = 'none';
+    return;
+  }
+
+  currentRouting = routing;
+  card.style.display = '';
+
+  const middleBtn = $('routingMiddleBtn');
+  if (middleBtn) {
+    const enabled = Boolean(routing.middle_proxy_enabled);
+    middleBtn.textContent = enabled ? 'MiddleProxy: ON' : 'MiddleProxy: OFF';
+    middleBtn.classList.toggle('active', enabled);
+  }
+
+  const upstreamSelect = $('routingUpstreamSelect');
+  const upstreamType = String(routing.upstream_type || 'auto').toLowerCase();
+  if (upstreamSelect) {
+    upstreamSelect.value = upstreamType;
+  }
+
+  const tunnelCtl = $('routingTunnelCtl');
+  const tunnelSelect = $('routingTunnelIfaceSelect');
+  const tunnelApplyBtn = $('routingTunnelIfaceApply');
+  if (tunnelCtl && tunnelSelect) {
+    if (upstreamType === 'tunnel') {
+      tunnelCtl.style.display = '';
+      const choices = Array.isArray(routing.available_tunnel_interfaces)
+        ? routing.available_tunnel_interfaces
+        : [];
+      const selectedIface = String(routing.selected_tunnel_interface || '');
+      const seen = new Set();
+      const options = [];
+
+      if (selectedIface && choices.includes(selectedIface)) {
+        seen.add(selectedIface);
+        options.push(selectedIface);
+      }
+
+      choices.forEach((iface) => {
+        const v = String(iface || '').trim();
+        if (!v || seen.has(v)) return;
+        seen.add(v);
+        options.push(v);
+      });
+
+      if (!options.length) {
+        tunnelSelect.innerHTML = '<option value="">no interfaces</option>';
+        tunnelSelect.value = '';
+        tunnelSelect.disabled = true;
+        if (tunnelApplyBtn) tunnelApplyBtn.disabled = true;
+      } else {
+        tunnelSelect.disabled = false;
+        if (tunnelApplyBtn) tunnelApplyBtn.disabled = false;
+        tunnelSelect.innerHTML = options
+          .map((iface) => '<option value="' + esc(iface) + '">' + esc(iface) + '</option>')
+          .join('');
+        if (selectedIface) {
+          tunnelSelect.value = selectedIface;
+        }
+      }
+    } else {
+      tunnelCtl.style.display = 'none';
+    }
+  }
+
+  const proxyCtl = $('routingProxyCtl');
+  const proxyHost = $('routingProxyHost');
+  const proxyPort = $('routingProxyPort');
+  const proxyUser = $('routingProxyUser');
+  const proxyPass = $('routingProxyPass');
+  const proxyHostLabel = $('routingProxyHostLabel');
+  if (proxyCtl && proxyHost && proxyPort && proxyUser && proxyPass && proxyHostLabel) {
+    if (upstreamType === 'socks5' || upstreamType === 'http') {
+      proxyCtl.style.display = '';
+      const cfg = upstreamType === 'socks5'
+        ? (routing.upstream_socks5 || {})
+        : (routing.upstream_http || {});
+      const host = String(cfg.host || '');
+      const port = Number(cfg.port || 0);
+      const username = String(cfg.username || '');
+      const password = String(cfg.password || '');
+
+      proxyHostLabel.textContent = upstreamType + ' host';
+      proxyHost.placeholder = upstreamType === 'socks5' ? '127.0.0.1' : '127.0.0.1';
+      proxyPort.placeholder = upstreamType === 'socks5' ? '1080' : '8080';
+      proxyHost.value = host;
+      proxyPort.value = port > 0 ? String(port) : '';
+      proxyUser.value = username;
+      proxyPass.value = password;
+    } else {
+      proxyCtl.style.display = 'none';
+    }
+  }
+
+  const badge = $('routingBadge');
+  if (routing.healthy) {
+    badge.className = 'badge';
+    $('routingStatus').textContent = 'Healthy';
+  } else {
+    badge.className = 'badge off';
+    $('routingStatus').textContent = 'Degraded';
+  }
+
+  $('routingMiddle').textContent = routing.middle_proxy_enabled ? 'enabled' : 'disabled';
+  $('routingUpstream').textContent = upstreamType || '—';
+  $('routingTarget').textContent = routing.upstream_target || '—';
+
+  const policy = routing.policy || {};
+  const policyTxt = (policy.rule_ok ? 'rule ok' : 'rule missing') +
+    ' · ' +
+    (policy.route_ok ? ('route ok' + (policy.route_dev ? (' (' + policy.route_dev + ')') : '')) : 'route missing');
+  $('routingPolicy').textContent = policyTxt;
+
+  const list = $('routingTunnelsList');
+  const tunnels = Array.isArray(routing.tunnels) ? routing.tunnels : [];
+  if (!tunnels.length) {
+    list.innerHTML = '<div class="routing-empty">No tunnel interfaces detected.</div>';
+    return;
+  }
+
+  const selected = routing.selected_tunnel_interface || '';
+
+  list.innerHTML = tunnels.map((t) => {
+    const iface = String(t.interface || '—');
+    const isSelected = upstreamType === 'tunnel' && iface === selected;
+    const state = t.active ? 'active' : (t.link_up ? 'up' : 'down');
+    const stateClass = t.active ? 'on' : (t.link_up ? 'mid' : 'off');
+
+    const meta = [];
+    if (t.tool && t.tool !== '-') meta.push(String(t.tool));
+    if (t.endpoint) meta.push(String(t.endpoint));
+    if (t.handshake) meta.push('hs: ' + String(t.handshake));
+    if (!meta.length) meta.push(String(t.reason || '—'));
+
+    const xfer = '↓ ' + String(t.rx || '—') + ' · ↑ ' + String(t.tx || '—');
+
+    return '<div class="routing-row">' +
+      '<div class="routing-iface">' + esc(iface) +
+      (isSelected ? '<span class="routing-tag">selected</span>' : '') +
+      '</div>' +
+      '<div class="routing-state ' + stateClass + '">' + esc(state) + '</div>' +
+      '<div class="routing-meta" title="' + esc(meta.join(' · ')) + '">' + esc(meta.join(' · ')) + '</div>' +
+      '<div class="routing-xfer">' + esc(xfer) + '</div>' +
+      '</div>';
+  }).join('');
+}
+
 // ── Polling ──
 async function poll() {
   const r = await fetch('/api/stats', { cache: 'no-store' });
@@ -579,26 +890,7 @@ async function poll() {
   $('pxDrops').style.color = drp > 0 ? 'var(--amber)' : 'var(--text-muted)';
   $('pxDropLbl').textContent = 'rate +' + drp + ' · cap +' + (p.cap_drops || 0) + ' · hs_t +' + (p.hs_timeout || 0);
 
-  // AmneziaWG tunnel
-  const awg = d.awg;
-  const tc = $('tunnelCard');
-  if (!awg) {
-    tc.style.display = 'none';
-  } else {
-    tc.style.display = '';
-    const badge = $('awgBadge');
-    if (awg.active) {
-      badge.className = 'badge';
-      $('awgStatus').textContent = 'Active';
-    } else {
-      badge.className = 'badge off';
-      $('awgStatus').textContent = awg.reason || 'Down';
-    }
-    $('awgEndpoint').textContent = awg.endpoint || '—';
-    $('awgHandshake').textContent = awg.handshake || '—';
-    $('awgRx').textContent = awg.rx || '—';
-    $('awgTx').textContent = awg.tx || '—';
-  }
+  renderRouting(d.routing || null);
 
   // Masking health
   const masking = d.masking;
@@ -751,6 +1043,7 @@ updatePollControls();
 updateFreshness();
 setupAddUserForm();
 setupDeleteModal();
+setupRoutingControls();
 runPoll();
 restartPollingLoop();
 setInterval(updateFreshness, 1000);

--- a/src/ctl/dashboard_assets/static/index.html
+++ b/src/ctl/dashboard_assets/static/index.html
@@ -147,31 +147,63 @@
     <div class="users-list" id="usersList"></div>
   </div>
 
-  <!-- AmneziaWG Tunnel -->
-  <div class="tunnel-card" id="tunnelCard" style="display:none">
+  <!-- Routing & upstream -->
+  <div class="tunnel-card" id="routingCard" style="display:none">
     <div class="tunnel-header">
-      <div class="tunnel-icon">🛡</div>
-      <div class="tunnel-title">AmneziaWG Tunnel</div>
-      <div class="badge" id="awgBadge"><div class="pulse-dot"></div><span id="awgStatus">—</span></div>
+      <div class="tunnel-icon">🧭</div>
+      <div class="tunnel-title">Routing &amp; Upstream</div>
+      <div class="badge" id="routingBadge"><div class="pulse-dot"></div><span id="routingStatus">—</span></div>
+    </div>
+    <div class="routing-controls">
+      <button class="ui-btn" id="routingMiddleBtn" type="button">MiddleProxy: —</button>
+      <div class="routing-upstream-ctl">
+        <label for="routingUpstreamSelect">Upstream</label>
+        <select id="routingUpstreamSelect" class="ui-select">
+          <option value="auto">auto</option>
+          <option value="direct">direct</option>
+          <option value="tunnel">tunnel</option>
+          <option value="socks5">socks5</option>
+          <option value="http">http</option>
+        </select>
+        <button class="ui-btn active" id="routingUpstreamApply" type="button">Apply</button>
+      </div>
+      <div class="routing-extra-ctl" id="routingTunnelCtl" style="display:none">
+        <label for="routingTunnelIfaceSelect">Tunnel iface</label>
+        <select id="routingTunnelIfaceSelect" class="ui-select"></select>
+        <button class="ui-btn" id="routingTunnelIfaceApply" type="button">Set iface</button>
+      </div>
+      <div class="routing-extra-ctl" id="routingProxyCtl" style="display:none">
+        <label id="routingProxyHostLabel" for="routingProxyHost">Proxy host</label>
+        <input id="routingProxyHost" class="ui-input routing-host" type="text" placeholder="127.0.0.1" autocomplete="off">
+        <label for="routingProxyPort">Port</label>
+        <input id="routingProxyPort" class="ui-input routing-port" type="number" min="1" max="65535" placeholder="1080" autocomplete="off">
+        <label for="routingProxyUser">User</label>
+        <input id="routingProxyUser" class="ui-input routing-user" type="text" placeholder="optional" autocomplete="off">
+        <label for="routingProxyPass">Pass</label>
+        <input id="routingProxyPass" class="ui-input routing-pass" type="password" placeholder="optional" autocomplete="off">
+        <button class="ui-btn" id="routingProxyApply" type="button">Set target</button>
+      </div>
+      <div class="routing-action-note" id="routingActionNote"></div>
     </div>
     <div class="tunnel-details">
       <div class="tunnel-stat">
-        <span class="tunnel-lbl">Endpoint</span>
-        <span class="tunnel-val" id="awgEndpoint">—</span>
+        <span class="tunnel-lbl">MiddleProxy</span>
+        <span class="tunnel-val" id="routingMiddle">—</span>
       </div>
       <div class="tunnel-stat">
-        <span class="tunnel-lbl">Handshake</span>
-        <span class="tunnel-val" id="awgHandshake">—</span>
+        <span class="tunnel-lbl">Upstream</span>
+        <span class="tunnel-val" id="routingUpstream">—</span>
       </div>
       <div class="tunnel-stat">
-        <span class="tunnel-lbl">↓ Received</span>
-        <span class="tunnel-val" id="awgRx">—</span>
+        <span class="tunnel-lbl">Target</span>
+        <span class="tunnel-val" id="routingTarget">—</span>
       </div>
       <div class="tunnel-stat">
-        <span class="tunnel-lbl">↑ Sent</span>
-        <span class="tunnel-val" id="awgTx">—</span>
+        <span class="tunnel-lbl">Policy</span>
+        <span class="tunnel-val" id="routingPolicy">—</span>
       </div>
     </div>
+    <div class="routing-list" id="routingTunnelsList"></div>
   </div>
 
   <!-- Masking health -->

--- a/src/ctl/dashboard_assets/static/index.html
+++ b/src/ctl/dashboard_assets/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>⚡ MTProto Proxy — Dashboard</title>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/style.css?v=20260411">
 </head>
 <body>
 <div class="app">
@@ -273,6 +273,6 @@
   </div>
 </div>
 
-<script src="/app.js"></script>
+<script src="/app.js?v=20260411"></script>
 </body>
 </html>

--- a/src/ctl/dashboard_assets/static/style.css
+++ b/src/ctl/dashboard_assets/static/style.css
@@ -626,6 +626,146 @@ body::after {
   font-variant-numeric: tabular-nums;
   color: var(--text);
 }
+
+.routing-list {
+  border-top: 1px solid rgba(247,164,29,0.05);
+}
+
+.routing-controls {
+  padding: 10px 24px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  border-bottom: 1px solid rgba(247,164,29,0.05);
+}
+
+.routing-upstream-ctl {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.routing-extra-ctl {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.routing-upstream-ctl label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-dim);
+}
+
+.routing-extra-ctl label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-dim);
+}
+
+.routing-host {
+  width: 160px;
+}
+
+.routing-port {
+  width: 92px;
+}
+
+.routing-user,
+.routing-pass {
+  width: 140px;
+}
+
+.routing-action-note {
+  font-size: 11px;
+  color: var(--text-muted);
+  min-height: 16px;
+  margin-left: auto;
+}
+
+.routing-action-note.error {
+  color: var(--red);
+}
+
+.routing-action-note.ok {
+  color: var(--green);
+}
+
+.routing-row {
+  display: grid;
+  grid-template-columns: minmax(80px, 110px) 80px 1fr auto;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 24px;
+  border-bottom: 1px solid rgba(247,164,29,0.04);
+}
+
+.routing-row:last-child {
+  border-bottom: 0;
+}
+
+.routing-iface {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  color: var(--text);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.routing-tag {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--zig);
+  border: 1px solid rgba(247,164,29,0.25);
+  border-radius: 999px;
+  padding: 2px 6px;
+}
+
+.routing-state {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.9px;
+  font-weight: 700;
+}
+
+.routing-state.on {
+  color: var(--green);
+}
+
+.routing-state.mid {
+  color: var(--amber);
+}
+
+.routing-state.off {
+  color: var(--red);
+}
+
+.routing-meta {
+  font-size: 11px;
+  color: var(--text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.routing-xfer {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: 'JetBrains Mono', monospace;
+  white-space: nowrap;
+}
+
+.routing-empty {
+  padding: 12px 24px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
 .app.stale .tunnel-card { opacity: 0.62; }
 
 /* ── Tooltips ── */
@@ -764,4 +904,32 @@ body::after {
   .user-delete { opacity: 1; }
   .form-row { flex-direction: column; }
   .tunnel-details { grid-template-columns: repeat(2, 1fr); }
+  .routing-row {
+    grid-template-columns: 1fr;
+    gap: 6px;
+    padding: 10px 14px;
+  }
+  .routing-meta { white-space: normal; }
+  .routing-controls {
+    padding: 10px 14px;
+    align-items: stretch;
+  }
+  .routing-upstream-ctl {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+  .routing-extra-ctl {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+  .routing-host,
+  .routing-port,
+  .routing-user,
+  .routing-pass {
+    width: 100%;
+  }
+  .routing-action-note {
+    margin-left: 0;
+    width: 100%;
+  }
 }

--- a/src/ctl/main.zig
+++ b/src/ctl/main.zig
@@ -320,8 +320,8 @@ fn printHelp() void {
     printCmd(&ui, "setup masking", "Setup local Nginx DPI masking");
     printCmd(&ui, "setup nfqws", "Setup nfqws TCP desync (Zapret)");
     printCmd(&ui, "setup tunnel <conf>", "Setup VPN tunnel (AmneziaWG, WireGuard, ...)");
-    printCmd(&ui, "setup dashboard",     "Install web monitoring dashboard");
-    printCmd(&ui, "setup recovery",      "Install DPI auto-recovery");
+    printCmd(&ui, "setup dashboard", "Install web monitoring dashboard");
+    printCmd(&ui, "setup recovery", "Install DPI auto-recovery");
     printCmd(&ui, "ipv6-hop", "IPv6 address rotation");
     printCmd(&ui, "update-dns <ip>", "Update Cloudflare DNS A record");
     printCmd(&ui, "status", "Show service status");
@@ -354,7 +354,6 @@ fn printHelp() void {
     ui.print("  {s}Setup options:{s}\n\n", .{ Color.accent, Color.reset });
     printOpt(&ui, "--domain <domain>", "TLS masking domain");
     printOpt(&ui, "--ttl <N>", "nfqws fake packet TTL (default: 6)");
-    printOpt(&ui, "--mode <mode>", "Tunnel mode: direct|preserve|middleproxy");
     printOpt(&ui, "--remove", "Remove nfqws installation");
     ui.writeRaw("\n");
 

--- a/src/ctl/recovery.zig
+++ b/src/ctl/recovery.zig
@@ -66,8 +66,6 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: RecoveryOpts) !void
         \\set -euo pipefail
         \\
         \\CONFIG_FILE="/opt/mtproto-proxy/config.toml"
-        \\NS_NAME="tg_proxy_ns"
-        \\NS_HOST_IP="10.200.200.1"
         \\LOCAL_HOST_IP="127.0.0.1"
         \\
         \\read_censorship_value() {
@@ -90,12 +88,6 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: RecoveryOpts) !void
         \\
         \\probe_endpoint() {
         \\    local host="$1" port="$2"
-        \\    if ip netns list 2>/dev/null | grep -qw "$NS_NAME"; then
-        \\        if ip -4 addr show 2>/dev/null | grep -q "${NS_HOST_IP}/"; then
-        \\            ip netns exec "$NS_NAME" curl -sk --max-time 3 "https://${host}:${port}/" >/dev/null 2>&1
-        \\            return $?
-        \\        fi
-        \\    fi
         \\    curl -sk --max-time 3 "https://${host}:${port}/" >/dev/null 2>&1
         \\}
         \\
@@ -111,11 +103,6 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: RecoveryOpts) !void
         \\[[ "$mask_port" == "443" ]] && exit 0
         \\
         \\target_host="$LOCAL_HOST_IP"
-        \\if ip netns list 2>/dev/null | grep -qw "$NS_NAME"; then
-        \\    if ip -4 addr show 2>/dev/null | grep -q "${NS_HOST_IP}/"; then
-        \\        target_host="$NS_HOST_IP"
-        \\    fi
-        \\fi
         \\
         \\if ! systemctl is-active --quiet nginx; then
         \\    logger -t mtproto-mask-health "nginx inactive, restarting"

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -1,9 +1,7 @@
 //! Setup tunnel command for mtbuddy.
 //!
-//! Ports setup_tunnel.sh (400 lines bash) — creates an isolated network
-//! namespace with a VPN tunnel so Telegram DCs become reachable
-//! while the host keeps normal connectivity.
-//! Currently supports AmneziaWG; other VPN types will be added.
+//! Configures AmneziaWG on the host and enables socket policy routing
+//! for mtproto-proxy (`SO_MARK=200 -> table 200`) without network namespaces.
 
 const std = @import("std");
 const tui_mod = @import("tui.zig");
@@ -13,42 +11,37 @@ const toml = @import("toml.zig");
 const Tunnel = @import("tunnel").Tunnel;
 
 const Tui = tui_mod.Tui;
-const Color = tui_mod.Color;
-const SummaryLine = tui_mod.SummaryLine;
 
 const INSTALL_DIR = "/opt/mtproto-proxy";
-const NS_NAME = "tg_proxy_ns";
 const AWG_CONF_DIR = "/etc/amnezia/amneziawg";
-const NETNS_SCRIPT = "/usr/local/bin/setup_netns.sh";
+const TUNNEL_SCRIPT = "/usr/local/bin/setup_tunnel.sh";
 const SERVICE_FILE = "/etc/systemd/system/mtproto-proxy.service";
 const AWG_CONFIG_PATH = AWG_CONF_DIR ++ "/awg0.conf";
+const TUNNEL_MARK: u32 = 200;
+const TUNNEL_TABLE: u32 = 200;
 
 pub const TunnelOpts = struct {
     awg_conf: []const u8 = "",
-    mode: TunnelMode = .direct,
-};
-
-pub const TunnelMode = enum {
-    direct,
-    preserve,
-    middleproxy,
 };
 
 /// Run in CLI mode.
 pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.ArgIterator) !void {
     var opts = TunnelOpts{};
+
     while (args.next()) |arg| {
         if (std.mem.eql(u8, arg, "--mode") or std.mem.eql(u8, arg, "-m")) {
-            if (args.next()) |val| {
-                if (std.mem.eql(u8, val, "middleproxy")) opts.mode = .middleproxy else if (std.mem.eql(u8, val, "preserve")) opts.mode = .preserve else opts.mode = .direct;
-            }
-        } else if (arg.len > 0 and arg[0] != '-') {
+            _ = args.next();
+            ui.warn("--mode is deprecated and ignored; use [general].use_middle_proxy in config.toml");
+            continue;
+        }
+
+        if (arg.len > 0 and arg[0] != '-') {
             opts.awg_conf = arg;
         }
     }
 
     if (opts.awg_conf.len == 0) {
-        ui.fail("Usage: mtbuddy setup tunnel <vpn-config.conf> [--mode direct|preserve|middleproxy]");
+        ui.fail("Usage: mtbuddy setup tunnel <vpn-config.conf>");
         return;
     }
 
@@ -67,24 +60,12 @@ pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
         &conf_buf,
     );
 
-    const mode_choice = try ui.menu("Tunnel mode", &.{
-        "direct — Direct DC connections (recommended)",
-        "preserve — Keep existing use_middle_proxy setting",
-        "middleproxy — Route through Telegram middle proxy",
-    });
-    const mode: TunnelMode = switch (mode_choice) {
-        0 => .direct,
-        1 => .preserve,
-        2 => .middleproxy,
-        else => .direct,
-    };
-
     if (!try ui.confirm(i18n.get(ui.lang, .confirm_proceed), true)) {
         ui.info(i18n.get(ui.lang, .aborting));
         return;
     }
 
-    try execute(ui, allocator, .{ .awg_conf = conf_path, .mode = mode });
+    try execute(ui, allocator, .{ .awg_conf = conf_path });
 }
 
 fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
@@ -100,21 +81,6 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
     if (!sys.fileExists(INSTALL_DIR ++ "/mtproto-proxy")) {
         ui.fail("mtproto-proxy not installed. Run install first.");
         return;
-    }
-
-    // Read port from config (dupe to ensure lifetime)
-    var port: []const u8 = "443";
-    var port_buf: [8]u8 = undefined;
-    {
-        var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch null;
-        if (doc) |*d| {
-            defer d.deinit();
-            if (d.get("server", "port")) |p| {
-                const len = @min(p.len, port_buf.len);
-                @memcpy(port_buf[0..len], p[0..len]);
-                port = port_buf[0..len];
-            }
-        }
     }
 
     // ── Install AmneziaWG ──
@@ -138,122 +104,86 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
 
     const dns_removed = stripAwgDnsLines(allocator, AWG_CONFIG_PATH) catch false;
     if (dns_removed) {
-        ui.warn("Removed DNS from awg0.conf (netns resolver is managed separately)");
+        ui.warn("Removed DNS from awg0.conf (host resolver will be used)");
+    }
+
+    const table_off_added = ensureAwgTableOff(allocator, AWG_CONFIG_PATH) catch false;
+    if (table_off_added) {
+        ui.warn("Added Table = off to [Interface] in awg0.conf");
     }
 
     ui.ok("Config installed to " ++ AWG_CONFIG_PATH);
 
-    // ── Create netns setup script ──
-    ui.step("Creating network namespace setup script...");
+    // ── Create tunnel policy script ──
+    ui.step("Creating tunnel policy routing script...");
 
-    var netns_script_buf: [4096]u8 = undefined;
-    const netns_script = std.fmt.bufPrint(&netns_script_buf,
+    var tunnel_script_buf: [2048]u8 = undefined;
+    const tunnel_script = std.fmt.bufPrint(&tunnel_script_buf,
         \\#!/bin/bash
-        \\set -e
-        \\NS_NAME="tg_proxy_ns"
-        \\MAIN_IF=$(ip -o -4 route show default | awk '{{print $5; exit}}')
-        \\if [[ -z "$MAIN_IF" ]]; then
-        \\    echo "Failed to detect main network interface" >&2
-        \\    exit 1
-        \\fi
+        \\set -euo pipefail
+        \\CONF="{[awg_conf]s}"
+        \\IFACE="awg0"
+        \\MARK={[mark]d}
+        \\TABLE={[table]d}
         \\
-        \\ip netns del $NS_NAME 2>/dev/null || true
-        \\ip link del veth_main 2>/dev/null || true
+        \\awg-quick down "$CONF" 2>/dev/null || true
+        \\awg-quick up "$CONF"
         \\
-        \\sysctl -w net.ipv4.ip_forward=1 > /dev/null
+        \\ip -4 route flush table "$TABLE" 2>/dev/null || true
+        \\ip -4 route add default dev "$IFACE" table "$TABLE"
+        \\ip -4 rule del fwmark "$MARK" table "$TABLE" 2>/dev/null || true
+        \\ip -4 rule add fwmark "$MARK" table "$TABLE" priority 1200
         \\
-        \\ip netns add $NS_NAME
-        \\
-        \\mkdir -p /etc/netns/$NS_NAME
-        \\echo -e "nameserver 8.8.8.8\nnameserver 1.1.1.1" > /etc/netns/$NS_NAME/resolv.conf
-        \\
-        \\ip link add veth_main type veth peer name veth_ns
-        \\ip link set veth_ns netns $NS_NAME
-        \\
-        \\ip addr add 10.200.200.1/24 dev veth_main
-        \\ip link set veth_main up
-        \\
-        \\ip netns exec $NS_NAME ip addr add 10.200.200.2/24 dev veth_ns
-        \\ip netns exec $NS_NAME ip link set veth_ns up
-        \\ip netns exec $NS_NAME ip link set lo up
-        \\ip netns exec $NS_NAME ip route add default via 10.200.200.1
-        \\
-        \\ip netns exec $NS_NAME awg-quick up {[awg_conf]s}
-        \\
-        \\ip netns exec $NS_NAME ip rule add from 10.200.200.2 table 100 priority 100
-        \\ip netns exec $NS_NAME ip route add default via 10.200.200.1 table 100
-        \\
-        \\iptables -t nat -D PREROUTING -i $MAIN_IF -p tcp --dport {[port]s} -j DNAT --to-destination 10.200.200.2:{[port]s} 2>/dev/null || true
-        \\iptables -t nat -A PREROUTING -i $MAIN_IF -p tcp --dport {[port]s} -j DNAT --to-destination 10.200.200.2:{[port]s}
-        \\iptables -t nat -D POSTROUTING -s 10.200.200.0/24 -o $MAIN_IF -j MASQUERADE 2>/dev/null || true
-        \\iptables -t nat -A POSTROUTING -s 10.200.200.0/24 -o $MAIN_IF -j MASQUERADE
-        \\
-        \\iptables -D FORWARD -i $MAIN_IF -o veth_main -j ACCEPT 2>/dev/null || true
-        \\iptables -A FORWARD -i $MAIN_IF -o veth_main -j ACCEPT
-        \\iptables -D FORWARD -i veth_main -o $MAIN_IF -j ACCEPT 2>/dev/null || true
-        \\iptables -A FORWARD -i veth_main -o $MAIN_IF -j ACCEPT
-        \\
-        \\echo "Network namespace $NS_NAME ready, awg0 tunnel active inside namespace"
-    , .{ .port = port, .awg_conf = AWG_CONFIG_PATH }) catch "";
+        \\echo "Tunnel routing ready: fwmark=$MARK -> table $TABLE via $IFACE"
+    , .{ .awg_conf = AWG_CONFIG_PATH, .mark = TUNNEL_MARK, .table = TUNNEL_TABLE }) catch "";
 
-    if (netns_script.len > 0) {
-        // Write using native Zig I/O (no shell injection risk)
-        sys.writeFileMode(NETNS_SCRIPT, netns_script, 0o755) catch {
-            ui.fail("Failed to write netns script");
-            return;
-        };
+    if (tunnel_script.len == 0) {
+        ui.fail("Failed to render tunnel setup script");
+        return;
     }
-    ui.ok("Created " ++ NETNS_SCRIPT);
+
+    sys.writeFileMode(TUNNEL_SCRIPT, tunnel_script, 0o755) catch {
+        ui.fail("Failed to write tunnel setup script");
+        return;
+    };
+    ui.ok("Created " ++ TUNNEL_SCRIPT);
 
     // ── Patch systemd service ──
-    ui.step("Patching systemd service for tunnel mode...");
+    ui.step("Patching systemd service for tunnel policy routing...");
     const svc_content =
         \\[Unit]
-        \\Description=MTProto Proxy (Zig) via AmneziaWG Tunnel
+        \\Description=MTProto Proxy (Zig) via Tunnel Policy Routing
         \\Documentation=https://github.com/sleep3r/mtproto.zig
         \\After=network-online.target
         \\Wants=network-online.target
         \\
         \\[Service]
         \\Type=simple
-        \\ExecStartPre=/usr/local/bin/setup_netns.sh
-        \\ExecStart=/sbin/ip netns exec tg_proxy_ns /opt/mtproto-proxy/mtproto-proxy /opt/mtproto-proxy/config.toml
+        \\ExecStartPre=/usr/local/bin/setup_tunnel.sh
+        \\ExecStart=/opt/mtproto-proxy/mtproto-proxy /opt/mtproto-proxy/config.toml
         \\Restart=on-failure
         \\RestartSec=5
-        \\AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_ADMIN CAP_SYS_ADMIN
+        \\AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_ADMIN
         \\LimitNOFILE=131582
         \\TasksMax=65535
         \\
         \\[Install]
         \\WantedBy=multi-user.target
     ;
-    {
-        // Write using native Zig I/O
-        sys.writeFile(SERVICE_FILE, svc_content) catch {
-            ui.fail("Failed to write systemd service");
-            return;
-        };
-    }
-    _ = sys.execForward(&.{ "systemctl", "daemon-reload" }) catch {};
-    ui.ok("Systemd service patched for tunnel mode");
 
-    // ── Apply tunnel mode ──
-    const mode_label: []const u8 = switch (opts.mode) {
-        .direct => blk: {
-            setUseMiddleProxy(allocator, "false");
-            break :blk "Direct mode (no middle proxy)";
-        },
-        .preserve => "Preserved existing setting",
-        .middleproxy => blk: {
-            setUseMiddleProxy(allocator, "true");
-            break :blk "MiddleProxy mode enabled";
-        },
+    sys.writeFile(SERVICE_FILE, svc_content) catch {
+        ui.fail("Failed to write systemd service");
+        return;
     };
-    ui.ok(mode_label);
 
+    _ = sys.execForward(&.{ "systemctl", "daemon-reload" }) catch {};
+    ui.ok("Systemd service patched for tunnel policy routing");
+
+    // ── Configure proxy egress mode ──
     setUpstreamType(allocator, "tunnel");
     ui.stepOk("Set [upstream].type", "tunnel");
     ui.stepOk("Set [upstream.tunnel].interface", "awg0");
+    ui.stepOk("Preserved [general].use_middle_proxy", "unchanged");
 
     // ── Inject public IP (preserve existing custom value) ──
     var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch null;
@@ -285,6 +215,8 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
 
     // ── Preserve promotion tag from env.sh ──
     if (sys.readEnvFile(allocator, INSTALL_DIR ++ "/env.sh", "TAG")) |tag| {
+        defer allocator.free(tag);
+
         var doc2 = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch null;
         if (doc2) |*d| {
             defer d.deinit();
@@ -298,32 +230,6 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
         ui.stepOk("Preserved promotion tag", tag);
     }
 
-    // ── Patch Nginx masking for tunnel IP ──
-    if (sys.fileExists("/etc/nginx/sites-available/mtproto-masking")) {
-        const patch_cmd = "grep -q '10\\.200\\.200\\.1' /etc/nginx/sites-available/mtproto-masking 2>/dev/null || " ++
-            "sed -i '/listen.*127\\.0\\.0\\.1.*ssl/a\\    listen 10.200.200.1:8443 ssl;' /etc/nginx/sites-available/mtproto-masking && " ++
-            "nginx -t >/dev/null 2>&1 && systemctl reload nginx";
-        _ = sys.exec(allocator, &.{ "bash", "-c", patch_cmd }) catch {};
-        ui.ok("Nginx masking patched for tunnel netns");
-    }
-
-    // ── Firewall rules for namespace ──
-    if (sys.commandExists("ufw")) {
-        var ufw_buf: [128]u8 = undefined;
-        const ufw_rule = std.fmt.bufPrint(&ufw_buf, "ufw allow from 10.200.200.0/24 to 10.200.200.1 port {s}", .{port}) catch "";
-        if (ufw_rule.len > 0) {
-            _ = sys.exec(allocator, &.{ "bash", "-c", ufw_rule }) catch {};
-            ui.ok("Firewall: allowed namespace traffic to host veth");
-        }
-
-        var route_buf: [128]u8 = undefined;
-        const route_rule = std.fmt.bufPrint(&route_buf, "ufw route allow proto tcp to 10.200.200.2 port {s}", .{port}) catch "";
-        if (route_rule.len > 0) {
-            _ = sys.exec(allocator, &.{ "bash", "-c", route_rule }) catch {};
-            ui.ok("Firewall: allowed external client traffic forwarding");
-        }
-    }
-
     // ── Apply masking monitor (if recovery is already installed) ──
     if (sys.isServiceActive("mtproto-mask-health.timer") or sys.fileExists("/usr/local/bin/mtproto-mask-health.sh")) {
         const recovery = @import("recovery.zig");
@@ -335,28 +241,43 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
     _ = sys.execForward(&.{ "systemctl", "restart", "mtproto-proxy" }) catch {};
 
     if (sys.isServiceActive("mtproto-proxy")) {
-        ui.ok("Proxy running inside VPN tunnel");
+        ui.ok("Proxy running with tunnel policy routing");
     } else {
         ui.fail("Proxy failed to start. Check: journalctl -u mtproto-proxy -n 30");
         return;
     }
 
-    // ── Validate DC connectivity ──
-    ui.step("Validating Telegram DC connectivity...");
+    // ── Validate tunnel routing ──
+    ui.step("Validating policy routing to Telegram DCs...");
+
+    const awg_status = sys.exec(allocator, &.{ "awg", "show", "awg0" }) catch null;
+    if (awg_status) |result| {
+        defer result.deinit();
+        if (result.exit_code == 0) {
+            ui.stepOk("Tunnel interface active", "awg0");
+        } else {
+            ui.warn("awg0 is not active (check AWG config and endpoint)");
+        }
+    }
+
     const dc_ips = [_][]const u8{
         "149.154.175.50", "149.154.167.50", "149.154.175.100",
         "149.154.167.91", "91.108.56.100",
     };
+
     for (dc_ips) |dc_ip| {
         const r = sys.exec(allocator, &.{
-            "ip", "netns", "exec", NS_NAME, "nc", "-zw3", dc_ip, "443",
+            "ip", "-4", "route", "get", dc_ip, "mark", "200",
         }) catch null;
-        if (r) |result| {
-            defer result.deinit();
-            if (result.exit_code == 0) {
-                ui.stepOk("DC reachable", dc_ip);
+
+        if (r) |route_result| {
+            defer route_result.deinit();
+            if (route_result.exit_code == 0 and std.mem.indexOf(u8, route_result.stdout, "dev awg0") != null) {
+                ui.stepOk("Policy route via awg0", dc_ip);
             } else {
-                ui.print("  {s}⚠{s} DC NOT reachable: {s}\n", .{ Color.err, Color.reset, dc_ip });
+                var warn_buf: [96]u8 = undefined;
+                const warn_msg = std.fmt.bufPrint(&warn_buf, "Policy route check failed for {s}", .{dc_ip}) catch "Policy route check failed";
+                ui.warn(warn_msg);
             }
         }
     }
@@ -365,20 +286,14 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
     ui.summaryBox("VPN Tunnel Configured", &.{
         .{ .label = "Status:", .value = "systemctl status mtproto-proxy" },
         .{ .label = "Logs:", .value = "journalctl -u mtproto-proxy -f" },
-        .{ .label = "Tunnel:", .value = "ip netns exec " ++ NS_NAME ++ " awg show" },
-        .{ .label = "Mode:", .value = mode_label },
+        .{ .label = "Tunnel:", .value = "awg show awg0" },
+        .{ .label = "Policy:", .value = "ip -4 rule show | grep fwmark" },
+        .{ .label = "Mark:", .value = "SO_MARK=200 -> table 200" },
         .{ .label = "", .style = .blank },
-        .{ .label = "Proxy runs inside isolated network namespace", .style = .success },
-        .{ .label = "VPN tunnel active (host network untouched)", .style = .success },
-        .{ .label = "SSH and host services unaffected", .style = .success },
+        .{ .label = "Proxy runs in host network namespace", .style = .success },
+        .{ .label = "Tunnel routing is socket-level and explicit", .style = .success },
+        .{ .label = "SOCKS5/HTTP upstream stay orthogonal", .style = .success },
     });
-}
-
-fn setUseMiddleProxy(allocator: std.mem.Allocator, value: []const u8) void {
-    var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch return;
-    defer doc.deinit();
-    doc.set("general", "use_middle_proxy", value) catch return;
-    doc.save(INSTALL_DIR ++ "/config.toml") catch {};
 }
 
 fn setUpstreamType(allocator: std.mem.Allocator, value: []const u8) void {
@@ -441,23 +356,80 @@ fn stripAwgDnsLines(allocator: std.mem.Allocator, path: []const u8) !bool {
     return true;
 }
 
+fn ensureAwgTableOff(allocator: std.mem.Allocator, path: []const u8) !bool {
+    const file = try std.fs.cwd().openFile(path, .{});
+    defer file.close();
+
+    const content = try file.readToEndAlloc(allocator, 1024 * 1024);
+    defer allocator.free(content);
+
+    var in_interface = false;
+    var has_interface = false;
+    var has_table = false;
+    var interface_header_idx: ?usize = null;
+
+    var idx: usize = 0;
+    var lines_scan = std.mem.splitScalar(u8, content, '\n');
+    while (lines_scan.next()) |line| : (idx += 1) {
+        const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r' });
+
+        if (trimmed.len >= 2 and trimmed[0] == '[' and trimmed[trimmed.len - 1] == ']') {
+            in_interface = std.ascii.eqlIgnoreCase(trimmed, "[Interface]");
+            if (in_interface) {
+                has_interface = true;
+                if (interface_header_idx == null) interface_header_idx = idx;
+            }
+            continue;
+        }
+
+        if (!in_interface) continue;
+        if (trimmed.len == 0 or trimmed[0] == '#' or trimmed[0] == ';') continue;
+
+        if (std.mem.indexOfScalar(u8, trimmed, '=')) |eq_pos| {
+            const key = std.mem.trim(u8, trimmed[0..eq_pos], &[_]u8{ ' ', '\t' });
+            if (std.ascii.eqlIgnoreCase(key, "Table")) {
+                has_table = true;
+                break;
+            }
+        }
+    }
+
+    if (!has_interface or has_table or interface_header_idx == null) return false;
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(allocator);
+
+    var out_idx: usize = 0;
+    var wrote_any = false;
+    var lines_write = std.mem.splitScalar(u8, content, '\n');
+    while (lines_write.next()) |line| : (out_idx += 1) {
+        if (wrote_any) try out.append(allocator, '\n');
+        try out.appendSlice(allocator, line);
+        wrote_any = true;
+
+        if (out_idx == interface_header_idx.?) {
+            try out.appendSlice(allocator, "\nTable = off");
+        }
+    }
+
+    const sanitized = try out.toOwnedSlice(allocator);
+    defer allocator.free(sanitized);
+
+    try sys.writeFileMode(path, sanitized, 0o600);
+    return true;
+}
+
 /// Detect the currently active tunnel by inspecting runtime state.
 /// Returns the `Tunnel.Tag` corresponding to the detected tunnel,
 /// or `.none` if no known tunnel is active.
 pub fn detectActiveTunnel(allocator: std.mem.Allocator) Tunnel.Tag {
-    // Check if AmneziaWG interface is up inside the network namespace
-    const awg_result = sys.exec(allocator, &.{
-        "ip", "netns", "exec", NS_NAME, "awg", "show", "awg0",
-    }) catch null;
+    const awg_result = sys.exec(allocator, &.{ "awg", "show", "awg0" }) catch null;
     if (awg_result) |r| {
         defer r.deinit();
         if (r.exit_code == 0) return .tunnel;
     }
 
-    // Check if WireGuard interface is up inside the network namespace
-    const wg_result = sys.exec(allocator, &.{
-        "ip", "netns", "exec", NS_NAME, "wg", "show", "wg0",
-    }) catch null;
+    const wg_result = sys.exec(allocator, &.{ "wg", "show", "wg0" }) catch null;
     if (wg_result) |r| {
         defer r.deinit();
         if (r.exit_code == 0) return .tunnel;

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -14,6 +14,7 @@ const Tui = tui_mod.Tui;
 
 const INSTALL_DIR = "/opt/mtproto-proxy";
 const AWG_CONF_DIR = "/etc/amnezia/amneziawg";
+const AWG_IFACE_CONF_PATH = "/etc/amnezia/awg0.conf";
 const TUNNEL_SCRIPT = "/usr/local/bin/setup_tunnel.sh";
 const SERVICE_FILE = "/etc/systemd/system/mtproto-proxy.service";
 const AWG_CONFIG_PATH = AWG_CONF_DIR ++ "/awg0.conf";
@@ -98,9 +99,11 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
 
     // ── Copy AWG config ──
     ui.step("Installing AmneziaWG config...");
+    _ = sys.exec(allocator, &.{ "mkdir", "-p", "/etc/amnezia" }) catch {};
     _ = sys.exec(allocator, &.{ "mkdir", "-p", AWG_CONF_DIR }) catch {};
     _ = sys.execForward(&.{ "cp", opts.awg_conf, AWG_CONFIG_PATH }) catch {};
     _ = sys.exec(allocator, &.{ "chmod", "600", AWG_CONFIG_PATH }) catch {};
+    _ = sys.execForward(&.{ "ln", "-sfn", AWG_CONFIG_PATH, AWG_IFACE_CONF_PATH }) catch {};
 
     const dns_removed = stripAwgDnsLines(allocator, AWG_CONFIG_PATH) catch false;
     if (dns_removed) {
@@ -121,13 +124,12 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
     const tunnel_script = std.fmt.bufPrint(&tunnel_script_buf,
         \\#!/bin/bash
         \\set -euo pipefail
-        \\CONF="{[awg_conf]s}"
         \\IFACE="awg0"
         \\MARK={[mark]d}
         \\TABLE={[table]d}
         \\
-        \\awg-quick down "$CONF" 2>/dev/null || true
-        \\awg-quick up "$CONF"
+        \\awg-quick down "$IFACE" 2>/dev/null || true
+        \\awg-quick up "$IFACE"
         \\
         \\ip -4 route flush table "$TABLE" 2>/dev/null || true
         \\ip -4 route add default dev "$IFACE" table "$TABLE"
@@ -135,7 +137,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
         \\ip -4 rule add fwmark "$MARK" table "$TABLE" priority 1200
         \\
         \\echo "Tunnel routing ready: fwmark=$MARK -> table $TABLE via $IFACE"
-    , .{ .awg_conf = AWG_CONFIG_PATH, .mark = TUNNEL_MARK, .table = TUNNEL_TABLE }) catch "";
+    , .{ .mark = TUNNEL_MARK, .table = TUNNEL_TABLE }) catch "";
 
     if (tunnel_script.len == 0) {
         ui.fail("Failed to render tunnel setup script");

--- a/src/ctl/uninstall.zig
+++ b/src/ctl/uninstall.zig
@@ -80,7 +80,11 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
     // 3. Remove user
     _ = sys.execForward(&.{ "userdel", "mtproto" }) catch {};
 
-    // 4. Remove netns if exists
+    // 4. Cleanup tunnel routing artifacts (new + legacy)
+    _ = sys.execForward(&.{ "ip", "-4", "rule", "del", "fwmark", "200", "table", "200" }) catch {};
+    _ = sys.execForward(&.{ "ip", "-4", "route", "flush", "table", "200" }) catch {};
+    _ = sys.execForward(&.{ "rm", "-f", "/usr/local/bin/setup_tunnel.sh" }) catch {};
+    _ = sys.execForward(&.{ "rm", "-f", "/usr/local/bin/setup_netns.sh" }) catch {};
     _ = sys.execForward(&.{ "ip", "netns", "del", "tg_proxy_ns" }) catch {};
 
     // 5. Remove masking config if exists

--- a/src/ctl/update.zig
+++ b/src/ctl/update.zig
@@ -198,7 +198,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: UpdateOpts) !void {
 fn isTunnelServiceUnit() bool {
     if (!sys.fileExists(SERVICE_FILE)) return false;
     const result = sys.exec(std.heap.page_allocator, &.{
-        "grep", "-Eq", "setup_netns\\.sh|ip[[:space:]]+netns[[:space:]]+exec|AmneziaWG[[:space:]]+Tunnel", SERVICE_FILE,
+        "grep", "-Eq", "setup_(netns|tunnel)\\.sh|ip[[:space:]]+netns[[:space:]]+exec|AmneziaWG[[:space:]]+Tunnel|Tunnel[[:space:]]+Policy[[:space:]]+Routing", SERVICE_FILE,
     }) catch return false;
     defer result.deinit();
     return result.exit_code == 0;

--- a/src/main.zig
+++ b/src/main.zig
@@ -424,7 +424,7 @@ pub fn main() !void {
         const log_main = std.log.scoped(.config);
         log_main.warn(
             "AES backend is software-only for this build/target. MiddleProxy video traffic will be CPU-heavy. " ++
-                "Rebuild with CPU features enabled (example: -Dcpu=native or -Dcpu=x86_64_v3).",
+                "Rebuild with CPU features enabled (example: -Dcpu=native or -Dcpu=x86_64_v3+aes).",
             .{},
         );
     }

--- a/src/proxy/http_connect.zig
+++ b/src/proxy/http_connect.zig
@@ -240,6 +240,14 @@ test "http_connect - parse response no terminator yet" {
     try std.testing.expect(result == null);
 }
 
+test "http_connect - parse response with pipelined payload" {
+    const data = "HTTP/1.1 200 Connection Established\r\nX-Test: 1\r\n\r\n\x01\x02";
+    const result = parseResponse(data);
+    try std.testing.expect(result != null);
+    try std.testing.expectEqual(@as(u16, 200), result.?.status);
+    try std.testing.expectEqualSlices(u8, "\x01\x02", data[result.?.header_end..]);
+}
+
 test "http_connect - address formatting ipv4" {
     var buf: [64]u8 = undefined;
     const addr = net.Address.initIp4(.{ 10, 0, 0, 1 }, 8080);

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -35,7 +35,7 @@ const nofile_fd_overhead: usize = 512;
 const middle_proxy_config_url = "https://core.telegram.org/getProxyConfig";
 const middle_proxy_secret_url = "https://core.telegram.org/getProxySecret";
 const middle_proxy_update_period_ns: u64 = 24 * 60 * 60 * std.time.ns_per_s;
-const tunnel_mask_gateway_ip = "10.200.200.1";
+const tunnel_socket_mark: u32 = 200;
 const min_nofile_soft: usize = 65535;
 const client_hello_inline_size: usize = 512;
 const mp_handshake_frame_buf_size: usize = 2048;
@@ -912,19 +912,10 @@ pub const ProxyState = struct {
 
         var resolved_addr: ?net.Address = null;
         if (cfg.mask) {
-            const mask_target = blk: {
-                if (cfg.mask_port == 443) break :blk cfg.tls_domain;
-
-                if (isRunningInNonInitNetns()) {
-                    log.info(
-                        "mask_port={d} with non-init netns detected, using host veth IP {s} for local masking",
-                        .{ cfg.mask_port, tunnel_mask_gateway_ip },
-                    );
-                    break :blk tunnel_mask_gateway_ip;
-                }
-
-                break :blk "127.0.0.1";
-            };
+            const mask_target = if (cfg.mask_port == 443) cfg.tls_domain else "127.0.0.1";
+            if (cfg.mask_port != 443) {
+                log.info("mask_port={d} configured, using local mask target 127.0.0.1", .{cfg.mask_port});
+            }
             const list = net.getAddressList(allocator, mask_target, cfg.mask_port) catch |err| blk: {
                 log.err("Failed to resolve mask target '{s}': {any}", .{ mask_target, err });
                 break :blk null;
@@ -1009,6 +1000,7 @@ pub const ProxyState = struct {
             .middle_proxy_nat_ip4 = detected_nat_ip4,
             .upstream = upblk: {
                 switch (cfg.upstream_mode) {
+                    .tunnel => break :upblk upstream_mod.Upstream.initDirectWithMark(tunnel_socket_mark),
                     .socks5 => {
                         if (cfg.upstream_proxy_host) |host| {
                             if (cfg.upstream_proxy_port > 0) {
@@ -1051,27 +1043,18 @@ pub const ProxyState = struct {
                         log.warn("upstream.type=http but proxy host/port not configured; falling back to direct", .{});
                         break :upblk upstream_mod.Upstream.initDirect();
                     },
-                    else => break :upblk upstream_mod.Upstream.initDirect(),
+                    .direct, .auto => break :upblk upstream_mod.Upstream.initDirect(),
                 }
             },
             .tunnel_info = blk: {
-                const in_non_init_netns = isRunningInNonInitNetns();
                 switch (cfg.upstream_mode) {
                     .direct => {
-                        if (in_non_init_netns) {
-                            log.warn("upstream.type=direct but proxy runs in non-init netns; egress still follows namespace routing", .{});
-                        }
                         log.info("Upstream mode: direct (configured)", .{});
                         break :blk tunnel_mod.Tunnel{ .tag = .none };
                     },
                     .tunnel => {
-                        const t = tunnel_mod.Tunnel{ .tag = .tunnel };
-                        if (in_non_init_netns) {
-                            log.info("Upstream mode: {s} (configured)", .{t.name()});
-                        } else {
-                            log.warn("upstream.type=tunnel configured, but proxy is not running in tunnel netns", .{});
-                        }
-                        break :blk t;
+                        log.info("Upstream mode: tunnel (socket policy routing via SO_MARK={d})", .{tunnel_socket_mark});
+                        break :blk tunnel_mod.Tunnel{ .tag = .tunnel };
                     },
                     .socks5 => {
                         break :blk tunnel_mod.Tunnel{ .tag = .socks5 };
@@ -1080,10 +1063,8 @@ pub const ProxyState = struct {
                         break :blk tunnel_mod.Tunnel{ .tag = .http_connect };
                     },
                     .auto => {
-                        if (in_non_init_netns) {
-                            const t = tunnel_mod.Tunnel{ .tag = .tunnel };
-                            log.info("Upstream mode: {s} (auto-detected from network namespace)", .{t.name()});
-                            break :blk t;
+                        if (isRunningInNonInitNetns()) {
+                            log.warn("auto mode does not infer tunnel from netns; using direct egress", .{});
                         }
                         log.info("Upstream mode: direct (auto)", .{});
                         break :blk tunnel_mod.Tunnel{ .tag = .none };
@@ -1099,14 +1080,6 @@ pub const ProxyState = struct {
 
     pub fn run(self: *ProxyState) !void {
         if (builtin.os.tag != .linux) return error.UnsupportedOperatingSystem;
-
-        if (self.config.upstream_mode == .tunnel and !isRunningInNonInitNetns()) {
-            log.err(
-                "upstream.type=tunnel requires running proxy inside tunnel netns (expected via `mtbuddy setup tunnel`)",
-                .{},
-            );
-            return error.UpstreamTunnelNotActive;
-        }
 
         const address = net.Address.initIp6(
             .{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
@@ -2417,6 +2390,13 @@ const EventLoop = struct {
                     return;
                 }
 
+                if (have.len > result.consumed) {
+                    self.appendPipelined(slot, have[result.consumed..]) catch {
+                        self.closeSlot(slot, "socks5 pipelined append failed");
+                        return;
+                    };
+                }
+
                 // SOCKS5 handshake complete — proceed to DC path
                 self.proxyHandshakeComplete(slot);
             },
@@ -2536,6 +2516,13 @@ const EventLoop = struct {
             log.debug("[{d}] HTTP CONNECT failed: status={d}", .{ slot.conn_id, result.status });
             self.closeSlot(slot, "http connect rejected");
             return;
+        }
+
+        if (have.len > result.header_end) {
+            self.appendPipelined(slot, have[result.header_end..]) catch {
+                self.closeSlot(slot, "http connect pipelined append failed");
+                return;
+            };
         }
 
         // HTTP CONNECT handshake complete — proceed to DC path
@@ -2947,11 +2934,9 @@ const EventLoop = struct {
                 var ts_arr: [4]u8 = undefined;
                 std.mem.writeInt(u32, &ts_arr, slot.mp_timestamp, .little);
 
-                var peer_addr: net.Address = undefined;
-                var peer_len: posix.socklen_t = @sizeOf(net.Address);
-                posix.getpeername(slot.upstream_fd, &peer_addr.any, &peer_len) catch {
+                const tg_addr = slot.current_upstream_addr orelse {
                     self.state.middle_proxy_lock.unlockShared();
-                    self.closeSlot(slot, "mp getpeername failed");
+                    self.closeSlot(slot, "mp missing logical upstream addr");
                     return;
                 };
 
@@ -2971,39 +2956,45 @@ const EventLoop = struct {
                 var tg_ip_v6_opt: ?[16]u8 = null;
                 var my_ip_v6_opt: ?[16]u8 = null;
 
-                if (peer_addr.any.family == posix.AF.INET and local_addr.any.family == posix.AF.INET) {
+                const local_port = switch (local_addr.any.family) {
+                    posix.AF.INET => std.mem.bigToNative(u16, local_addr.in.sa.port),
+                    posix.AF.INET6 => std.mem.bigToNative(u16, local_addr.in6.sa.port),
+                    else => {
+                        self.state.middle_proxy_lock.unlockShared();
+                        self.closeSlot(slot, "mp unsupported local addr family");
+                        return;
+                    },
+                };
+                std.mem.writeInt(u16, &my_port, local_port, .little);
+
+                if (tg_addr.any.family == posix.AF.INET) {
                     var tg_ip_v4: [4]u8 = undefined;
-                    @memcpy(&tg_ip_v4, std.mem.asBytes(&peer_addr.in.sa.addr));
+                    @memcpy(&tg_ip_v4, std.mem.asBytes(&tg_addr.in.sa.addr));
                     std.mem.reverse(u8, &tg_ip_v4);
                     tg_ip_v4_opt = tg_ip_v4;
 
-                    var my_ip_v4: [4]u8 = undefined;
-                    @memcpy(&my_ip_v4, std.mem.asBytes(&local_addr.in.sa.addr));
-                    std.mem.reverse(u8, &my_ip_v4);
-
                     if (self.state.middle_proxy_nat_ip4) |nat_ip| {
-                        my_ip_v4 = ipv4NetworkToHostBytes(nat_ip);
-                        middle_local_addr = net.Address.initIp4(nat_ip, std.mem.bigToNative(u16, local_addr.in.sa.port));
+                        const my_ip_v4 = ipv4NetworkToHostBytes(nat_ip);
+                        my_ip_v4_opt = my_ip_v4;
+                        middle_local_addr = net.Address.initIp4(nat_ip, local_port);
                     }
 
-                    my_ip_v4_opt = my_ip_v4;
-
-                    std.mem.writeInt(u16, &tg_port, std.mem.bigToNative(u16, peer_addr.in.sa.port), .little);
-                    std.mem.writeInt(u16, &my_port, std.mem.bigToNative(u16, local_addr.in.sa.port), .little);
-                } else if (peer_addr.any.family == posix.AF.INET6 and local_addr.any.family == posix.AF.INET6) {
+                    std.mem.writeInt(u16, &tg_port, std.mem.bigToNative(u16, tg_addr.in.sa.port), .little);
+                } else if (tg_addr.any.family == posix.AF.INET6) {
                     var tg_ip_v6: [16]u8 = undefined;
-                    @memcpy(&tg_ip_v6, &peer_addr.in6.sa.addr);
+                    @memcpy(&tg_ip_v6, &tg_addr.in6.sa.addr);
                     tg_ip_v6_opt = tg_ip_v6;
 
-                    var my_ip_v6: [16]u8 = undefined;
-                    @memcpy(&my_ip_v6, &local_addr.in6.sa.addr);
-                    my_ip_v6_opt = my_ip_v6;
+                    if (local_addr.any.family == posix.AF.INET6) {
+                        var my_ip_v6: [16]u8 = undefined;
+                        @memcpy(&my_ip_v6, &local_addr.in6.sa.addr);
+                        my_ip_v6_opt = my_ip_v6;
+                    }
 
-                    std.mem.writeInt(u16, &tg_port, std.mem.bigToNative(u16, peer_addr.in6.sa.port), .little);
-                    std.mem.writeInt(u16, &my_port, std.mem.bigToNative(u16, local_addr.in6.sa.port), .little);
+                    std.mem.writeInt(u16, &tg_port, std.mem.bigToNative(u16, tg_addr.in6.sa.port), .little);
                 } else {
                     self.state.middle_proxy_lock.unlockShared();
-                    self.closeSlot(slot, "mp unsupported addr family");
+                    self.closeSlot(slot, "mp unsupported upstream addr family");
                     return;
                 }
 

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -1113,9 +1113,13 @@ pub const ProxyState = struct {
 
         setNonBlocking(server.stream.handle);
 
-        if (self.config.datacenter_override == null) {
+        if (self.config.use_middle_proxy and self.config.datacenter_override == null) {
             self.refreshMiddleProxyInfo() catch |err| {
-                log.warn("Initial middle-proxy refresh failed, using bundled defaults: {any}", .{err});
+                if (isMiddleProxyRefreshNetworkError(err)) {
+                    log.info("Initial middle-proxy refresh unavailable ({s}), using bundled defaults", .{@errorName(err)});
+                } else {
+                    log.warn("Initial middle-proxy refresh failed, using bundled defaults: {any}", .{err});
+                }
             };
 
             if (std.Thread.spawn(.{}, ProxyState.middleProxyUpdaterMain, .{self})) |updater| {
@@ -1188,9 +1192,25 @@ pub const ProxyState = struct {
         while (true) {
             std.Thread.sleep(middle_proxy_update_period_ns);
             self.refreshMiddleProxyInfo() catch |err| {
-                log.warn("Middle-proxy refresh failed: {any}", .{err});
+                if (isMiddleProxyRefreshNetworkError(err)) {
+                    log.info("Middle-proxy refresh unavailable ({s}), keeping current cache", .{@errorName(err)});
+                } else {
+                    log.warn("Middle-proxy refresh failed: {any}", .{err});
+                }
             };
         }
+    }
+
+    fn isMiddleProxyRefreshNetworkError(err: anyerror) bool {
+        const name = @errorName(err);
+        return std.mem.eql(u8, name, "UnexpectedConnectFailure") or
+            std.mem.eql(u8, name, "ConnectionRefused") or
+            std.mem.eql(u8, name, "ConnectionResetByPeer") or
+            std.mem.eql(u8, name, "NetworkUnreachable") or
+            std.mem.eql(u8, name, "HostUnreachable") or
+            std.mem.eql(u8, name, "ConnectionTimedOut") or
+            std.mem.eql(u8, name, "TemporaryNameServerFailure") or
+            std.mem.eql(u8, name, "NameServerFailure");
     }
 
     fn refreshMiddleProxyInfo(self: *ProxyState) !void {

--- a/src/proxy/socks5.zig
+++ b/src/proxy/socks5.zig
@@ -281,6 +281,14 @@ test "socks5 - parse connect response failure" {
     try std.testing.expectEqual(Reply.connection_refused, result.?.reply);
 }
 
+test "socks5 - parse connect response with pipelined tail" {
+    const resp = [_]u8{ 0x05, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xaa, 0xbb };
+    const result = parseConnectResponse(&resp);
+    try std.testing.expect(result != null);
+    try std.testing.expectEqual(Reply.succeeded, result.?.reply);
+    try std.testing.expectEqual(@as(usize, 10), result.?.consumed);
+}
+
 test "socks5 - parse connect response too short" {
     const resp = [_]u8{ 0x05, 0x00, 0x00 };
     const result = parseConnectResponse(&resp);

--- a/src/proxy/upstream.zig
+++ b/src/proxy/upstream.zig
@@ -13,11 +13,11 @@
 //!
 //! The `tunnel_info` field carries metadata about the active tunnel
 //! (see `tunnel.zig`). For namespace-based tunnels like AmneziaWG,
-//! the connect variant stays `direct` because the proxy process itself
-//! runs inside the namespace — so all TCP connects implicitly traverse
-//! the tunnel without socket-level wrapping.
+//! the connect variant stays `direct`, but may apply `SO_MARK` so Linux
+//! policy routing can steer selected sockets through the tunnel.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const net = std.net;
 const posix = std.posix;
 const tunnel_mod = @import("../tunnel.zig");
@@ -54,6 +54,10 @@ pub const Upstream = union(Tag) {
 
     pub fn initDirect() Upstream {
         return .{ .direct = .{} };
+    }
+
+    pub fn initDirectWithMark(mark: u32) Upstream {
+        return .{ .direct = .{ .socket_mark = mark } };
     }
 
     pub fn initSocks5(
@@ -122,13 +126,19 @@ pub const Upstream = union(Tag) {
 };
 
 pub const Direct = struct {
-    pub fn connect(_: Direct, addr: net.Address) !ConnectResult {
+    socket_mark: ?u32 = null,
+
+    pub fn connect(self: Direct, addr: net.Address) !ConnectResult {
         const fd = try posix.socket(
             addr.any.family,
             posix.SOCK.STREAM | posix.SOCK.NONBLOCK | posix.SOCK.CLOEXEC,
             posix.IPPROTO.TCP,
         );
         errdefer posix.close(fd);
+
+        if (self.socket_mark) |mark| {
+            try applySocketMark(fd, mark);
+        }
 
         posix.connect(fd, &addr.any, addr.getOsSockLen()) catch |err| switch (err) {
             error.WouldBlock, error.ConnectionPending => {
@@ -145,6 +155,7 @@ pub const Socks5 = struct {
     proxy_addr: net.Address,
     username: ?[]const u8 = null,
     password: ?[]const u8 = null,
+    socket_mark: ?u32 = null,
 
     /// Connect to the SOCKS5 proxy server (not the target DC).
     /// Returns a result with `.proxy_handshake = .socks5`.
@@ -155,6 +166,10 @@ pub const Socks5 = struct {
             posix.IPPROTO.TCP,
         );
         errdefer posix.close(fd);
+
+        if (self.socket_mark) |mark| {
+            try applySocketMark(fd, mark);
+        }
 
         posix.connect(fd, &self.proxy_addr.any, self.proxy_addr.getOsSockLen()) catch |err| switch (err) {
             error.WouldBlock, error.ConnectionPending => {
@@ -177,6 +192,7 @@ pub const HttpConnect = struct {
     proxy_addr: net.Address,
     username: ?[]const u8 = null,
     password: ?[]const u8 = null,
+    socket_mark: ?u32 = null,
 
     /// Connect to the HTTP proxy server (not the target DC).
     /// Returns a result with `.proxy_handshake = .http_connect`.
@@ -188,6 +204,10 @@ pub const HttpConnect = struct {
         );
         errdefer posix.close(fd);
 
+        if (self.socket_mark) |mark| {
+            try applySocketMark(fd, mark);
+        }
+
         posix.connect(fd, &self.proxy_addr.any, self.proxy_addr.getOsSockLen()) catch |err| switch (err) {
             error.WouldBlock, error.ConnectionPending => {
                 return .{ .fd = fd, .pending = true, .proxy_handshake = .http_connect };
@@ -198,3 +218,11 @@ pub const HttpConnect = struct {
         return .{ .fd = fd, .pending = false, .proxy_handshake = .http_connect };
     }
 };
+
+fn applySocketMark(fd: posix.fd_t, mark: u32) !void {
+    if (builtin.os.tag != .linux) return;
+
+    const so_mark: u32 = 36;
+    var mark_value: u32 = mark;
+    try posix.setsockopt(fd, posix.SOL.SOCKET, so_mark, std.mem.asBytes(&mark_value));
+}

--- a/src/tunnel.zig
+++ b/src/tunnel.zig
@@ -3,9 +3,9 @@
 //! Defines the `Tunnel` metadata type that describes which tunnel
 //! (if any) is active for outgoing proxy connections. This is a
 //! capability/metadata struct — not a socket connector — because
-//! network-level tunnels (AmneziaWG, WireGuard, ...) work by running
-//! the proxy inside a network namespace rather than wrapping individual
-//! connect() calls. The specific VPN type is an mtbuddy concern.
+//! network-level tunnels (AmneziaWG, WireGuard, ...) are configured
+//! by mtbuddy and selected at runtime via socket policy routing marks.
+//! The specific VPN type is an mtbuddy concern.
 //!
 //! Socket-level proxy types (SOCKS5, HTTP CONNECT) are also tracked
 //! here for logging and status display, even though their actual I/O
@@ -17,9 +17,7 @@ pub const Tunnel = struct {
     pub const Tag = enum {
         /// Direct connection — no tunnel active.
         none,
-        /// VPN tunnel via Linux network namespace. The proxy process
-        /// runs inside `tg_proxy_ns` and all outgoing TCP connects
-        /// traverse the VPN interface (AmneziaWG, WireGuard, etc.).
+        /// VPN tunnel selected via socket policy routing (SO_MARK).
         tunnel,
         /// SOCKS5 proxy — socket-level upstream wrapping.
         socks5,
@@ -43,7 +41,7 @@ pub const Tunnel = struct {
     pub fn requiresNetns(self: *const Tunnel) bool {
         return switch (self.tag) {
             .none => false,
-            .tunnel => true,
+            .tunnel => false,
             .socks5 => false,
             .http_connect => false,
         };
@@ -53,7 +51,7 @@ pub const Tunnel = struct {
     pub fn netnsName(self: *const Tunnel) ?[]const u8 {
         return switch (self.tag) {
             .none => null,
-            .tunnel => "tg_proxy_ns",
+            .tunnel => null,
             .socks5 => null,
             .http_connect => null,
         };
@@ -106,7 +104,7 @@ test "tunnel - requiresNetns" {
     try std.testing.expect(!direct.requiresNetns());
 
     const vpn = Tunnel{ .tag = .tunnel };
-    try std.testing.expect(vpn.requiresNetns());
+    try std.testing.expect(!vpn.requiresNetns());
 
     const socks = Tunnel{ .tag = .socks5 };
     try std.testing.expect(!socks.requiresNetns());
@@ -120,7 +118,7 @@ test "tunnel - netnsName" {
     try std.testing.expect(direct.netnsName() == null);
 
     const vpn = Tunnel{ .tag = .tunnel };
-    try std.testing.expectEqualStrings("tg_proxy_ns", vpn.netnsName().?);
+    try std.testing.expect(vpn.netnsName() == null);
 
     const socks = Tunnel{ .tag = .socks5 };
     try std.testing.expect(socks.netnsName() == null);


### PR DESCRIPTION
## Summary
- Switch tunnel egress from netns-coupled behavior to explicit socket policy routing (`SO_MARK=200`), and harden upstream handshake flow by preserving SOCKS5/HTTP CONNECT pipelined payload bytes.
- Rework `mtbuddy setup tunnel` around host-namespace policy routing, and align config/docs/runtime messaging with the new tunnel model.
- Expand the dashboard routing block with live upstream diagnostics plus controls to toggle MiddleProxy, switch upstream type, choose tunnel interface from host interfaces, and edit SOCKS5/HTTP target+auth.

## Testing
- `zig build`
- `zig build test`
- `python3 -m py_compile src/ctl/dashboard_assets/server.py`