### PR TITLE
feat: Metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,9 @@ alice = true   # bypass MiddleProxy for this user
 | `[server] unsafe_override_limits` | `false` | Disable auto-clamping of `max_connections` |
 | `[monitor] host` | `"127.0.0.1"` | Dashboard bind address |
 | `[monitor] port` | `61208` | Dashboard port |
+| `[monitoring] enabled` | `false` | Enable embedded Prometheus `/metrics` endpoint |
+| `[monitoring] host` | `"127.0.0.1"` | Metrics bind address |
+| `[monitoring] port` | `9100` | Metrics port |
 | `[censorship] tls_domain` | `"google.com"` | Domain to impersonate |
 | `[censorship] mask` | `true` | Forward unauthenticated clients to `tls_domain` |
 | `[censorship] mask_port` | `443` | Local masking port (use `8443` for Nginx zero-RTT) |
@@ -380,6 +383,37 @@ Alternatively, expose the dashboard port via `[monitor]` config section and acce
 <br>
 
 </details>
+
+---
+
+## Prometheus metrics
+
+`mtproto-proxy` can expose an embedded Prometheus-compatible metrics endpoint on a dedicated port.
+
+```toml
+[monitoring]
+enabled = true
+host = "127.0.0.1"
+port = 9100
+```
+
+The endpoint is plaintext HTTP and serves:
+
+```text
+GET /metrics
+```
+
+Typical Docker usage:
+
+```bash
+docker run --rm \
+  -p 443:443 \
+  -p 9100:9100 \
+  -v "$PWD/config.toml:/etc/mtproto-proxy/config.toml:ro" \
+  mtproto-zig
+```
+
+It exposes proxy counters plus process metrics such as RSS, virtual memory, CPU time, and open file descriptors.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -339,9 +339,9 @@ alice = true   # bypass MiddleProxy for this user
 | `[server] unsafe_override_limits` | `false` | Disable auto-clamping of `max_connections` |
 | `[monitor] host` | `"127.0.0.1"` | Dashboard bind address |
 | `[monitor] port` | `61208` | Dashboard port |
-| `[monitoring] enabled` | `false` | Enable embedded Prometheus `/metrics` endpoint |
-| `[monitoring] host` | `"127.0.0.1"` | Metrics bind address |
-| `[monitoring] port` | `9100` | Metrics port |
+| `[metrics] enabled` | `false` | Enable embedded Prometheus `/metrics` endpoint |
+| `[metrics] host` | `"127.0.0.1"` | Metrics bind address |
+| `[metrics] port` | `9400` | Metrics port |
 | `[censorship] tls_domain` | `"google.com"` | Domain to impersonate |
 | `[censorship] mask` | `true` | Forward unauthenticated clients to `tls_domain` |
 | `[censorship] mask_port` | `443` | Local masking port (use `8443` for Nginx zero-RTT) |
@@ -390,13 +390,13 @@ Alternatively, expose the dashboard port via `[monitor]` config section and acce
 
 `mtproto-proxy` can expose an embedded Prometheus-compatible metrics endpoint on a dedicated port.
 
-For a complete Docker-based monitoring stack with `mtproto-zig`, Prometheus, Grafana, and an importable dashboard, see [hack/docker/README.md](/Users/freerunner/Work/misc/mtproto.zig/hack/docker/README.md).
+For a complete Docker-based monitoring stack with `mtproto-zig`, Prometheus, Grafana, and an importable dashboard, see [hack/docker/README.md](hack/docker/README.md).
 
 ```toml
-[monitoring]
+[metrics]
 enabled = true
 host = "127.0.0.1"
-port = 9100
+port = 9400
 ```
 
 The endpoint is plaintext HTTP and serves:
@@ -410,7 +410,7 @@ Typical Docker usage:
 ```bash
 docker run --rm \
   -p 443:443 \
-  -p 9100:9100 \
+  -p 9400:9400 \
   -v "$PWD/config.toml:/etc/mtproto-proxy/config.toml:ro" \
   mtproto-zig
 ```

--- a/README.md
+++ b/README.md
@@ -390,6 +390,8 @@ Alternatively, expose the dashboard port via `[monitor]` config section and acce
 
 `mtproto-proxy` can expose an embedded Prometheus-compatible metrics endpoint on a dedicated port.
 
+For a complete Docker-based monitoring stack with `mtproto-zig`, Prometheus, Grafana, and an importable dashboard, see [hack/docker/README.md](/Users/freerunner/Work/misc/mtproto.zig/hack/docker/README.md).
+
 ```toml
 [monitoring]
 enabled = true

--- a/build.zig
+++ b/build.zig
@@ -3,11 +3,19 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
+    const version_mod = b.createModule(.{
+        .root_source_file = b.path("src/version.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
 
     const exe_mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
+        .imports = &.{
+            .{ .name = "version", .module = version_mod },
+        },
     });
 
     const exe = b.addExecutable(.{
@@ -69,6 +77,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .imports = &.{
             .{ .name = "tunnel", .module = tunnel_mod },
+            .{ .name = "version", .module = version_mod },
         },
     });
 
@@ -93,6 +102,9 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
+        .imports = &.{
+            .{ .name = "version", .module = version_mod },
+        },
     });
 
     const unit_tests = b.addTest(.{

--- a/config.toml.example
+++ b/config.toml.example
@@ -72,6 +72,17 @@ port = 443
 # TCP port for the monitoring dashboard.
 # port = 61208
 
+[monitoring]
+# Embedded Prometheus-compatible metrics endpoint.
+# Disabled by default; enable explicitly when scraping from Docker/Prometheus.
+# enabled = true
+
+# Bind address for the metrics listener.
+# host = "127.0.0.1"
+
+# TCP port for GET /metrics.
+# port = 9100
+
 [upstream]
 # Upstream egress mode for outgoing DC connections.
 # "auto"       — direct TCP from host routing (default)

--- a/config.toml.example
+++ b/config.toml.example
@@ -72,7 +72,7 @@ port = 443
 # TCP port for the monitoring dashboard.
 # port = 61208
 
-[monitoring]
+[metrics]
 # Embedded Prometheus-compatible metrics endpoint.
 # Disabled by default; enable explicitly when scraping from Docker/Prometheus.
 # enabled = true
@@ -81,7 +81,7 @@ port = 443
 # host = "127.0.0.1"
 
 # TCP port for GET /metrics.
-# port = 9100
+# port = 9400
 
 [upstream]
 # Upstream egress mode for outgoing DC connections.

--- a/hack/docker/README.md
+++ b/hack/docker/README.md
@@ -1,0 +1,140 @@
+# Docker Monitoring Stack
+
+This directory contains a minimal Docker Compose setup for running:
+
+- `mtproto-zig`
+- `Prometheus`
+- `Grafana`
+
+The stack is intended for a VPS or any other Linux host where you want:
+
+- the proxy exposed on a public TCP port
+- the metrics endpoint available only on localhost
+- Prometheus scraping metrics from the proxy container
+- Grafana available over SSH port forwarding
+
+## Files
+
+- [docker-compose.yml](/Users/freerunner/Work/misc/mtproto.zig/hack/docker/docker-compose.yml)
+- [prometheus.yml](/Users/freerunner/Work/misc/mtproto.zig/hack/docker/prometheus.yml)
+- [mtproto-zig-grafana.json](/Users/freerunner/Work/misc/mtproto.zig/hack/docker/mtproto-zig-grafana.json)
+
+## 1. Prepare the proxy config
+
+Create `zigconf.toml` next to [docker-compose.yml](/Users/freerunner/Work/misc/mtproto.zig/hack/docker/docker-compose.yml).
+
+The important part for metrics is:
+
+```toml
+[monitoring]
+enabled = true
+host = "0.0.0.0"
+port = 9100
+```
+
+`host = "0.0.0.0"` is required because Prometheus connects to the proxy from another container over the Docker network.
+
+## 2. Set the proxy image tag
+
+Edit [docker-compose.yml](/Users/freerunner/Work/misc/mtproto.zig/hack/docker/docker-compose.yml) and replace:
+
+```yaml
+mtproto-zig:<change_me>
+```
+
+with the image tag you actually want to run.
+
+## 3. Start the stack
+
+From `hack/docker` run:
+
+```bash
+docker compose up -d
+```
+
+This starts:
+
+- `mtg-zig` on `10000:8443`
+- Prometheus on `127.0.0.1:9090`
+- Grafana on `127.0.0.1:3000`
+
+Make sure that you have proper port in server.port configured. 443 is the default, but in that example we use 8443 as 
+internal port inside container and 10000 as exposed port on the host.
+
+## 4. Check that metrics are available
+
+On the VM:
+
+```bash
+curl -s http://127.0.0.1:9100/metrics | head
+```
+
+Prometheus target check:
+
+```bash
+curl -s http://127.0.0.1:9090/api/v1/targets | jq .
+```
+
+You should see `mtg-zig:9100` in the target list with `health: "up"`.
+
+## 5. Open Grafana over SSH
+
+From your local machine:
+
+```bash
+ssh -L 3000:127.0.0.1:3000 <vm_ssh_user>@<vm_ip>
+```
+
+Then open:
+
+```text
+http://127.0.0.1:3000
+```
+
+Default login from [docker-compose.yml](/Users/freerunner/Work/misc/mtproto.zig/hack/docker/docker-compose.yml):
+
+- username: `admin`
+- password: `admin`
+
+## 6. Add the Prometheus datasource in Grafana
+
+In Grafana:
+
+1. Open `Connections` -> `Data sources`
+2. Click `Add data source`
+3. Choose `Prometheus`
+4. Set the URL to:
+
+```text
+http://prometheus:9090
+```
+
+5. Click `Save & test`
+
+This works because Grafana and Prometheus run in the same Compose network.
+
+## 7. Import the dashboard
+
+In Grafana:
+
+1. Open `Dashboards` -> `New` -> `Import`
+2. Upload [mtproto-zig-grafana.json](/Users/freerunner/Work/misc/mtproto.zig/hack/docker/mtproto-zig-grafana.json)
+3. Select your Prometheus datasource
+4. Click `Import`
+
+The dashboard includes:
+
+- active connections
+- memory usage
+- total throughput
+- total transferred bytes
+- traffic throughput graphs
+- per-user active connections
+- top users by throughput
+- top users by transferred bytes
+
+## Notes
+
+- The proxy metrics are exposed on `127.0.0.1:9100` on the host, not publicly.
+- Per-user metrics are generated from users in the proxy config loaded by the current process.
+- Counter-based totals reset on proxy restart, which is expected for Prometheus counters.

--- a/hack/docker/README.md
+++ b/hack/docker/README.md
@@ -15,28 +15,28 @@ The stack is intended for a VPS or any other Linux host where you want:
 
 ## Files
 
-- [docker-compose.yml](/Users/freerunner/Work/misc/mtproto.zig/hack/docker/docker-compose.yml)
-- [prometheus.yml](/Users/freerunner/Work/misc/mtproto.zig/hack/docker/prometheus.yml)
-- [mtproto-zig-grafana.json](/Users/freerunner/Work/misc/mtproto.zig/hack/docker/mtproto-zig-grafana.json)
+- [docker-compose.yml](docker-compose.yml)
+- [prometheus.yml](prometheus.yml)
+- [mtproto-zig-grafana.json](mtproto-zig-grafana.json)
 
 ## 1. Prepare the proxy config
 
-Create `zigconf.toml` next to [docker-compose.yml](/Users/freerunner/Work/misc/mtproto.zig/hack/docker/docker-compose.yml).
+Create `zigconf.toml` next to [docker-compose.yml](docker-compose.yml).
 
 The important part for metrics is:
 
 ```toml
