### PR TITLE
Fix: dashboard config parsing, UV installation, port conflicts, and Grafana dashboard

### DIFF
--- a/hack/docker/mtproto-zig-grafana.json
+++ b/hack/docker/mtproto-zig-grafana.json
@@ -1,0 +1,304 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "title": "Proxy Info",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "textMode": "value_and_name", "colorMode": "value" },
+      "targets": [
+        { "expr": "mtproto_build_info", "legendFormat": "v{{version}}", "refId": "A" }
+      ]
+    },
+    {
+      "title": "Uptime",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" },
+      "targets": [
+        { "expr": "mtproto_uptime_seconds", "legendFormat": "uptime", "refId": "A" }
+      ]
+    },
+    {
+      "title": "Active Connections",
+      "type": "gauge",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": null,
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null },
+            { "color": "yellow", "value": 200 },
+            { "color": "red", "value": 450 }
+          ]}
+        },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        { "expr": "mtproto_connections_active", "legendFormat": "active", "refId": "A" },
+        { "expr": "mtproto_connections_max", "legendFormat": "max", "refId": "B" }
+      ]
+    },
+    {
+      "title": "Handshakes Inflight",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "thresholds": { "mode": "absolute", "steps": [
+          { "color": "green", "value": null },
+          { "color": "yellow", "value": 10 },
+          { "color": "red", "value": 30 }
+        ]}},
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" },
+      "targets": [
+        { "expr": "mtproto_handshakes_inflight", "legendFormat": "inflight", "refId": "A" }
+      ]
+    },
+    {
+      "title": "Connections Over Time",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "custom": { "lineWidth": 2, "fillOpacity": 10, "gradientMode": "scheme" } },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        { "expr": "mtproto_connections_active", "legendFormat": "active", "refId": "A" },
+        { "expr": "mtproto_connections_max", "legendFormat": "max", "refId": "B" },
+        { "expr": "mtproto_handshakes_inflight", "legendFormat": "handshakes", "refId": "C" }
+      ]
+    },
+    {
+      "title": "Connection Rate (accepted / closed)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "cps", "custom": { "lineWidth": 2, "fillOpacity": 10, "gradientMode": "scheme" } },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        { "expr": "rate(mtproto_connections_accepted_total[5m])", "legendFormat": "accepted/s", "refId": "A" },
+        { "expr": "rate(mtproto_connections_closed_total[5m])", "legendFormat": "closed/s", "refId": "B" }
+      ]
+    },
+    {
+      "title": "Traffic Throughput",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "Bps", "custom": { "lineWidth": 2, "fillOpacity": 15, "gradientMode": "scheme" } },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        { "expr": "rate(mtproto_client_to_upstream_bytes_total[5m])", "legendFormat": "client → upstream", "refId": "A" },
+        { "expr": "rate(mtproto_upstream_to_client_bytes_total[5m])", "legendFormat": "upstream → client", "refId": "B" }
+      ]
+    },
+    {
+      "title": "Total Transferred",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "decbytes", "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] } },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" },
+      "targets": [
+        { "expr": "mtproto_client_to_upstream_bytes_total", "legendFormat": "C→S", "refId": "A" },
+        { "expr": "mtproto_upstream_to_client_bytes_total", "legendFormat": "S→C", "refId": "B" }
+      ]
+    },
+    {
+      "title": "Total Connections",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "thresholds": { "mode": "absolute", "steps": [{ "color": "purple", "value": null }] } },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" },
+      "targets": [
+        { "expr": "mtproto_connections_total", "legendFormat": "total", "refId": "A" },
+        { "expr": "mtproto_connections_accepted_total", "legendFormat": "accepted", "refId": "B" },
+        { "expr": "mtproto_connections_closed_total", "legendFormat": "closed", "refId": "C" }
+      ]
+    },
+    {
+      "title": "Drops",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "cps", "custom": { "lineWidth": 2, "fillOpacity": 10, "drawStyle": "bars" } },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        { "expr": "rate(mtproto_drops_capacity_total[5m])", "legendFormat": "capacity", "refId": "A" },
+        { "expr": "rate(mtproto_drops_saturation_total[5m])", "legendFormat": "saturation", "refId": "B" },
+        { "expr": "rate(mtproto_drops_rate_limit_total[5m])", "legendFormat": "rate limit", "refId": "C" },
+        { "expr": "rate(mtproto_drops_handshake_budget_total[5m])", "legendFormat": "hs budget", "refId": "D" },
+        { "expr": "rate(mtproto_handshake_timeouts_total[5m])", "legendFormat": "hs timeout", "refId": "E" },
+        { "expr": "rate(mtproto_middleproxy_fallback_total[5m])", "legendFormat": "mp fallback", "refId": "F" }
+      ]
+    },
+    {
+      "title": "Per-User Active Connections",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "custom": { "lineWidth": 2, "fillOpacity": 20, "gradientMode": "scheme", "stacking": { "mode": "normal" } } },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "right", "calcs": ["lastNotNull", "max"] } },
+      "targets": [
+        { "expr": "mtproto_user_connections_active", "legendFormat": "{{user}}", "refId": "A" }
+      ]
+    },
+    {
+      "title": "Top Users by Throughput",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "Bps", "custom": { "lineWidth": 2, "fillOpacity": 10, "gradientMode": "scheme" } },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "right", "calcs": ["lastNotNull", "max"] } },
+      "targets": [
+        { "expr": "topk(10, rate(mtproto_user_client_to_upstream_bytes_total[5m]) + rate(mtproto_user_upstream_to_client_bytes_total[5m]))", "legendFormat": "{{user}}", "refId": "A" }
+      ]
+    },
+    {
+      "title": "Top Users by Transferred Bytes",
+      "type": "bargauge",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 28 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "decbytes", "thresholds": { "mode": "absolute", "steps": [
+          { "color": "blue", "value": null },
+          { "color": "green", "value": 1073741824 },
+          { "color": "yellow", "value": 10737418240 }
+        ]}},
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "horizontal", "displayMode": "gradient" },
+      "targets": [
+        { "expr": "topk(10, mtproto_user_client_to_upstream_bytes_total + mtproto_user_upstream_to_client_bytes_total)", "legendFormat": "{{user}}", "refId": "A" }
+      ]
+    },
+    {
+      "title": "Memory Usage",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 32 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "decbytes", "custom": { "lineWidth": 2, "fillOpacity": 10, "gradientMode": "scheme" } },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        { "expr": "process_resident_memory_bytes", "legendFormat": "RSS", "refId": "A" },
+        { "expr": "process_virtual_memory_bytes", "legendFormat": "Virtual", "refId": "B" },
+        { "expr": "mtproto_cgroup_memory_usage_bytes", "legendFormat": "cgroup usage", "refId": "C" },
+        { "expr": "mtproto_cgroup_memory_limit_bytes", "legendFormat": "cgroup limit", "refId": "D" }
+      ]
+    },
+    {
+      "title": "Process Metrics",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 36 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "custom": { "lineWidth": 2, "fillOpacity": 10 } },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "CPU" }, "properties": [{ "id": "unit", "value": "s" }] },
+          { "matcher": { "id": "byName", "options": "open FDs" }, "properties": [{ "id": "unit", "value": "short" }] }
+        ]
+      },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        { "expr": "rate(process_cpu_seconds_total[5m])", "legendFormat": "CPU", "refId": "A" },
+        { "expr": "process_open_fds", "legendFormat": "open FDs", "refId": "B" }
+      ]
+    },
+    {
+      "title": "Config Flags",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 24, "x": 0, "y": 44 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "OFF", "color": "red" }, "1": { "text": "ON", "color": "green" } } }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "text", "value": null }] }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "port" }, "properties": [{ "id": "mappings", "value": [] }] }
+        ]
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "textMode": "value_and_name", "orientation": "horizontal" },
+      "targets": [
+        { "expr": "mtproto_middleproxy_enabled", "legendFormat": "middleproxy", "refId": "A" },
+        { "expr": "mtproto_fast_mode_enabled", "legendFormat": "fast_mode", "refId": "B" },
+        { "expr": "mtproto_mask_enabled", "legendFormat": "mask", "refId": "C" },
+        { "expr": "mtproto_desync_enabled", "legendFormat": "desync", "refId": "D" },
+        { "expr": "mtproto_drs_enabled", "legendFormat": "DRS", "refId": "E" },
+        { "expr": "mtproto_config_port", "legendFormat": "port", "refId": "F" },
+        { "expr": "mtproto_config_max_connections", "legendFormat": "max_conn", "refId": "G" },
+        { "expr": "mtproto_accept_paused", "legendFormat": "accept_paused", "refId": "H" },
+        { "expr": "mtproto_saturation_paused", "legendFormat": "saturation", "refId": "I" }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["mtproto", "proxy", "telegram"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "MTProto Proxy",
+  "uid": "mtproto-zig",
+  "version": 1
+}

--- a/src/config.zig
+++ b/src/config.zig
@@ -162,6 +162,15 @@ pub const Config = struct {
 
     /// Emit startup warnings for configuration values known to cause issues.
     pub fn emitWarnings(self: *const Config) void {
+        if (self.mask and self.port == self.mask_port) {
+            const log = std.log.scoped(.config);
+            log.err(
+                "proxy port ({d}) equals mask_port ({d}). The proxy listen socket " ++
+                    "will collide with the local masking server (Nginx). " ++
+                    "Change [server].port or [censorship].mask_port so they differ.",
+                .{ self.port, self.mask_port },
+            );
+        }
         if (self.use_middle_proxy and self.middleproxy_buffer_kb < 1024) {
             const log = std.log.scoped(.config);
             log.warn(

--- a/src/ctl/dashboard.zig
+++ b/src/ctl/dashboard.zig
@@ -1,7 +1,7 @@
 //! Setup dashboard command for mtbuddy.
 //!
 //! Embeds the Python FastAPI dashboard and its static files directly into the
-//! mtbuddy binary using @embedFile. Uses `uv` (astral.sh) to manage an
+//! mtbuddy binary using @embedFile. Uses `uv` (installed from GitHub) to manage an
 //! isolated virtualenv with all Python dependencies, avoiding PEP 668 breakage
 //! on modern Debian/Ubuntu systems.
 
@@ -59,46 +59,39 @@ fn uvExists() bool {
     return sys.commandExists("uv");
 }
 
-/// Install `uv` via the official astral.sh installer.
+/// Install `uv` from GitHub releases (astral.sh is blocked in some regions).
 fn bootstrapUv(ui: *Tui, allocator: std.mem.Allocator) bool {
-    ui.step("Installing uv package manager...");
+    ui.step("Installing uv package manager from GitHub...");
 
-    // Download and run the official installer (installs to ~/.local/bin or /usr/local/bin)
+    // Download the latest release tarball from GitHub and extract `uv` binary.
+    // GitHub is reliably accessible even when astral.sh is blocked.
     const result = sys.exec(allocator, &.{
-        "sh", "-c", "curl -fsSL https://astral.sh/uv/install.sh | sh",
+        "sh", "-c",
+        \\set -e
+        \\UV_URL="https://github.com/astral-sh/uv/releases/latest/download/uv-x86_64-unknown-linux-gnu.tar.gz"
+        \\TMP_DIR=$(mktemp -d)
+        \\trap 'rm -rf "$TMP_DIR"' EXIT
+        \\curl -fsSL "$UV_URL" -o "$TMP_DIR/uv.tar.gz"
+        \\tar -xzf "$TMP_DIR/uv.tar.gz" -C "$TMP_DIR" --strip-components=1
+        \\install -m 0755 "$TMP_DIR/uv" /usr/local/bin/uv
+        \\if [ -f "$TMP_DIR/uvx" ]; then install -m 0755 "$TMP_DIR/uvx" /usr/local/bin/uvx; fi
     }) catch {
-        ui.fail("Failed to download uv installer");
+        ui.fail("Failed to download uv from GitHub");
         return false;
     };
     defer result.deinit();
 
     if (result.exit_code != 0) {
-        ui.fail("uv installer exited with an error");
+        ui.fail("uv installation from GitHub failed");
         return false;
     }
 
-    // The installer puts uv in ~/.local/bin for root → /root/.local/bin
-    // Also check /usr/local/bin.  Symlink to /usr/local/bin for PATH stability.
     if (!sys.commandExists("uv")) {
-        const symlink_result = sys.exec(allocator, &.{
-            "sh", "-c",
-            \\if [ -f /root/.local/bin/uv ]; then
-            \\  ln -sf /root/.local/bin/uv /usr/local/bin/uv
-            \\  ln -sf /root/.local/bin/uvx /usr/local/bin/uvx 2>/dev/null
-            \\fi
-        }) catch {
-            ui.fail("uv installed but not found on PATH");
-            return false;
-        };
-        defer symlink_result.deinit();
-
-        if (!sys.commandExists("uv")) {
-            ui.fail("uv installed but not found on PATH");
-            return false;
-        }
+        ui.fail("uv binary installed but not found on PATH");
+        return false;
     }
 
-    ui.ok("uv installed successfully");
+    ui.ok("uv installed successfully (from GitHub)");
     return true;
 }
 

--- a/src/ctl/dashboard_assets/server.py
+++ b/src/ctl/dashboard_assets/server.py
@@ -38,25 +38,48 @@ def _proxy_config_candidates():
 
 
 def _load_dashboard_config() -> dict:
-    """Load [monitor] section from config.toml (host, port)."""
+    """Load [monitor] section from config.toml (host, port).
+
+    Uses the same line-by-line parser as _load_proxy_runtime_config() to avoid
+    silent failures when tomllib rejects slightly non-standard config files.
+    """
     defaults = {"host": "127.0.0.1", "port": 61208}
-    if tomllib is None:
-        return defaults
-    # Look for config.toml relative to the install directory
     for p in _proxy_config_candidates():
-        if p.is_file():
-            try:
-                with open(p, "rb") as f:
-                    cfg = tomllib.load(f)
-                mon = cfg.get("monitor", {})
-                return {
-                    "host": str(mon.get("host", defaults["host"])),
-                    "port": int(mon.get("port", defaults["port"])),
-                }
-            except Exception as exc:
-                print(
-                    f"[dashboard] warning: failed to parse {p}: {exc}", file=sys.stderr
-                )
+        if not p.is_file():
+            continue
+        try:
+            section = ""
+            result = dict(defaults)
+            with open(p, "r", encoding="utf-8", errors="replace") as f:
+                for raw_line in f:
+                    line = raw_line.strip()
+                    if not line or line.startswith("#"):
+                        continue
+                    if line.startswith("[") and line.endswith("]"):
+                        section = line.lower()
+                        continue
+                    if section != "[monitor]":
+                        continue
+                    if "=" not in line:
+                        continue
+                    key, value = line.split("=", 1)
+                    key = key.strip()
+                    value = value.strip()
+                    if "#" in value:
+                        value = value.split("#", 1)[0].strip()
+                    if len(value) >= 2 and value[0] == '"' and value[-1] == '"':
+                        value = value[1:-1]
+                    if key == "host":
+                        result["host"] = value
+                    elif key == "port":
+                        digits = "".join(ch for ch in value if ch.isdigit())
+                        if digits:
+                            result["port"] = int(digits)
+            return result
+        except Exception as exc:
+            print(
+                f"[dashboard] warning: failed to parse {p}: {exc}", file=sys.stderr
+            )
     return defaults
 
 

--- a/src/ctl/install.zig
+++ b/src/ctl/install.zig
@@ -280,6 +280,17 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
         return;
     }
 
+    // ── Check port / masking collision ──
+    // The masking Nginx binds to 127.0.0.1:8443. If the proxy listens on
+    // the same port, its 0.0.0.0 bind will collide with Nginx and the
+    // service won't start.
+    const masking_port: u16 = std.fmt.parseInt(u16, masking.NGINX_PORT, 10) catch 8443;
+    if (opts.enable_masking and opts.port == masking_port) {
+        ui.fail("Port conflict: proxy port and masking port are both " ++ masking.NGINX_PORT ++ ".");
+        ui.info("Choose a different proxy port (e.g. 443) or disable masking (--no-masking).");
+        return;
+    }
+
     ui.writeRaw("\n");
     ui.rule();
 

--- a/src/ctl/masking.zig
+++ b/src/ctl/masking.zig
@@ -16,7 +16,7 @@ const SummaryLine = tui_mod.SummaryLine;
 
 const INSTALL_DIR = "/opt/mtproto-proxy";
 const CERT_DIR = "/etc/nginx/ssl";
-const NGINX_PORT = "8443";
+pub const NGINX_PORT = "8443";
 
 pub const MaskingOpts = struct {
     tls_domain: []const u8 = "wb.ru",


### PR DESCRIPTION
Addresses a set of reported issues:
- **Port Conflict (#211):** Installer and proxy runtime now guard against binding the proxy to the same port as Nginx zero-RTT masking (8443).
- **UV Installation:** Switches the `uv` package manager bootstrap script from astral.sh to GitHub releases, bypassing regional blocks.
- **Dashboard Config Parsing (#213):** Replaces the fragile `tomllib` parser for the `[monitor]` section with a robust line-by-line parser consistent with the rest of the proxy.
- **Grafana Dashboard (#214):** Adds the missing `mtproto-zig-grafana.json` file referenced in the Docker documentation, featuring comprehensive metrics visualization.
