### PR TITLE
fix(docker): build portable amd64 image to avoid invalid opcode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,27 @@ WORKDIR /build
 COPY build.zig ./
 COPY src ./src
 
-RUN zig build -Doptimize=ReleaseFast
+RUN set -eu \
+    && arch="${TARGETARCH:-$(dpkg --print-architecture 2>/dev/null || uname -m)}" \
+    && case "$arch" in \
+        amd64|x86_64) \
+            target="x86_64-linux"; \
+            cpu="x86_64"; \
+            ;; \
+        arm64|aarch64) \
+            target="aarch64-linux"; \
+            cpu=""; \
+            ;; \
+        *) \
+            echo "unsupported TARGETARCH=$arch" >&2; \
+            exit 1; \
+            ;; \
+       esac \
+    && if [ -n "$cpu" ]; then \
+         zig build -Doptimize=ReleaseFast -Dtarget="$target" -Dcpu="$cpu"; \
+       else \
+         zig build -Doptimize=ReleaseFast -Dtarget="$target"; \
+       fi
 
 FROM debian:bookworm-slim
 

--- a/README.md
+++ b/README.md
@@ -424,6 +424,8 @@ docker build -t mtproto-zig .
 docker buildx build --platform linux/amd64,linux/arm64 -t your-registry/mtproto-zig:latest --push .
 ```
 
+Published `linux/amd64` images are built with a portable CPU profile (`-Dcpu=x86_64`) to avoid `Illegal instruction` crashes on older VPS CPUs.
+
 > OS-level mitigations (iptables TCPMSS, nfqws, etc.) are not applied inside the container; only the proxy binary runs there.
 
 ---

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -1267,7 +1267,7 @@ pub const ProxyState = struct {
 
         for (0..next_primary.len) |i| {
             if (next_primary[i]) |addr| {
-                if (!isSameIpEndpoint(self.middle_proxy_addrs_primary[i], addr)) {
+                if (!self.middle_proxy_addrs_primary[i].eql(addr)) {
                     self.middle_proxy_addrs_primary[i] = addr;
                     changed = true;
                 }
@@ -1275,7 +1275,7 @@ pub const ProxyState = struct {
         }
 
         if (next_addr_203) |addr| {
-            if (!isSameIpEndpoint(self.middle_proxy_addr_203, addr)) {
+            if (!self.middle_proxy_addr_203.eql(addr)) {
                 self.middle_proxy_addr_203 = addr;
                 changed = true;
             }
@@ -1302,7 +1302,7 @@ pub const ProxyState = struct {
         }
 
         if (self.middle_proxy_secret_len != next_secret.len or
-            !bytesEqualScalar(self.middle_proxy_secret[0..self.middle_proxy_secret_len], next_secret))
+            !std.mem.eql(u8, self.middle_proxy_secret[0..self.middle_proxy_secret_len], next_secret))
         {
             @memset(self.middle_proxy_secret[0..], 0);
             @memcpy(self.middle_proxy_secret[0..next_secret.len], next_secret);
@@ -4058,14 +4058,6 @@ fn isSameIpEndpoint(a: net.Address, b: net.Address) bool {
     return false;
 }
 
-fn bytesEqualScalar(a: []const u8, b: []const u8) bool {
-    if (a.len != b.len) return false;
-    for (a, b) |lhs, rhs| {
-        if (lhs != rhs) return false;
-    }
-    return true;
-}
-
 fn appendUniqueAddress(addrs: *[16]net.Address, count: *usize, addr: net.Address) void {
     if (count.* >= addrs.len) return;
     for (addrs[0..count.*]) |existing| {
@@ -4179,7 +4171,7 @@ fn parseMiddleProxyAddressesForDc(config_text: []const u8, target_dc: i16, out: 
 
         var dup = false;
         for (out[0..count]) |existing| {
-            if (isSameIpEndpoint(existing, parsed)) {
+            if (existing.eql(parsed)) {
                 dup = true;
                 break;
             }
@@ -4204,7 +4196,7 @@ fn trySelectReachableMiddleProxy(candidates: []const net.Address, timeout_ms: i3
 fn addressesEqual(a: []const net.Address, b: []const net.Address) bool {
     if (a.len != b.len) return false;
     for (a, b) |lhs, rhs| {
-        if (!isSameIpEndpoint(lhs, rhs)) return false;
+        if (!lhs.eql(rhs)) return false;
     }
     return true;
 }

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -1267,7 +1267,7 @@ pub const ProxyState = struct {
 
         for (0..next_primary.len) |i| {
             if (next_primary[i]) |addr| {
-                if (!self.middle_proxy_addrs_primary[i].eql(addr)) {
+                if (!isSameIpEndpoint(self.middle_proxy_addrs_primary[i], addr)) {
                     self.middle_proxy_addrs_primary[i] = addr;
                     changed = true;
                 }
@@ -1275,7 +1275,7 @@ pub const ProxyState = struct {
         }
 
         if (next_addr_203) |addr| {
-            if (!self.middle_proxy_addr_203.eql(addr)) {
+            if (!isSameIpEndpoint(self.middle_proxy_addr_203, addr)) {
                 self.middle_proxy_addr_203 = addr;
                 changed = true;
             }
@@ -1302,7 +1302,7 @@ pub const ProxyState = struct {
         }
 
         if (self.middle_proxy_secret_len != next_secret.len or
-            !std.mem.eql(u8, self.middle_proxy_secret[0..self.middle_proxy_secret_len], next_secret))
+            !bytesEqualScalar(self.middle_proxy_secret[0..self.middle_proxy_secret_len], next_secret))
         {
             @memset(self.middle_proxy_secret[0..], 0);
             @memcpy(self.middle_proxy_secret[0..next_secret.len], next_secret);
@@ -4058,6 +4058,14 @@ fn isSameIpEndpoint(a: net.Address, b: net.Address) bool {
     return false;
 }
 
+fn bytesEqualScalar(a: []const u8, b: []const u8) bool {
+    if (a.len != b.len) return false;
+    for (a, b) |lhs, rhs| {
+        if (lhs != rhs) return false;
+    }
+    return true;
+}
+
 fn appendUniqueAddress(addrs: *[16]net.Address, count: *usize, addr: net.Address) void {
     if (count.* >= addrs.len) return;
     for (addrs[0..count.*]) |existing| {
@@ -4171,7 +4179,7 @@ fn parseMiddleProxyAddressesForDc(config_text: []const u8, target_dc: i16, out: 
 
         var dup = false;
         for (out[0..count]) |existing| {
-            if (existing.eql(parsed)) {
+            if (isSameIpEndpoint(existing, parsed)) {
                 dup = true;
                 break;
             }
@@ -4196,7 +4204,7 @@ fn trySelectReachableMiddleProxy(candidates: []const net.Address, timeout_ms: i3
 fn addressesEqual(a: []const net.Address, b: []const net.Address) bool {
     if (a.len != b.len) return false;
     for (a, b) |lhs, rhs| {
-        if (!lhs.eql(rhs)) return false;
+        if (!isSameIpEndpoint(lhs, rhs)) return false;
     }
     return true;
 }


### PR DESCRIPTION
## Summary
- build `linux/amd64` Docker images with an explicit portable target profile (`-Dtarget=x86_64-linux -Dcpu=x86_64`) instead of host-native defaults
- keep `linux/arm64` builds explicit with `-Dtarget=aarch64-linux`
- document the portable amd64 profile in the Docker section of the README

## Root Cause
Issue #168 reported `exit code 132` (`SIGILL`) only when `use_middle_proxy=true`.
Kernel trace + addr2line maps the crash to an instruction at `0x109f2fb`.
Disassembly at that address shows `extrq` (`66 0f 78 ...`), which is an AMD SSE4a opcode and is invalid on Intel CPUs.

This can happen when the amd64 Docker image is built from a host-native CPU profile (builder CPU features leak into the binary).
The fix pins a portable CPU baseline for published amd64 images.

## Testing
- `zig build test`
- `zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux -Dcpu=x86_64`
- `zig build -Doptimize=ReleaseFast -Dtarget=aarch64-linux`

Closes #168