-[monitoring]
+[metrics]
 enabled = true
 host = "0.0.0.0"
-port = 9100
+port = 9400
 ```
 
 `host = "0.0.0.0"` is required because Prometheus connects to the proxy from another container over the Docker network.
 
 ## 2. Set the proxy image tag
 
-Edit [docker-compose.yml](/Users/freerunner/Work/misc/mtproto.zig/hack/docker/docker-compose.yml) and replace:
+Edit [docker-compose.yml](docker-compose.yml) and replace:
 
 ```yaml
 mtproto-zig:<change_me>
@@ -66,7 +66,7 @@ internal port inside container and 10000 as exposed port on the host.
 On the VM:
 
 ```bash
-curl -s http://127.0.0.1:9100/metrics | head
+curl -s http://127.0.0.1:9400/metrics | head
 ```
 
 Prometheus target check:
@@ -75,7 +75,7 @@ Prometheus target check:
 curl -s http://127.0.0.1:9090/api/v1/targets | jq .
 ```
 
-You should see `mtg-zig:9100` in the target list with `health: "up"`.
+You should see `mtg-zig:9400` in the target list with `health: "up"`.
 
 ## 5. Open Grafana over SSH
 
@@ -91,7 +91,7 @@ Then open:
 http://127.0.0.1:3000
 ```
 
-Default login from [docker-compose.yml](/Users/freerunner/Work/misc/mtproto.zig/hack/docker/docker-compose.yml):
+Default login from [docker-compose.yml](docker-compose.yml):
 
 - username: `admin`
 - password: `admin`
@@ -118,7 +118,7 @@ This works because Grafana and Prometheus run in the same Compose network.
 In Grafana:
 
 1. Open `Dashboards` -> `New` -> `Import`
-2. Upload [mtproto-zig-grafana.json](/Users/freerunner/Work/misc/mtproto.zig/hack/docker/mtproto-zig-grafana.json)
+2. Upload [mtproto-zig-grafana.json](mtproto-zig-grafana.json)
 3. Select your Prometheus datasource
 4. Click `Import`
 
@@ -135,6 +135,6 @@ The dashboard includes:
 
 ## Notes
 
-- The proxy metrics are exposed on `127.0.0.1:9100` on the host, not publicly.
+- The proxy metrics are exposed on `127.0.0.1:9400` on the host, not publicly.
 - Per-user metrics are generated from users in the proxy config loaded by the current process.
 - Counter-based totals reset on proxy restart, which is expected for Prometheus counters.

--- a/hack/docker/docker-compose.yml
+++ b/hack/docker/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  mtg-zig:
+    image: mtproto-zig:<change_me>
+    container_name: mtg-zig
+    restart: unless-stopped
+    pids_limit: 65535
+    ulimits:
+      nofile:
+        soft: 65535
+        hard: 65535
+      nproc: 65535
+    volumes:
+      - ./zigconf.toml:/etc/mtproto-proxy/config.toml:ro
+    ports:
+      - "10000:8443"
+      - "127.0.0.1:9100:9100"
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: mtg-prometheus
+    restart: unless-stopped
+    depends_on:
+      - mtg-zig
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    ports:
+      - "127.0.0.1:9090:9090"
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: mtg-grafana
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+    volumes:
+      - grafana-data:/var/lib/grafana
+    ports:
+      - "127.0.0.1:3000:3000"
+
+volumes:
+  prometheus-data:
+  grafana-data:

--- a/hack/docker/docker-compose.yml
+++ b/hack/docker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./zigconf.toml:/etc/mtproto-proxy/config.toml:ro
     ports:
       - "10000:8443"
-      - "127.0.0.1:9100:9100"
+      - "127.0.0.1:9400:9400"
 
   prometheus:
     image: prom/prometheus:latest

--- a/hack/docker/prometheus.yml
+++ b/hack/docker/prometheus.yml
@@ -4,4 +4,4 @@ global:
 scrape_configs:
   - job_name: mtproto-zig
     static_configs:
-      - targets: ["mtg-zig:9100"]
+      - targets: ["mtg-zig:9400"]

--- a/hack/docker/prometheus.yml
+++ b/hack/docker/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: mtproto-zig
+    static_configs:
+      - targets: ["mtg-zig:9100"]

