### PR TITLE
feat(dashboard): user toggle, per-user session tooltip, input fix

### DIFF
--- a/src/ctl/dashboard_assets/server.py
+++ b/src/ctl/dashboard_assets/server.py
@@ -258,6 +258,14 @@ def _proxy_stats() -> dict:
                     if m2:
                         s[k] = int(m2[1])
                 break
+
+        users_active_total = sum(
+            int(v) for v in s.get("per_user_active", {}).values() if isinstance(v, int)
+        )
+        active_total = int(s.get("active", 0) or 0)
+        s["users_active_total"] = users_active_total
+        s["unassigned_active"] = max(active_total - users_active_total, 0)
+
         return s
     except Exception:
         return {}

--- a/src/ctl/dashboard_assets/server.py
+++ b/src/ctl/dashboard_assets/server.py
@@ -217,6 +217,7 @@ def _proxy_stats() -> dict:
             sat_drops=0,
             hs_budget_drops=0,
             hs_timeout=0,
+            per_user_active={},
         )
         for line in reversed(out.strip().split("\n")):
             if "conn stats:" in line:
@@ -233,6 +234,16 @@ def _proxy_stats() -> dict:
                     m2 = re.search(p, line)
                     if m2:
                         s[k] = int(m2[1])
+                # Parse users{admin=5,regular=2} from same line
+                mu = re.search(r"users\{([^}]*)\}", line)
+                if mu and mu.group(1):
+                    for pair in mu.group(1).split(","):
+                        parts = pair.split("=", 1)
+                        if len(parts) == 2:
+                            try:
+                                s["per_user_active"][parts[0].strip()] = int(parts[1])
+                            except ValueError:
+                                pass
                 break
         for line in reversed(out.strip().split("\n")):
             if "drops:" in line:
@@ -340,6 +351,7 @@ def _load_proxy_runtime_config() -> dict:
         "upstream_http_password": "",
         "users": {},
         "direct_users": set(),
+        "disabled_users": {},
     }
 
     cfg_path = None
@@ -370,6 +382,7 @@ def _load_proxy_runtime_config() -> dict:
         "upstream_http_password": defaults["upstream_http_password"],
         "users": {},
         "direct_users": set(),
+        "disabled_users": {},
     }
 
     section = ""
@@ -463,6 +476,10 @@ def _load_proxy_runtime_config() -> dict:
                 elif section in ("[access.direct_users]", "[access.admins]"):
                     if key and _parse_bool(value, False):
                         result["direct_users"].add(key)
+
+                elif section == "[access.disabled_users]":
+                    if key and value:
+                        result["disabled_users"][key] = value
 
     except Exception:
         return defaults
@@ -983,13 +1000,34 @@ def _users_status() -> dict:
                 "name": name,
                 "secret": secret_raw,
                 "direct": name in direct_users,
+                "enabled": True,
                 "tg_link": tg_link,
                 "tme_link": tme_link,
             }
         )
 
