### PR TITLE
feat(dashboard): show proxy version in header

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,8 +10,7 @@
       "draft": false,
       "prerelease": false,
       "extra-files": [
-        "src/main.zig",
-        "src/ctl/main.zig"
+        "src/version.zig"
       ]
     }
   }

--- a/src/ctl/dashboard.zig
+++ b/src/ctl/dashboard.zig
@@ -134,6 +134,10 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: DashboardOpts) !voi
     // ── Create virtualenv & install dependencies ──
     ui.step("Setting up Python virtualenv via uv...");
 
+    // Remove stale venv first — `make deploy` chowns everything to mtproto:mtproto,
+    // so `uv venv` (running as root) can fail to overwrite it.
+    _ = sys.exec(allocator, &.{ "rm", "-rf", VENV_DIR }) catch {};
+
     const venv_res = sys.exec(allocator, &.{
         "uv", "venv", VENV_DIR, "--python", "python3",
     }) catch {

--- a/src/ctl/dashboard_assets/server.py
+++ b/src/ctl/dashboard_assets/server.py
@@ -64,6 +64,57 @@ DASHBOARD_CFG = _load_dashboard_config()
 
 STATIC_DIR = Path(__file__).parent / "static"
 
+_version_cache = {"ts": 0, "version": None}
+VERSION_CACHE_TTL = 300  # 5 minutes
+
+
+def _proxy_version() -> str | None:
+    """Detect proxy version. Cached for 5 minutes."""
+    now = time.time()
+    if now - _version_cache["ts"] < VERSION_CACHE_TTL and _version_cache["version"]:
+        return _version_cache["version"]
+
+    version = None
+
+    # 1. Try running the binary
+    for binary in ("/opt/mtproto-proxy/mtproto-proxy",):
+        if not Path(binary).is_file():
+            continue
+        try:
+            out = subprocess.check_output(
+                [binary, "--version"],
+                text=True,
+                timeout=3,
+                stderr=subprocess.STDOUT,
+            ).strip()
+            # Output may be like "mtproto-proxy 0.17.1" or just "0.17.1"
+            m = re.search(r"(\d+\.\d+\.\d+)", out)
+            if m:
+                version = m[1]
+                break
+        except Exception:
+            pass
+
+    # 2. Fallback: parse version.zig from install directory
+    if not version:
+        for p in (
+            Path(__file__).parent.parent / "version.zig",  # dev layout
+            Path("/opt/mtproto-proxy/version.zig"),
+        ):
+            if p.is_file():
+                try:
+                    text = p.read_text(encoding="utf-8", errors="replace")
+                    m = re.search(r'"(\d+\.\d+\.\d+)"', text)
+                    if m:
+                        version = m[1]
+                        break
+                except Exception:
+                    pass
+
+    _version_cache.update(ts=now, version=version)
+    return version
+
+
 app = FastAPI()
 
 _prev_net = {"ts": 0, "rx": 0, "tx": 0}
@@ -1331,6 +1382,7 @@ def api_stats():
             "uptime": f"{d}d {h}h {rem2 // 60}m",
             "proxy": _proxy_stats(),
             "proxy_info": _proxy_info(),
+            "proxy_version": _proxy_version(),
             "awg": _awg_status(),
             "routing": _routing_status(),
             "masking": _masking_status(),

--- a/src/ctl/dashboard_assets/static/app.js
+++ b/src/ctl/dashboard_assets/static/app.js
@@ -890,6 +890,12 @@ async function poll() {
   $('pxDrops').style.color = drp > 0 ? 'var(--amber)' : 'var(--text-muted)';
   $('pxDropLbl').textContent = 'rate +' + drp + ' · cap +' + (p.cap_drops || 0) + ' · hs_t +' + (p.hs_timeout || 0);
 
+  // Version
+  const vEl = $('dashboardVersion');
+  if (vEl && d.proxy_version) {
+    vEl.textContent = ' · v' + d.proxy_version;
+  }
+
   renderRouting(d.routing || null);
 
   // Masking health

--- a/src/ctl/dashboard_assets/static/app.js
+++ b/src/ctl/dashboard_assets/static/app.js
@@ -893,7 +893,7 @@ async function poll() {
   // Version
   const vEl = $('dashboardVersion');
   if (vEl && d.proxy_version) {
-    vEl.textContent = ' · v' + d.proxy_version;
+    vEl.textContent = 'v' + d.proxy_version;
   }
 
   renderRouting(d.routing || null);

--- a/src/ctl/dashboard_assets/static/index.html
+++ b/src/ctl/dashboard_assets/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>⚡ MTProto Proxy — Dashboard</title>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/style.css?v=20260411">
+  <link rel="stylesheet" href="/style.css?v=20260415">
 </head>
 <body>
 <div class="app">
@@ -252,7 +252,7 @@
     <div class="logs-body" id="logsBody"></div>
   </div>
 
-  <div class="footer">Built with <a href="https://ziglang.org" target="_blank">Zig</a> · proxy.sleep3r.ru</div>
+  <div class="footer">Built with <a href="https://ziglang.org" target="_blank">Zig</a> · proxy.sleep3r.ru<span id="dashboardVersion"></span></div>
 
   <!-- Shared tooltip for all charts -->
   <div id="chartTooltip" class="chart-tooltip"></div>
@@ -273,6 +273,6 @@
   </div>
 </div>
 
-<script src="/app.js?v=20260411"></script>
+<script src="/app.js?v=20260415"></script>
 </body>
 </html>

--- a/src/ctl/dashboard_assets/static/index.html
+++ b/src/ctl/dashboard_assets/static/index.html
@@ -19,6 +19,7 @@
       <h1>
         <span class="accent">MTProto</span>Proxy
         <span class="dim">dashboard</span>
+        <span class="version-pill" id="dashboardVersion"></span>
       </h1>
     </div>
     <div class="header-right">
@@ -252,7 +253,7 @@
     <div class="logs-body" id="logsBody"></div>
   </div>
 
-  <div class="footer">Built with <a href="https://ziglang.org" target="_blank">Zig</a> · proxy.sleep3r.ru<span id="dashboardVersion"></span></div>
+  <div class="footer">Built with <a href="https://ziglang.org" target="_blank">Zig</a> · proxy.sleep3r.ru</div>
 
   <!-- Shared tooltip for all charts -->
   <div id="chartTooltip" class="chart-tooltip"></div>

--- a/src/ctl/dashboard_assets/static/style.css
+++ b/src/ctl/dashboard_assets/static/style.css
@@ -62,6 +62,18 @@ body::after {
 }
 .header h1 .accent { color: var(--zig); }
 .header h1 .dim { color: var(--text-dim); font-weight: 400; font-size: 15px; }
+.version-pill {
+  font-size: 10px;
+  font-weight: 600;
+  font-family: 'JetBrains Mono', monospace;
+  color: var(--zig);
+  background: rgba(247,164,29,0.08);
+  border: 1px solid rgba(247,164,29,0.18);
+  border-radius: 100px;
+  padding: 2px 10px;
+  letter-spacing: 0.5px;
+  vertical-align: middle;
+}
 .header-right {
   display: flex;
   align-items: center;

--- a/src/version.zig
+++ b/src/version.zig
@@ -1,1 +1,1 @@
-pub const version = "0.17.1"; // x-release-please-version
+pub const version = "0.18.0"; // x-release-please-version


### PR DESCRIPTION
## Summary

Отображение версии прокси в хедере дашборда в виде pill-бейджа рядом с названием, чтобы пользователь мог визуально убедиться, что панель обновилась.

### Changes

- **server.py**: добавлена `_proxy_version()` — определяет версию из `mtproto-proxy --version` или парсит `version.zig`. Кэш 5 минут. Включено в ответ `/api/stats` как `proxy_version`.
- **index.html**: добавлен `<span class="version-pill" id="dashboardVersion">` в header рядом с названием.
- **style.css**: стиль `.version-pill` — pill-бейдж с Zig accent цветом.
- **app.js**: рендерит версию из API ответа (`v0.18.0`).
- **version.zig**: `0.17.1` → `0.18.0` (release-please не обновил).
- **release-please-config.json**: `extra-files` теперь указывает на `src/version.zig` (где маркер `x-release-please-version`).
- **dashboard.zig**: фикс повторных деплоев — `rm -rf .venv` перед `uv venv` (ownership mismatch после `chown mtproto:mtproto`).

### Result

Хедер дашборда: `MTProtoProxy dashboard [v0.18.0]`

Closes #190