--- a/src/config.zig
+++ b/src/config.zig
@@ -65,10 +65,15 @@ fn stripInlineComment(value: []const u8) []const u8 {
 
 pub const Config = struct {
     pub const UserSecret = struct { name: []const u8, secret: [16]u8 };
-    pub const Monitoring = struct {
+    pub const Metrics = struct {
         enabled: bool = false,
-        host: []const u8 = "127.0.0.1",
-        port: u16 = 9100,
+        host: ?[]const u8 = null,
+        port: u16 = 9400,
+
+        /// Return bound host, falling back to localhost.
+        pub fn effectiveHost(self: *const Metrics) []const u8 {
+            return self.host orelse "127.0.0.1";
+        }
     };
 
     /// Route regular DC traffic via Telegram MiddleProxy transport.
@@ -145,7 +150,7 @@ pub const Config = struct {
     /// VPN tunnel interface name (e.g. "awg0", "wg0").
     /// Parsed from [upstream.tunnel].interface.
     upstream_tunnel_interface: ?[]const u8 = null,
-    monitoring: Monitoring = .{},
+    metrics: Metrics = .{},
 
     pub fn middleProxyBufferBytes(self: *const Config) usize {
         return @as(usize, self.middleproxy_buffer_kb) * 1024;
@@ -211,7 +216,7 @@ pub const Config = struct {
         var in_censorship_section = false;
         var in_server_section = false;
         var in_general_section = false;
-        var in_monitoring_section = false;
+        var in_metrics_section = false;
         var in_upstream_section = false;
         var in_upstream_socks5_section = false;
         var in_upstream_http_section = false;
@@ -231,7 +236,7 @@ pub const Config = struct {
                 in_censorship_section = std.mem.eql(u8, line, "[censorship]");
                 in_server_section = std.mem.eql(u8, line, "[server]");
                 in_general_section = std.mem.eql(u8, line, "[general]");
-                in_monitoring_section = std.mem.eql(u8, line, "[monitoring]");
+                in_metrics_section = std.mem.eql(u8, line, "[metrics]");
                 in_upstream_section = std.mem.eql(u8, line, "[upstream]");
                 in_upstream_socks5_section = std.mem.eql(u8, line, "[upstream.socks5]");
                 in_upstream_http_section = std.mem.eql(u8, line, "[upstream.http]");
@@ -350,16 +355,14 @@ pub const Config = struct {
                     } else if (std.mem.eql(u8, key, "fast_mode")) {
                         cfg.fast_mode = std.mem.eql(u8, value, "true");
                     }
-                } else if (in_monitoring_section) {
+                } else if (in_metrics_section) {
                     if (std.mem.eql(u8, key, "enabled")) {
-                        cfg.monitoring.enabled = std.mem.eql(u8, value, "true");
+                        cfg.metrics.enabled = std.mem.eql(u8, value, "true");
                     } else if (std.mem.eql(u8, key, "host")) {
-                        if (!std.mem.eql(u8, cfg.monitoring.host, "127.0.0.1")) {
-                            allocator.free(cfg.monitoring.host);
-                        }
-                        cfg.monitoring.host = try allocator.dupe(u8, value);
+                        if (cfg.metrics.host) |prev| allocator.free(prev);
+                        cfg.metrics.host = try allocator.dupe(u8, value);
                     } else if (std.mem.eql(u8, key, "port")) {
-                        cfg.monitoring.port = std.fmt.parseInt(u16, value, 10) catch cfg.monitoring.port;
+                        cfg.metrics.port = std.fmt.parseInt(u16, value, 10) catch cfg.metrics.port;
                     }
                 } else if (in_upstream_section) {
                     if (std.mem.eql(u8, key, "type")) {
@@ -431,8 +434,8 @@ pub const Config = struct {
         if (self.bind_address) |ba| {
             allocator.free(ba);
         }
-        if (!std.mem.eql(u8, self.monitoring.host, "127.0.0.1")) {
-            allocator.free(self.monitoring.host);
+        if (self.metrics.host) |h| {
+            allocator.free(h);
         }
     }
 
@@ -517,16 +520,16 @@ test "parse config - missing fields defaults" {
     try std.testing.expectEqual(@as(usize, 1024 * 1024), cfg.middleProxyBufferBytes());
     try std.testing.expectEqual(@as(u8, 30), cfg.rate_limit_per_subnet);
     try std.testing.expect(!cfg.unsafe_override_limits);
-    try std.testing.expect(!cfg.monitoring.enabled);
-    try std.testing.expectEqualStrings("127.0.0.1", cfg.monitoring.host);
-    try std.testing.expectEqual(@as(u16, 9100), cfg.monitoring.port);
+    try std.testing.expect(!cfg.metrics.enabled);
+    try std.testing.expect(cfg.metrics.host == null);
+    try std.testing.expectEqual(@as(u16, 9400), cfg.metrics.port);
     try std.testing.expectEqual(@as(usize, 1), cfg.users.count());
     try std.testing.expectEqual(@as(usize, 0), cfg.direct_users.count());
 }
 
-test "parse config - monitoring section" {
+test "parse config - metrics section" {
     const content =
-        \\[monitoring]
+        \\[metrics]
         \\enabled = true
         \\host = "0.0.0.0"
         \\port = 9200
@@ -537,9 +540,9 @@ test "parse config - monitoring section" {
     var cfg = try Config.parse(std.testing.allocator, content);
     defer cfg.deinit(std.testing.allocator);
 
-    try std.testing.expect(cfg.monitoring.enabled);
-    try std.testing.expectEqualStrings("0.0.0.0", cfg.monitoring.host);
-    try std.testing.expectEqual(@as(u16, 9200), cfg.monitoring.port);
+    try std.testing.expect(cfg.metrics.enabled);
+    try std.testing.expectEqualStrings("0.0.0.0", cfg.metrics.host.?);
+    try std.testing.expectEqual(@as(u16, 9200), cfg.metrics.port);
 }
 
 test "parse config - direct users allowlist" {

--- a/src/config.zig
+++ b/src/config.zig
@@ -65,6 +65,11 @@ fn stripInlineComment(value: []const u8) []const u8 {
 
 pub const Config = struct {
     pub const UserSecret = struct { name: []const u8, secret: [16]u8 };
+    pub const Monitoring = struct {
+        enabled: bool = false,
+        host: []const u8 = "127.0.0.1",
+        port: u16 = 9100,
+    };
 
     /// Route regular DC traffic via Telegram MiddleProxy transport.
     /// Mirrors telemt's [general].use_middle_proxy behavior.
@@ -140,6 +145,7 @@ pub const Config = struct {
     /// VPN tunnel interface name (e.g. "awg0", "wg0").
     /// Parsed from [upstream.tunnel].interface.
     upstream_tunnel_interface: ?[]const u8 = null,
+    monitoring: Monitoring = .{},
 
     pub fn middleProxyBufferBytes(self: *const Config) usize {
         return @as(usize, self.middleproxy_buffer_kb) * 1024;
@@ -205,6 +211,7 @@ pub const Config = struct {
         var in_censorship_section = false;
         var in_server_section = false;
         var in_general_section = false;
+        var in_monitoring_section = false;
         var in_upstream_section = false;
         var in_upstream_socks5_section = false;
         var in_upstream_http_section = false;
@@ -224,6 +231,7 @@ pub const Config = struct {
                 in_censorship_section = std.mem.eql(u8, line, "[censorship]");
                 in_server_section = std.mem.eql(u8, line, "[server]");
                 in_general_section = std.mem.eql(u8, line, "[general]");
+                in_monitoring_section = std.mem.eql(u8, line, "[monitoring]");
                 in_upstream_section = std.mem.eql(u8, line, "[upstream]");
                 in_upstream_socks5_section = std.mem.eql(u8, line, "[upstream.socks5]");
                 in_upstream_http_section = std.mem.eql(u8, line, "[upstream.http]");
@@ -342,6 +350,17 @@ pub const Config = struct {
                     } else if (std.mem.eql(u8, key, "fast_mode")) {
                         cfg.fast_mode = std.mem.eql(u8, value, "true");
                     }
+                } else if (in_monitoring_section) {
+                    if (std.mem.eql(u8, key, "enabled")) {
+                        cfg.monitoring.enabled = std.mem.eql(u8, value, "true");
+                    } else if (std.mem.eql(u8, key, "host")) {
+                        if (!std.mem.eql(u8, cfg.monitoring.host, "127.0.0.1")) {
+                            allocator.free(cfg.monitoring.host);
+                        }
+                        cfg.monitoring.host = try allocator.dupe(u8, value);
+                    } else if (std.mem.eql(u8, key, "port")) {
+                        cfg.monitoring.port = std.fmt.parseInt(u16, value, 10) catch cfg.monitoring.port;
+                    }
                 } else if (in_upstream_section) {
                     if (std.mem.eql(u8, key, "type")) {
                         if (parseUpstreamMode(value)) |mode| {
@@ -411,6 +430,9 @@ pub const Config = struct {
         }
         if (self.bind_address) |ba| {
             allocator.free(ba);
+        }
+        if (!std.mem.eql(u8, self.monitoring.host, "127.0.0.1")) {
+            allocator.free(self.monitoring.host);
         }
     }
 
@@ -495,8 +517,29 @@ test "parse config - missing fields defaults" {
     try std.testing.expectEqual(@as(usize, 1024 * 1024), cfg.middleProxyBufferBytes());
     try std.testing.expectEqual(@as(u8, 30), cfg.rate_limit_per_subnet);
     try std.testing.expect(!cfg.unsafe_override_limits);
+    try std.testing.expect(!cfg.monitoring.enabled);
+    try std.testing.expectEqualStrings("127.0.0.1", cfg.monitoring.host);
+    try std.testing.expectEqual(@as(u16, 9100), cfg.monitoring.port);
     try std.testing.expectEqual(@as(usize, 1), cfg.users.count());
     try std.testing.expectEqual(@as(usize, 0), cfg.direct_users.count());
+}
+
+test "parse config - monitoring section" {
+    const content =
+        \\[monitoring]
+        \\enabled = true
+        \\host = "0.0.0.0"
+        \\port = 9200
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expect(cfg.monitoring.enabled);
+    try std.testing.expectEqualStrings("0.0.0.0", cfg.monitoring.host);
+    try std.testing.expectEqual(@as(u16, 9200), cfg.monitoring.port);
 }
 
 test "parse config - direct users allowlist" {

--- a/src/ctl/main.zig
+++ b/src/ctl/main.zig
@@ -22,12 +22,13 @@ const tunnel = @import("tunnel.zig");
 const recovery = @import("recovery.zig");
 const dashboard = @import("dashboard.zig");
 const ipv6hop = @import("ipv6hop.zig");
+const version_mod = @import("version");
 const uninstall = @import("uninstall.zig");
 
 const Tui = tui_mod.Tui;
 const Color = tui_mod.Color;
 
-const version = "0.17.1"; // x-release-please-version
+pub const version = version_mod.version;
 
 pub fn main() !void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);

--- a/src/main.zig
+++ b/src/main.zig
@@ -11,6 +11,7 @@ const obfuscation = @import("protocol/obfuscation.zig");
 const tls = @import("protocol/tls.zig");
 const config = @import("config.zig");
 const proxy = @import("proxy/proxy.zig");
+const version_mod = @import("version");
 
 // Custom lock-free log function: formats into a stack buffer and writes
 // to stderr in a single write() syscall. On Linux, write() is atomic for
@@ -47,7 +48,7 @@ fn lockFreeLog(
 
 const log = std.log.scoped(.mtproto);
 
-const version = "0.17.1"; // x-release-please-version
+pub const version = version_mod.version;
 
 // ============= Output Helpers (Zig 0.15 compatible) =============
 

--- a/src/monitoring.zig
+++ b/src/monitoring.zig
@@ -1,0 +1,299 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const net = std.net;
+const posix = std.posix;
+const linux = std.os.linux;
+const proxy = @import("proxy/proxy.zig");
+const config = @import("config.zig");
+const version = @import("version.zig").version;
+
+const log = std.log.scoped(.monitoring);
+const metrics_content_type = "text/plain; version=0.0.4";
+
+const ProcessMetrics = struct {
+    resident_memory_bytes: ?u64 = null,
+    virtual_memory_bytes: ?u64 = null,
+    cpu_seconds_total: ?f64 = null,
+    open_fds: ?u64 = null,
+    max_fds: ?u64 = null,
+};
+
+pub fn start(state: *proxy.ProxyState) !void {
+    if (builtin.os.tag != .linux) return error.UnsupportedOperatingSystem;
+
+    const host = state.config.monitoring.host;
+    const port = state.config.monitoring.port;
+
+    const addr_list = try net.getAddressList(std.heap.page_allocator, host, port);
+    defer addr_list.deinit();
+
+    if (addr_list.addrs.len == 0) return error.AddressNotAvailable;
+
+    var server = try addr_list.addrs[0].listen(.{
+        .reuse_address = true,
+        .kernel_backlog = 64,
+    });
+    errdefer server.deinit();
+
+    log.info("metrics endpoint listening on {s}:{d}", .{ host, port });
+
+    const thread = try std.Thread.spawn(.{}, acceptLoop, .{ state, server });
+    thread.detach();
+}
+
+fn acceptLoop(state: *proxy.ProxyState, server: net.Server) void {
+    var local_server = server;
+    defer local_server.deinit();
+
+    while (true) {
+        const conn = local_server.accept() catch |err| {
+            log.warn("metrics accept failed: {any}", .{err});
+            std.Thread.sleep(200 * std.time.ns_per_ms);
+            continue;
+        };
+        handleConnection(state, conn.stream.handle);
+    }
+}
+
+fn handleConnection(state: *proxy.ProxyState, fd: posix.fd_t) void {
+    defer posix.close(fd);
+
+    var req_buf: [2048]u8 = undefined;
+    const req_len = posix.read(fd, &req_buf) catch return;
+    if (req_len == 0) return;
+
+    const request = req_buf[0..req_len];
+    if (!isGetRequest(request)) {
+        writeSimpleResponse(fd, "405 Method Not Allowed", "text/plain", "method not allowed\n");
+        return;
+    }
+    if (!isGetMetrics(request)) {
+        writeSimpleResponse(fd, "404 Not Found", "text/plain", "not found\n");
+        return;
+    }
+    writeMetricsResponse(fd, state) catch {
+        writeSimpleResponse(fd, "500 Internal Server Error", "text/plain", "internal error\n");
+    };
+}
+
+fn writeMetricsResponse(fd: posix.fd_t, state: *proxy.ProxyState) !void {
+    var body_buf: [16 * 1024]u8 = undefined;
+    var body_stream = std.io.fixedBufferStream(&body_buf);
+    try writeMetrics(body_stream.writer(), state, collectProcessMetrics());
+    const body = body_stream.getWritten();
+
+    var header_buf: [256]u8 = undefined;
+    var header_stream = std.io.fixedBufferStream(&header_buf);
+    const w = header_stream.writer();
+    try w.print(
+        "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Type: {s}\r\nContent-Length: {d}\r\n\r\n",
+        .{ metrics_content_type, body.len },
+    );
+    try writeAll(fd, header_stream.getWritten());
+    try writeAll(fd, body);
+}
+
+fn writeSimpleResponse(fd: posix.fd_t, status: []const u8, content_type: []const u8, body: []const u8) void {
+    var buf: [512]u8 = undefined;
+    var stream = std.io.fixedBufferStream(&buf);
+    const w = stream.writer();
+    w.print(
+        "HTTP/1.1 {s}\r\nConnection: close\r\nContent-Type: {s}\r\nContent-Length: {d}\r\n\r\n{s}",
+        .{ status, content_type, body.len, body },
+    ) catch return;
+    writeAll(fd, stream.getWritten()) catch {};
+}
+
+fn writeAll(fd: posix.fd_t, bytes: []const u8) !void {
+    var off: usize = 0;
+    while (off < bytes.len) {
+        off += try posix.write(fd, bytes[off..]);
+    }
+}
+
+fn isGetRequest(request: []const u8) bool {
+    return std.mem.startsWith(u8, request, "GET ");
+}
+
+fn isGetMetrics(request: []const u8) bool {
+    if (!std.mem.startsWith(u8, request, "GET /metrics")) return false;
+    if (request.len < "GET /metrics".len + 1) return false;
+    const next = request["GET /metrics".len];
+    return next == ' ' or next == '?' or next == '\r';
+}
+
+fn writeMetrics(writer: anytype, state: *proxy.ProxyState, process: ProcessMetrics) !void {
+    const snapshot = state.getMetricsSnapshot();
+
+    try writeMetricHeader(writer, "mtproto_build_info", "build and version metadata", "gauge");
+    try writer.print("mtproto_build_info{{version=\"{s}\"}} 1\n", .{version});
+
+    try writeGauge(writer, "mtproto_start_time_seconds", "proxy process start time", snapshot.start_time_seconds);
+    try writeGauge(writer, "mtproto_uptime_seconds", "proxy process uptime", snapshot.uptime_seconds);
+    try writeGauge(writer, "mtproto_connections_active", "current active client connections", snapshot.connections_active);
+    try writeGauge(writer, "mtproto_connections_max", "configured maximum concurrent connections", snapshot.connections_max);
+    try writeGauge(writer, "mtproto_handshakes_inflight", "current handshake budget usage", snapshot.handshakes_inflight);
+    try writeCounter(writer, "mtproto_connections_accepted_total", "accepted client connections", snapshot.connections_accepted_total);
+    try writeCounter(writer, "mtproto_connections_closed_total", "closed client connections", snapshot.connections_closed_total);
+    try writeCounter(writer, "mtproto_connections_total", "total accepted client connections", snapshot.connections_total);
+    try writeGauge(writer, "mtproto_accept_paused", "whether accepts are paused due to fd pressure", boolToInt(snapshot.accept_paused));
+    try writeGauge(writer, "mtproto_saturation_paused", "whether accepts are paused due to saturation", boolToInt(snapshot.saturation_paused));
+    try writeCounter(writer, "mtproto_drops_capacity_total", "connections dropped because max_connections was reached", snapshot.drops_capacity_total);
+    try writeCounter(writer, "mtproto_drops_saturation_total", "accept attempts dropped due to saturation hysteresis", snapshot.drops_saturation_total);
+    try writeCounter(writer, "mtproto_drops_rate_limit_total", "connections dropped by subnet rate limiter", snapshot.drops_rate_limit_total);
+    try writeCounter(writer, "mtproto_drops_handshake_budget_total", "connections dropped because handshake budget was exhausted", snapshot.drops_handshake_budget_total);
+    try writeCounter(writer, "mtproto_handshake_timeouts_total", "connections dropped due to handshake timeout", snapshot.handshake_timeouts_total);
+    try writeCounter(writer, "mtproto_middleproxy_fallback_total", "times middleproxy fell back to direct path", snapshot.middleproxy_fallback_total);
+    try writeGauge(writer, "mtproto_config_max_connections", "configured max_connections", snapshot.config_max_connections);
+    try writeGauge(writer, "mtproto_config_port", "configured MTProto listen port", snapshot.config_port);
+    try writeGauge(writer, "mtproto_middleproxy_enabled", "whether middleproxy mode is enabled", boolToInt(snapshot.middleproxy_enabled));
+    try writeGauge(writer, "mtproto_fast_mode_enabled", "whether fast mode is enabled", boolToInt(snapshot.fast_mode_enabled));
+    try writeGauge(writer, "mtproto_mask_enabled", "whether masking is enabled", boolToInt(snapshot.mask_enabled));
+    try writeGauge(writer, "mtproto_desync_enabled", "whether desync is enabled", boolToInt(snapshot.desync_enabled));
+    try writeGauge(writer, "mtproto_drs_enabled", "whether dynamic record sizing is enabled", boolToInt(snapshot.drs_enabled));
+
+    if (process.resident_memory_bytes) |value| {
+        try writeGauge(writer, "process_resident_memory_bytes", "resident set size", value);
+    }
+    if (process.virtual_memory_bytes) |value| {
+        try writeGauge(writer, "process_virtual_memory_bytes", "virtual memory size", value);
+    }
+    if (process.cpu_seconds_total) |value| {
+        try writeMetricHeader(writer, "process_cpu_seconds_total", "user and system CPU time", "counter");
+        try writer.print("process_cpu_seconds_total {d:.6}\n", .{value});
+    }
+    if (process.open_fds) |value| {
+        try writeGauge(writer, "process_open_fds", "open file descriptors", value);
+    }
+    if (process.max_fds) |value| {
+        try writeGauge(writer, "process_max_fds", "maximum file descriptors", value);
+    }
+}
+
+fn writeMetricHeader(writer: anytype, name: []const u8, help: []const u8, metric_type: []const u8) !void {
+    try writer.print("# HELP {s} {s}\n", .{ name, help });
+    try writer.print("# TYPE {s} {s}\n", .{ name, metric_type });
+}
+
+fn writeGauge(writer: anytype, name: []const u8, help: []const u8, value: anytype) !void {
+    try writeMetricHeader(writer, name, help, "gauge");
+    try writer.print("{s} {d}\n", .{ name, value });
+}
+
+fn writeCounter(writer: anytype, name: []const u8, help: []const u8, value: anytype) !void {
+    try writeMetricHeader(writer, name, help, "counter");
+    try writer.print("{s} {d}\n", .{ name, value });
+}
+
+fn boolToInt(value: bool) u8 {
+    return if (value) 1 else 0;
+}
+
+fn collectProcessMetrics() ProcessMetrics {
+    return .{
+        .resident_memory_bytes = readStatusValueBytes("VmRSS:"),
+        .virtual_memory_bytes = readStatusValueBytes("VmSize:"),
+        .cpu_seconds_total = readCpuSecondsTotal(),
+        .open_fds = countOpenFds(),
+        .max_fds = readMaxFds(),
+    };
+}
+
+fn readStatusValueBytes(label: []const u8) ?u64 {
+    var buf: [16 * 1024]u8 = undefined;
+    const text = readFileAbsolute("/proc/self/status", &buf) orelse return null;
+
+    var lines = std.mem.splitScalar(u8, text, '\n');
+    while (lines.next()) |line| {
+        if (!std.mem.startsWith(u8, line, label)) continue;
+        var it = std.mem.tokenizeAny(u8, line[label.len..], " \t");
+        const value_txt = it.next() orelse return null;
+        const kib = std.fmt.parseInt(u64, value_txt, 10) catch return null;
+        return kib * 1024;
+    }
+    return null;
+}
+
+fn readCpuSecondsTotal() ?f64 {
+    var buf: [8 * 1024]u8 = undefined;
+    const text = readFileAbsolute("/proc/self/stat", &buf) orelse return null;
+    const close_idx = std.mem.lastIndexOfScalar(u8, text, ')') orelse return null;
+    if (close_idx + 2 >= text.len) return null;
+
+    var fields = std.mem.tokenizeScalar(u8, text[close_idx + 2 ..], ' ');
+    var idx: usize = 0;
+    var utime_ticks: ?u64 = null;
+    var stime_ticks: ?u64 = null;
+    while (fields.next()) |field| : (idx += 1) {
+        if (idx == 11) {
+            utime_ticks = std.fmt.parseInt(u64, field, 10) catch return null;
+        } else if (idx == 12) {
+            stime_ticks = std.fmt.parseInt(u64, field, 10) catch return null;
+            break;
+        }
+    }
+    if (utime_ticks == null or stime_ticks == null) return null;
+    return @as(f64, @floatFromInt(utime_ticks.? + stime_ticks.?)) / 100.0;
+}
+
+fn countOpenFds() ?u64 {
+    var dir = std.fs.openDirAbsolute("/proc/self/fd", .{ .iterate = true }) catch return null;
+    defer dir.close();
+
+    var it = dir.iterate();
+    var count: u64 = 0;
+    while (it.next() catch return null) |_| {
+        count += 1;
+    }
+    return count;
+}
+
+fn readMaxFds() ?u64 {
+    if (builtin.os.tag != .linux) return null;
+
+    var lim: linux.rlimit = undefined;
+    const rc = linux.getrlimit(.NOFILE, &lim);
+    switch (posix.errno(rc)) {
+        .SUCCESS => return @intCast(lim.cur),
+        else => return null,
+    }
+}
+
+fn readFileAbsolute(path: []const u8, buffer: []u8) ?[]const u8 {
+    const file = std.fs.openFileAbsolute(path, .{}) catch return null;
+    defer file.close();
+    const len = file.readAll(buffer) catch return null;
+    return buffer[0..len];
+}
+
+test "monitoring metrics output contains required metrics" {
+    var cfg = config.Config{
+        .users = std.StringHashMap([16]u8).init(std.testing.allocator),
+        .direct_users = std.StringHashMap(void).init(std.testing.allocator),
+    };
+    defer cfg.deinit(std.testing.allocator);
+
+    var state = proxy.ProxyState.init(std.testing.allocator, cfg);
+    defer state.deinit();
+
+    var buf: [16 * 1024]u8 = undefined;
+    var stream = std.io.fixedBufferStream(&buf);
+    try writeMetrics(stream.writer(), &state, .{});
+    const out = stream.getWritten();
+    try std.testing.expect(std.mem.indexOf(u8, out, "mtproto_connections_active") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "mtproto_build_info") != null);
+}
+
+test "monitoring rejects unknown path" {
+    var cfg = config.Config{
+        .users = std.StringHashMap([16]u8).init(std.testing.allocator),
+        .direct_users = std.StringHashMap(void).init(std.testing.allocator),
+    };
+    defer cfg.deinit(std.testing.allocator);
+
+    var state = proxy.ProxyState.init(std.testing.allocator, cfg);
+    defer state.deinit();
+
+    try std.testing.expect(!isGetMetrics("GET /nope HTTP/1.1\r\nHost: localhost\r\n\r\n"));
+    try std.testing.expect(isGetRequest("GET /nope HTTP/1.1\r\nHost: localhost\r\n\r\n"));
+}

--- a/src/monitoring.zig
+++ b/src/monitoring.zig
@@ -7,7 +7,7 @@ const proxy = @import("proxy/proxy.zig");
 const config = @import("config.zig");
 const version = @import("version").version;
 
-const log = std.log.scoped(.monitoring);
+const log = std.log.scoped(.metrics);
 const metrics_content_type = "text/plain; version=0.0.4";
 
 const ProcessMetrics = struct {
@@ -23,8 +23,8 @@ const ProcessMetrics = struct {
 pub fn start(state: *proxy.ProxyState) !void {
     if (builtin.os.tag != .linux) return error.UnsupportedOperatingSystem;
 
-    const host = state.config.monitoring.host;
-    const port = state.config.monitoring.port;
+    const host = state.config.metrics.effectiveHost();
+    const port = state.config.metrics.port;
 
     const addr_list = try net.getAddressList(std.heap.page_allocator, host, port);
     defer addr_list.deinit();
@@ -60,6 +60,13 @@ fn acceptLoop(state: *proxy.ProxyState, server: net.Server) void {
 fn handleConnection(state: *proxy.ProxyState, fd: posix.fd_t) void {
     defer posix.close(fd);
 
+    // Prevent slow clients from blocking the accept thread.
+    if (builtin.os.tag == .linux) {
+        const timeout = posix.timeval{ .sec = 5, .usec = 0 };
+        posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.RCVTIMEO, std.mem.asBytes(&timeout)) catch {};
+        posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.SNDTIMEO, std.mem.asBytes(&timeout)) catch {};
+    }
+
     var req_buf: [2048]u8 = undefined;
     const req_len = posix.read(fd, &req_buf) catch return;
     if (req_len == 0) return;
@@ -79,7 +86,7 @@ fn handleConnection(state: *proxy.ProxyState, fd: posix.fd_t) void {
 }
 
 fn writeMetricsResponse(fd: posix.fd_t, state: *proxy.ProxyState) !void {
-    var body_buf: [16 * 1024]u8 = undefined;
+    var body_buf: [32 * 1024]u8 = undefined;
     var body_stream = std.io.fixedBufferStream(&body_buf);
     try writeMetrics(body_stream.writer(), state, collectProcessMetrics());
     const body = body_stream.getWritten();
@@ -354,7 +361,7 @@ fn readFileAbsolute(path: []const u8, buffer: []u8) ?[]const u8 {
     return buffer[0..len];
 }
 
-test "monitoring metrics output contains required metrics" {
+test "metrics output contains required metrics" {
     var cfg = config.Config{
         .users = std.StringHashMap([16]u8).init(std.testing.allocator),
         .direct_users = std.StringHashMap(void).init(std.testing.allocator),
@@ -364,7 +371,7 @@ test "monitoring metrics output contains required metrics" {
     var state = proxy.ProxyState.init(std.testing.allocator, cfg);
     defer state.deinit();
 
-    var buf: [16 * 1024]u8 = undefined;
+    var buf: [32 * 1024]u8 = undefined;
     var stream = std.io.fixedBufferStream(&buf);
     try writeMetrics(stream.writer(), &state, .{});
     const out = stream.getWritten();
@@ -373,7 +380,7 @@ test "monitoring metrics output contains required metrics" {
     try std.testing.expect(std.mem.indexOf(u8, out, "mtproto_client_to_upstream_bytes_total") != null);
 }
 
-test "monitoring rejects unknown path" {
+test "metrics rejects unknown path" {
     var cfg = config.Config{
         .users = std.StringHashMap([16]u8).init(std.testing.allocator),
         .direct_users = std.StringHashMap(void).init(std.testing.allocator),

--- a/src/monitoring.zig
+++ b/src/monitoring.zig
@@ -5,7 +5,7 @@ const posix = std.posix;
 const linux = std.os.linux;
 const proxy = @import("proxy/proxy.zig");
 const config = @import("config.zig");
-const version = @import("version.zig").version;
+const version = @import("version").version;
 
 const log = std.log.scoped(.monitoring);
 const metrics_content_type = "text/plain; version=0.0.4";

--- a/src/monitoring.zig
+++ b/src/monitoring.zig
@@ -16,6 +16,8 @@ const ProcessMetrics = struct {
     cpu_seconds_total: ?f64 = null,
     open_fds: ?u64 = null,
     max_fds: ?u64 = null,
+    cgroup_memory_usage_bytes: ?u64 = null,
+    cgroup_memory_limit_bytes: ?u64 = null,
 };
 
 pub fn start(state: *proxy.ProxyState) !void {
@@ -144,6 +146,8 @@ fn writeMetrics(writer: anytype, state: *proxy.ProxyState, process: ProcessMetri
     try writeCounter(writer, "mtproto_drops_handshake_budget_total", "connections dropped because handshake budget was exhausted", snapshot.drops_handshake_budget_total);
     try writeCounter(writer, "mtproto_handshake_timeouts_total", "connections dropped due to handshake timeout", snapshot.handshake_timeouts_total);
     try writeCounter(writer, "mtproto_middleproxy_fallback_total", "times middleproxy fell back to direct path", snapshot.middleproxy_fallback_total);
+    try writeCounter(writer, "mtproto_client_to_upstream_bytes_total", "bytes successfully written from client side toward upstream", snapshot.client_to_upstream_bytes_total);
+    try writeCounter(writer, "mtproto_upstream_to_client_bytes_total", "bytes successfully written from upstream toward client side", snapshot.upstream_to_client_bytes_total);
     try writeGauge(writer, "mtproto_config_max_connections", "configured max_connections", snapshot.config_max_connections);
     try writeGauge(writer, "mtproto_config_port", "configured MTProto listen port", snapshot.config_port);
     try writeGauge(writer, "mtproto_middleproxy_enabled", "whether middleproxy mode is enabled", boolToInt(snapshot.middleproxy_enabled));
@@ -167,6 +171,12 @@ fn writeMetrics(writer: anytype, state: *proxy.ProxyState, process: ProcessMetri
     }
     if (process.max_fds) |value| {
         try writeGauge(writer, "process_max_fds", "maximum file descriptors", value);
+    }
+    if (process.cgroup_memory_usage_bytes) |value| {
+        try writeGauge(writer, "mtproto_cgroup_memory_usage_bytes", "memory usage reported by cgroup", value);
+    }
+    if (process.cgroup_memory_limit_bytes) |value| {
+        try writeGauge(writer, "mtproto_cgroup_memory_limit_bytes", "memory limit reported by cgroup", value);
     }
 }
 
@@ -196,7 +206,35 @@ fn collectProcessMetrics() ProcessMetrics {
         .cpu_seconds_total = readCpuSecondsTotal(),
         .open_fds = countOpenFds(),
         .max_fds = readMaxFds(),
+        .cgroup_memory_usage_bytes = readCgroupMemoryCurrent(),
+        .cgroup_memory_limit_bytes = readCgroupMemoryLimit(),
     };
+}
+
+fn readCgroupMemoryCurrent() ?u64 {
+    return readNumericFileAbsolute("/sys/fs/cgroup/memory.current") orelse
+        readNumericFileAbsolute("/sys/fs/cgroup/memory/memory.usage_in_bytes");
+}
+
+fn readCgroupMemoryLimit() ?u64 {
+    return readCgroupMemoryLimitFile("/sys/fs/cgroup/memory.max") orelse
+        readCgroupMemoryLimitFile("/sys/fs/cgroup/memory/memory.limit_in_bytes");
+}
+
+fn readCgroupMemoryLimitFile(path: []const u8) ?u64 {
+    var buf: [256]u8 = undefined;
+    const text = readFileAbsolute(path, &buf) orelse return null;
+    const trimmed = std.mem.trim(u8, text, " \t\r\n");
+    if (trimmed.len == 0 or std.mem.eql(u8, trimmed, "max")) return null;
+    return std.fmt.parseInt(u64, trimmed, 10) catch null;
+}
+
+fn readNumericFileAbsolute(path: []const u8) ?u64 {
+    var buf: [256]u8 = undefined;
+    const text = readFileAbsolute(path, &buf) orelse return null;
+    const trimmed = std.mem.trim(u8, text, " \t\r\n");
+    if (trimmed.len == 0) return null;
+    return std.fmt.parseInt(u64, trimmed, 10) catch null;
 }
 
 fn readStatusValueBytes(label: []const u8) ?u64 {
@@ -282,6 +320,7 @@ test "monitoring metrics output contains required metrics" {
     const out = stream.getWritten();
     try std.testing.expect(std.mem.indexOf(u8, out, "mtproto_connections_active") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "mtproto_build_info") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "mtproto_client_to_upstream_bytes_total") != null);
 }
 
 test "monitoring rejects unknown path" {

--- a/src/monitoring.zig
+++ b/src/monitoring.zig
@@ -155,6 +155,7 @@ fn writeMetrics(writer: anytype, state: *proxy.ProxyState, process: ProcessMetri
     try writeGauge(writer, "mtproto_mask_enabled", "whether masking is enabled", boolToInt(snapshot.mask_enabled));
     try writeGauge(writer, "mtproto_desync_enabled", "whether desync is enabled", boolToInt(snapshot.desync_enabled));
     try writeGauge(writer, "mtproto_drs_enabled", "whether dynamic record sizing is enabled", boolToInt(snapshot.drs_enabled));
+    try writePerUserMetrics(writer, state);
 
     if (process.resident_memory_bytes) |value| {
         try writeGauge(writer, "process_resident_memory_bytes", "resident set size", value);
@@ -183,6 +184,55 @@ fn writeMetrics(writer: anytype, state: *proxy.ProxyState, process: ProcessMetri
 fn writeMetricHeader(writer: anytype, name: []const u8, help: []const u8, metric_type: []const u8) !void {
     try writer.print("# HELP {s} {s}\n", .{ name, help });
     try writer.print("# TYPE {s} {s}\n", .{ name, metric_type });
+}
+
+fn writePerUserMetrics(writer: anytype, state: *proxy.ProxyState) !void {
+    try writeMetricHeader(writer, "mtproto_user_connections_active", "active connections by configured user", "gauge");
+    for (state.user_metrics) |entry| {
+        try writeLabeledMetricLine(
+            writer,
+            "mtproto_user_connections_active",
+            entry.name,
+            entry.connections_active.load(.monotonic),
+        );
+    }
+
+    try writeMetricHeader(writer, "mtproto_user_client_to_upstream_bytes_total", "bytes successfully written upstream by configured user", "counter");
+    for (state.user_metrics) |entry| {
+        try writeLabeledMetricLine(
+            writer,
+            "mtproto_user_client_to_upstream_bytes_total",
+            entry.name,
+            entry.client_to_upstream_bytes_total.load(.monotonic),
+        );
+    }
+
+    try writeMetricHeader(writer, "mtproto_user_upstream_to_client_bytes_total", "bytes successfully written to client by configured user", "counter");
+    for (state.user_metrics) |entry| {
+        try writeLabeledMetricLine(
+            writer,
+            "mtproto_user_upstream_to_client_bytes_total",
+            entry.name,
+            entry.upstream_to_client_bytes_total.load(.monotonic),
+        );
+    }
+}
+
+fn writeLabeledMetricLine(writer: anytype, metric_name: []const u8, user_name: []const u8, value: anytype) !void {
+    try writer.print("{s}{{user=\"", .{metric_name});
+    try writePrometheusLabelValue(writer, user_name);
+    try writer.print("\"}} {d}\n", .{value});
+}
+
+fn writePrometheusLabelValue(writer: anytype, value: []const u8) !void {
+    for (value) |ch| {
+        switch (ch) {
+            '\\' => try writer.writeAll("\\\\"),
+            '"' => try writer.writeAll("\\\""),
+            '\n' => try writer.writeAll("\\n"),
+            else => try writer.writeByte(ch),
+        }
+    }
 }
 
 fn writeGauge(writer: anytype, name: []const u8, help: []const u8, value: anytype) !void {

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -602,6 +602,7 @@ const ConnectionSlot = struct {
     s2c_bytes: u64 = 0,
     traffic_client_to_upstream_counter: ?*std.atomic.Value(u64) = null,
     traffic_upstream_to_client_counter: ?*std.atomic.Value(u64) = null,
+    user_metrics: ?*ProxyState.UserMetrics = null,
 
     // Non-blocking write queues (slab-like chain buffers)
     client_queue: MessageQueue = .{ .allocator = std.heap.page_allocator },
@@ -704,6 +705,7 @@ const ConnectionSlot = struct {
         self.current_upstream_addr = null;
         self.dc_abs = 0;
         self.is_media_path = false;
+        self.user_metrics = null;
 
         if (self.mp_frame_buf) |buf| allocator.free(buf);
         self.mp_frame_buf = null;
@@ -871,6 +873,13 @@ const ConnectionPool = struct {
 };
 
 pub const ProxyState = struct {
+    pub const UserMetrics = struct {
+        name: []const u8,
+        connections_active: std.atomic.Value(u32),
+        client_to_upstream_bytes_total: std.atomic.Value(u64),
+        upstream_to_client_bytes_total: std.atomic.Value(u64),
+    };
+
     pub const MetricsSnapshot = struct {
         start_time_seconds: i64,
         uptime_seconds: i64,
@@ -902,6 +911,7 @@ pub const ProxyState = struct {
     allocator: std.mem.Allocator,
     config: Config,
     user_secrets: []const obfuscation.UserSecret,
+    user_metrics: []UserMetrics,
     start_time_seconds: i64,
     connection_count: std.atomic.Value(u64),
     closed_count: std.atomic.Value(u64),
@@ -938,11 +948,18 @@ pub const ProxyState = struct {
 
     pub fn init(allocator: std.mem.Allocator, cfg: Config) ProxyState {
         var secrets: std.ArrayList(obfuscation.UserSecret) = .empty;
+        var user_metrics: std.ArrayList(UserMetrics) = .empty;
         var it = @constCast(&cfg.users).iterator();
         while (it.next()) |entry| {
             secrets.append(allocator, .{
                 .name = entry.key_ptr.*,
                 .secret = entry.value_ptr.*,
+            }) catch continue;
+            user_metrics.append(allocator, .{
+                .name = entry.key_ptr.*,
+                .connections_active = std.atomic.Value(u32).init(0),
+                .client_to_upstream_bytes_total = std.atomic.Value(u64).init(0),
+                .upstream_to_client_bytes_total = std.atomic.Value(u64).init(0),
             }) catch continue;
         }
 
@@ -1013,6 +1030,7 @@ pub const ProxyState = struct {
             .allocator = allocator,
             .config = cfg,
             .user_secrets = secrets.toOwnedSlice(allocator) catch &.{},
+            .user_metrics = user_metrics.toOwnedSlice(allocator) catch &.{},
             .start_time_seconds = std.time.timestamp(),
             .connection_count = std.atomic.Value(u64).init(0),
             .closed_count = std.atomic.Value(u64).init(0),
@@ -1118,6 +1136,14 @@ pub const ProxyState = struct {
 
     pub fn deinit(self: *ProxyState) void {
         self.allocator.free(self.user_secrets);
+        self.allocator.free(self.user_metrics);
+    }
+
+    pub fn findUserMetrics(self: *ProxyState, user_name: []const u8) ?*UserMetrics {
+        for (self.user_metrics) |*entry| {
+            if (std.mem.eql(u8, entry.name, user_name)) return entry;
+        }
+        return null;
     }
 
     pub fn getMetricsSnapshot(self: *const ProxyState) MetricsSnapshot {
@@ -1653,6 +1679,7 @@ const EventLoop = struct {
             slot.active_reserved = true;
             slot.traffic_client_to_upstream_counter = &self.state.client_to_upstream_bytes_total;
             slot.traffic_upstream_to_client_counter = &self.state.upstream_to_client_bytes_total;
+            slot.user_metrics = null;
             slot.conn_id = self.state.connection_count.fetchAdd(1, .monotonic);
             slot.client_fd = cfd;
             slot.peer_addr = client_addr;
@@ -2269,6 +2296,11 @@ const EventLoop = struct {
         if (plan.count == 0) {
             self.closeSlot(slot, "no upstream candidates");
             return;
+        }
+
+        slot.user_metrics = self.state.findUserMetrics(result.user);
+        if (slot.user_metrics) |entry| {
+            _ = entry.connections_active.fetchAdd(1, .monotonic);
         }
 
         slot.dc_abs = @intCast(dc_abs);
@@ -3654,6 +3686,10 @@ const EventLoop = struct {
         if (slot.active_reserved) {
             _ = self.state.active_connections.fetchSub(1, .monotonic);
             _ = self.state.closed_count.fetchAdd(1, .monotonic);
+            if (slot.user_metrics) |entry| {
+                _ = entry.connections_active.fetchSub(1, .monotonic);
+                slot.user_metrics = null;
+            }
             // If connection was still in handshake phase, release from handshake budget
             if (slot.handshakeInProgress()) {
                 _ = self.state.handshakes_inflight.fetchSub(1, .monotonic);
@@ -4350,7 +4386,11 @@ fn noteTraffic(counter: *std.atomic.Value(u64), bytes: usize) void {
     _ = counter.fetchAdd(@intCast(bytes), .monotonic);
 }
 
-fn queueOrWriteMsg(fd: posix.fd_t, queue: *MessageQueue, data: []const u8, counter: *std.atomic.Value(u64)) !bool {
+fn noteTrafficOptional(counter: ?*std.atomic.Value(u64), bytes: usize) void {
+    if (counter) |ptr| noteTraffic(ptr, bytes);
+}
+
+fn queueOrWriteMsg(fd: posix.fd_t, queue: *MessageQueue, data: []const u8, counter: *std.atomic.Value(u64), user_counter: ?*std.atomic.Value(u64)) !bool {
     if (data.len == 0) return true;
 
     if (queue.isEmpty()) {
@@ -4363,6 +4403,7 @@ fn queueOrWriteMsg(fd: posix.fd_t, queue: *MessageQueue, data: []const u8, count
         };
 
         noteTraffic(counter, n);
+        noteTrafficOptional(user_counter, n);
         if (n == data.len) return true;
         try queue.appendCopy(data[n..]);
         return false;
@@ -4372,7 +4413,7 @@ fn queueOrWriteMsg(fd: posix.fd_t, queue: *MessageQueue, data: []const u8, count
     return false;
 }
 
-fn queueOrWriteMsgPair(fd: posix.fd_t, queue: *MessageQueue, first: []const u8, second: []const u8, counter: *std.atomic.Value(u64)) !bool {
+fn queueOrWriteMsgPair(fd: posix.fd_t, queue: *MessageQueue, first: []const u8, second: []const u8, counter: *std.atomic.Value(u64), user_counter: ?*std.atomic.Value(u64)) !bool {
     if (first.len == 0 and second.len == 0) return true;
 
     if (queue.isEmpty()) {
@@ -4399,6 +4440,7 @@ fn queueOrWriteMsgPair(fd: posix.fd_t, queue: *MessageQueue, first: []const u8, 
 
         if (n == 0) return error.ConnectionReset;
         noteTraffic(counter, n);
+        noteTrafficOptional(user_counter, n);
         if (n == total_len) return true;
 
         if (n < first.len) {
@@ -4419,7 +4461,7 @@ fn queueOrWriteMsgPair(fd: posix.fd_t, queue: *MessageQueue, first: []const u8, 
     return false;
 }
 
-fn queueOrWriteOwnedMsg(fd: posix.fd_t, queue: *MessageQueue, owned: []u8, counter: *std.atomic.Value(u64)) !bool {
+fn queueOrWriteOwnedMsg(fd: posix.fd_t, queue: *MessageQueue, owned: []u8, counter: *std.atomic.Value(u64), user_counter: ?*std.atomic.Value(u64)) !bool {
     if (owned.len == 0) {
         queue.allocator.free(owned);
         return true;
@@ -4436,6 +4478,7 @@ fn queueOrWriteOwnedMsg(fd: posix.fd_t, queue: *MessageQueue, owned: []u8, count
         };
 
         noteTraffic(counter, n);
+        noteTrafficOptional(user_counter, n);
         if (n == owned.len) {
             queue.allocator.free(owned);
             return true;
@@ -4451,7 +4494,7 @@ fn queueOrWriteOwnedMsg(fd: posix.fd_t, queue: *MessageQueue, owned: []u8, count
     return false;
 }
 
-fn flushQueue(fd: posix.fd_t, queue: *MessageQueue, counter: *std.atomic.Value(u64)) !bool {
+fn flushQueue(fd: posix.fd_t, queue: *MessageQueue, counter: *std.atomic.Value(u64), user_counter: ?*std.atomic.Value(u64)) !bool {
     if (queue.isEmpty()) return true;
 
     var iovecs: [max_scatter_parts]posix.iovec_const = undefined;
@@ -4470,6 +4513,7 @@ fn flushQueue(fd: posix.fd_t, queue: *MessageQueue, counter: *std.atomic.Value(u
 
         if (n == 0) return error.ConnectionReset;
         noteTraffic(counter, n);
+        noteTrafficOptional(user_counter, n);
         try queue.consume(n);
 
         if (n < total_req) return false;
@@ -4480,32 +4524,67 @@ fn flushQueue(fd: posix.fd_t, queue: *MessageQueue, counter: *std.atomic.Value(u
 
 fn slotQueueClient(slot: *ConnectionSlot, allocator: std.mem.Allocator, data: []const u8) !bool {
     _ = allocator;
-    return queueOrWriteMsg(slot.client_fd, &slot.client_queue, data, slot.traffic_upstream_to_client_counter orelse return error.MissingTrafficCounter);
+    return queueOrWriteMsg(
+        slot.client_fd,
+        &slot.client_queue,
+        data,
+        slot.traffic_upstream_to_client_counter orelse return error.MissingTrafficCounter,
+        if (slot.user_metrics) |entry| &entry.upstream_to_client_bytes_total else null,
+    );
 }
 
 fn slotQueueClientPair(slot: *ConnectionSlot, allocator: std.mem.Allocator, first: []const u8, second: []const u8) !bool {
     _ = allocator;
-    return queueOrWriteMsgPair(slot.client_fd, &slot.client_queue, first, second, slot.traffic_upstream_to_client_counter orelse return error.MissingTrafficCounter);
+    return queueOrWriteMsgPair(
+        slot.client_fd,
+        &slot.client_queue,
+        first,
+        second,
+        slot.traffic_upstream_to_client_counter orelse return error.MissingTrafficCounter,
+        if (slot.user_metrics) |entry| &entry.upstream_to_client_bytes_total else null,
+    );
 }
 
 fn slotQueueClientOwned(slot: *ConnectionSlot, allocator: std.mem.Allocator, owned: []u8) !bool {
     _ = allocator;
-    return queueOrWriteOwnedMsg(slot.client_fd, &slot.client_queue, owned, slot.traffic_upstream_to_client_counter orelse return error.MissingTrafficCounter);
+    return queueOrWriteOwnedMsg(
+        slot.client_fd,
+        &slot.client_queue,
+        owned,
+        slot.traffic_upstream_to_client_counter orelse return error.MissingTrafficCounter,
+        if (slot.user_metrics) |entry| &entry.upstream_to_client_bytes_total else null,
+    );
 }
 
 fn slotQueueUpstream(slot: *ConnectionSlot, allocator: std.mem.Allocator, data: []const u8) !bool {
     _ = allocator;
-    return queueOrWriteMsg(slot.upstream_fd, &slot.upstream_queue, data, slot.traffic_client_to_upstream_counter orelse return error.MissingTrafficCounter);
+    return queueOrWriteMsg(
+        slot.upstream_fd,
+        &slot.upstream_queue,
+        data,
+        slot.traffic_client_to_upstream_counter orelse return error.MissingTrafficCounter,
+        if (slot.user_metrics) |entry| &entry.client_to_upstream_bytes_total else null,
+    );
 }
 
 fn slotFlushClientPending(slot: *ConnectionSlot, allocator: std.mem.Allocator) !bool {
     _ = allocator;
-    return flushQueue(slot.client_fd, &slot.client_queue, slot.traffic_upstream_to_client_counter orelse return error.MissingTrafficCounter);
+    return flushQueue(
+        slot.client_fd,
+        &slot.client_queue,
+        slot.traffic_upstream_to_client_counter orelse return error.MissingTrafficCounter,
+        if (slot.user_metrics) |entry| &entry.upstream_to_client_bytes_total else null,
+    );
 }
 
 fn slotFlushUpstreamPending(slot: *ConnectionSlot, allocator: std.mem.Allocator) !bool {
     _ = allocator;
-    return flushQueue(slot.upstream_fd, &slot.upstream_queue, slot.traffic_client_to_upstream_counter orelse return error.MissingTrafficCounter);
+    return flushQueue(
+        slot.upstream_fd,
+        &slot.upstream_queue,
+        slot.traffic_client_to_upstream_counter orelse return error.MissingTrafficCounter,
+        if (slot.user_metrics) |entry| &entry.client_to_upstream_bytes_total else null,
+    );
 }
 
 fn slotMpReadReset(slot: *ConnectionSlot, encrypted: bool) void {

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -869,12 +869,42 @@ const ConnectionPool = struct {
 };
 
 pub const ProxyState = struct {
+    pub const MetricsSnapshot = struct {
+        start_time_seconds: i64,
+        uptime_seconds: i64,
+        connections_active: u32,
+        connections_max: u32,
+        handshakes_inflight: u32,
+        connections_accepted_total: u64,
+        connections_closed_total: u64,
+        connections_total: u64,
+        accept_paused: bool,
+        saturation_paused: bool,
+        drops_capacity_total: u64,
+        drops_saturation_total: u64,
+        drops_rate_limit_total: u64,
+        drops_handshake_budget_total: u64,
+        handshake_timeouts_total: u64,
+        middleproxy_fallback_total: u64,
+        config_port: u16,
+        config_max_connections: u32,
+        middleproxy_enabled: bool,
+        fast_mode_enabled: bool,
+        mask_enabled: bool,
+        desync_enabled: bool,
+        drs_enabled: bool,
+    };
+
     allocator: std.mem.Allocator,
     config: Config,
     user_secrets: []const obfuscation.UserSecret,
+    start_time_seconds: i64,
     connection_count: std.atomic.Value(u64),
+    closed_count: std.atomic.Value(u64),
     active_connections: std.atomic.Value(u32),
     handshakes_inflight: std.atomic.Value(u32),
+    accept_paused: std.atomic.Value(bool),
+    saturation_paused: std.atomic.Value(bool),
     mask_addr: ?net.Address,
     replay_cache: ReplayCache,
     tls_server_hello_template: [tls.server_hello_template_len]u8,
@@ -977,9 +1007,13 @@ pub const ProxyState = struct {
             .allocator = allocator,
             .config = cfg,
             .user_secrets = secrets.toOwnedSlice(allocator) catch &.{},
+            .start_time_seconds = std.time.timestamp(),
             .connection_count = std.atomic.Value(u64).init(0),
+            .closed_count = std.atomic.Value(u64).init(0),
             .active_connections = std.atomic.Value(u32).init(0),
             .handshakes_inflight = std.atomic.Value(u32).init(0),
+            .accept_paused = std.atomic.Value(bool).init(false),
+            .saturation_paused = std.atomic.Value(bool).init(false),
             .mask_addr = resolved_addr,
             .replay_cache = ReplayCache.init(),
             .tls_server_hello_template = tls.buildServerHelloTemplate(null),
@@ -1078,6 +1112,36 @@ pub const ProxyState = struct {
         self.allocator.free(self.user_secrets);
     }
 
+    pub fn getMetricsSnapshot(self: *const ProxyState) MetricsSnapshot {
+        const now = std.time.timestamp();
+        const accepted_total = self.connection_count.load(.monotonic);
+        return .{
+            .start_time_seconds = self.start_time_seconds,
+            .uptime_seconds = @max(@as(i64, 0), now - self.start_time_seconds),
+            .connections_active = self.active_connections.load(.monotonic),
+            .connections_max = self.config.max_connections,
+            .handshakes_inflight = self.handshakes_inflight.load(.monotonic),
+            .connections_accepted_total = accepted_total,
+            .connections_closed_total = self.closed_count.load(.monotonic),
+            .connections_total = accepted_total,
+            .accept_paused = self.accept_paused.load(.monotonic),
+            .saturation_paused = self.saturation_paused.load(.monotonic),
+            .drops_capacity_total = self.stats_dropped_cap.load(.monotonic),
+            .drops_saturation_total = self.stats_dropped_saturation.load(.monotonic),
+            .drops_rate_limit_total = self.stats_dropped_rate_limit.load(.monotonic),
+            .drops_handshake_budget_total = self.stats_dropped_hs_budget.load(.monotonic),
+            .handshake_timeouts_total = self.stats_hs_timeout.load(.monotonic),
+            .middleproxy_fallback_total = self.stats_mp_fallback.load(.monotonic),
+            .config_port = self.config.port,
+            .config_max_connections = self.config.max_connections,
+            .middleproxy_enabled = self.config.use_middle_proxy,
+            .fast_mode_enabled = self.config.fast_mode,
+            .mask_enabled = self.config.mask,
+            .desync_enabled = self.config.desync,
+            .drs_enabled = self.config.drs,
+        };
+    }
+
     pub fn run(self: *ProxyState) !void {
         if (builtin.os.tag != .linux) return error.UnsupportedOperatingSystem;
 
@@ -1164,6 +1228,10 @@ pub const ProxyState = struct {
 
         const effective_needed_fds = requiredFdsForConnections(self.config.max_connections);
         checkNofileLimit(@max(effective_needed_fds, min_nofile_soft), self.config.max_connections);
+
+        if (self.config.monitoring.enabled) {
+            try @import("../monitoring.zig").start(self);
+        }
 
         var loop = try EventLoop.init(self, server.stream.handle);
         defer loop.deinit();
@@ -1659,6 +1727,7 @@ const EventLoop = struct {
         };
 
         self.accept_paused = true;
+        self.state.accept_paused.store(true, .monotonic);
         const needed = requiredFdsForConnections(self.state.config.max_connections);
         log.warn("fd quota reached ({any}); pausing accepts for {d}ms (recommended LimitNOFILE >= {d})", .{
             err,
@@ -1678,6 +1747,7 @@ const EventLoop = struct {
 
         self.accept_paused = false;
         self.accept_resume_ns = 0;
+        self.state.accept_paused.store(false, .monotonic);
     }
 
     fn pauseSaturation(self: *EventLoop) void {
@@ -1689,6 +1759,7 @@ const EventLoop = struct {
         };
 
         self.saturation_paused = true;
+        self.state.saturation_paused.store(true, .monotonic);
         const active = self.state.active_connections.load(.monotonic);
         const max = self.state.config.max_connections;
         log.warn(
@@ -1708,6 +1779,7 @@ const EventLoop = struct {
         };
 
         self.saturation_paused = false;
+        self.state.saturation_paused.store(false, .monotonic);
         const active = self.state.active_connections.load(.monotonic);
         log.info("saturation eased: active={d}/{d}; resuming accepts", .{ active, self.state.config.max_connections });
     }
@@ -3569,6 +3641,7 @@ const EventLoop = struct {
 
         if (slot.active_reserved) {
             _ = self.state.active_connections.fetchSub(1, .monotonic);
+            _ = self.state.closed_count.fetchAdd(1, .monotonic);
             // If connection was still in handshake phase, release from handshake budget
             if (slot.handshakeInProgress()) {
                 _ = self.state.handshakes_inflight.fetchSub(1, .monotonic);

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -1265,7 +1265,7 @@ pub const ProxyState = struct {
         const effective_needed_fds = requiredFdsForConnections(self.config.max_connections);
         checkNofileLimit(@max(effective_needed_fds, min_nofile_soft), self.config.max_connections);
 
-        if (self.config.monitoring.enabled) {
+        if (self.config.metrics.enabled) {
             try @import("../monitoring.zig").start(self);
         }
 
@@ -4381,6 +4381,11 @@ fn parseMiddleProxyAddressForDc(config_text: []const u8, target_dc: i16) ?net.Ad
     return one[0];
 }
 
+/// Dummy counter for slots that don't yet have traffic counters attached
+/// (e.g. during mask phase or before handshake completes).  Writes are
+/// silently absorbed so the data path never errors out on missing metrics.
+var noop_counter = std.atomic.Value(u64).init(0);
+
 fn noteTraffic(counter: *std.atomic.Value(u64), bytes: usize) void {
     if (bytes == 0) return;
     _ = counter.fetchAdd(@intCast(bytes), .monotonic);
@@ -4528,7 +4533,7 @@ fn slotQueueClient(slot: *ConnectionSlot, allocator: std.mem.Allocator, data: []
         slot.client_fd,
         &slot.client_queue,
         data,
-        slot.traffic_upstream_to_client_counter orelse return error.MissingTrafficCounter,
+        slot.traffic_upstream_to_client_counter orelse &noop_counter,
         if (slot.user_metrics) |entry| &entry.upstream_to_client_bytes_total else null,
     );
 }
@@ -4540,7 +4545,7 @@ fn slotQueueClientPair(slot: *ConnectionSlot, allocator: std.mem.Allocator, firs
         &slot.client_queue,
         first,
         second,
-        slot.traffic_upstream_to_client_counter orelse return error.MissingTrafficCounter,
+        slot.traffic_upstream_to_client_counter orelse &noop_counter,
         if (slot.user_metrics) |entry| &entry.upstream_to_client_bytes_total else null,
     );
 }
@@ -4551,7 +4556,7 @@ fn slotQueueClientOwned(slot: *ConnectionSlot, allocator: std.mem.Allocator, own
         slot.client_fd,
         &slot.client_queue,
         owned,
-        slot.traffic_upstream_to_client_counter orelse return error.MissingTrafficCounter,
+        slot.traffic_upstream_to_client_counter orelse &noop_counter,
         if (slot.user_metrics) |entry| &entry.upstream_to_client_bytes_total else null,
     );
 }
@@ -4562,7 +4567,7 @@ fn slotQueueUpstream(slot: *ConnectionSlot, allocator: std.mem.Allocator, data: 
         slot.upstream_fd,
         &slot.upstream_queue,
         data,
-        slot.traffic_client_to_upstream_counter orelse return error.MissingTrafficCounter,
+        slot.traffic_client_to_upstream_counter orelse &noop_counter,
         if (slot.user_metrics) |entry| &entry.client_to_upstream_bytes_total else null,
     );
 }
@@ -4572,7 +4577,7 @@ fn slotFlushClientPending(slot: *ConnectionSlot, allocator: std.mem.Allocator) !
     return flushQueue(
         slot.client_fd,
         &slot.client_queue,
-        slot.traffic_upstream_to_client_counter orelse return error.MissingTrafficCounter,
+        slot.traffic_upstream_to_client_counter orelse &noop_counter,
         if (slot.user_metrics) |entry| &entry.upstream_to_client_bytes_total else null,
     );
 }
@@ -4582,7 +4587,7 @@ fn slotFlushUpstreamPending(slot: *ConnectionSlot, allocator: std.mem.Allocator)
     return flushQueue(
         slot.upstream_fd,
         &slot.upstream_queue,
-        slot.traffic_client_to_upstream_counter orelse return error.MissingTrafficCounter,
+        slot.traffic_client_to_upstream_counter orelse &noop_counter,
         if (slot.user_metrics) |entry| &entry.client_to_upstream_bytes_total else null,
     );
 }

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -600,6 +600,8 @@ const ConnectionSlot = struct {
     },
     c2s_bytes: u64 = 0,
     s2c_bytes: u64 = 0,
+    traffic_client_to_upstream_counter: ?*std.atomic.Value(u64) = null,
+    traffic_upstream_to_client_counter: ?*std.atomic.Value(u64) = null,
 
     // Non-blocking write queues (slab-like chain buffers)
     client_queue: MessageQueue = .{ .allocator = std.heap.page_allocator },
@@ -886,6 +888,8 @@ pub const ProxyState = struct {
         drops_handshake_budget_total: u64,
         handshake_timeouts_total: u64,
         middleproxy_fallback_total: u64,
+        client_to_upstream_bytes_total: u64,
+        upstream_to_client_bytes_total: u64,
         config_port: u16,
         config_max_connections: u32,
         middleproxy_enabled: bool,
@@ -901,6 +905,8 @@ pub const ProxyState = struct {
     start_time_seconds: i64,
     connection_count: std.atomic.Value(u64),
     closed_count: std.atomic.Value(u64),
+    client_to_upstream_bytes_total: std.atomic.Value(u64),
+    upstream_to_client_bytes_total: std.atomic.Value(u64),
     active_connections: std.atomic.Value(u32),
     handshakes_inflight: std.atomic.Value(u32),
     accept_paused: std.atomic.Value(bool),
@@ -1010,6 +1016,8 @@ pub const ProxyState = struct {
             .start_time_seconds = std.time.timestamp(),
             .connection_count = std.atomic.Value(u64).init(0),
             .closed_count = std.atomic.Value(u64).init(0),
+            .client_to_upstream_bytes_total = std.atomic.Value(u64).init(0),
+            .upstream_to_client_bytes_total = std.atomic.Value(u64).init(0),
             .active_connections = std.atomic.Value(u32).init(0),
             .handshakes_inflight = std.atomic.Value(u32).init(0),
             .accept_paused = std.atomic.Value(bool).init(false),
@@ -1132,6 +1140,8 @@ pub const ProxyState = struct {
             .drops_handshake_budget_total = self.stats_dropped_hs_budget.load(.monotonic),
             .handshake_timeouts_total = self.stats_hs_timeout.load(.monotonic),
             .middleproxy_fallback_total = self.stats_mp_fallback.load(.monotonic),
+            .client_to_upstream_bytes_total = self.client_to_upstream_bytes_total.load(.monotonic),
+            .upstream_to_client_bytes_total = self.upstream_to_client_bytes_total.load(.monotonic),
             .config_port = self.config.port,
             .config_max_connections = self.config.max_connections,
             .middleproxy_enabled = self.config.use_middle_proxy,
@@ -1641,6 +1651,8 @@ const EventLoop = struct {
             };
 
             slot.active_reserved = true;
+            slot.traffic_client_to_upstream_counter = &self.state.client_to_upstream_bytes_total;
+            slot.traffic_upstream_to_client_counter = &self.state.upstream_to_client_bytes_total;
             slot.conn_id = self.state.connection_count.fetchAdd(1, .monotonic);
             slot.client_fd = cfd;
             slot.peer_addr = client_addr;
@@ -4333,7 +4345,12 @@ fn parseMiddleProxyAddressForDc(config_text: []const u8, target_dc: i16) ?net.Ad
     return one[0];
 }
 
-fn queueOrWriteMsg(fd: posix.fd_t, queue: *MessageQueue, data: []const u8) !bool {
+fn noteTraffic(counter: *std.atomic.Value(u64), bytes: usize) void {
+    if (bytes == 0) return;
+    _ = counter.fetchAdd(@intCast(bytes), .monotonic);
+}
+
+fn queueOrWriteMsg(fd: posix.fd_t, queue: *MessageQueue, data: []const u8, counter: *std.atomic.Value(u64)) !bool {
     if (data.len == 0) return true;
 
     if (queue.isEmpty()) {
@@ -4345,6 +4362,7 @@ fn queueOrWriteMsg(fd: posix.fd_t, queue: *MessageQueue, data: []const u8) !bool
             return err;
         };
 
+        noteTraffic(counter, n);
         if (n == data.len) return true;
         try queue.appendCopy(data[n..]);
         return false;
@@ -4354,7 +4372,7 @@ fn queueOrWriteMsg(fd: posix.fd_t, queue: *MessageQueue, data: []const u8) !bool
     return false;
 }
 
-fn queueOrWriteMsgPair(fd: posix.fd_t, queue: *MessageQueue, first: []const u8, second: []const u8) !bool {
+fn queueOrWriteMsgPair(fd: posix.fd_t, queue: *MessageQueue, first: []const u8, second: []const u8, counter: *std.atomic.Value(u64)) !bool {
     if (first.len == 0 and second.len == 0) return true;
 
     if (queue.isEmpty()) {
@@ -4380,6 +4398,7 @@ fn queueOrWriteMsgPair(fd: posix.fd_t, queue: *MessageQueue, first: []const u8, 
         };
 
         if (n == 0) return error.ConnectionReset;
+        noteTraffic(counter, n);
         if (n == total_len) return true;
 
         if (n < first.len) {
@@ -4400,7 +4419,7 @@ fn queueOrWriteMsgPair(fd: posix.fd_t, queue: *MessageQueue, first: []const u8, 
     return false;
 }
 
-fn queueOrWriteOwnedMsg(fd: posix.fd_t, queue: *MessageQueue, owned: []u8) !bool {
+fn queueOrWriteOwnedMsg(fd: posix.fd_t, queue: *MessageQueue, owned: []u8, counter: *std.atomic.Value(u64)) !bool {
     if (owned.len == 0) {
         queue.allocator.free(owned);
         return true;
@@ -4416,6 +4435,7 @@ fn queueOrWriteOwnedMsg(fd: posix.fd_t, queue: *MessageQueue, owned: []u8) !bool
             return err;
         };
 
+        noteTraffic(counter, n);
         if (n == owned.len) {
             queue.allocator.free(owned);
             return true;
@@ -4431,7 +4451,7 @@ fn queueOrWriteOwnedMsg(fd: posix.fd_t, queue: *MessageQueue, owned: []u8) !bool
     return false;
 }
 
-fn flushQueue(fd: posix.fd_t, queue: *MessageQueue) !bool {
+fn flushQueue(fd: posix.fd_t, queue: *MessageQueue, counter: *std.atomic.Value(u64)) !bool {
     if (queue.isEmpty()) return true;
 
     var iovecs: [max_scatter_parts]posix.iovec_const = undefined;
@@ -4449,6 +4469,7 @@ fn flushQueue(fd: posix.fd_t, queue: *MessageQueue) !bool {
         };
 
         if (n == 0) return error.ConnectionReset;
+        noteTraffic(counter, n);
         try queue.consume(n);
 
         if (n < total_req) return false;
@@ -4459,32 +4480,32 @@ fn flushQueue(fd: posix.fd_t, queue: *MessageQueue) !bool {
 
 fn slotQueueClient(slot: *ConnectionSlot, allocator: std.mem.Allocator, data: []const u8) !bool {
     _ = allocator;
-    return queueOrWriteMsg(slot.client_fd, &slot.client_queue, data);
+    return queueOrWriteMsg(slot.client_fd, &slot.client_queue, data, slot.traffic_upstream_to_client_counter orelse return error.MissingTrafficCounter);
 }
 
 fn slotQueueClientPair(slot: *ConnectionSlot, allocator: std.mem.Allocator, first: []const u8, second: []const u8) !bool {
     _ = allocator;
-    return queueOrWriteMsgPair(slot.client_fd, &slot.client_queue, first, second);
+    return queueOrWriteMsgPair(slot.client_fd, &slot.client_queue, first, second, slot.traffic_upstream_to_client_counter orelse return error.MissingTrafficCounter);
 }
 
 fn slotQueueClientOwned(slot: *ConnectionSlot, allocator: std.mem.Allocator, owned: []u8) !bool {
     _ = allocator;
-    return queueOrWriteOwnedMsg(slot.client_fd, &slot.client_queue, owned);
+    return queueOrWriteOwnedMsg(slot.client_fd, &slot.client_queue, owned, slot.traffic_upstream_to_client_counter orelse return error.MissingTrafficCounter);
 }
 
 fn slotQueueUpstream(slot: *ConnectionSlot, allocator: std.mem.Allocator, data: []const u8) !bool {
     _ = allocator;
-    return queueOrWriteMsg(slot.upstream_fd, &slot.upstream_queue, data);
+    return queueOrWriteMsg(slot.upstream_fd, &slot.upstream_queue, data, slot.traffic_client_to_upstream_counter orelse return error.MissingTrafficCounter);
 }
 
 fn slotFlushClientPending(slot: *ConnectionSlot, allocator: std.mem.Allocator) !bool {
     _ = allocator;
-    return flushQueue(slot.client_fd, &slot.client_queue);
+    return flushQueue(slot.client_fd, &slot.client_queue, slot.traffic_upstream_to_client_counter orelse return error.MissingTrafficCounter);
 }
 
 fn slotFlushUpstreamPending(slot: *ConnectionSlot, allocator: std.mem.Allocator) !bool {
     _ = allocator;
-    return flushQueue(slot.upstream_fd, &slot.upstream_queue);
+    return flushQueue(slot.upstream_fd, &slot.upstream_queue, slot.traffic_client_to_upstream_counter orelse return error.MissingTrafficCounter);
 }
 
 fn slotMpReadReset(slot: *ConnectionSlot, encrypted: bool) void {

--- a/src/version.zig
+++ b/src/version.zig
@@ -1,0 +1,1 @@
+pub const version = "0.17.0"; // x-release-please-version

--- a/src/version.zig
+++ b/src/version.zig
@@ -1,1 +1,1 @@
-pub const version = "0.17.0"; // x-release-please-version
+pub const version = "0.17.1"; // x-release-please-version


### PR DESCRIPTION
## Summary

Add embedded Prometheus monitoring to `mtproto-proxy` and provide a ready-to-use Docker monitoring stack with Prometheus + Grafana.

related #169 

This PR adds:
- version module. all version consts moved into separated constant module to maintain it via one parameter
- an in-process `/metrics` endpoint on a dedicated configurable port
- global proxy traffic counters
- optional cgroup RAM metrics for container environments
- per-user traffic and active connection metrics
- Grafana dashboard JSON for import
- Docker Compose example and monitoring docs

## What Changed

### Embedded Prometheus endpoint
- Add `[monitoring]` config section:
  - `enabled`
  - `host`
  - `port`
- Start a dedicated HTTP listener inside `mtproto-proxy`
- Expose `GET /metrics` in Prometheus text format

### Global proxy metrics
- Active connections
- Handshakes in flight
- Accepted / closed totals
- Drop counters
- Pause state gauges
- Global traffic counters:
  - `mtproto_client_to_upstream_bytes_total`
  - `mtproto_upstream_to_client_bytes_total`

### Memory metrics
- Keep process metrics:
  - `process_resident_memory_bytes`
  - `process_virtual_memory_bytes`
  - `process_cpu_seconds_total`
  - `process_open_fds`
  - `process_max_fds`
- Add optional cgroup memory metrics when available:
  - `mtproto_cgroup_memory_usage_bytes`
  - `mtproto_cgroup_memory_limit_bytes`

This works both on bare metal and in containers:
- bare metal: `process_*` metrics still work
- containers: cgroup memory metrics appear when exposed by the runtime

### Per-user metrics
Pre-create per-user metric records from configured users and expose:
- `mtproto_user_connections_active{user="..."}`
- `mtproto_user_client_to_upstream_bytes_total{user="..."}`
- `mtproto_user_upstream_to_client_bytes_total{user="..."}`

Per-user byte counters are updated on the actual write path, so they match the semantics of global traffic totals.

### Dashboard and docs
- Add Grafana dashboard JSON with:
  - memory usage
  - total throughput
  - total transferred
  - connection stats
  - traffic throughput
  - per-user active connections
  - top users by throughput
  - top users by transferred volume
- Add `hack/docker` example with:
  - `docker-compose.yml`
  - `prometheus.yml`
  - dashboard JSON
  - README walkthrough
- Link the Docker monitoring guide from the main README

## Why

This makes monitoring usable in the common Docker deployment model without relying on the existing Python dashboard stack.

Key goals:
- one proxy process exports its own metrics
- no log parsing for metrics
- no extra exporter sidecar required
- works in both Docker and raw system deployments
- supports operator visibility by configured user

## Testing

Verified with:
- `zig build test`
- `zig build`
- dashboard JSON validation via `jq empty`
- compose file validation via `docker compose config`
- deployment on staging with real load and usage

## Notes

- Counter totals are process-lifetime counters and reset on proxy restart, which is expected for Prometheus counters.
- cgroup memory metrics are best-effort and only appear when the relevant cgroup files are available.
- Per-user metrics are based on users from the current loaded config and update after proxy restart when config changes.