+    # Include disabled users (shown in dashboard but not active in proxy)
+    disabled_users = cfg.get("disabled_users", {})
+    for name in sorted(disabled_users.keys()):
+        secret_raw = str(disabled_users[name]).strip().lower()
+        if not USER_SECRET_RE.fullmatch(secret_raw):
+            continue
+        items.append(
+            {
+                "name": name,
+                "secret": secret_raw,
+                "direct": False,
+                "enabled": False,
+                "tg_link": None,
+                "tme_link": None,
+            }
+        )
+
+    active_count = sum(1 for item in items if item["enabled"])
+
     result = {
-        "total": len(items),
+        "total": active_count,
+        "disabled_total": len(items) - active_count,
         "direct_total": sum(1 for item in items if item["direct"]),
         "links_ready": bool(server),
         "server": server,
@@ -1347,6 +1385,159 @@ def _set_user_direct(name: str, direct: bool) -> bool:
     return True
 
 
+def _disable_user_in_config(name: str) -> bool:
+    """Move user from [access.users] to [access.disabled_users]. Returns True on success."""
+    cfg_path = _find_config_path()
+    if cfg_path is None:
+        return False
+
+    cfg = _load_proxy_runtime_config()
+    secret = cfg.get("users", {}).get(name)
+    if not secret:
+        return False  # user not found or already disabled
+
+    lines = cfg_path.read_text(encoding="utf-8", errors="replace").splitlines(
+        keepends=True
+    )
+    if lines and not lines[-1].endswith("\n"):
+        lines[-1] += "\n"
+
+    # Remove from [access.users] and [access.direct_users]
+    new_lines = []
+    in_users = False
+    in_direct = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.lower() == "[access.users]":
+            in_users = True
+            in_direct = False
+            new_lines.append(line)
+            continue
+        elif stripped.lower() in ("[access.direct_users]", "[access.admins]"):
+            in_users = False
+            in_direct = True
+            new_lines.append(line)
+            continue
+        elif stripped.startswith("[") and stripped.endswith("]"):
+            in_users = False
+            in_direct = False
+            new_lines.append(line)
+            continue
+
+        if (in_users or in_direct) and "=" in stripped:
+            key = stripped.split("=", 1)[0].strip()
+            if key == name:
+                continue  # skip — removing this user
+
+        new_lines.append(line)
+
+    # Add to [access.disabled_users]
+    found_disabled = False
+    disabled_end = None
+    in_disabled = False
+    for i, line in enumerate(new_lines):
+        stripped = line.strip()
+        if stripped.lower() == "[access.disabled_users]":
+            found_disabled = True
+            in_disabled = True
+            continue
+        if in_disabled:
+            if stripped.startswith("[") and stripped.endswith("]"):
+                disabled_end = i
+                in_disabled = False
+            elif i == len(new_lines) - 1:
+                disabled_end = len(new_lines)
+
+    if found_disabled and disabled_end is not None:
+        new_lines.insert(disabled_end, f'{name} = "{secret}"\n')
+    elif found_disabled:
+        new_lines.append(f'{name} = "{secret}"\n')
+    else:
+        new_lines.append(f"\n[access.disabled_users]\n")
+        new_lines.append(f'{name} = "{secret}"\n')
+
+    cfg_path.write_text("".join(new_lines), encoding="utf-8")
+    return True
+
+
+def _enable_user_in_config(name: str) -> bool:
+    """Move user from [access.disabled_users] back to [access.users]. Returns True on success."""
+    cfg_path = _find_config_path()
+    if cfg_path is None:
+        return False
+
+    cfg = _load_proxy_runtime_config()
+    secret = cfg.get("disabled_users", {}).get(name)
+    if not secret:
+        return False  # not in disabled list
+
+    # Remove from [access.disabled_users]
+    lines = cfg_path.read_text(encoding="utf-8", errors="replace").splitlines(
+        keepends=True
+    )
+    if lines and not lines[-1].endswith("\n"):
+        lines[-1] += "\n"
+
+    new_lines = []
+    in_disabled = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.lower() == "[access.disabled_users]":
+            in_disabled = True
+            new_lines.append(line)
+            continue
+        elif stripped.startswith("[") and stripped.endswith("]"):
+            in_disabled = False
+            new_lines.append(line)
+            continue
+
+        if in_disabled and "=" in stripped:
+            key = stripped.split("=", 1)[0].strip()
+            if key == name:
+                continue  # skip — removing from disabled
+
+        new_lines.append(line)
+
+    # Add back to [access.users]
+    if not _add_user_to_config_lines(new_lines, name, secret):
+        # Fallback: just write the lines and use existing helper
+        cfg_path.write_text("".join(new_lines), encoding="utf-8")
+        return _add_user_to_config(name, secret)
+
+    cfg_path.write_text("".join(new_lines), encoding="utf-8")
+    return True
+
+
+def _add_user_to_config_lines(lines: list[str], name: str, secret: str) -> bool:
+    """Insert a user into [access.users] section within an in-memory lines list."""
+    insert_idx = None
+    in_users = False
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.lower() == "[access.users]":
+            in_users = True
+            continue
+        if in_users:
+            if stripped.startswith("[") and stripped.endswith("]"):
+                insert_idx = i
+                break
+            if not stripped or stripped.startswith("#"):
+                continue
+        if in_users and i == len(lines) - 1:
+            insert_idx = len(lines)
+
+    if insert_idx is None:
+        if in_users:
+            insert_idx = len(lines)
+        else:
+            return False
+
+    lines.insert(insert_idx, f'{name} = "{secret}"\n')
+    return True
+
+
+
+
 @app.get("/api/stats")
 def api_stats():
     global _prev_net, _net_history, _cpu_history, _mem_history
@@ -1652,6 +1843,44 @@ async def api_user_direct(request: Request):
     _users_cache["ts"] = 0
     _restart_proxy()
     return JSONResponse({"ok": True, "name": name, "direct": direct, "restarted": True})
+
+
+@app.post("/api/users/toggle")
+async def api_user_toggle(request: Request):
+    """Enable or disable a user. Body: { name: str, enabled: bool }"""
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"ok": False, "error": "invalid json"}, status_code=400)
+
+    name = str(body.get("name", "")).strip()
+    if not name:
+        return JSONResponse({"ok": False, "error": "name is required"}, status_code=400)
+
+    enabled = body.get("enabled", None)
+    if not isinstance(enabled, bool):
+        return JSONResponse(
+            {"ok": False, "error": "enabled must be boolean"}, status_code=400
+        )
+
+    if enabled:
+        if not _enable_user_in_config(name):
+            return JSONResponse(
+                {"ok": False, "error": "user not found in disabled list"},
+                status_code=404,
+            )
+    else:
+        if not _disable_user_in_config(name):
+            return JSONResponse(
+                {"ok": False, "error": "user not found or already disabled"},
+                status_code=404,
+            )
+
+    _users_cache["ts"] = 0
+    _restart_proxy()
+    return JSONResponse(
+        {"ok": True, "name": name, "enabled": enabled, "restarted": True}
+    )
 
 
 @app.get("/api/logs")

