### PR TITLE
fix(ci): use valid Zig CLI args in release AES check

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -83,7 +83,7 @@ jobs:
 
           pub fn main() void {}
           EOF
-          zig build-exe -target=${{ matrix.target }} -mcpu=${{ matrix.cpu }} /tmp/check_aes_target.zig
+          zig build-exe -target "${{ matrix.target }}" -mcpu "${{ matrix.cpu }}" /tmp/check_aes_target.zig
 
       - name: Build release binary
         run: |


### PR DESCRIPTION
## Summary
- Fix the release workflow AES profile check command to use valid Zig CLI syntax for target/cpu args.
- Replace `-target=...` with `-target "..."` (and same for `-mcpu`) so the `build-and-upload` matrix job does not fail before release artifacts are built.

## Verification
- `zig build-exe -target "x86_64-linux" -mcpu "x86_64_v3+aes" "src/main.zig" -femit-bin="/tmp/mtproxy-argtest"`