### PR TITLE
Fix dead code in capacity safety, IPv6 subnet hash, and config memory leaks

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -90,6 +90,8 @@ pub const Config = struct {
     handshake_timeout_sec: u32 = 15,
     tag: ?[16]u8 = null,
     tls_domain: []const u8 = "google.com",
+    /// Whether tls_domain was allocated and needs freeing in deinit.
+    tls_domain_owned: bool = false,
     users: std.StringHashMap([16]u8),
     /// Users that always bypass MiddleProxy and connect to DC directly.
     /// Section: [access.direct_users] (alias: [access.admins])
@@ -325,6 +327,7 @@ pub const Config = struct {
                 } else if (in_censorship_section) {
                     if (std.mem.eql(u8, key, "tls_domain")) {
                         cfg.tls_domain = try allocator.dupe(u8, value);
+                        cfg.tls_domain_owned = true;
                     } else if (std.mem.eql(u8, key, "mask")) {
                         cfg.mask = std.mem.eql(u8, value, "true");
                     } else if (std.mem.eql(u8, key, "mask_port")) {
@@ -357,6 +360,7 @@ pub const Config = struct {
                     }
                 } else if (in_upstream_tunnel_section) {
                     if (std.mem.eql(u8, key, "interface")) {
+                        if (cfg.upstream_tunnel_interface) |old| allocator.free(old);
                         cfg.upstream_tunnel_interface = try allocator.dupe(u8, value);
                     }
                 }
@@ -382,7 +386,7 @@ pub const Config = struct {
         direct_users.deinit();
 
         // Free tls_domain if it was allocated (not the default)
-        if (!std.mem.eql(u8, self.tls_domain, "google.com")) {
+        if (self.tls_domain_owned) {
             allocator.free(self.tls_domain);
         }
         if (self.public_ip) |ip| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -237,14 +237,6 @@ fn enforceCapacitySafety(cfg: *config.Config, capacity_estimate: ?CapacityEstima
     const configured_limit = cfg.max_connections;
     cfg.max_connections = est.safe_connections;
 
-    if (cfg.max_connections > est.safe_connections) {
-        log_main.err(
-            "failed to enforce RAM safety limit: max_connections={d}, safe={d}; refusing startup",
-            .{ cfg.max_connections, est.safe_connections },
-        );
-        return error.CapacitySafetyEnforcementFailed;
-    }
-
     log_main.warn(
         "auto-clamping max_connections from {d} to {d} " ++
             "(host has {d} MiB RAM, ~{d} KiB/connection). " ++

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -149,7 +149,9 @@ const SubnetRateLimit = struct {
         } else if (addr.any.family == posix.AF.INET6) {
             // /48 subnet: first 6 bytes hashed to u32
             const ip6 = &addr.in6.sa.addr;
-            return @as(u32, ip6[0]) << 24 | @as(u32, ip6[1]) << 16 | @as(u32, ip6[2]) << 8 | @as(u32, ip6[3]) ^ (@as(u32, ip6[4]) << 8 | @as(u32, ip6[5]));
+            const hi: u32 = @as(u32, ip6[0]) << 24 | @as(u32, ip6[1]) << 16 | @as(u32, ip6[2]) << 8 | @as(u32, ip6[3]);
+            const lo: u32 = @as(u32, ip6[4]) << 8 | @as(u32, ip6[5]);
+            return hi ^ lo;
         }
         return 0;
     }


### PR DESCRIPTION
## Summary

Three bugs fixed across the proxy core:

- **Dead code in `enforceCapacitySafety`** (`main.zig`): After setting `cfg.max_connections = est.safe_connections`, the subsequent check `cfg.max_connections > est.safe_connections` could never be true since both values were identical. Removed the unreachable error branch.

- **IPv6 subnet key operator precedence** (`proxy.zig`): The `/48` subnet key computation had an operator precedence bug where `^` bound tighter than `|`. This caused `ip6[3]` to be XORed with only the low bytes (`ip6[4..5]`) instead of being OR'd into the high word first. Split into explicit `hi`/`lo` variables to make the intent clear and correct the hash distribution.

- **Config memory management** (`config.zig`):
  - `tls_domain`: Used content-based comparison (`eql("google.com")`) to decide whether to free. If a user explicitly sets `tls_domain = "google.com"` in config, the allocated copy would never be freed. Added a `tls_domain_owned` flag.
  - `upstream_tunnel_interface`: When set twice in config, the previous allocation was leaked (unlike `upstream_proxy_host`/`username`/`password` which already freed old values before re-dupe). Added the missing `free` before `dupe`.

## Test plan

- [x] Existing tests should continue to pass (`zig build test`)
- [ ] Verify capacity safety clamp test still passes (dead code removal doesn't affect behavior)
- [ ] Verify IPv6 subnet rate limiting has better hash distribution
- [ ] Verify no memory leaks with repeated config values

🤖 Generated with [Claude Code](https://claude.com/claude-code)