### PR TITLE
fix(ctl): remove legacy netns listen directives from nginx masking config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ fix_tui.py
 test_list.zig
 bundle.sh
 codebase.txt
+.agent/skills/local-env/

--- a/src/ctl/masking.zig
+++ b/src/ctl/masking.zig
@@ -64,17 +64,7 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: MaskingOpts) !void 
         return;
     }
 
-    // Detect tunnel veth
-    var tunnel_host_ip: ?[]const u8 = null;
-    {
-        const r = sys.exec(allocator, &.{ "ip", "-4", "addr", "show" }) catch null;
-        if (r) |result| {
-            defer result.deinit();
-            if (std.mem.indexOf(u8, result.stdout, "10.200.200.1/") != null) {
-                tunnel_host_ip = "10.200.200.1";
-            }
-        }
-    }
+
 
     // ── Install Nginx ──
     if (sys.commandExists("nginx")) {
@@ -135,19 +125,14 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: MaskingOpts) !void 
     sys.execSilent(allocator, &.{ "mkdir", "-p", "/var/www/masking" });
     sys.writeFile("/var/www/masking/index.html", "<!DOCTYPE html><html><head><title>Welcome</title></head><body><h1>It works!</h1></body></html>\n") catch {};
 
-    // Build nginx config
-    var extra_listen: []const u8 = "";
-    var extra_listen_buf: [128]u8 = undefined;
-    if (tunnel_host_ip) |tip| {
-        extra_listen = std.fmt.bufPrint(&extra_listen_buf, "    listen {s}:{s} ssl;\n", .{ tip, NGINX_PORT }) catch "";
-    }
+
 
     var nginx_cfg_buf: [2048]u8 = undefined;
     const nginx_cfg = std.fmt.bufPrint(&nginx_cfg_buf,
         \\# MTProto proxy masking server — local only
         \\server {{
         \\    listen 127.0.0.1:{[port]s} ssl;
-        \\{[extra]s}
+        \\
         \\    server_name {[domain]s};
         \\
         \\    ssl_certificate     {[cert_dir]s}/cert.pem;
@@ -168,7 +153,6 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: MaskingOpts) !void 
         \\}}
     , .{
         .port = NGINX_PORT,
-        .extra = extra_listen,
         .domain = opts.tls_domain,
         .cert_dir = CERT_DIR,
     }) catch "";
@@ -196,9 +180,6 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: MaskingOpts) !void 
     _ = sys.execForward(&.{ "systemctl", "restart", "nginx" }) catch {};
     _ = sys.exec(allocator, &.{ "systemctl", "enable", "nginx" }) catch {};
     ui.ok("Nginx configured on 127.0.0.1:" ++ NGINX_PORT);
-    if (tunnel_host_ip != null) {
-        ui.ok("Nginx configured on 10.200.200.1:" ++ NGINX_PORT ++ " for tunnel netns");
-    }
 
     // ── Verify Nginx ──
     {

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -232,6 +232,13 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
         ui.stepOk("Preserved promotion tag", tag);
     }
 
+    // ── Cleanup legacy netns nginx listen directives ──
+    const nginx_cleaned = cleanupNetnsNginxListen(allocator);
+    if (nginx_cleaned) {
+        ui.ok("Removed legacy netns listen directives from nginx masking config");
+        _ = sys.execForward(&.{ "systemctl", "try-reload-or-restart", "nginx" }) catch {};
+    }
+
     // ── Apply masking monitor (if recovery is already installed) ──
     if (sys.isServiceActive("mtproto-mask-health.timer") or sys.fileExists("/usr/local/bin/mtproto-mask-health.sh")) {
         const recovery = @import("recovery.zig");
@@ -418,6 +425,49 @@ fn ensureAwgTableOff(allocator: std.mem.Allocator, path: []const u8) !bool {
     defer allocator.free(sanitized);
 
     try sys.writeFileMode(path, sanitized, 0o600);
+    return true;
+}
+
+const NGINX_MASKING_CONF = "/etc/nginx/sites-available/mtproto-masking";
+
+/// Strip legacy netns listen directives (e.g. `listen 10.200.200.1:8443 ssl;`)
+/// from the nginx masking config. Returns true if any lines were removed.
+fn cleanupNetnsNginxListen(allocator: std.mem.Allocator) bool {
+    const file = std.fs.cwd().openFile(NGINX_MASKING_CONF, .{}) catch return false;
+    defer file.close();
+
+    const content = file.readToEndAlloc(allocator, 256 * 1024) catch return false;
+    defer allocator.free(content);
+
+    var output: std.ArrayList(u8) = .empty;
+    defer output.deinit(allocator);
+
+    var removed_any = false;
+    var wrote_any = false;
+
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r' });
+
+        // Match directives like: listen 10.200.200.1:8443 ssl;
+        if (std.mem.startsWith(u8, trimmed, "listen ") and
+            std.mem.indexOf(u8, trimmed, "10.200.200.") != null)
+        {
+            removed_any = true;
+            continue;
+        }
+
+        if (wrote_any) output.append(allocator, '\n') catch return false;
+        output.appendSlice(allocator, line) catch return false;
+        wrote_any = true;
+    }
+
+    if (!removed_any) return false;
+
+    const sanitized = output.toOwnedSlice(allocator) catch return false;
+    defer allocator.free(sanitized);
+
+    sys.writeFile(NGINX_MASKING_CONF, sanitized) catch return false;
     return true;
 }
 


### PR DESCRIPTION
## Problem

After migrating from netns-based tunnel routing to socket policy routing (v0.15.1), nginx masking config could still contain `listen 10.200.200.1:8443 ssl;` — an address from the now-removed `tg_proxy_ns` network namespace.

This caused a **restart loop** in production:
1. Health timer detects nginx is down
2. Tries `systemctl restart nginx` → fails (`bind() to 10.200.200.1:8443 failed: Cannot assign requested address`)
3. Escalates to restarting `mtproto-proxy`
4. Repeats every ~60s

## Root Cause

Two code paths still referenced the legacy netns architecture:
- **`masking.zig`**: detected `10.200.200.1/` via `ip addr` and added an extra `listen` directive for it
- **`tunnel.zig`**: did not clean up stale nginx config when migrating to policy routing

## Changes

### `masking.zig`
- Removed netns veth detection (`10.200.200.1`) and `extra_listen` generation
- Nginx masking now always listens on `127.0.0.1:8443` only

### `tunnel.zig`
- Added `cleanupNetnsNginxListen()` — strips `listen 10.200.200.x:...` lines from nginx masking config
- Called during `mtbuddy setup tunnel` before recovery module, so migration is fully automatic
- Also reloads nginx after cleanup

## Testing

- Cross-compiled successfully (`zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux -Dcpu=x86_64_v3+aes`)
- Verified fix on production server `proxy.sleep3r.ru`: nginx starts cleanly, health-check passes, proxy stable