### PR TITLE
fix(dashboard): detect dead tunnels as unhealthy

### DIFF
--- a/src/ctl/dashboard_assets/server.py
+++ b/src/ctl/dashboard_assets/server.py
@@ -432,6 +432,30 @@ _routing_cache = {"ts": 0, "data": None}
 ROUTING_CACHE_TTL = 8  # seconds
 
 
+def _parse_transfer_bytes(value: str | None) -> float:
+    """Parse a WireGuard transfer string like '5.69 KiB' into bytes."""
+    if not value:
+        return 0.0
+    m = re.match(r"([\d.]+)\s*(\S+)", value.strip())
+    if not m:
+        return 0.0
+    num = float(m[1])
+    unit = m[2].lower()
+    multipliers = {"b": 1, "kib": 1024, "mib": 1048576, "gib": 1073741824, "tib": 1099511627776}
+    return num * multipliers.get(unit, 1)
+
+
+def _has_valid_handshake(handshake: str | None) -> bool:
+    """Check whether the WireGuard handshake value indicates a completed handshake.
+
+    Returns False for None, empty, 'none (idle)', or '0' (epoch = never).
+    """
+    if not handshake:
+        return False
+    hs = handshake.strip().lower()
+    return hs not in ("", "0", "none", "none (idle)")
+
+
 def _detect_tunnel_interface(interface: str, tool_hint: str | None = None) -> dict:
     result = {
         "interface": interface,
@@ -440,6 +464,7 @@ def _detect_tunnel_interface(interface: str, tool_hint: str | None = None) -> di
         "active": False,
         "endpoint": None,
         "handshake": None,
+        "handshake_ok": False,
         "rx": None,
         "tx": None,
         "reason": None,
@@ -495,8 +520,22 @@ def _detect_tunnel_interface(interface: str, tool_hint: str | None = None) -> di
             result["rx"] = m[1]
             result["tx"] = m[2]
 
+        # A tunnel is truly active only if the handshake completed AND
+        # we have received data. A configured endpoint with handshake=0
+        # and rx=0 means the VPN server is unreachable.
+        hs_ok = _has_valid_handshake(result.get("handshake"))
+        rx_ok = _parse_transfer_bytes(result.get("rx")) > 0
+        result["handshake_ok"] = hs_ok
+
         if result.get("endpoint"):
-            result["active"] = True
+            if hs_ok and rx_ok:
+                result["active"] = True
+            elif hs_ok:
+                result["active"] = True  # handshake done, rx may lag behind
+            else:
+                # endpoint configured but handshake never completed
+                result["active"] = False
+                result["reason"] = "endpoint configured, no handshake (VPN server unreachable)"
             if not result.get("handshake"):
                 result["handshake"] = "none (idle)"
         elif result["link_up"]:
@@ -678,6 +717,8 @@ def _routing_status() -> dict:
             and policy.get("route_ok")
             and primary_tunnel
             and primary_tunnel.get("link_up")
+            and primary_tunnel.get("active")
+            and primary_tunnel.get("handshake_ok")
         )
     elif upstream_type == "socks5":
         healthy = bool(


### PR DESCRIPTION
## Problem

The dashboard health check reported `healthy: true` for dead WireGuard tunnels. It only verified that an endpoint was configured and the link was UP — both are static kernel state that remain true even when the VPN server is completely unreachable.

This led to a false "healthy" indicator on the dashboard while the proxy was unable to reach any Telegram DC (all upstream connections stuck in SYN-SENT).

## Root Cause

`_detect_tunnel_interface()` set `active = True` solely based on the presence of an `endpoint` field in `awg show` output. But endpoint is a static config value — it's always present regardless of whether the tunnel is actually passing traffic.

## Fix

- Added `_parse_transfer_bytes()` to parse WG transfer strings (`5.69 KiB` → bytes)
- Added `_has_valid_handshake()` to check `latest-handshake` is not `0`/`none`/`idle`
- `_detect_tunnel_interface()` now requires a completed handshake before marking `active = True`
- New `handshake_ok` field exposed in tunnel status
- `_routing_status()` healthy check for tunnel mode now requires `active` and `handshake_ok`
- Dead tunnels get a clear reason: `endpoint configured, no handshake (VPN server unreachable)`

## Before / After

| Scenario | Before | After |
|---|---|---|
| Dead VPN, no handshake, rx=0 | `healthy: true` ❌ | `healthy: false` ✅ |
| Working VPN, handshake OK, rx>0 | `healthy: true` ✅ | `healthy: true` ✅ |
| Interface down | `healthy: false` ✅ | `healthy: false` ✅ |

Already deployed and verified on production.