### PR TITLE
fix: prevent config corruption when adding users via dashboard

### DIFF
--- a/src/ctl/dashboard_assets/server.py
+++ b/src/ctl/dashboard_assets/server.py
@@ -1202,6 +1202,8 @@ def _add_user_to_config(name: str, secret: str) -> bool:
     lines = cfg_path.read_text(encoding="utf-8", errors="replace").splitlines(
         keepends=True
     )
+    if lines and not lines[-1].endswith("\n"):
+        lines[-1] += "\n"
 
     # Find [access.users] section
     insert_idx = None
@@ -1244,6 +1246,8 @@ def _remove_user_from_config(name: str) -> bool:
     lines = cfg_path.read_text(encoding="utf-8", errors="replace").splitlines(
         keepends=True
     )
+    if lines and not lines[-1].endswith("\n"):
+        lines[-1] += "\n"
     new_lines = []
     in_users = False
     in_direct = False
@@ -1289,6 +1293,8 @@ def _set_user_direct(name: str, direct: bool) -> bool:
     lines = cfg_path.read_text(encoding="utf-8", errors="replace").splitlines(
         keepends=True
     )
+    if lines and not lines[-1].endswith("\n"):
+        lines[-1] += "\n"
     new_lines = []
     found_direct_section = False
     in_direct = False

--- a/src/ctl/toml.zig
+++ b/src/ctl/toml.zig
@@ -42,11 +42,9 @@ pub const TomlDoc = struct {
         const file = try std.fs.cwd().createFile(path, .{});
         defer file.close();
 
-        for (self.lines.items, 0..) |line, idx| {
+        for (self.lines.items) |line| {
             try file.writeAll(line);
-            if (idx < self.lines.items.len - 1) {
-                try file.writeAll("\n");
-            }
+            try file.writeAll("\n");
         }
     }
 


### PR DESCRIPTION
Fixes a bug where adding a new user through the dashboard UI after a clean installation would concatenate the new user to the default user's line because of a missing trailing newline in the generated `config.toml`.