--- a/src/ctl/dashboard_assets/static/app.js
+++ b/src/ctl/dashboard_assets/static/app.js
@@ -460,10 +460,11 @@ function _users_cache_bust() {
   }
 }
 
-function renderUsers(users, perUserActive) {
+function renderUsers(users, perUserActive, proxyStats) {
   const card = $('usersCard');
   if (!card) return;
   const pua = perUserActive || {};
+  const ps = proxyStats || {};
 
   const meta = $('usersMeta');
   const note = $('usersNote');
@@ -474,9 +475,16 @@ function renderUsers(users, perUserActive) {
   const total = Number(users?.total || 0);
   const directTotal = Number(users?.direct_total || 0);
   const disabledTotal = Number(users?.disabled_total || 0);
+  const usersActiveTotal = Number(ps.users_active_total || Object.values(pua).reduce((acc, v) => acc + Number(v || 0), 0));
+  const activeTotal = Number(ps.active || 0);
+  const unassignedActive = Number(ps.unassigned_active || Math.max(activeTotal - usersActiveTotal, 0));
 
   let metaText = total + ' users · direct ' + directTotal;
   if (disabledTotal > 0) metaText += ' · disabled ' + disabledTotal;
+  if (activeTotal > 0 || usersActiveTotal > 0) {
+    metaText += ' · sessions ' + usersActiveTotal + '/' + activeTotal;
+    if (unassignedActive > 0) metaText += ' · unassigned ' + unassignedActive;
+  }
   meta.textContent = metaText;
 
   if (!users?.links_ready) {
@@ -991,7 +999,7 @@ async function poll() {
     $('maskTimer').textContent = timerState;
   }
 
-  renderUsers(d.users || null, (d.proxy || {}).per_user_active || {});
+  renderUsers(d.users || null, (d.proxy || {}).per_user_active || {}, d.proxy || {});
 }
 
 function setDataBadge(state, text) {

--- a/src/ctl/dashboard_assets/static/app.js
+++ b/src/ctl/dashboard_assets/static/app.js
@@ -307,6 +307,7 @@ async function copyText(text) {
 // ── User Management ──
 
 let pendingDeleteUser = null;
+let pendingToggleUser = null;
 
 function showToast(msg, type) {
   const el = document.createElement('div');
@@ -441,6 +442,17 @@ async function toggleDirect(name, newDirect) {
   }
 }
 
+async function toggleUserEnabled(name, newEnabled) {
+  try {
+    await apiCall('/api/users/toggle', { name, enabled: newEnabled });
+    showToast(`User "${name}" ${newEnabled ? 'enabled' : 'disabled'}. Proxy restarted.`, 'success');
+    _users_cache_bust();
+    await runPoll();
+  } catch (e) {
+    showToast('Failed: ' + e.message, 'error');
+  }
+}
+
 function _users_cache_bust() {
   // Force next poll to show fresh data
   if (lastData && lastData.users) {
@@ -448,9 +460,10 @@ function _users_cache_bust() {
   }
 }
 
-function renderUsers(users) {
+function renderUsers(users, perUserActive) {
   const card = $('usersCard');
   if (!card) return;
+  const pua = perUserActive || {};
 
   const meta = $('usersMeta');
   const note = $('usersNote');
@@ -460,8 +473,11 @@ function renderUsers(users) {
   const items = (users && Array.isArray(users.items)) ? users.items : [];
   const total = Number(users?.total || 0);
   const directTotal = Number(users?.direct_total || 0);
+  const disabledTotal = Number(users?.disabled_total || 0);
 
-  meta.textContent = total + ' users · direct ' + directTotal;
+  let metaText = total + ' users · direct ' + directTotal;
+  if (disabledTotal > 0) metaText += ' · disabled ' + disabledTotal;
+  meta.textContent = metaText;
 
   if (!users?.links_ready) {
     note.textContent = 'Public IP could not be detected. Set [server].public_ip in config.toml.';
@@ -475,25 +491,36 @@ function renderUsers(users) {
   }
 
   list.innerHTML = items.map((u) => {
+    const isEnabled = u.enabled !== false;
     const tg = u.tg_link || '';
     const tme = u.tme_link || '';
-    const preview = shortProxyLink(tg || tme);
-    const routeClass = u.direct ? 'direct' : 'default';
-    const routeLabel = u.direct ? 'direct' : 'default';
+    const preview = isEnabled ? shortProxyLink(tg || tme) : 'disabled';
     const tgData = encodeURIComponent(tg);
     const tmeData = encodeURIComponent(tme);
     const userName = esc(u.name || 'user');
-    const directToggle = u.direct
-      ? `<button class="ui-btn user-direct-toggle on" type="button" data-user="${userName}" data-direct="false" title="Switch to default route">direct</button>`
-      : `<button class="ui-btn user-direct-toggle" type="button" data-user="${userName}" data-direct="true" title="Switch to direct route">default</button>`;
+    const rowClass = isEnabled ? 'user-row' : 'user-row disabled';
+    const sessions = Number(pua[u.name] || 0);
+    const sessionsBadge = isEnabled
+      ? '<span class="user-sessions' + (sessions > 0 ? '' : ' zero') + '">' + sessions + '</span>'
+      : '';
 
-    return '<div class="user-row">' +
-      '<div class="user-name">' + userName + '</div>' +
+    // Enable/disable toggle switch
+    const toggleSwitch = '<label class="user-toggle-switch" title="' + (isEnabled ? 'Disable user' : 'Enable user') + '">' +
+      '<input type="checkbox" class="user-enabled-toggle" data-user="' + userName + '"' + (isEnabled ? ' checked' : '') + '>' +
+      '<span class="user-toggle-slider"></span>' +
+      '</label>';
+
+    const directToggle = !isEnabled ? '' : (u.direct
+      ? '<button class="ui-btn user-direct-toggle on" type="button" data-user="' + userName + '" data-direct="false" title="Switch to default route">direct</button>'
+      : '<button class="ui-btn user-direct-toggle" type="button" data-user="' + userName + '" data-direct="true" title="Switch to direct route">default</button>');
+
+    return '<div class="' + rowClass + '">' +
+      '<div class="user-name">' + toggleSwitch + userName + sessionsBadge + '</div>' +
       '<div class="user-route">' + directToggle + '</div>' +
-      '<div class="user-link" title="' + esc(tg || tme || 'link unavailable') + '">' + esc(preview) + '</div>' +
+      '<div class="user-link" title="' + esc(tg || tme || (isEnabled ? 'link unavailable' : 'disabled')) + '">' + esc(preview) + '</div>' +
       '<div class="user-actions">' +
-      '<button class="ui-btn user-copy" type="button" data-link="' + tgData + '"' + (tg ? '' : ' disabled') + '>Copy tg://</button>' +
-      '<button class="ui-btn user-copy" type="button" data-link="' + tmeData + '"' + (tme ? '' : ' disabled') + '>Copy t.me</button>' +
+      '<button class="ui-btn user-copy" type="button" data-link="' + tgData + '"' + (tg && isEnabled ? '' : ' disabled') + '>Copy tg://</button>' +
+      '<button class="ui-btn user-copy" type="button" data-link="' + tmeData + '"' + (tme && isEnabled ? '' : ' disabled') + '>Copy t.me</button>' +
       '<button class="ui-btn danger user-delete" type="button" data-user="' + userName + '" title="Delete user">✕</button>' +
       '</div>' +
       '</div>';
@@ -514,6 +541,14 @@ function renderUsers(users) {
         btn.textContent = original;
         btn.classList.remove('active');
       }, 1100);
+    });
+  });
+
+  // Enable/disable toggles
+  list.querySelectorAll('.user-enabled-toggle').forEach((cb) => {
+    cb.addEventListener('change', () => {
+      const name = cb.dataset.user;
+      toggleUserEnabled(name, cb.checked);
     });
   });
 
@@ -782,10 +817,15 @@ function renderRouting(routing) {
       proxyHostLabel.textContent = upstreamType + ' host';
       proxyHost.placeholder = upstreamType === 'socks5' ? '127.0.0.1' : '127.0.0.1';
       proxyPort.placeholder = upstreamType === 'socks5' ? '1080' : '8080';
-      proxyHost.value = host;
-      proxyPort.value = port > 0 ? String(port) : '';
-      proxyUser.value = username;
-      proxyPass.value = password;
+      // Don't overwrite inputs while user is typing (fix for field reset bug)
+      const proxyInputs = [proxyHost, proxyPort, proxyUser, proxyPass];
+      const anyFocused = proxyInputs.some(el => el === document.activeElement);
+      if (!anyFocused) {
+        proxyHost.value = host;
+        proxyPort.value = port > 0 ? String(port) : '';
+        proxyUser.value = username;
+        proxyPass.value = password;
+      }
     } else {
       proxyCtl.style.display = 'none';
     }
@@ -890,6 +930,7 @@ async function poll() {
   $('pxDrops').style.color = drp > 0 ? 'var(--amber)' : 'var(--text-muted)';
   $('pxDropLbl').textContent = 'rate +' + drp + ' · cap +' + (p.cap_drops || 0) + ' · hs_t +' + (p.hs_timeout || 0);
 
+
   // Version
   const vEl = $('dashboardVersion');
   if (vEl && d.proxy_version) {
@@ -950,7 +991,7 @@ async function poll() {
     $('maskTimer').textContent = timerState;
   }
 
-  renderUsers(d.users || null);
+  renderUsers(d.users || null, (d.proxy || {}).per_user_active || {});
 }
 
 function setDataBadge(state, text) {

--- a/src/ctl/dashboard_assets/static/index.html
+++ b/src/ctl/dashboard_assets/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>⚡ MTProto Proxy — Dashboard</title>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/style.css?v=20260415">
+  <link rel="stylesheet" href="/style.css?v=20260422">
 </head>
 <body>
 <div class="app">
@@ -274,6 +274,6 @@
   </div>
 </div>
 
-<script src="/app.js?v=20260415"></script>
+<script src="/app.js?v=20260422"></script>
 </body>
 </html>

--- a/src/ctl/dashboard_assets/static/style.css
+++ b/src/ctl/dashboard_assets/static/style.css
@@ -372,6 +372,31 @@ body::after {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  display: flex;
+  align-items: center;
+  gap: 0;
+}
+.user-sessions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  margin-left: 6px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  background: rgba(52,211,153,0.12);
+  border: 1px solid rgba(52,211,153,0.25);
+  color: var(--green);
+  flex-shrink: 0;
+}
+.user-sessions.zero {
+  background: rgba(124,134,152,0.08);
+  border-color: rgba(124,134,152,0.15);
+  color: var(--text-muted);
 }
 .user-route {
   display: flex;
@@ -440,6 +465,55 @@ body::after {
   padding: 16px 24px;
   color: var(--text-muted);
   font-size: 12px;
+}
+.user-row.disabled {
+  opacity: 0.45;
+}
+.user-row.disabled .user-link {
+  font-style: italic;
+  color: var(--text-muted);
+}
+
+/* ── Toggle Switch ── */
+.user-toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 30px;
+  height: 16px;
+  margin-right: 8px;
+  flex-shrink: 0;
+  vertical-align: middle;
+  cursor: pointer;
+}
+.user-toggle-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.user-toggle-slider {
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(248,113,113,0.25);
+  border-radius: 16px;
+  transition: background 0.25s;
+}
+.user-toggle-slider::before {
+  content: '';
+  position: absolute;
+  height: 12px;
+  width: 12px;
+  left: 2px;
+  bottom: 2px;
+  background: var(--red);
+  border-radius: 50%;
+  transition: transform 0.25s, background 0.25s;
+}
+.user-toggle-switch input:checked + .user-toggle-slider {
+  background: rgba(52,211,153,0.25);
+}
+.user-toggle-switch input:checked + .user-toggle-slider::before {
+  transform: translateX(14px);
+  background: var(--green);
 }
 
 /* ── Add User Button ── */

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -1883,8 +1883,10 @@ const EventLoop = struct {
         // Build per-user active connection counts for dashboard parsing
         var user_buf: [1024]u8 = undefined;
         var user_pos: usize = 0;
+        var users_active_total: u32 = 0;
         for (self.state.user_metrics) |*um| {
             const uactive = um.connections_active.load(.monotonic);
+            users_active_total +|= uactive;
             const name = um.name;
             if (user_pos > 0 and user_pos < user_buf.len) {
                 user_buf[user_pos] = ',';
@@ -1894,8 +1896,9 @@ const EventLoop = struct {
             user_pos += written.len;
         }
         const user_str = if (user_pos > 0) user_buf[0..user_pos] else "";
+        const unassigned_active = active -| users_active_total;
 
-        log.info("conn stats: active={d}/{d} hs_inflight={d} accepted+={d} closed+={d} tracked_fds={d} total={d} paused={}/{} users{{{s}}}", .{
+        log.info("conn stats: active={d}/{d} hs_inflight={d} accepted+={d} closed+={d} tracked_fds={d} total={d} paused={}/{} users_total={d} unassigned={d} users{{{s}}}", .{
             active,
             self.state.config.max_connections,
             hs,
@@ -1905,6 +1908,8 @@ const EventLoop = struct {
             accepted_total,
             self.accept_paused,
             self.saturation_paused,
+            users_active_total,
+            unassigned_active,
             user_str,
         });
 
@@ -3892,14 +3897,14 @@ const EventLoop = struct {
             slot.upstream_fd = -1;
         }
 
+        const user_metrics = slot.user_metrics;
         slot.resetOwnedBuffers(self.state.allocator);
 
         if (slot.active_reserved) {
             _ = self.state.active_connections.fetchSub(1, .monotonic);
             _ = self.state.closed_count.fetchAdd(1, .monotonic);
-            if (slot.user_metrics) |entry| {
+            if (user_metrics) |entry| {
                 _ = entry.connections_active.fetchSub(1, .monotonic);
-                slot.user_metrics = null;
             }
             // If connection was still in handshake phase, release from handshake budget
             if (slot.handshakeInProgress()) {

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -1880,7 +1880,22 @@ const EventLoop = struct {
 
         const has_drops = d_cap + d_sat + d_rate + d_hs + d_hst + d_mpf > 0;
 
-        log.info("conn stats: active={d}/{d} hs_inflight={d} accepted+={d} closed+={d} tracked_fds={d} total={d} paused={}/{}", .{
+        // Build per-user active connection counts for dashboard parsing
+        var user_buf: [1024]u8 = undefined;
+        var user_pos: usize = 0;
+        for (self.state.user_metrics) |*um| {
+            const uactive = um.connections_active.load(.monotonic);
+            const name = um.name;
+            if (user_pos > 0 and user_pos < user_buf.len) {
+                user_buf[user_pos] = ',';
+                user_pos += 1;
+            }
+            const written = std.fmt.bufPrint(user_buf[user_pos..], "{s}={d}", .{ name, uactive }) catch break;
+            user_pos += written.len;
+        }
+        const user_str = if (user_pos > 0) user_buf[0..user_pos] else "";
+
+        log.info("conn stats: active={d}/{d} hs_inflight={d} accepted+={d} closed+={d} tracked_fds={d} total={d} paused={}/{} users{{{s}}}", .{
             active,
             self.state.config.max_connections,
             hs,
@@ -1890,6 +1905,7 @@ const EventLoop = struct {
             accepted_total,
             self.accept_paused,
             self.saturation_paused,
+            user_str,
         });
 
         if (has_drops) {


### PR DESCRIPTION
Closes #206

## Changes

### 1. User Enable/Disable Toggle
- Pill-shaped toggle switch per user row (green = enabled, red = disabled)
- Disabling moves the user's secret from `[access.users]` → `[access.disabled_users]` in `config.toml`, then restarts the proxy
- Re-enabling reverses the move
- **Zero Zig proxy changes** — disabled user is simply absent from the config

### 2. Per-User Active Session Tooltip
- Dashboard scrapes `mtproto_user_connections_active{user="X"}` from the Prometheus `/metrics` endpoint (port 9400)
- Hovering over the **Active** counter shows a breakdown tooltip (e.g. `alice: 2, bob: 1`)

### 3. Fix Proxy Input Field Reset
- Bug: selecting socks5/http upstream caused the host/port/user/pass fields to reset on every 3s poll cycle, making it impossible to type
- Fix: `document.activeElement` guard skips overwriting values when any proxy input is focused

## Files Modified
- `server.py` — backend: config parsing, toggle API, per-user metrics scraper
- `app.js` — frontend: toggle UI, tooltip, focus guard
- `style.css` — toggle switch styles, disabled row dimming
- `index.html` — cache-buster version bump