### PR TITLE
feat(mtbuddy): ask about MiddleProxy during install

### DIFF
--- a/src/ctl/i18n.zig
+++ b/src/ctl/i18n.zig
@@ -91,6 +91,9 @@ pub const S = enum(u16) {
     install_dpi_desync_help,
     install_dpi_drs,
     install_dpi_drs_help,
+    install_middle_proxy_prompt,
+    install_middle_proxy_help,
+    install_middle_proxy_warn,
     install_checking_deps,
     install_resolving_tag,
     install_download_ok,
@@ -277,6 +280,12 @@ const en_strings = [_][]const u8{
     "Dynamic Record Sizing (DRS)",
     // install_dpi_drs_help
     "Ramp TLS records 1369→16384 bytes to mimic browser behavior, evade traffic analysis.",
+    // install_middle_proxy_prompt
+    "Enable MiddleProxy (Telegram relay)?",
+    // install_middle_proxy_help
+    "Routes traffic through Telegram's relay servers.\nUses more RAM (~2 MB per connection) but is required for:\n  • Promo tag / sponsored messages (ad_tag)\n  • Media loading (photos, video, stories) on non-Premium accounts",
+    // install_middle_proxy_warn
+    "Without MiddleProxy: promo tags will not work, and non-Premium users may fail to load media.",
     // install_checking_deps
     "Installing system dependencies...",
     // install_resolving_tag
@@ -502,6 +511,12 @@ const ru_strings = [_][]const u8{
     "Dynamic Record Sizing (DRS)",
     // install_dpi_drs_help
     "Наращивание TLS записей 1369→16384 байт, имитируя браузер, обход анализа трафика.",
+    // install_middle_proxy_prompt
+    "Включить MiddleProxy (релей Telegram)?",
+    // install_middle_proxy_help
+    "Маршрутизирует трафик через релей-серверы Telegram.\nПотребляет больше RAM (~2 МБ на подключение), но необходим для:\n  • Промо-тега / спонсорских сообщений (ad_tag)\n  • Загрузки медиа (фото, видео, истории) на аккаунтах без Premium",
+    // install_middle_proxy_warn
+    "Без MiddleProxy: промо-тег не будет работать, а у пользователей без Premium могут не загружаться медиа.",
     // install_checking_deps
     "Установка системных зависимостей...",
     // install_resolving_tag

--- a/src/ctl/install.zig
+++ b/src/ctl/install.zig
@@ -33,6 +33,9 @@ pub const InstallOpts = struct {
     enable_ipv6_hop: bool = false,
     enable_desync: bool = true,
     enable_drs: bool = false,
+    /// Enable MiddleProxy (Telegram relay). Required for promo tags and
+    /// non-Premium media loading.
+    enable_middle_proxy: bool = false,
     /// Pre-set user secret (32-char hex). If null, auto-generated.
     secret: ?[32]u8 = null,
     /// User name for config.toml. If null, defaults to "user".
@@ -95,6 +98,8 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.ArgIterato
             opts.enable_tcpmss = false;
         } else if (std.mem.eql(u8, arg, "--ipv6-hop")) {
             opts.enable_ipv6_hop = true;
+        } else if (std.mem.eql(u8, arg, "--middle-proxy")) {
+            opts.enable_middle_proxy = true;
         } else if (std.mem.eql(u8, arg, "--version") or std.mem.eql(u8, arg, "-v")) {
             opts.version = args.next();
         }
@@ -132,6 +137,7 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.ArgIterato
         ui.print("  {s}TCPMSS:{s}   {s}\n", .{ Color.dim, Color.reset, if (opts.enable_tcpmss) "enabled" else "disabled" });
         ui.print("  {s}Masking:{s}  {s}\n", .{ Color.dim, Color.reset, if (opts.enable_masking) "enabled" else "disabled" });
         ui.print("  {s}nfqws:{s}    {s}\n", .{ Color.dim, Color.reset, if (opts.enable_nfqws) "enabled" else "disabled" });
+        ui.print("  {s}Middle:{s}   {s}\n", .{ Color.dim, Color.reset, if (opts.enable_middle_proxy) "enabled" else "disabled" });
         ui.writeRaw("\n");
 
         if (!try ui.confirm("Proceed with installation?", true)) {
@@ -229,6 +235,28 @@ pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
     opts.enable_drs = (dpi_result & 16) != 0;
     opts.enable_ipv6_hop = (dpi_result & 32) != 0;
     opts.secret = secret_hex;
+
+    // MiddleProxy toggle
+    ui.writeRaw("\n");
+    ui.print("  {s}╭─ {s}{s}{s}\n", .{ Color.gray, Color.bold, ui.str(.install_middle_proxy_prompt), Color.reset });
+    // Print multi-line help with border
+    {
+        var help_lines = std.mem.splitScalar(u8, ui.str(.install_middle_proxy_help), '\n');
+        while (help_lines.next()) |line| {
+            ui.print("  {s}│{s}  {s}{s}{s}\n", .{
+                Color.gray, Color.reset,
+                Color.dim,  line,
+                Color.reset,
+            });
+        }
+    }
+    ui.print("  {s}╰─{s}\n", .{ Color.gray, Color.reset });
+    opts.enable_middle_proxy = try ui.confirm(ui.str(.install_middle_proxy_prompt), false);
+
+    if (!opts.enable_middle_proxy) {
+        ui.warn(ui.str(.install_middle_proxy_warn));
+    }
+
     opts.yes = true; // already confirmed via wizard
 
     // Confirm
@@ -340,6 +368,9 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
         try doc.addKv("desync", if (opts.enable_desync) "true" else "false");
         try doc.addKv("drs", if (opts.enable_drs) "true" else "false");
         try doc.addKv("fast_mode", "true");
+
+        try doc.addSection("general");
+        try doc.addKv("use_middle_proxy", if (opts.enable_middle_proxy) "true" else "false");
 
         try doc.addSection("access.users");
         try doc.addKvStr(user_name, &secret_hex);
@@ -643,6 +674,11 @@ fn printSummary(
         .{
             .label = if (opts.enable_drs) "Dynamic Record Sizing (built-in)" else "",
             .style = if (opts.enable_drs) .success else .blank,
+        },
+        .{ .label = "", .style = .blank },
+        .{
+            .label = if (opts.enable_middle_proxy) "MiddleProxy (Telegram relay)" else "MiddleProxy: disabled",
+            .style = if (opts.enable_middle_proxy) .success else .label_value,
         },
     });
 


### PR DESCRIPTION
## Что изменилось

При установке через `mtbuddy` теперь спрашиваем про MiddleProxy (релей Telegram) — после выбора DPI модулей.

### Интерактивный режим (TUI)

- Показывается блок с описанием: что даёт, сколько ест RAM
- `confirm()` с дефолтом **No**
- Если отказывается — предупреждение ⚠:
  > Без MiddleProxy: промо-тег не будет работать, а у пользователей без Premium могут не загружаться медиа

### CLI режим

- Новый флаг `--middle-proxy`
- Отображается в compact summary перед подтверждением

### Генерация конфига

- Пишет `[general].use_middle_proxy = true/false` в `config.toml`

### Post-install summary

- MiddleProxy статус показывается в финальном summary box (✔ или disabled)

### i18n

- Все строки на EN и RU

---

**Пример one-liner:**
```bash
sudo mtbuddy install --port 443 --domain wb.ru --middle-proxy --yes
```