### PR TITLE
Refactor proxy core, migrate to Zig 0.16, and harden release verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Run tests
         run: zig build test
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Run microbenchmark
         run: zig build -Doptimize=ReleaseFast bench 2>&1 | tee bench-output.txt

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Verify AES-enabled x86_64_v3 profile
         if: contains(matrix.cpu, 'x86_64_v3')
@@ -86,10 +86,15 @@ jobs:
           zig build-exe -target "${{ matrix.target }}" -mcpu "${{ matrix.cpu }}" /tmp/check_aes_target.zig
 
       - name: Build release binary
+        env:
+          MINISIGN_PUBKEY_B64: ${{ secrets.MINISIGN_PUBKEY_B64 }}
         run: |
           BUILD_ARGS="-Doptimize=ReleaseFast -Dtarget=${{ matrix.target }}"
           if [ -n "${{ matrix.cpu }}" ]; then
             BUILD_ARGS="$BUILD_ARGS -Dcpu=${{ matrix.cpu }}"
+          fi
+          if [ -n "${MINISIGN_PUBKEY_B64}" ]; then
+            BUILD_ARGS="$BUILD_ARGS -Dminisign_pubkey=${MINISIGN_PUBKEY_B64}"
           fi
           zig build $BUILD_ARGS
 
@@ -99,8 +104,46 @@ jobs:
           cp zig-out/bin/${{ matrix.binary }} dist/${{ matrix.artifact_name }}
           chmod +x dist/${{ matrix.artifact_name }}
           tar -C dist -czf dist/${{ matrix.artifact_name }}.tar.gz ${{ matrix.artifact_name }}
+          (
+            cd dist
+            sha256sum ${{ matrix.artifact_name }}.tar.gz > ${{ matrix.artifact_name }}.tar.gz.sha256
+          )
+
+      - name: Sign checksum with minisign
+        env:
+          MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
+          MINISIGN_PUBLIC_KEY: ${{ secrets.MINISIGN_PUBLIC_KEY }}
+        run: |
+          if [ -z "${MINISIGN_SECRET_KEY}" ] || [ -z "${MINISIGN_PUBLIC_KEY}" ]; then
+            echo "Minisign secrets are not configured; skipping signature generation"
+            exit 0
+          fi
+          sudo apt-get update -qq
+          sudo apt-get install -y minisign
+
+          printf '%s\n' "${MINISIGN_SECRET_KEY}" > /tmp/minisign.key
+          chmod 600 /tmp/minisign.key
+          printf '%s\n' "${MINISIGN_PUBLIC_KEY}" > dist/minisign.pub
+          minisign -S \
+            -s /tmp/minisign.key \
+            -m dist/${{ matrix.artifact_name }}.tar.gz.sha256 \
+            -x dist/${{ matrix.artifact_name }}.tar.gz.sha256.minisig \
+            -t "tag:${{ needs.release-please.outputs.tag_name }} artifact:${{ matrix.artifact_name }}"
 
       - name: Upload release asset
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${{ needs.release-please.outputs.tag_name }}" dist/${{ matrix.artifact_name }}.tar.gz --clobber
+        run: |
+          FILES=(
+            "dist/${{ matrix.artifact_name }}.tar.gz"
+            "dist/${{ matrix.artifact_name }}.tar.gz.sha256"
+          )
+          if [ -f "dist/${{ matrix.artifact_name }}.tar.gz.sha256.minisig" ]; then
+            FILES+=("dist/${{ matrix.artifact_name }}.tar.gz.sha256.minisig")
+          fi
+          if [ -f "dist/minisign.pub" ]; then
+            FILES+=("dist/minisign.pub")
+          fi
+          gh release upload "${{ needs.release-please.outputs.tag_name }}" \
+            "${FILES[@]}" \
+            --clobber

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,8 @@ test: ## Run unit tests
 # ── server ops ────────────────────────────────────────────────────────────────
 
 deploy: build ## Build and push proxy + mtbuddy to server
-	ssh root@$(SERVER) 'pkill -9 -x mtproto-proxy || true; systemctl reset-failed mtproto-proxy 2>/dev/null; true'
-	scp zig-out/bin/mtproto-proxy root@$(SERVER):/opt/mtproto-proxy/
-	scp zig-out/bin/mtbuddy root@$(SERVER):/usr/local/bin/mtbuddy
+	scp zig-out/bin/mtproto-proxy root@$(SERVER):/opt/mtproto-proxy/mtproto-proxy.new
+	scp zig-out/bin/mtbuddy root@$(SERVER):/usr/local/bin/mtbuddy.new
 	-@if [ -f $(CONFIG) ]; then scp $(CONFIG) root@$(SERVER):/opt/mtproto-proxy/config.toml; fi
 	-@if [ -f .env ]; then \
 		awk '{print "export " $$0}' .env > .env.tmp && \
@@ -32,7 +31,9 @@ deploy: build ## Build and push proxy + mtbuddy to server
 		ssh root@$(SERVER) 'chmod 600 /opt/mtproto-proxy/env.sh' && \
 		rm .env.tmp; \
 	fi
-	ssh root@$(SERVER) 'chown -R mtproto:mtproto /opt/mtproto-proxy/ && systemctl start mtproto-proxy'
+	ssh root@$(SERVER) 'install -m 0755 /opt/mtproto-proxy/mtproto-proxy.new /opt/mtproto-proxy/mtproto-proxy'
+	ssh root@$(SERVER) 'install -m 0755 /usr/local/bin/mtbuddy.new /usr/local/bin/mtbuddy'
+	ssh root@$(SERVER) 'chown -R mtproto:mtproto /opt/mtproto-proxy/ && systemctl restart mtproto-proxy && systemctl is-active --quiet mtproto-proxy'
 	ssh root@$(SERVER) 'if [ -f /etc/systemd/system/proxy-monitor.service ]; then mtbuddy setup dashboard --quiet; fi'
 
 # ── dashboard ─────────────────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -70,7 +70,12 @@ All installation, updates, and management are done through **mtbuddy** — a nat
 curl -fsSL https://raw.githubusercontent.com/sleep3r/mtproto.zig/main/deploy/bootstrap.sh | sudo bash
 ```
 
-This downloads the latest `mtbuddy` binary and runs `mtbuddy --help`. Then install the proxy:
+This downloads the latest `mtbuddy` binary, verifies its SHA-256 checksum from the GitHub Release, and runs `mtbuddy --help`. Then install the proxy:
+
+```bash
+# Optional: enforce minisign verification for bootstrap checksum files
+export MTPROTO_MINISIGN_PUBKEY="RW..."
+```
 
 ```bash
 # Minimal — auto-generates a secret, enables all DPI bypass modules
@@ -138,7 +143,7 @@ sudo mtbuddy --interactive
 ## Update
 
 ```bash
-# Update to latest release (checks CPU compat, auto-rollback on failure)
+# Update to latest release (verifies checksum, checks CPU compat, auto-rollback on failure)
 sudo mtbuddy update
 
 # Pin to a specific version
@@ -238,7 +243,7 @@ You can also explicitly configure the tunnel interface in `config.toml`:
 type = "tunnel"
 
 [upstream.tunnel]
-tunnel_interface = "awg0"
+interface = "awg0"
 ```
 
 ### SOCKS5 proxy
@@ -285,6 +290,7 @@ use_middle_proxy = true   # ME mode for promo-channel parity
 
 [upstream]
 type = "auto"            # auto | direct | tunnel | socks5 | http
+# allow_direct_fallback = false   # fail-closed by default for socks5/http misconfig
 
 [server]
 port = 443
@@ -317,7 +323,8 @@ alice = true   # bypass MiddleProxy for this user
 | Key | Default | Description |
 |-----|---------|-------------|
 | `[upstream].type` | `auto` | Egress mode: `auto` (direct), `direct`, `tunnel` (VPN via socket policy routing), `socks5`, or `http` |
-| `[upstream.tunnel] tunnel_interface` | `"awg0"` | Name of the VPN network interface for SO_MARK routing |
+| `[upstream] allow_direct_fallback` | `false` | If `true`, allows socks5/http modes to fall back to direct egress when upstream is unavailable |
+| `[upstream.tunnel] interface` | `"awg0"` | Name of the VPN network interface for SO_MARK routing |
 | `[upstream.socks5] host` | — | SOCKS5 proxy address |
 | `[upstream.socks5] port` | — | SOCKS5 proxy port |
 | `[upstream.socks5] username` | — | SOCKS5 username (empty = no auth) |
@@ -424,18 +431,23 @@ It exposes proxy counters plus process metrics such as RSS, virtual memory, CPU 
 
 ## Building locally
 
-Requires [Zig 0.15.2](https://ziglang.org/download/).
+Requires [Zig 0.16.0](https://ziglang.org/download/).
 
 ```bash
 git clone https://github.com/sleep3r/mtproto.zig.git
 cd mtproto.zig
 
-make build     # debug
-make release   # optimized
-make run       # run with config.toml
-make test      # unit tests (78 tests)
-make bench     # C2S encapsulation microbenchmark
-make soak      # 30s multithreaded stability test
+make build      # cross-compile ReleaseFast binaries for Linux x86_64_v3+aes
+make test       # run Zig tests
+make fmt        # format Zig sources
+make deploy     # build + deploy to SERVER (see Makefile)
+make dashboard  # SSH tunnel for web dashboard (localhost:61208)
+```
+
+Release builders can embed a minisign public key into `mtbuddy`:
+
+```bash
+zig build -Dminisign_pubkey=RW... -Doptimize=ReleaseFast -Dtarget=x86_64-linux
 ```
 
 Cross-compile for Linux from macOS:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Disguises Telegram traffic as standard TLS 1.3 HTTPS to bypass network censorshi
 **177 KB binary · Sub-1 MB RAM · Boots in <10 ms · Zero dependencies**
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Zig](https://img.shields.io/badge/zig-0.15.2-f7a41d.svg?logo=zig&logoColor=white)](https://ziglang.org)
+[![Zig](https://img.shields.io/badge/zig-0.16.0-f7a41d.svg?logo=zig&logoColor=white)](https://ziglang.org)
 [![Platform](https://img.shields.io/badge/platform-linux-blueviolet.svg?logo=linux&logoColor=white)](#install)
 
 </div>

--- a/build.zig
+++ b/build.zig
@@ -8,6 +8,11 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    const linux_io_mod = b.createModule(.{
+        .root_source_file = b.path("src/linux_io.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
 
     const exe_mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
@@ -15,6 +20,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .imports = &.{
             .{ .name = "version", .module = version_mod },
+            .{ .name = "linux_io", .module = linux_io_mod },
         },
     });
 
@@ -78,6 +84,7 @@ pub fn build(b: *std.Build) void {
         .imports = &.{
             .{ .name = "tunnel", .module = tunnel_mod },
             .{ .name = "version", .module = version_mod },
+            .{ .name = "linux_io", .module = linux_io_mod },
         },
     });
 
@@ -104,6 +111,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .imports = &.{
             .{ .name = "version", .module = version_mod },
+            .{ .name = "linux_io", .module = linux_io_mod },
         },
     });
 

--- a/build.zig
+++ b/build.zig
@@ -3,6 +3,15 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
+    const minisign_pubkey = b.option(
+        []const u8,
+        "minisign_pubkey",
+        "Minisign public key (base64) for release signature verification",
+    ) orelse "";
+
+    const build_options = b.addOptions();
+    build_options.addOption([]const u8, "minisign_pubkey", minisign_pubkey);
+    const build_options_mod = build_options.createModule();
     const version_mod = b.createModule(.{
         .root_source_file = b.path("src/version.zig"),
         .target = target,
@@ -85,6 +94,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "tunnel", .module = tunnel_mod },
             .{ .name = "version", .module = version_mod },
             .{ .name = "linux_io", .module = linux_io_mod },
+            .{ .name = "build_options", .module = build_options_mod },
         },
     });
 

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -14,6 +14,7 @@ REPO="sleep3r/mtproto.zig"
 INSTALL_TO="/usr/local/bin/mtbuddy"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
+MINISIGN_PUBKEY="${MTPROTO_MINISIGN_PUBKEY:-}"
 
 # ── colour helpers ────────────────────────────────────────────────
 Y='\033[0;33m'; G='\033[0;32m'; R='\033[0;31m'; N='\033[0m'
@@ -73,10 +74,39 @@ ok "Latest release: $TAG"
 # ── download helper ───────────────────────────────────────────────
 download_artifact() {
   local artifact="$1"
-  local url="https://github.com/${REPO}/releases/download/${TAG}/${artifact}.tar.gz"
+  local tar_name="${artifact}.tar.gz"
+  local sha_name="${tar_name}.sha256"
+  local url="https://github.com/${REPO}/releases/download/${TAG}/${tar_name}"
+  local sha_url="https://github.com/${REPO}/releases/download/${TAG}/${sha_name}"
   step "Downloading $artifact"
-  curl -fsSL "$url" -o "$TMP/mtbuddy.tar.gz" || fail "Download failed: $url"
-  tar xzf "$TMP/mtbuddy.tar.gz" -C "$TMP"
+  curl -fsSL "$url" -o "$TMP/${tar_name}" || fail "Download failed: $url"
+  curl -fsSL "$sha_url" -o "$TMP/${sha_name}" || fail "Checksum download failed: $sha_url"
+  if [ -n "$MINISIGN_PUBKEY" ]; then
+    local sig_name="${sha_name}.minisig"
+    local sig_url="https://github.com/${REPO}/releases/download/${TAG}/${sig_name}"
+    curl -fsSL "$sig_url" -o "$TMP/${sig_name}" || fail "Signature download failed: $sig_url"
+    if ! command -v minisign >/dev/null 2>&1; then
+      fail "minisign is required for signature verification (install minisign or unset MTPROTO_MINISIGN_PUBKEY)"
+    fi
+    step "Verifying signature for $artifact"
+    minisign -V -q -m "$TMP/${sha_name}" -x "$TMP/${sig_name}" -P "$MINISIGN_PUBKEY" \
+      || fail "Signature verification failed: $sha_name"
+  fi
+
+  step "Verifying checksum for $artifact"
+  if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$TMP" && sha256sum -c "${sha_name}" >/dev/null) || fail "Checksum verification failed: $artifact"
+  elif command -v shasum >/dev/null 2>&1; then
+    local expected actual
+    expected="$(awk '{print $1}' "$TMP/${sha_name}" | head -n1)"
+    [ -n "$expected" ] || fail "Malformed checksum file: ${sha_name}"
+    actual="$(shasum -a 256 "$TMP/${tar_name}" | awk '{print $1}')"
+    [ "$expected" = "$actual" ] || fail "Checksum verification failed: $artifact"
+  else
+    fail "Neither sha256sum nor shasum is available for checksum verification"
+  fi
+
+  tar xzf "$TMP/${tar_name}" -C "$TMP"
   echo "$TMP/$artifact"
 }
 

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -1,11 +1,26 @@
 const std = @import("std");
-const net = std.net;
+const net = std.Io.net;
 const crypto = @import("crypto/crypto.zig");
 const middleproxy = @import("protocol/middleproxy.zig");
 const obfuscation = @import("protocol/obfuscation.zig");
 const constants = @import("protocol/constants.zig");
 const tls = @import("protocol/tls.zig");
 const proxy = @import("proxy/proxy.zig");
+
+fn ip4(bytes: [4]u8, port: u16) net.IpAddress {
+    return .{ .ip4 = .{ .bytes = bytes, .port = port } };
+}
+
+fn nowNs() u64 {
+    var ts: std.posix.timespec = undefined;
+    const rc = std.os.linux.clock_gettime(std.os.linux.CLOCK.MONOTONIC, &ts);
+    if (std.os.linux.errno(rc) != .SUCCESS) return 0;
+    return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+}
+
+fn nowMs() i64 {
+    return @as(i64, @intCast(nowNs() / std.time.ns_per_ms));
+}
 
 const Mode = enum {
     bench,
@@ -37,10 +52,10 @@ const WorkerArgs = struct {
     shared: *SoakShared,
 };
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
     const allocator = std.heap.page_allocator;
 
-    const opts = parseArgs(allocator) catch |err| {
+    const opts = parseArgs(init.minimal.args, allocator) catch |err| {
         if (err != error.ShowHelp) {
             std.debug.print("error: {any}\n\n", .{err});
         }
@@ -86,7 +101,7 @@ fn runBench(allocator: std.mem.Allocator) !void {
             _ = try ctx.encapsulateSingleMessageC2S(payload, (w & 1) == 1, out_buf);
         }
 
-        var timer = try std.time.Timer.start();
+        const t0 = nowNs();
 
         var produced_out_bytes: u64 = 0;
         var i: usize = 0;
@@ -96,7 +111,7 @@ fn runBench(allocator: std.mem.Allocator) !void {
             produced_out_bytes += @as(u64, @intCast(written));
         }
 
-        const elapsed_ns = timer.read();
+        const elapsed_ns = nowNs() - t0;
         const total_in_bytes = @as(u64, @intCast(payload_size)) * @as(u64, @intCast(iters));
         const ns_per_op = elapsedNsPerOp(elapsed_ns, iters);
 
@@ -136,7 +151,7 @@ fn runHandshakeBench(allocator: std.mem.Allocator, iterations: usize) !void {
         if (ok == null) return error.BenchmarkValidationFailed;
     }
 
-    var timer = try std.time.Timer.start();
+    const t0 = nowNs();
     var matched: usize = 0;
     var i: usize = 0;
     while (i < iterations) : (i += 1) {
@@ -144,7 +159,7 @@ fn runHandshakeBench(allocator: std.mem.Allocator, iterations: usize) !void {
         if (ok != null) matched += 1;
     }
 
-    const elapsed_ns = timer.read();
+    const elapsed_ns = nowNs() - t0;
     const ns_per_op = elapsedNsPerOp(elapsed_ns, iterations);
     const ops_per_sec = if (elapsed_ns == 0)
         0
@@ -169,7 +184,7 @@ fn runHandshakePathBench(allocator: std.mem.Allocator, opts: Options) !void {
         handshake.* = buildObfuscationHandshake(&bench_secret, .intermediate, dc_idx, nonce_seed);
     }
 
-    var candidates: [16]net.Address = undefined;
+    var candidates: [16]net.IpAddress = undefined;
     fillBenchmarkCandidates(&candidates);
     const windows = candidates.len - opts.candidate_count + 1;
 
@@ -189,7 +204,7 @@ fn runHandshakePathBench(allocator: std.mem.Allocator, opts: Options) !void {
         _ = try candidate_state.apply(allocator, candidates[base .. base + opts.candidate_count]);
     }
 
-    var timer = try std.time.Timer.start();
+    const t0 = nowNs();
     var matched: usize = 0;
     var checksum: u64 = 0;
     var i: usize = 0;
@@ -206,10 +221,10 @@ fn runHandshakePathBench(allocator: std.mem.Allocator, opts: Options) !void {
 
         checksum +%= @as(u64, @intCast(candidate_len));
         checksum +%= @as(u64, @intCast(@abs(parsed.params.dc_idx)));
-        checksum +%= std.mem.bigToNative(u16, candidate_slice[0].in.sa.port);
+        checksum +%= @as(u64, candidate_slice[0].getPort());
     }
 
-    const elapsed_ns = timer.read();
+    const elapsed_ns = nowNs() - t0;
     const ns_per_op = elapsedNsPerOp(elapsed_ns, opts.iterations);
     const ops_per_sec = if (elapsed_ns == 0)
         0
@@ -229,7 +244,7 @@ fn runHandshakePathBench(allocator: std.mem.Allocator, opts: Options) !void {
 }
 
 fn runSoak(allocator: std.mem.Allocator, opts: Options) !void {
-    const start_ms = std.time.milliTimestamp();
+    const start_ms = nowMs();
     const duration_ms = @as(i64, @intCast(opts.seconds)) * 1000;
 
     var shared = SoakShared{
@@ -259,7 +274,7 @@ fn runSoak(allocator: std.mem.Allocator, opts: Options) !void {
         thread.join();
     }
 
-    const end_ms = std.time.milliTimestamp();
+    const end_ms = nowMs();
     const elapsed_ms_i64 = @max(@as(i64, 1), end_ms - start_ms);
     const elapsed_ms: u64 = @intCast(elapsed_ms_i64);
 
@@ -305,7 +320,7 @@ fn soakWorker(args: WorkerArgs) void {
 
     var rng_state = makeSeed(args.worker_id);
 
-    while (std.time.milliTimestamp() < args.shared.deadline_ms) {
+    while (nowMs() < args.shared.deadline_ms) {
         const payload_len = nextPayloadLen(&rng_state, args.max_payload);
         payload_buf[0] +%= 1;
         const quickack = (nextRand(&rng_state) & 1) == 1;
@@ -331,8 +346,8 @@ fn initContext(allocator: std.mem.Allocator, proto_tag: constants.ProtoTag) !mid
         crypto.AesCbc.init(&key, &iv),
         [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 },
         -2,
-        net.Address.initIp4(.{ 10, 20, 30, 40 }, 12345),
-        net.Address.initIp4(.{ 91, 105, 192, 110 }, 443),
+        ip4(.{ 10, 20, 30, 40 }, 12345),
+        ip4(.{ 91, 105, 192, 110 }, 443),
         proto_tag,
         null,
     );
@@ -374,18 +389,18 @@ fn buildObfuscationHandshake(secret: *const [16]u8, proto_tag: constants.ProtoTa
     return handshake;
 }
 
-fn fillBenchmarkCandidates(out: *[16]net.Address) void {
+fn fillBenchmarkCandidates(out: *[16]net.IpAddress) void {
     for (out, 0..) |*addr, idx| {
         const octet: u8 = @intCast(100 + idx);
         const port = constants.tg_datacenter_port + @as(u16, @intCast(idx));
-        addr.* = net.Address.initIp4(.{ 149, 154, 167, octet }, port);
+        addr.* = ip4(.{ 149, 154, 167, octet }, port);
     }
 }
 
-fn parseArgs(allocator: std.mem.Allocator) !Options {
+fn parseArgs(args_source: std.process.Args, allocator: std.mem.Allocator) !Options {
     var opts = Options{};
 
-    var args = try std.process.argsWithAllocator(allocator);
+    var args = try args_source.iterateAllocator(allocator);
     defer args.deinit();
 
     _ = args.next();
@@ -503,7 +518,7 @@ fn bytesPerSecToMiBMs(bytes: u64, elapsed_ms: u64) u64 {
 }
 
 fn makeSeed(worker_id: usize) u64 {
-    const now_ms = std.time.milliTimestamp();
+    const now_ms = nowMs();
     const base: u64 = if (now_ms >= 0)
         @intCast(now_ms)
     else

--- a/src/config.zig
+++ b/src/config.zig
@@ -4,6 +4,7 @@
 //! Format is compatible with the Rust telemt config.toml.
 
 const std = @import("std");
+const net = std.Io.net;
 
 pub const UpstreamMode = enum {
     /// Automatic egress mode (default).
@@ -56,11 +57,11 @@ fn stripInlineComment(value: []const u8) []const u8 {
         }
 
         if (!in_quotes and (ch == '#' or ch == ';')) {
-            return std.mem.trimRight(u8, value[0..i], &[_]u8{ ' ', '\t' });
+            return std.mem.trim(u8, value[0..i], &[_]u8{ ' ', '\t' });
         }
     }
 
-    return std.mem.trimRight(u8, value, &[_]u8{ ' ', '\t' });
+    return std.mem.trim(u8, value, &[_]u8{ ' ', '\t' });
 }
 
 pub const Config = struct {
@@ -134,7 +135,7 @@ pub const Config = struct {
     /// Use only if you know your host has enough memory for the configured limits.
     unsafe_override_limits: bool = false,
     /// Test-only hook to redirect upstream connections locally
-    datacenter_override: ?std.net.Address = null,
+    datacenter_override: ?net.IpAddress = null,
     /// Upstream egress mode. Parsed from [upstream].type.
     /// Supported values: auto | direct | tunnel | socks5 | http.
     upstream_mode: UpstreamMode = .auto,
@@ -206,9 +207,13 @@ pub const Config = struct {
     }
 
     pub fn loadFromFile(allocator: std.mem.Allocator, path: []const u8) !Config {
-        const file = try std.fs.cwd().openFile(path, .{});
-        defer file.close();
-        const content = try file.readToEndAlloc(allocator, 1024 * 1024);
+        const io = std.Io.Threaded.global_single_threaded.io();
+        const content = try std.Io.Dir.cwd().readFileAlloc(
+            io,
+            path,
+            allocator,
+            .limited(1024 * 1024),
+        );
         defer allocator.free(content);
         return parse(allocator, content);
     }

--- a/src/config.zig
+++ b/src/config.zig
@@ -5,6 +5,7 @@
 
 const std = @import("std");
 const net = std.Io.net;
+const default_tls_domain = "google.com";
 
 pub const UpstreamMode = enum {
     /// Automatic egress mode (default).
@@ -104,7 +105,7 @@ pub const Config = struct {
     /// Handshake read timeout after first byte arrives
     handshake_timeout_sec: u32 = 15,
     tag: ?[16]u8 = null,
-    tls_domain: []const u8 = "google.com",
+    tls_domain: []const u8 = default_tls_domain,
     users: std.StringHashMap([16]u8),
     /// Users that always bypass MiddleProxy and connect to DC directly.
     /// Section: [access.direct_users] (alias: [access.admins])
@@ -139,6 +140,9 @@ pub const Config = struct {
     /// Upstream egress mode. Parsed from [upstream].type.
     /// Supported values: auto | direct | tunnel | socks5 | http.
     upstream_mode: UpstreamMode = .auto,
+    /// Allow fallback to direct egress when explicit upstream mode
+    /// (socks5/http) is misconfigured or unavailable.
+    allow_direct_fallback: bool = false,
     /// Proxy server host for socks5/http upstream modes.
     /// Parsed from [upstream.socks5].host or [upstream.http].host.
     upstream_proxy_host: ?[]const u8 = null,
@@ -223,6 +227,7 @@ pub const Config = struct {
             .users = std.StringHashMap([16]u8).init(allocator),
             .direct_users = std.StringHashMap(void).init(allocator),
         };
+        errdefer cfg.deinit(allocator);
 
         var lines = std.mem.splitScalar(u8, content, '\n');
         var in_users_section = false;
@@ -277,9 +282,9 @@ pub const Config = struct {
 
                 if (in_users_section) {
                     // Parse user secret (32 hex chars = 16 bytes)
-                    if (value.len != 32) continue;
+                    if (value.len != 32) return error.InvalidUserSecretLength;
                     var secret: [16]u8 = undefined;
-                    _ = std.fmt.hexToBytes(&secret, value) catch continue;
+                    _ = std.fmt.hexToBytes(&secret, value) catch return error.InvalidUserSecretHex;
                     const name = try allocator.dupe(u8, key);
                     try cfg.users.put(name, secret);
                 } else if (in_direct_users_section) {
@@ -383,6 +388,8 @@ pub const Config = struct {
                         if (parseUpstreamMode(value)) |mode| {
                             cfg.upstream_mode = mode;
                         }
+                    } else if (std.mem.eql(u8, key, "allow_direct_fallback")) {
+                        cfg.allow_direct_fallback = std.mem.eql(u8, value, "true");
                     }
                 } else if (in_upstream_socks5_section or in_upstream_http_section) {
                     if (std.mem.eql(u8, key, "host")) {
@@ -423,8 +430,8 @@ pub const Config = struct {
         }
         direct_users.deinit();
 
-        // Free tls_domain if it was allocated (not the default)
-        if (!std.mem.eql(u8, self.tls_domain, "google.com")) {
+        // Free tls_domain only when it does not point to the compile-time default.
+        if (self.tls_domain.ptr != default_tls_domain.ptr) {
             allocator.free(self.tls_domain);
         }
         if (self.public_ip) |ip| {
@@ -698,19 +705,14 @@ test "parse config - spaces and tabs" {
     try std.testing.expect(cfg.users.contains("user"));
 }
 
-test "parse config - invalid hex secret skipped" {
+test "parse config - invalid user secret fails fast" {
     const content =
         \\[access.users]
         \\valid = "00112233445566778899aabbccddeeff"
         \\invalid_len = "001122"
         \\invalid_hex = "zz112233445566778899aabbccddeeff"
     ;
-
-    var cfg = try Config.parse(std.testing.allocator, content);
-    defer cfg.deinit(std.testing.allocator);
-
-    try std.testing.expectEqual(@as(usize, 1), cfg.users.count());
-    try std.testing.expect(cfg.users.contains("valid"));
+    try std.testing.expectError(error.InvalidUserSecretLength, Config.parse(std.testing.allocator, content));
 }
 
 test "parse config - getUserSecrets" {

--- a/src/crypto/crypto.zig
+++ b/src/crypto/crypto.zig
@@ -214,13 +214,27 @@ pub fn md5(data: []const u8) [16]u8 {
 
 /// Fill buffer with cryptographically secure random bytes.
 pub fn randomBytes(buf: []u8) void {
-    std.crypto.random.bytes(buf);
+    var source: std.Random.IoSource = .{
+        .io = std.Io.Threaded.global_single_threaded.io(),
+    };
+    source.interface().bytes(buf);
 }
 
 /// Generate a random integer in [0, max).
 pub fn randomRange(comptime T: type, max: T) T {
     if (max == 0) return 0;
-    return std.crypto.random.intRangeLessThan(T, 0, max);
+    var source: std.Random.IoSource = .{
+        .io = std.Io.Threaded.global_single_threaded.io(),
+    };
+    return source.interface().uintLessThan(T, max);
+}
+
+/// Generate a random integer in the full range of T.
+pub fn randomInt(comptime T: type) T {
+    var source: std.Random.IoSource = .{
+        .io = std.Io.Threaded.global_single_threaded.io(),
+    };
+    return source.interface().int(T);
 }
 
 // ============= Tests =============

--- a/src/ctl/dashboard.zig
+++ b/src/ctl/dashboard.zig
@@ -32,7 +32,7 @@ pub const DashboardOpts = struct {
 };
 
 /// Run in CLI mode.
-pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.ArgIterator) !void {
+pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) !void {
     var opts = DashboardOpts{};
     while (args.next()) |arg| {
         if (std.mem.eql(u8, arg, "--quiet")) {
@@ -149,9 +149,10 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: DashboardOpts) !voi
     ui.step("Installing Python dependencies (fastapi, uvicorn, psutil, websockets)...");
 
     const pip_res = sys.exec(allocator, &.{
-        "uv",     "pip",   "install",
-        "--python", VENV_PYTHON,
-        "fastapi", "uvicorn", "psutil", "websockets", "starlette",
+        "uv",        "pip",       "install",
+        "--python",  VENV_PYTHON, "fastapi",
+        "uvicorn",   "psutil",    "websockets",
+        "starlette",
     }) catch {
         ui.fail("Failed to install Python dependencies via uv");
         return;
@@ -211,8 +212,8 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: DashboardOpts) !voi
     if (!opts.quiet) {
         ui.summaryBox("Monitoring Dashboard Installed", &.{
             .{ .label = "Status:", .value = "systemctl status " ++ SERVICE_NAME },
-            .{ .label = "Logs:",   .value = "journalctl -u " ++ SERVICE_NAME ++ " -f" },
-            .{ .label = "Port:",   .value = "61208 (default, see config.toml)" },
+            .{ .label = "Logs:", .value = "journalctl -u " ++ SERVICE_NAME ++ " -f" },
+            .{ .label = "Port:", .value = "61208 (default, see config.toml)" },
             .{ .label = "", .style = .blank },
             .{ .label = "Access via secure SSH Tunnel:", .style = .success },
             .{ .label = "  ssh -L 61208:localhost:61208 root@<server_ip>", .style = .success },

--- a/src/ctl/dashboard.zig
+++ b/src/ctl/dashboard.zig
@@ -63,19 +63,45 @@ fn uvExists() bool {
 fn bootstrapUv(ui: *Tui, allocator: std.mem.Allocator) bool {
     ui.step("Installing uv package manager from GitHub...");
 
-    // Download the latest release tarball from GitHub and extract `uv` binary.
-    // GitHub is reliably accessible even when astral.sh is blocked.
-    const result = sys.exec(allocator, &.{
-        "sh", "-c",
+    const archive_name = switch (sys.getArch() catch {
+        ui.fail("Unable to detect CPU architecture for uv bootstrap");
+        return false;
+    }) {
+        .x86_64 => "uv-x86_64-unknown-linux-gnu.tar.gz",
+        .aarch64 => "uv-aarch64-unknown-linux-gnu.tar.gz",
+    };
+
+    const uv_url = std.fmt.allocPrint(
+        allocator,
+        "https://github.com/astral-sh/uv/releases/latest/download/{s}",
+        .{archive_name},
+    ) catch {
+        ui.fail("Failed to prepare uv download URL");
+        return false;
+    };
+    defer allocator.free(uv_url);
+
+    const install_script = std.fmt.allocPrint(
+        allocator,
         \\set -e
-        \\UV_URL="https://github.com/astral-sh/uv/releases/latest/download/uv-x86_64-unknown-linux-gnu.tar.gz"
+        \\UV_URL="{s}"
         \\TMP_DIR=$(mktemp -d)
         \\trap 'rm -rf "$TMP_DIR"' EXIT
         \\curl -fsSL "$UV_URL" -o "$TMP_DIR/uv.tar.gz"
         \\tar -xzf "$TMP_DIR/uv.tar.gz" -C "$TMP_DIR" --strip-components=1
         \\install -m 0755 "$TMP_DIR/uv" /usr/local/bin/uv
         \\if [ -f "$TMP_DIR/uvx" ]; then install -m 0755 "$TMP_DIR/uvx" /usr/local/bin/uvx; fi
-    }) catch {
+    ,
+        .{uv_url},
+    ) catch {
+        ui.fail("Failed to prepare uv install script");
+        return false;
+    };
+    defer allocator.free(install_script);
+
+    // Download the latest release tarball from GitHub and extract `uv` binary.
+    // GitHub is reliably accessible even when astral.sh is blocked.
+    const result = sys.exec(allocator, &.{ "sh", "-c", install_script }) catch {
         ui.fail("Failed to download uv from GitHub");
         return false;
     };

--- a/src/ctl/i18n.zig
+++ b/src/ctl/i18n.zig
@@ -4,22 +4,23 @@
 //! Language selection happens once at startup; lookups are a simple
 //! array index with zero runtime overhead.
 
+const std = @import("std");
+
 pub const Lang = enum {
     en,
     ru,
 
     pub fn fromEnv() Lang {
-        const lang_env = @import("std").posix.getenv("LANG") orelse
-            @import("std").posix.getenv("LC_ALL") orelse
-            return .en;
-        if (indexOf(lang_env, "ru") != null) return .ru;
+        // Zig 0.16 no longer exposes a libc-free getenv helper in std.posix.
+        // Keep deterministic default language in non-interactive mode.
+        _ = indexOf;
         return .en;
     }
 
     fn indexOf(haystack: []const u8, needle: []const u8) ?usize {
         if (needle.len > haystack.len) return null;
         for (0..haystack.len - needle.len + 1) |i| {
-            if (@import("std").mem.eql(u8, haystack[i..][0..needle.len], needle)) return i;
+            if (std.mem.eql(u8, haystack[i..][0..needle.len], needle)) return i;
         }
         return null;
     }

--- a/src/ctl/install.zig
+++ b/src/ctl/install.zig
@@ -302,7 +302,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
         _ = sys.exec(allocator, &.{
             "apt-get",  "install", "-y",
             "iptables", "xxd",     "curl",
-            "openssl",  "tar",
+            "openssl",  "tar",     "minisign",
         }) catch {};
         sp.stop(true, "");
     }

--- a/src/ctl/install.zig
+++ b/src/ctl/install.zig
@@ -54,7 +54,7 @@ pub const InstallOpts = struct {
 };
 
 /// Run install in CLI (non-interactive) mode.
-pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.ArgIterator) !void {
+pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) !void {
     var opts = InstallOpts{};
 
     // Parse CLI flags

--- a/src/ctl/ipv6hop.zig
+++ b/src/ctl/ipv6hop.zig
@@ -16,6 +16,30 @@ const SummaryLine = tui_mod.SummaryLine;
 
 const PROXY_SERVICE = "mtproto-proxy";
 
+fn sleepSeconds(seconds: u64) void {
+    const req: std.posix.timespec = .{
+        .sec = @intCast(seconds),
+        .nsec = 0,
+    };
+    _ = std.os.linux.nanosleep(&req, null);
+}
+
+fn fillRandom(bytes: []u8) bool {
+    var off: usize = 0;
+    while (off < bytes.len) {
+        const rc = std.os.linux.getrandom(bytes[off..].ptr, bytes.len - off, 0);
+        switch (std.os.linux.errno(rc)) {
+            .SUCCESS => {
+                if (rc == 0) return false;
+                off += rc;
+            },
+            .INTR => continue,
+            else => return false,
+        }
+    }
+    return true;
+}
+
 pub const Ipv6Opts = struct {
     mode: Mode = .manual,
     interface: []const u8 = "eth0",
@@ -27,7 +51,7 @@ pub const Ipv6Opts = struct {
 pub const Mode = enum { manual, check, auto };
 
 /// Run in CLI mode.
-pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.ArgIterator) !void {
+pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) !void {
     var opts = Ipv6Opts{};
     while (args.next()) |arg| {
         if (std.mem.eql(u8, arg, "--check")) {
@@ -128,9 +152,9 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: Ipv6Opts) !void {
                         updateDns(ui, allocator, ip, opts.dns_name);
                         ui.stepOk("Hop complete, sleeping 60s", ip);
                     }
-                    std.Thread.sleep(60 * std.time.ns_per_s);
+                    sleepSeconds(60);
                 } else {
-                    std.Thread.sleep(15 * std.time.ns_per_s);
+                    sleepSeconds(15);
                 }
             }
         },
@@ -161,15 +185,19 @@ fn removeOldIpv6(allocator: std.mem.Allocator, interface: []const u8) void {
 fn addNewIpv6(allocator: std.mem.Allocator, prefix: []const u8, interface: []const u8) ?[]const u8 {
     // Generate random suffix
     var rand_bytes: [8]u8 = undefined;
-    std.crypto.random.bytes(&rand_bytes);
+    if (!fillRandom(&rand_bytes)) return null;
 
     var ip_buf: [128]u8 = undefined;
     const ip = std.fmt.bufPrint(&ip_buf, "{s}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}", .{
         prefix,
-        rand_bytes[0], rand_bytes[1],
-        rand_bytes[2], rand_bytes[3],
-        rand_bytes[4], rand_bytes[5],
-        rand_bytes[6], rand_bytes[7],
+        rand_bytes[0],
+        rand_bytes[1],
+        rand_bytes[2],
+        rand_bytes[3],
+        rand_bytes[4],
+        rand_bytes[5],
+        rand_bytes[6],
+        rand_bytes[7],
     }) catch return null;
 
     var addr_buf: [192]u8 = undefined;
@@ -187,7 +215,7 @@ fn addNewIpv6(allocator: std.mem.Allocator, prefix: []const u8, interface: []con
 
 fn countRecentTimeouts(allocator: std.mem.Allocator) u32 {
     const r = sys.exec(allocator, &.{
-        "bash", "-c",
+        "bash",                                                                                                                             "-c",
         "journalctl -u " ++ PROXY_SERVICE ++ " --since '60 seconds ago' --no-pager -q 2>/dev/null | grep -c 'Handshake timeout' || echo 0",
     }) catch return 0;
     defer r.deinit();
@@ -197,13 +225,11 @@ fn countRecentTimeouts(allocator: std.mem.Allocator) u32 {
 
 fn updateDns(ui: *Tui, allocator: std.mem.Allocator, new_ip: []const u8, dns_name: []const u8) void {
     // Load CF credentials: check env first, then .env file
-    const cf_token = std.posix.getenv("CF_TOKEN") orelse
-        sys.readEnvFile(allocator, "/opt/mtproto-proxy/.env", "CF_TOKEN") orelse {
+    const cf_token = sys.readEnvFile(allocator, "/opt/mtproto-proxy/.env", "CF_TOKEN") orelse {
         ui.warn("CF_TOKEN not set — skipping DNS update");
         return;
     };
-    const cf_zone = std.posix.getenv("CF_ZONE") orelse
-        sys.readEnvFile(allocator, "/opt/mtproto-proxy/.env", "CF_ZONE") orelse {
+    const cf_zone = sys.readEnvFile(allocator, "/opt/mtproto-proxy/.env", "CF_ZONE") orelse {
         ui.warn("CF_ZONE not set — skipping DNS update");
         return;
     };
@@ -215,11 +241,9 @@ fn updateDns(ui: *Tui, allocator: std.mem.Allocator, new_ip: []const u8, dns_nam
 
     // Get record ID
     var get_cmd_buf: [512]u8 = undefined;
-    const get_cmd = std.fmt.bufPrint(&get_cmd_buf,
-        "curl -s -X GET 'https://api.cloudflare.com/client/v4/zones/{s}/dns_records?type=AAAA&name={s}' " ++
+    const get_cmd = std.fmt.bufPrint(&get_cmd_buf, "curl -s -X GET 'https://api.cloudflare.com/client/v4/zones/{s}/dns_records?type=AAAA&name={s}' " ++
         "-H 'Authorization: Bearer {s}' -H 'Content-Type: application/json' | " ++
-        "grep -oE '\"id\":\"[^\"]+\"' | head -1 | cut -d'\"' -f4",
-    .{ cf_zone, dns_name, cf_token }) catch return;
+        "grep -oE '\"id\":\"[^\"]+\"' | head -1 | cut -d'\"' -f4", .{ cf_zone, dns_name, cf_token }) catch return;
 
     const id_result = sys.exec(allocator, &.{ "bash", "-c", get_cmd }) catch return;
     defer id_result.deinit();
@@ -228,18 +252,14 @@ fn updateDns(ui: *Tui, allocator: std.mem.Allocator, new_ip: []const u8, dns_nam
     // Create or update
     var dns_cmd_buf: [1024]u8 = undefined;
     if (record_id.len == 0) {
-        const dns_cmd = std.fmt.bufPrint(&dns_cmd_buf,
-            "curl -s -X POST 'https://api.cloudflare.com/client/v4/zones/{s}/dns_records' " ++
+        const dns_cmd = std.fmt.bufPrint(&dns_cmd_buf, "curl -s -X POST 'https://api.cloudflare.com/client/v4/zones/{s}/dns_records' " ++
             "-H 'Authorization: Bearer {s}' -H 'Content-Type: application/json' " ++
-            "--data '{{\"type\":\"AAAA\",\"name\":\"{s}\",\"content\":\"{s}\",\"ttl\":30,\"proxied\":false}}' > /dev/null",
-        .{ cf_zone, cf_token, dns_name, new_ip }) catch return;
+            "--data '{{\"type\":\"AAAA\",\"name\":\"{s}\",\"content\":\"{s}\",\"ttl\":30,\"proxied\":false}}' > /dev/null", .{ cf_zone, cf_token, dns_name, new_ip }) catch return;
         _ = sys.exec(allocator, &.{ "bash", "-c", dns_cmd }) catch {};
     } else {
-        const dns_cmd = std.fmt.bufPrint(&dns_cmd_buf,
-            "curl -s -X PUT 'https://api.cloudflare.com/client/v4/zones/{s}/dns_records/{s}' " ++
+        const dns_cmd = std.fmt.bufPrint(&dns_cmd_buf, "curl -s -X PUT 'https://api.cloudflare.com/client/v4/zones/{s}/dns_records/{s}' " ++
             "-H 'Authorization: Bearer {s}' -H 'Content-Type: application/json' " ++
-            "--data '{{\"type\":\"AAAA\",\"name\":\"{s}\",\"content\":\"{s}\",\"ttl\":30,\"proxied\":false}}' > /dev/null",
-        .{ cf_zone, record_id, cf_token, dns_name, new_ip }) catch return;
+            "--data '{{\"type\":\"AAAA\",\"name\":\"{s}\",\"content\":\"{s}\",\"ttl\":30,\"proxied\":false}}' > /dev/null", .{ cf_zone, record_id, cf_token, dns_name, new_ip }) catch return;
         _ = sys.exec(allocator, &.{ "bash", "-c", dns_cmd }) catch {};
     }
 
@@ -247,7 +267,7 @@ fn updateDns(ui: *Tui, allocator: std.mem.Allocator, new_ip: []const u8, dns_nam
 }
 
 /// Update DNS A record (from update_dns.sh).
-pub fn updateDnsA(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.ArgIterator) !void {
+pub fn updateDnsA(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) !void {
     const new_ip = args.next() orelse {
         ui.fail("Usage: mtbuddy update-dns <new_ip>");
         return;
@@ -256,13 +276,11 @@ pub fn updateDnsA(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Arg
     const dns_name = "proxy.sleep3r.ru";
 
     // Load .env natively (child shell env doesn't propagate to parent)
-    const cf_token = std.posix.getenv("CF_TOKEN") orelse
-        sys.readEnvFile(allocator, "/opt/mtproto-proxy/.env", "CF_TOKEN") orelse {
+    const cf_token = sys.readEnvFile(allocator, "/opt/mtproto-proxy/.env", "CF_TOKEN") orelse {
         ui.warn("CF_TOKEN not set — skipping DNS update");
         return;
     };
-    const cf_zone = std.posix.getenv("CF_ZONE") orelse
-        sys.readEnvFile(allocator, "/opt/mtproto-proxy/.env", "CF_ZONE") orelse {
+    const cf_zone = sys.readEnvFile(allocator, "/opt/mtproto-proxy/.env", "CF_ZONE") orelse {
         ui.warn("CF_ZONE not set — skipping DNS update");
         return;
     };
@@ -270,11 +288,9 @@ pub fn updateDnsA(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Arg
     ui.step("Updating DNS A record...");
 
     var get_buf: [512]u8 = undefined;
-    const get_cmd = std.fmt.bufPrint(&get_buf,
-        "curl -s -X GET 'https://api.cloudflare.com/client/v4/zones/{s}/dns_records?type=A&name={s}' " ++
+    const get_cmd = std.fmt.bufPrint(&get_buf, "curl -s -X GET 'https://api.cloudflare.com/client/v4/zones/{s}/dns_records?type=A&name={s}' " ++
         "-H 'Authorization: Bearer {s}' -H 'Content-Type: application/json' | " ++
-        "grep -oE '\"id\":\"[^\"]+\"' | head -1 | cut -d'\"' -f4",
-    .{ cf_zone, dns_name, cf_token }) catch return;
+        "grep -oE '\"id\":\"[^\"]+\"' | head -1 | cut -d'\"' -f4", .{ cf_zone, dns_name, cf_token }) catch return;
 
     const id_r = sys.exec(allocator, &.{ "bash", "-c", get_cmd }) catch return;
     defer id_r.deinit();
@@ -282,18 +298,14 @@ pub fn updateDnsA(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Arg
 
     var cmd_buf: [1024]u8 = undefined;
     if (record_id.len == 0) {
-        const cmd = std.fmt.bufPrint(&cmd_buf,
-            "curl -s -X POST 'https://api.cloudflare.com/client/v4/zones/{s}/dns_records' " ++
+        const cmd = std.fmt.bufPrint(&cmd_buf, "curl -s -X POST 'https://api.cloudflare.com/client/v4/zones/{s}/dns_records' " ++
             "-H 'Authorization: Bearer {s}' -H 'Content-Type: application/json' " ++
-            "--data '{{\"type\":\"A\",\"name\":\"{s}\",\"content\":\"{s}\",\"ttl\":60,\"proxied\":false}}' > /dev/null",
-        .{ cf_zone, cf_token, dns_name, new_ip }) catch return;
+            "--data '{{\"type\":\"A\",\"name\":\"{s}\",\"content\":\"{s}\",\"ttl\":60,\"proxied\":false}}' > /dev/null", .{ cf_zone, cf_token, dns_name, new_ip }) catch return;
         _ = sys.exec(allocator, &.{ "bash", "-c", cmd }) catch {};
     } else {
-        const cmd = std.fmt.bufPrint(&cmd_buf,
-            "curl -s -X PUT 'https://api.cloudflare.com/client/v4/zones/{s}/dns_records/{s}' " ++
+        const cmd = std.fmt.bufPrint(&cmd_buf, "curl -s -X PUT 'https://api.cloudflare.com/client/v4/zones/{s}/dns_records/{s}' " ++
             "-H 'Authorization: Bearer {s}' -H 'Content-Type: application/json' " ++
-            "--data '{{\"type\":\"A\",\"name\":\"{s}\",\"content\":\"{s}\",\"ttl\":60,\"proxied\":false}}' > /dev/null",
-        .{ cf_zone, record_id, cf_token, dns_name, new_ip }) catch return;
+            "--data '{{\"type\":\"A\",\"name\":\"{s}\",\"content\":\"{s}\",\"ttl\":60,\"proxied\":false}}' > /dev/null", .{ cf_zone, record_id, cf_token, dns_name, new_ip }) catch return;
         _ = sys.exec(allocator, &.{ "bash", "-c", cmd }) catch {};
     }
 

--- a/src/ctl/ipv6hop.zig
+++ b/src/ctl/ipv6hop.zig
@@ -15,6 +15,22 @@ const Color = tui_mod.Color;
 const SummaryLine = tui_mod.SummaryLine;
 
 const PROXY_SERVICE = "mtproto-proxy";
+const CLOUDFLARE_ENV_PATH = "/opt/mtproto-proxy/.env";
+
+const CloudflareRecordType = enum {
+    a,
+    aaaa,
+};
+
+const CloudflareCredentials = struct {
+    token: []const u8,
+    zone: []const u8,
+
+    fn deinit(self: *const CloudflareCredentials, allocator: std.mem.Allocator) void {
+        allocator.free(self.token);
+        allocator.free(self.zone);
+    }
+};
 
 fn sleepSeconds(seconds: u64) void {
     const req: std.posix.timespec = .{
@@ -215,55 +231,30 @@ fn addNewIpv6(allocator: std.mem.Allocator, prefix: []const u8, interface: []con
 
 fn countRecentTimeouts(allocator: std.mem.Allocator) u32 {
     const r = sys.exec(allocator, &.{
-        "bash",                                                                                                                             "-c",
-        "journalctl -u " ++ PROXY_SERVICE ++ " --since '60 seconds ago' --no-pager -q 2>/dev/null | grep -c 'Handshake timeout' || echo 0",
+        "journalctl",
+        "-u",
+        PROXY_SERVICE,
+        "--since",
+        "60 seconds ago",
+        "--no-pager",
+        "-q",
     }) catch return 0;
     defer r.deinit();
-    const trimmed = std.mem.trim(u8, r.stdout, &[_]u8{ ' ', '\t', '\r', '\n' });
-    return std.fmt.parseInt(u32, trimmed, 10) catch 0;
+
+    var count: u32 = 0;
+    var lines = std.mem.splitScalar(u8, r.stdout, '\n');
+    while (lines.next()) |line| {
+        if (std.mem.indexOf(u8, line, "Handshake timeout") != null) {
+            count +|= 1;
+        }
+    }
+    return count;
 }
 
 fn updateDns(ui: *Tui, allocator: std.mem.Allocator, new_ip: []const u8, dns_name: []const u8) void {
-    // Load CF credentials: check env first, then .env file
-    const cf_token = sys.readEnvFile(allocator, "/opt/mtproto-proxy/.env", "CF_TOKEN") orelse {
-        ui.warn("CF_TOKEN not set — skipping DNS update");
-        return;
-    };
-    const cf_zone = sys.readEnvFile(allocator, "/opt/mtproto-proxy/.env", "CF_ZONE") orelse {
-        ui.warn("CF_ZONE not set — skipping DNS update");
-        return;
-    };
-
-    if (cf_token.len == 0 or cf_zone.len == 0) {
-        ui.warn("CF_TOKEN or CF_ZONE empty — skipping DNS update");
-        return;
+    if (updateCloudflareRecord(ui, allocator, .aaaa, dns_name, new_ip, 30)) {
+        ui.ok("DNS AAAA record updated");
     }
-
-    // Get record ID
-    var get_cmd_buf: [512]u8 = undefined;
-    const get_cmd = std.fmt.bufPrint(&get_cmd_buf, "curl -s -X GET 'https://api.cloudflare.com/client/v4/zones/{s}/dns_records?type=AAAA&name={s}' " ++
-        "-H 'Authorization: Bearer {s}' -H 'Content-Type: application/json' | " ++
-        "grep -oE '\"id\":\"[^\"]+\"' | head -1 | cut -d'\"' -f4", .{ cf_zone, dns_name, cf_token }) catch return;
-
-    const id_result = sys.exec(allocator, &.{ "bash", "-c", get_cmd }) catch return;
-    defer id_result.deinit();
-    const record_id = std.mem.trim(u8, id_result.stdout, &[_]u8{ ' ', '\t', '\r', '\n' });
-
-    // Create or update
-    var dns_cmd_buf: [1024]u8 = undefined;
-    if (record_id.len == 0) {
-        const dns_cmd = std.fmt.bufPrint(&dns_cmd_buf, "curl -s -X POST 'https://api.cloudflare.com/client/v4/zones/{s}/dns_records' " ++
-            "-H 'Authorization: Bearer {s}' -H 'Content-Type: application/json' " ++
-            "--data '{{\"type\":\"AAAA\",\"name\":\"{s}\",\"content\":\"{s}\",\"ttl\":30,\"proxied\":false}}' > /dev/null", .{ cf_zone, cf_token, dns_name, new_ip }) catch return;
-        _ = sys.exec(allocator, &.{ "bash", "-c", dns_cmd }) catch {};
-    } else {
-        const dns_cmd = std.fmt.bufPrint(&dns_cmd_buf, "curl -s -X PUT 'https://api.cloudflare.com/client/v4/zones/{s}/dns_records/{s}' " ++
-            "-H 'Authorization: Bearer {s}' -H 'Content-Type: application/json' " ++
-            "--data '{{\"type\":\"AAAA\",\"name\":\"{s}\",\"content\":\"{s}\",\"ttl\":30,\"proxied\":false}}' > /dev/null", .{ cf_zone, record_id, cf_token, dns_name, new_ip }) catch return;
-        _ = sys.exec(allocator, &.{ "bash", "-c", dns_cmd }) catch {};
-    }
-
-    ui.ok("DNS AAAA record updated");
 }
 
 /// Update DNS A record (from update_dns.sh).
@@ -275,39 +266,249 @@ pub fn updateDnsA(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Arg
 
     const dns_name = "proxy.sleep3r.ru";
 
-    // Load .env natively (child shell env doesn't propagate to parent)
-    const cf_token = sys.readEnvFile(allocator, "/opt/mtproto-proxy/.env", "CF_TOKEN") orelse {
-        ui.warn("CF_TOKEN not set — skipping DNS update");
-        return;
-    };
-    const cf_zone = sys.readEnvFile(allocator, "/opt/mtproto-proxy/.env", "CF_ZONE") orelse {
-        ui.warn("CF_ZONE not set — skipping DNS update");
-        return;
-    };
-
     ui.step("Updating DNS A record...");
+    if (!updateCloudflareRecord(ui, allocator, .a, dns_name, new_ip, 60)) return;
+    ui.ok("DNS A record updated successfully");
+}
 
-    var get_buf: [512]u8 = undefined;
-    const get_cmd = std.fmt.bufPrint(&get_buf, "curl -s -X GET 'https://api.cloudflare.com/client/v4/zones/{s}/dns_records?type=A&name={s}' " ++
-        "-H 'Authorization: Bearer {s}' -H 'Content-Type: application/json' | " ++
-        "grep -oE '\"id\":\"[^\"]+\"' | head -1 | cut -d'\"' -f4", .{ cf_zone, dns_name, cf_token }) catch return;
+fn updateCloudflareRecord(
+    ui: *Tui,
+    allocator: std.mem.Allocator,
+    record_type: CloudflareRecordType,
+    dns_name: []const u8,
+    new_ip: []const u8,
+    ttl: u16,
+) bool {
+    const creds = loadCloudflareCredentials(ui, allocator) orelse return false;
+    defer creds.deinit(allocator);
 
-    const id_r = sys.exec(allocator, &.{ "bash", "-c", get_cmd }) catch return;
-    defer id_r.deinit();
-    const record_id = std.mem.trim(u8, id_r.stdout, &[_]u8{ ' ', '\t', '\r', '\n' });
+    const header_file = createCloudflareHeaderFile(allocator, creds.token) catch {
+        ui.warn("Failed to prepare Cloudflare auth headers");
+        return false;
+    };
+    defer allocator.free(header_file);
+    defer deleteFileBestEffort(header_file);
 
-    var cmd_buf: [1024]u8 = undefined;
-    if (record_id.len == 0) {
-        const cmd = std.fmt.bufPrint(&cmd_buf, "curl -s -X POST 'https://api.cloudflare.com/client/v4/zones/{s}/dns_records' " ++
-            "-H 'Authorization: Bearer {s}' -H 'Content-Type: application/json' " ++
-            "--data '{{\"type\":\"A\",\"name\":\"{s}\",\"content\":\"{s}\",\"ttl\":60,\"proxied\":false}}' > /dev/null", .{ cf_zone, cf_token, dns_name, new_ip }) catch return;
-        _ = sys.exec(allocator, &.{ "bash", "-c", cmd }) catch {};
-    } else {
-        const cmd = std.fmt.bufPrint(&cmd_buf, "curl -s -X PUT 'https://api.cloudflare.com/client/v4/zones/{s}/dns_records/{s}' " ++
-            "-H 'Authorization: Bearer {s}' -H 'Content-Type: application/json' " ++
-            "--data '{{\"type\":\"A\",\"name\":\"{s}\",\"content\":\"{s}\",\"ttl\":60,\"proxied\":false}}' > /dev/null", .{ cf_zone, record_id, cf_token, dns_name, new_ip }) catch return;
-        _ = sys.exec(allocator, &.{ "bash", "-c", cmd }) catch {};
+    const maybe_record_id = findCloudflareRecordId(allocator, creds.zone, dns_name, record_type, header_file) catch {
+        ui.warn("Cloudflare DNS lookup failed");
+        return false;
+    };
+    defer if (maybe_record_id) |record_id| allocator.free(record_id);
+
+    const payload = std.json.Stringify.valueAlloc(allocator, .{
+        .type = cloudflareRecordTypeText(record_type),
+        .name = dns_name,
+        .content = new_ip,
+        .ttl = ttl,
+        .proxied = false,
+    }, .{}) catch {
+        ui.warn("Failed to prepare Cloudflare DNS request body");
+        return false;
+    };
+    defer allocator.free(payload);
+
+    const url = if (maybe_record_id) |record_id|
+        std.fmt.allocPrint(allocator, "https://api.cloudflare.com/client/v4/zones/{s}/dns_records/{s}", .{ creds.zone, record_id }) catch {
+            ui.warn("Failed to prepare Cloudflare DNS request URL");
+            return false;
+        }
+    else
+        std.fmt.allocPrint(allocator, "https://api.cloudflare.com/client/v4/zones/{s}/dns_records", .{creds.zone}) catch {
+            ui.warn("Failed to prepare Cloudflare DNS request URL");
+            return false;
+        };
+    defer allocator.free(url);
+
+    const method = if (maybe_record_id != null) "PUT" else "POST";
+    var response = curlJsonRequest(allocator, method, url, header_file, payload) catch {
+        ui.warn("Cloudflare DNS update request failed");
+        return false;
+    };
+    defer response.deinit();
+
+    if (response.exit_code != 0) {
+        ui.warn("Cloudflare DNS update command exited with non-zero status");
+        return false;
+    }
+    if (!cloudflareResponseSuccess(allocator, response.stdout)) {
+        ui.warn("Cloudflare API returned an unsuccessful response");
+        return false;
+    }
+    return true;
+}
+
+fn loadCloudflareCredentials(ui: *Tui, allocator: std.mem.Allocator) ?CloudflareCredentials {
+    const token = sys.readEnvFile(allocator, CLOUDFLARE_ENV_PATH, "CF_TOKEN") orelse {
+        ui.warn("CF_TOKEN not set — skipping DNS update");
+        return null;
+    };
+    errdefer allocator.free(token);
+
+    const zone = sys.readEnvFile(allocator, CLOUDFLARE_ENV_PATH, "CF_ZONE") orelse {
+        ui.warn("CF_ZONE not set — skipping DNS update");
+        return null;
+    };
+    errdefer allocator.free(zone);
+
+    if (token.len == 0 or zone.len == 0) {
+        ui.warn("CF_TOKEN or CF_ZONE empty — skipping DNS update");
+        return null;
     }
 
-    ui.ok("DNS A record updated successfully");
+    return .{
+        .token = token,
+        .zone = zone,
+    };
+}
+
+fn createCloudflareHeaderFile(allocator: std.mem.Allocator, token: []const u8) ![]u8 {
+    var rand_bytes: [8]u8 = undefined;
+    if (!fillRandom(&rand_bytes)) return error.RandomUnavailable;
+
+    const path = try std.fmt.allocPrint(
+        allocator,
+        "/tmp/mtbuddy-cf-{x:0>2}{x:0>2}{x:0>2}{x:0>2}{x:0>2}{x:0>2}{x:0>2}{x:0>2}.headers",
+        .{
+            rand_bytes[0],
+            rand_bytes[1],
+            rand_bytes[2],
+            rand_bytes[3],
+            rand_bytes[4],
+            rand_bytes[5],
+            rand_bytes[6],
+            rand_bytes[7],
+        },
+    );
+    errdefer allocator.free(path);
+
+    const content = try std.fmt.allocPrint(
+        allocator,
+        "Authorization: Bearer {s}\nContent-Type: application/json\n",
+        .{token},
+    );
+    defer allocator.free(content);
+
+    try sys.writeFileMode(path, content, 0o600);
+    return path;
+}
+
+fn deleteFileBestEffort(path: []const u8) void {
+    std.Io.Dir.deleteFileAbsolute(std.Io.Threaded.global_single_threaded.io(), path) catch {};
+}
+
+fn curlJsonRequest(
+    allocator: std.mem.Allocator,
+    method: []const u8,
+    url: []const u8,
+    header_file: []const u8,
+    payload: []const u8,
+) !sys.ExecResult {
+    const header_arg = try std.fmt.allocPrint(allocator, "@{s}", .{header_file});
+    defer allocator.free(header_arg);
+    return sys.exec(allocator, &.{
+        "curl",
+        "-fsS",
+        "-X",
+        method,
+        url,
+        "-H",
+        header_arg,
+        "--data",
+        payload,
+    });
+}
+
+fn curlGetRequest(
+    allocator: std.mem.Allocator,
+    url: []const u8,
+    header_file: []const u8,
+) !sys.ExecResult {
+    const header_arg = try std.fmt.allocPrint(allocator, "@{s}", .{header_file});
+    defer allocator.free(header_arg);
+    return sys.exec(allocator, &.{
+        "curl",
+        "-fsS",
+        "-X",
+        "GET",
+        url,
+        "-H",
+        header_arg,
+    });
+}
+
+fn findCloudflareRecordId(
+    allocator: std.mem.Allocator,
+    zone: []const u8,
+    dns_name: []const u8,
+    record_type: CloudflareRecordType,
+    header_file: []const u8,
+) !?[]u8 {
+    const query_url = try std.fmt.allocPrint(
+        allocator,
+        "https://api.cloudflare.com/client/v4/zones/{s}/dns_records?type={s}&name={s}",
+        .{ zone, cloudflareRecordTypeText(record_type), dns_name },
+    );
+    defer allocator.free(query_url);
+
+    var response = try curlGetRequest(allocator, query_url, header_file);
+    defer response.deinit();
+    if (response.exit_code != 0) return error.CloudflareRequestFailed;
+
+    return cloudflareExtractRecordId(allocator, response.stdout);
+}
+
+fn cloudflareRecordTypeText(record_type: CloudflareRecordType) []const u8 {
+    return switch (record_type) {
+        .a => "A",
+        .aaaa => "AAAA",
+    };
+}
+
+fn cloudflareExtractRecordId(allocator: std.mem.Allocator, response_json: []const u8) ?[]u8 {
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, response_json, .{}) catch return null;
+    defer parsed.deinit();
+
+    const root = switch (parsed.value) {
+        .object => |object| object,
+        else => return null,
+    };
+    const result_value = root.get("result") orelse return null;
+
+    return switch (result_value) {
+        .array => |arr| blk: {
+            if (arr.items.len == 0) break :blk null;
+            const first = switch (arr.items[0]) {
+                .object => |obj| obj,
+                else => break :blk null,
+            };
+            const id_value = first.get("id") orelse break :blk null;
+            break :blk switch (id_value) {
+                .string => |id| allocator.dupe(u8, id) catch null,
+                else => null,
+            };
+        },
+        .object => |obj| blk: {
+            const id_value = obj.get("id") orelse break :blk null;
+            break :blk switch (id_value) {
+                .string => |id| allocator.dupe(u8, id) catch null,
+                else => null,
+            };
+        },
+        else => null,
+    };
+}
+
+fn cloudflareResponseSuccess(allocator: std.mem.Allocator, response_json: []const u8) bool {
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, response_json, .{}) catch return false;
+    defer parsed.deinit();
+
+    const root = switch (parsed.value) {
+        .object => |object| object,
+        else => return false,
+    };
+    const success_value = root.get("success") orelse return false;
+    return switch (success_value) {
+        .bool => |ok| ok,
+        else => false,
+    };
 }

--- a/src/ctl/main.zig
+++ b/src/ctl/main.zig
@@ -14,6 +14,7 @@
 const std = @import("std");
 const i18n = @import("i18n.zig");
 const tui_mod = @import("tui.zig");
+const linux_io = @import("linux_io");
 const install = @import("install.zig");
 const update = @import("update.zig");
 const masking = @import("masking.zig");
@@ -30,12 +31,10 @@ const Color = tui_mod.Color;
 
 pub const version = version_mod.version;
 
-pub fn main() !void {
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.arena.allocator();
 
-    var args = try std.process.argsWithAllocator(allocator);
+    var args = try init.minimal.args.iterateAllocator(allocator);
     defer args.deinit();
     _ = args.next(); // skip program name
 
@@ -402,5 +401,5 @@ fn printOpt(ui: *Tui, flag: []const u8, desc: []const u8) void {
 }
 
 fn printVersion() void {
-    _ = std.posix.write(std.posix.STDOUT_FILENO, "mtbuddy v" ++ version ++ "\n") catch {};
+    linux_io.writeAllFd(std.posix.STDOUT_FILENO, "mtbuddy v" ++ version ++ "\n");
 }

--- a/src/ctl/masking.zig
+++ b/src/ctl/masking.zig
@@ -24,7 +24,7 @@ pub const MaskingOpts = struct {
 };
 
 /// Run in CLI mode.
-pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.ArgIterator) !void {
+pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) !void {
     var opts = MaskingOpts{};
     while (args.next()) |arg| {
         if (std.mem.eql(u8, arg, "--domain")) {
@@ -63,8 +63,6 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: MaskingOpts) !void 
         ui.fail(i18n.get(ui.lang, .error_not_root));
         return;
     }
-
-
 
     // ── Install Nginx ──
     if (sys.commandExists("nginx")) {
@@ -124,8 +122,6 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: MaskingOpts) !void 
     ui.step("Configuring Nginx...");
     sys.execSilent(allocator, &.{ "mkdir", "-p", "/var/www/masking" });
     sys.writeFile("/var/www/masking/index.html", "<!DOCTYPE html><html><head><title>Welcome</title></head><body><h1>It works!</h1></body></html>\n") catch {};
-
-
 
     var nginx_cfg_buf: [2048]u8 = undefined;
     const nginx_cfg = std.fmt.bufPrint(&nginx_cfg_buf,

--- a/src/ctl/nfqws.zig
+++ b/src/ctl/nfqws.zig
@@ -24,7 +24,7 @@ pub const NfqwsOpts = struct {
 };
 
 /// Run in CLI mode.
-pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.ArgIterator) !void {
+pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) !void {
     var opts = NfqwsOpts{};
     while (args.next()) |arg| {
         if (std.mem.eql(u8, arg, "--ttl")) {
@@ -93,8 +93,8 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: NfqwsOpts) !void {
     ui.step("Installing build dependencies...");
     _ = sys.execForward(&.{ "apt-get", "update", "-qq" }) catch {};
     _ = sys.execForward(&.{
-        "apt-get", "install", "-y", "build-essential", "git",
-        "libnetfilter-queue-dev", "libcap-dev", "iptables", "libmnl-dev", "zlib1g-dev",
+        "apt-get",                "install",    "-y",       "build-essential", "git",
+        "libnetfilter-queue-dev", "libcap-dev", "iptables", "libmnl-dev",      "zlib1g-dev",
     }) catch {};
     ui.ok("Dependencies installed");
 
@@ -125,14 +125,14 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: NfqwsOpts) !void {
     removeNfqwsRules(allocator, "ip6tables");
 
     _ = sys.exec(allocator, &.{
-        "iptables", "-t", "mangle", "-A", "OUTPUT",
-        "-p", "tcp", "--sport", port,
-        "-j", "NFQUEUE", "--queue-num", NFQUEUE_NUM,
+        "iptables", "-t",          "mangle",    "-A", "OUTPUT",
+        "-p",       "tcp",         "--sport",   port, "-j",
+        "NFQUEUE",  "--queue-num", NFQUEUE_NUM,
     }) catch {};
     _ = sys.exec(allocator, &.{
-        "ip6tables", "-t", "mangle", "-A", "OUTPUT",
-        "-p", "tcp", "--sport", port,
-        "-j", "NFQUEUE", "--queue-num", NFQUEUE_NUM,
+        "ip6tables", "-t",          "mangle",    "-A", "OUTPUT",
+        "-p",        "tcp",         "--sport",   port, "-j",
+        "NFQUEUE",   "--queue-num", NFQUEUE_NUM,
     }) catch {};
 
     _ = sys.exec(allocator, &.{ "bash", "-c", "mkdir -p /etc/iptables && iptables-save > /etc/iptables/rules.v4 && ip6tables-save > /etc/iptables/rules.v6" }) catch {};
@@ -202,7 +202,8 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: NfqwsOpts) !void {
 fn removeNfqwsRules(allocator: std.mem.Allocator, ipt: []const u8) void {
     // Remove any existing NFQUEUE rules for our queue number
     var cmd_buf: [512]u8 = undefined;
-    const cmd = std.fmt.bufPrint(&cmd_buf,
+    const cmd = std.fmt.bufPrint(
+        &cmd_buf,
         "{s} -t mangle -S OUTPUT 2>/dev/null | grep 'NFQUEUE --queue-num {s}' | while read -r line; do rule=$(echo \"$line\" | sed 's/-A /-D /'); {s} -t mangle $rule 2>/dev/null || true; done",
         .{ ipt, NFQUEUE_NUM, ipt },
     ) catch return;

--- a/src/ctl/recovery.zig
+++ b/src/ctl/recovery.zig
@@ -25,7 +25,7 @@ pub const RecoveryOpts = struct {
 };
 
 /// Run in CLI mode.
-pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.ArgIterator) !void {
+pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) !void {
     var opts = RecoveryOpts{};
     while (args.next()) |arg| {
         if (std.mem.eql(u8, arg, "--quiet")) {

--- a/src/ctl/release.zig
+++ b/src/ctl/release.zig
@@ -1,11 +1,13 @@
 //! Shared GitHub Releases helpers for install and update commands.
 //!
 //! Centralises tag resolution, artifact download with architecture-aware
-//! candidate selection, binary validation, and temp-directory cleanup.
+//! candidate selection, checksum verification, binary validation, and
+//! temp-directory cleanup.
 //! Used by both install.zig and update.zig to avoid duplication.
 
 const std = @import("std");
 const sys = @import("sys.zig");
+const build_options = @import("build_options");
 
 // ── Shared constants ────────────────────────────────────────────
 
@@ -16,6 +18,7 @@ pub const SERVICE_NAME = "mtproto-proxy";
 pub const SERVICE_FILE = "/etc/systemd/system/mtproto-proxy.service";
 
 const RELEASES_API = "https://api.github.com/repos/" ++ REPO_OWNER ++ "/" ++ REPO_NAME ++ "/releases/latest";
+const MINISIGN_PUBKEY = build_options.minisign_pubkey;
 
 // ── Result types ────────────────────────────────────────────────
 
@@ -117,28 +120,25 @@ pub fn downloadProxyArtifact(
     artifact.extract_dir_len = extract_dir.len;
 
     _ = sys.exec(allocator, &.{ "rm", "-rf", extract_dir }) catch {};
-    _ = sys.exec(allocator, &.{ "mkdir", "-p", extract_dir }) catch {};
+    const mk = sys.exec(allocator, &.{ "mkdir", "-p", extract_dir }) catch return false;
+    defer mk.deinit();
+    if (mk.exit_code != 0) return false;
 
     // ── Try each candidate ──
     for (candidates) |candidate| {
-        var url_buf: [512]u8 = undefined;
-        const url = std.fmt.bufPrint(
-            &url_buf,
-            "https://github.com/{s}/{s}/releases/download/{s}/{s}.tar.gz",
-            .{ REPO_OWNER, REPO_NAME, tag, candidate },
-        ) catch continue;
+        var tar_name_buf: [192]u8 = undefined;
+        const tar_name = std.fmt.bufPrint(&tar_name_buf, "{s}.tar.gz", .{candidate}) catch continue;
 
         const dl_path = std.fmt.bufPrint(
             &artifact.dl_path_buf,
-            "/tmp/{s}.tar.gz",
-            .{candidate},
+            "{s}/{s}",
+            .{ extract_dir, tar_name },
         ) catch continue;
         artifact.dl_path_len = dl_path.len;
 
-        // Download
-        const dl = sys.exec(allocator, &.{ "curl", "-fsSL", url, "-o", dl_path }) catch continue;
-        defer dl.deinit();
-        if (dl.exit_code != 0) continue;
+        // Download + checksum verify
+        if (!downloadReleaseFile(allocator, tag, tar_name, dl_path)) continue;
+        if (!verifyReleaseChecksum(allocator, tag, tar_name, dl_path, extract_dir)) continue;
 
         // Extract
         const tar_exit = sys.execForward(&.{ "tar", "-xzf", dl_path, "-C", extract_dir }) catch continue;
@@ -191,18 +191,15 @@ pub fn downloadBuddyArtifact(
     var name_buf: [128]u8 = undefined;
     const buddy_name = std.fmt.bufPrint(&name_buf, "mtbuddy{s}", .{suffix}) catch return null;
 
-    var url_buf: [512]u8 = undefined;
-    const url = std.fmt.bufPrint(
-        &url_buf,
-        "https://github.com/{s}/{s}/releases/download/{s}/{s}.tar.gz",
-        .{ REPO_OWNER, REPO_NAME, tag, buddy_name },
-    ) catch return null;
+    var tar_name_buf: [192]u8 = undefined;
+    const tar_name = std.fmt.bufPrint(&tar_name_buf, "{s}.tar.gz", .{buddy_name}) catch return null;
 
-    const dl = sys.exec(allocator, &.{ "curl", "-fsSL", url, "-o", "/tmp/mtbuddy.tar.gz" }) catch return null;
-    defer dl.deinit();
-    if (dl.exit_code != 0) return null;
+    var dl_path_buf: [320]u8 = undefined;
+    const dl_path = std.fmt.bufPrint(&dl_path_buf, "{s}/{s}", .{ extract_dir, tar_name }) catch return null;
+    if (!downloadReleaseFile(allocator, tag, tar_name, dl_path)) return null;
+    if (!verifyReleaseChecksum(allocator, tag, tar_name, dl_path, extract_dir)) return null;
 
-    const tar_exit = sys.execForward(&.{ "tar", "-xzf", "/tmp/mtbuddy.tar.gz", "-C", extract_dir }) catch return null;
+    const tar_exit = sys.execForward(&.{ "tar", "-xzf", dl_path, "-C", extract_dir }) catch return null;
     if (tar_exit != 0) return null;
 
     const bin_path = std.fmt.bufPrint(out_buf, "{s}/{s}", .{ extract_dir, buddy_name }) catch return null;
@@ -261,8 +258,6 @@ pub fn cleanup(allocator: std.mem.Allocator, artifact: *const Artifact) void {
     if (artifact.dl_path_len > 0) {
         _ = sys.exec(allocator, &.{ "rm", "-f", artifact.dlPath() }) catch {};
     }
-    // Clean up buddy tarball if it was downloaded
-    _ = sys.exec(allocator, &.{ "rm", "-f", "/tmp/mtbuddy.tar.gz" }) catch {};
 }
 
 // ── Helpers ─────────────────────────────────────────────────────
@@ -275,6 +270,124 @@ fn resolveLatest(allocator: std.mem.Allocator, tag: *Tag) bool {
     const n = @min(parsed.len, tag.buf.len);
     @memcpy(tag.buf[0..n], parsed[0..n]);
     tag.len = n;
+    return true;
+}
+
+fn downloadReleaseFile(
+    allocator: std.mem.Allocator,
+    tag: []const u8,
+    file_name: []const u8,
+    out_path: []const u8,
+) bool {
+    var url_buf: [512]u8 = undefined;
+    const url = std.fmt.bufPrint(
+        &url_buf,
+        "https://github.com/{s}/{s}/releases/download/{s}/{s}",
+        .{ REPO_OWNER, REPO_NAME, tag, file_name },
+    ) catch return false;
+    const dl = sys.exec(allocator, &.{ "curl", "-fsSL", url, "-o", out_path }) catch return false;
+    defer dl.deinit();
+    return dl.exit_code == 0;
+}
+
+fn verifyReleaseChecksum(
+    allocator: std.mem.Allocator,
+    tag: []const u8,
+    tar_name: []const u8,
+    tar_path: []const u8,
+    work_dir: []const u8,
+) bool {
+    var checksum_name_buf: [224]u8 = undefined;
+    const checksum_name = std.fmt.bufPrint(&checksum_name_buf, "{s}.sha256", .{tar_name}) catch return false;
+
+    var checksum_path_buf: [320]u8 = undefined;
+    const checksum_path = std.fmt.bufPrint(&checksum_path_buf, "{s}/{s}", .{ work_dir, checksum_name }) catch return false;
+    if (!downloadReleaseFile(allocator, tag, checksum_name, checksum_path)) return false;
+    if (minisignVerificationEnabled()) {
+        var sig_name_buf: [256]u8 = undefined;
+        const sig_name = std.fmt.bufPrint(&sig_name_buf, "{s}.minisig", .{checksum_name}) catch return false;
+
+        var sig_path_buf: [352]u8 = undefined;
+        const sig_path = std.fmt.bufPrint(&sig_path_buf, "{s}/{s}", .{ work_dir, sig_name }) catch return false;
+        if (!downloadReleaseFile(allocator, tag, sig_name, sig_path)) return false;
+        if (!verifyMinisignSignature(allocator, checksum_path, sig_path)) return false;
+    }
+
+    var expected_buf: [64]u8 = undefined;
+    if (!readExpectedSha256(allocator, checksum_path, &expected_buf)) return false;
+    var actual_buf: [64]u8 = undefined;
+    if (!computeSha256Hex(allocator, tar_path, &actual_buf)) return false;
+    return std.ascii.eqlIgnoreCase(expected_buf[0..], actual_buf[0..]);
+}
+
+fn minisignVerificationEnabled() bool {
+    return MINISIGN_PUBKEY.len > 0 and std.mem.startsWith(u8, MINISIGN_PUBKEY, "RW");
+}
+
+pub fn requiresSignatureVerification() bool {
+    return minisignVerificationEnabled();
+}
+
+fn verifyMinisignSignature(
+    allocator: std.mem.Allocator,
+    message_path: []const u8,
+    signature_path: []const u8,
+) bool {
+    if (!sys.commandExists("minisign")) return false;
+    const res = sys.exec(allocator, &.{
+        "minisign",
+        "-V",
+        "-q",
+        "-m",
+        message_path,
+        "-x",
+        signature_path,
+        "-P",
+        MINISIGN_PUBKEY,
+    }) catch return false;
+    defer res.deinit();
+    return res.exit_code == 0;
+}
+
+fn readExpectedSha256(allocator: std.mem.Allocator, checksum_path: []const u8, out: *[64]u8) bool {
+    const r = sys.exec(allocator, &.{ "cat", checksum_path }) catch return false;
+    defer r.deinit();
+    if (r.exit_code != 0) return false;
+
+    var lines = std.mem.splitScalar(u8, r.stdout, '\n');
+    while (lines.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r' });
+        if (trimmed.len < 64) continue;
+        const hash = trimmed[0..64];
+        if (!isHexString(hash)) continue;
+        @memcpy(out[0..], hash);
+        return true;
+    }
+    return false;
+}
+
+fn computeSha256Hex(allocator: std.mem.Allocator, file_path: []const u8, out: *[64]u8) bool {
+    if (readShaOutput(allocator, &.{ "sha256sum", file_path }, out)) return true;
+    if (readShaOutput(allocator, &.{ "shasum", "-a", "256", file_path }, out)) return true;
+    return false;
+}
+
+fn readShaOutput(allocator: std.mem.Allocator, argv: []const []const u8, out: *[64]u8) bool {
+    const r = sys.exec(allocator, argv) catch return false;
+    defer r.deinit();
+    if (r.exit_code != 0) return false;
+
+    var tokens = std.mem.tokenizeAny(u8, r.stdout, " \t\r\n");
+    const first = tokens.next() orelse return false;
+    if (first.len != 64 or !isHexString(first)) return false;
+    @memcpy(out[0..], first[0..64]);
+    return true;
+}
+
+fn isHexString(s: []const u8) bool {
+    for (s) |c| {
+        if (!std.ascii.isHex(c)) return false;
+    }
     return true;
 }
 

--- a/src/ctl/sys.zig
+++ b/src/ctl/sys.zig
@@ -201,7 +201,7 @@ pub fn execSilent(allocator: std.mem.Allocator, argv: []const []const u8) void {
     result.deinit();
 }
 
-/// Write content to a file atomically. Avoids shell injection from bash -c.
+/// Write content to a file path. Avoids shell injection from bash -c.
 pub fn writeFile(path: []const u8, content: []const u8) !void {
     try std.Io.Dir.cwd().writeFile(io(), .{
         .sub_path = path,

--- a/src/ctl/sys.zig
+++ b/src/ctl/sys.zig
@@ -7,6 +7,24 @@
 const std = @import("std");
 const tui_mod = @import("tui.zig");
 
+fn io() std.Io {
+    return std.Io.Threaded.global_single_threaded.io();
+}
+
+fn readFileAllocAbsolute(allocator: std.mem.Allocator, path: []const u8, limit: usize) ?[]u8 {
+    var file = std.Io.Dir.openFileAbsolute(io(), path, .{}) catch return null;
+    defer file.close(io());
+    var reader = file.reader(io(), &.{});
+    return reader.interface.allocRemaining(allocator, .limited(limit)) catch null;
+}
+
+fn readFileAllocCwd(allocator: std.mem.Allocator, path: []const u8, limit: usize) ?[]u8 {
+    var file = std.Io.Dir.cwd().openFile(io(), path, .{}) catch return null;
+    defer file.close(io());
+    var reader = file.reader(io(), &.{});
+    return reader.interface.allocRemaining(allocator, .limited(limit)) catch null;
+}
+
 pub const ExecResult = struct {
     exit_code: u8,
     stdout: []const u8,
@@ -33,17 +51,20 @@ pub const Arch = enum {
 
 /// Run a command, capture stdout/stderr, return result.
 pub fn exec(allocator: std.mem.Allocator, argv: []const []const u8) !ExecResult {
-    const result = try std.process.Child.run(.{
-        .allocator = allocator,
+    var io_instance: std.Io.Threaded = .init(std.heap.page_allocator, .{});
+    defer io_instance.deinit();
+
+    const result = try std.process.run(allocator, io_instance.io(), .{
         .argv = argv,
-        .max_output_bytes = 1024 * 1024,
+        .stdout_limit = std.Io.Limit.limited(1024 * 1024),
+        .stderr_limit = std.Io.Limit.limited(1024 * 1024),
     });
 
     const exit_code: u8 = switch (result.term) {
-        .Exited => |code| code,
-        .Signal => |sig| @as(u8, 128) +| @as(u8, @intCast(@min(sig, 127))),
-        .Stopped => 1,
-        .Unknown => 1,
+        .exited => |code| code,
+        .signal => |sig| @as(u8, 128) +| @as(u8, @intCast(@min(@intFromEnum(sig), 127))),
+        .stopped => 1,
+        .unknown => 1,
     };
 
     return .{
@@ -56,18 +77,24 @@ pub fn exec(allocator: std.mem.Allocator, argv: []const []const u8) !ExecResult 
 
 /// Run a command with output forwarded directly to the terminal (no capture).
 pub fn execForward(argv: []const []const u8) !u8 {
-    var child = std.process.Child.init(argv, std.heap.page_allocator);
-    child.stdout_behavior = .Inherit;
-    child.stderr_behavior = .Inherit;
+    var io_instance: std.Io.Threaded = .init(std.heap.page_allocator, .{});
+    defer io_instance.deinit();
 
-    try child.spawn();
-    const term = try child.wait();
+    const io_ctx = io_instance.io();
+    var child = try std.process.spawn(io_ctx, .{
+        .argv = argv,
+        .stdout = .inherit,
+        .stderr = .inherit,
+    });
+    defer child.kill(io_ctx);
+
+    const term = try child.wait(io_ctx);
 
     return switch (term) {
-        .Exited => |code| code,
-        .Signal => |sig| @as(u8, 128) +| @as(u8, @intCast(@min(sig, 127))),
-        .Stopped => 1,
-        .Unknown => 1,
+        .exited => |code| code,
+        .signal => |sig| @as(u8, 128) +| @as(u8, @intCast(@min(@intFromEnum(sig), 127))),
+        .stopped => 1,
+        .unknown => 1,
     };
 }
 
@@ -106,10 +133,7 @@ pub fn getArch() !Arch {
 pub fn supportsV3(allocator: std.mem.Allocator) bool {
     if (@import("builtin").os.tag != .linux) return false;
 
-    const cpuinfo = std.fs.openFileAbsolute("/proc/cpuinfo", .{}) catch return false;
-    defer cpuinfo.close();
-
-    const content = cpuinfo.readToEndAlloc(allocator, 256 * 1024) catch return false;
+    const content = readFileAllocAbsolute(allocator, "/proc/cpuinfo", 256 * 1024) orelse return false;
     defer allocator.free(content);
 
     // Find "flags" line
@@ -167,7 +191,7 @@ pub fn isServiceActive(service: []const u8) bool {
 
 /// Check if a file exists.
 pub fn fileExists(path: []const u8) bool {
-    std.fs.accessAbsolute(path, .{}) catch return false;
+    std.Io.Dir.accessAbsolute(io(), path, .{}) catch return false;
     return true;
 }
 
@@ -179,23 +203,26 @@ pub fn execSilent(allocator: std.mem.Allocator, argv: []const []const u8) void {
 
 /// Write content to a file atomically. Avoids shell injection from bash -c.
 pub fn writeFile(path: []const u8, content: []const u8) !void {
-    const file = try std.fs.cwd().createFile(path, .{});
-    defer file.close();
-    try file.writeAll(content);
+    try std.Io.Dir.cwd().writeFile(io(), .{
+        .sub_path = path,
+        .data = content,
+    });
 }
 
 /// Write content and set permissions.
 pub fn writeFileMode(path: []const u8, content: []const u8, mode: u9) !void {
-    const file = try std.fs.cwd().createFile(path, .{ .mode = mode });
-    defer file.close();
-    try file.writeAll(content);
+    try std.Io.Dir.cwd().writeFile(io(), .{
+        .sub_path = path,
+        .data = content,
+        .flags = .{
+            .permissions = std.Io.File.Permissions.fromMode(mode),
+        },
+    });
 }
 
 /// Parse a simple KEY=VALUE .env file, return value for given key.
 pub fn readEnvFile(allocator: std.mem.Allocator, path: []const u8, key: []const u8) ?[]const u8 {
-    const file = std.fs.cwd().openFile(path, .{}) catch return null;
-    defer file.close();
-    const content = file.readToEndAlloc(allocator, 64 * 1024) catch return null;
+    const content = readFileAllocCwd(allocator, path, 64 * 1024) orelse return null;
     defer allocator.free(content);
 
     var lines_iter = std.mem.splitScalar(u8, content, '\n');
@@ -219,7 +246,18 @@ pub fn readEnvFile(allocator: std.mem.Allocator, path: []const u8, key: []const 
 /// Generate 16 random bytes as a hex string (32 chars).
 pub fn generateSecret(buf: *[32]u8) void {
     var bytes: [16]u8 = undefined;
-    std.crypto.random.bytes(&bytes);
+    var off: usize = 0;
+    while (off < bytes.len) {
+        const rc = std.os.linux.getrandom(bytes[off..].ptr, bytes.len - off, 0);
+        switch (std.os.linux.errno(rc)) {
+            .SUCCESS => {
+                if (rc == 0) break;
+                off += rc;
+            },
+            .INTR => continue,
+            else => break,
+        }
+    }
     const hex = "0123456789abcdef";
     for (bytes, 0..) |byte, idx| {
         buf[idx * 2] = hex[byte >> 4];

--- a/src/ctl/toml.zig
+++ b/src/ctl/toml.zig
@@ -7,15 +7,19 @@
 const std = @import("std");
 
 pub const TomlDoc = struct {
-    lines: std.ArrayListUnmanaged([]const u8) = .{},
+    lines: std.ArrayListUnmanaged([]const u8) = .empty,
     allocator: std.mem.Allocator,
 
     const Self = @This();
 
     pub fn load(allocator: std.mem.Allocator, path: []const u8) !Self {
-        const file = try std.fs.cwd().openFile(path, .{});
-        defer file.close();
-        const content = try file.readToEndAlloc(allocator, 1024 * 1024);
+        const io = std.Io.Threaded.global_single_threaded.io();
+        const content = try std.Io.Dir.cwd().readFileAlloc(
+            io,
+            path,
+            allocator,
+            .limited(1024 * 1024),
+        );
         defer allocator.free(content);
 
         var doc = Self{
@@ -39,12 +43,13 @@ pub const TomlDoc = struct {
 
     /// Save the document back to a file.
     pub fn save(self: *Self, path: []const u8) !void {
-        const file = try std.fs.cwd().createFile(path, .{});
-        defer file.close();
+        const io = std.Io.Threaded.global_single_threaded.io();
+        var file = try std.Io.Dir.cwd().createFile(io, path, .{});
+        defer file.close(io);
 
         for (self.lines.items) |line| {
-            try file.writeAll(line);
-            try file.writeAll("\n");
+            try file.writeStreamingAll(io, line);
+            try file.writeStreamingAll(io, "\n");
         }
     }
 

--- a/src/ctl/tui.zig
+++ b/src/ctl/tui.zig
@@ -8,6 +8,21 @@
 
 const std = @import("std");
 const i18n = @import("i18n.zig");
+const linux_io = @import("linux_io");
+
+fn sleepMs(ms: u64) void {
+    const req: std.posix.timespec = .{
+        .sec = @intCast(ms / 1000),
+        .nsec = @intCast((ms % 1000) * std.time.ns_per_ms),
+    };
+    _ = std.os.linux.nanosleep(&req, null);
+}
+
+fn isTty(fd: std.posix.fd_t) bool {
+    var ws: std.posix.winsize = .{ .row = 0, .col = 0, .xpixel = 0, .ypixel = 0 };
+    const rc = std.posix.system.ioctl(fd, std.posix.T.IOCGWINSZ, @intFromPtr(&ws));
+    return std.posix.errno(rc) == .SUCCESS;
+}
 
 // ── Terminal geometry helpers (used by draw closures) ──────────────────────
 
@@ -78,7 +93,16 @@ pub const Color = struct {
 // ── Braille spinner frames ──────────────────────────────────────────────────
 
 const SPINNER_FRAMES = [_][]const u8{
-    "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏",
+    "⠋",
+    "⠙",
+    "⠹",
+    "⠸",
+    "⠼",
+    "⠴",
+    "⠦",
+    "⠧",
+    "⠇",
+    "⠏",
 };
 
 // ── Spinner state (thread-safe write via atomic, rendered in main thread) ──
@@ -155,14 +179,14 @@ pub const Spinner = struct {
             self.tui.print("\r  {s}{s}{s} {s}", .{
                 Color.bright_yellow, SPINNER_FRAMES[frame], Color.reset, self.label,
             });
-            std.Thread.sleep(80 * std.time.ns_per_ms);
+            sleepMs(80);
         }
     }
 };
 
 pub const Tui = struct {
-    out: std.fs.File,
-    in: std.fs.File,
+    out_fd: std.posix.fd_t,
+    in_fd: std.posix.fd_t,
     lang: i18n.Lang,
     is_tty: bool,
     line_buf: [16 * 1024]u8 = undefined,
@@ -171,13 +195,13 @@ pub const Tui = struct {
     const Self = @This();
 
     pub fn init(lang: i18n.Lang) Self {
-        const out = std.fs.File.stdout();
-        const in = std.fs.File.stdin();
+        const out_fd = std.posix.STDOUT_FILENO;
+        const in_fd = std.posix.STDIN_FILENO;
         return .{
-            .out = out,
-            .in = in,
+            .out_fd = out_fd,
+            .in_fd = in_fd,
             .lang = lang,
-            .is_tty = out.isTty(),
+            .is_tty = isTty(out_fd),
         };
     }
 
@@ -185,7 +209,7 @@ pub const Tui = struct {
 
     pub fn enterRawMode(self: *Self) void {
         if (!self.is_tty) return;
-        const current = std.posix.tcgetattr(self.in.handle) catch return;
+        const current = std.posix.tcgetattr(self.in_fd) catch return;
         self.orig_termios = current;
 
         var raw = current;
@@ -196,19 +220,19 @@ pub const Tui = struct {
         raw.cc[@intFromEnum(std.posix.V.MIN)] = 1;
         raw.cc[@intFromEnum(std.posix.V.TIME)] = 0;
 
-        std.posix.tcsetattr(self.in.handle, .FLUSH, raw) catch {};
+        std.posix.tcsetattr(self.in_fd, .FLUSH, raw) catch {};
     }
 
     pub fn exitRawMode(self: *Self) void {
         if (self.orig_termios) |orig| {
-            std.posix.tcsetattr(self.in.handle, .FLUSH, orig) catch {};
+            std.posix.tcsetattr(self.in_fd, .FLUSH, orig) catch {};
             self.orig_termios = null;
         }
     }
 
     pub fn readKey(self: *Self) !KeyEvent {
         var byte: [1]u8 = undefined;
-        const n = try self.in.read(&byte);
+        const n = try std.posix.read(self.in_fd, &byte);
         if (n == 0) return error.EndOfStream;
         const c = byte[0];
 
@@ -219,13 +243,13 @@ pub const Tui = struct {
 
         if (c == '\x1b') {
             var fds = [_]std.posix.pollfd{
-                .{ .fd = self.in.handle, .events = std.posix.POLL.IN, .revents = 0 },
+                .{ .fd = self.in_fd, .events = std.posix.POLL.IN, .revents = 0 },
             };
             const p = std.posix.poll(&fds, 0) catch 0;
             if (p == 0) return .{ .key = .escape };
 
             var seq: [2]u8 = undefined;
-            const seq_n = self.in.read(&seq) catch 0;
+            const seq_n = std.posix.read(self.in_fd, &seq) catch 0;
             if (seq_n < 2) return .{ .key = .escape };
             if (seq[0] == '[') {
                 if (seq[1] == 'A') return .{ .key = .up };
@@ -250,7 +274,7 @@ pub const Tui = struct {
     pub fn getTermWidth(self: *Self) u16 {
         if (!self.is_tty) return 80;
         var ws: std.posix.winsize = .{ .row = 0, .col = 0, .xpixel = 0, .ypixel = 0 };
-        const rc = std.posix.system.ioctl(self.out.handle, std.posix.T.IOCGWINSZ, @intFromPtr(&ws));
+        const rc = std.posix.system.ioctl(self.out_fd, std.posix.T.IOCGWINSZ, @intFromPtr(&ws));
         if (std.posix.errno(rc) == .SUCCESS and ws.col > 0) return ws.col;
         return 80;
     }
@@ -262,7 +286,7 @@ pub const Tui = struct {
 
     /// Write raw bytes to stdout.
     pub fn writeRaw(self: *Self, bytes: []const u8) void {
-        _ = self.out.write(bytes) catch {};
+        linux_io.writeAllFd(self.out_fd, bytes);
     }
 
     /// Write formatted output to stdout.
@@ -747,9 +771,9 @@ pub const Tui = struct {
 
         self.print("  {s}╭──────────────────────────────────────────────────────────────────╮{s}\n", .{ Color.gray, Color.reset });
         self.print("  {s}│{s} {s}⚙  {s}{s}{s}{s}{s}│{s}\n", .{
-            Color.gray,          Color.reset,
-            Color.bold,          Color.bright_yellow,
-            clean_title,         Color.reset,
+            Color.gray,                         Color.reset,
+            Color.bold,                         Color.bright_yellow,
+            clean_title,                        Color.reset,
             pad_buf[0..@min(pad, pad_buf.len)], Color.gray,
             Color.reset,
         });
@@ -781,7 +805,7 @@ pub const Tui = struct {
         var pos: usize = 0;
         while (pos < self.line_buf.len) {
             var byte: [1]u8 = undefined;
-            const n = self.in.read(&byte) catch return error.InputError;
+            const n = std.posix.read(self.in_fd, &byte) catch return error.InputError;
             if (n == 0) {
                 if (pos == 0) return error.EndOfStream;
                 return self.line_buf[0..pos];
@@ -795,7 +819,7 @@ pub const Tui = struct {
         // Buffer full — drain remaining input until newline
         while (true) {
             var byte: [1]u8 = undefined;
-            const n = self.in.read(&byte) catch break;
+            const n = std.posix.read(self.in_fd, &byte) catch break;
             if (n == 0 or byte[0] == '\n') break;
         }
         return self.line_buf[0..pos];

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -21,6 +21,14 @@ const AWG_CONFIG_PATH = AWG_CONF_DIR ++ "/awg0.conf";
 const TUNNEL_MARK: u32 = 200;
 const TUNNEL_TABLE: u32 = 200;
 
+fn io() std.Io {
+    return std.Io.Threaded.global_single_threaded.io();
+}
+
+fn readFileAllocCwd(allocator: std.mem.Allocator, path: []const u8, limit: usize) ![]u8 {
+    return std.Io.Dir.cwd().readFileAlloc(io(), path, allocator, .limited(limit));
+}
+
 pub const TunnelOpts = struct {
     awg_source: []const u8 = "",
 };
@@ -37,7 +45,7 @@ const AwgQuickValidation = enum {
 };
 
 /// Run in CLI mode.
-pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.ArgIterator) !void {
+pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) !void {
     var opts = TunnelOpts{};
 
     while (args.next()) |arg| {
@@ -359,13 +367,10 @@ fn installAwgConfigSource(allocator: std.mem.Allocator, source: []const u8, dest
     if (isAmneziaVpnLinkSource(trimmed)) {
         try sys.writeFileMode(dest_path, trimmed, 0o600);
     } else {
-        const src_file = std.fs.cwd().openFile(trimmed, .{}) catch |err| switch (err) {
+        const content = readFileAllocCwd(allocator, trimmed, 1024 * 1024) catch |err| switch (err) {
             error.FileNotFound => return error.ConfigSourceNotFound,
             else => return err,
         };
-        defer src_file.close();
-
-        const content = try src_file.readToEndAlloc(allocator, 1024 * 1024);
         defer allocator.free(content);
 
         try sys.writeFileMode(dest_path, content, 0o600);
@@ -375,10 +380,7 @@ fn installAwgConfigSource(allocator: std.mem.Allocator, source: []const u8, dest
 }
 
 fn normalizeAwgConfig(allocator: std.mem.Allocator, path: []const u8) !AwgConfigKind {
-    const file = try std.fs.cwd().openFile(path, .{});
-    defer file.close();
-
-    const content = try file.readToEndAlloc(allocator, 1024 * 1024);
+    const content = try readFileAllocCwd(allocator, path, 1024 * 1024);
     defer allocator.free(content);
 
     const trimmed = std.mem.trim(u8, content, &[_]u8{ ' ', '\t', '\r', '\n' });
@@ -598,7 +600,9 @@ fn appendConfigLine(
     value: []const u8,
 ) !void {
     if (wrote_any.*) try output.append(allocator, '\n');
-    try output.writer(allocator).print("{s} = {s}", .{ key, value });
+    try output.appendSlice(allocator, key);
+    try output.appendSlice(allocator, " = ");
+    try output.appendSlice(allocator, value);
     wrote_any.* = true;
 }
 
@@ -749,10 +753,7 @@ fn setUpstreamType(allocator: std.mem.Allocator, value: []const u8) void {
 }
 
 fn stripAwgDnsLines(allocator: std.mem.Allocator, path: []const u8) !bool {
-    const file = try std.fs.cwd().openFile(path, .{});
-    defer file.close();
-
-    const content = try file.readToEndAlloc(allocator, 1024 * 1024);
+    const content = try readFileAllocCwd(allocator, path, 1024 * 1024);
     defer allocator.free(content);
 
     var output: std.ArrayList(u8) = .empty;
@@ -795,10 +796,7 @@ fn stripAwgDnsLines(allocator: std.mem.Allocator, path: []const u8) !bool {
 }
 
 fn stripAwgEmptyAssignments(allocator: std.mem.Allocator, path: []const u8) !bool {
-    const file = try std.fs.cwd().openFile(path, .{});
-    defer file.close();
-
-    const content = try file.readToEndAlloc(allocator, 1024 * 1024);
+    const content = try readFileAllocCwd(allocator, path, 1024 * 1024);
     defer allocator.free(content);
 
     var output: std.ArrayList(u8) = .empty;
@@ -842,10 +840,7 @@ fn stripAwgEmptyAssignments(allocator: std.mem.Allocator, path: []const u8) !boo
 }
 
 fn ensureAwgTableOff(allocator: std.mem.Allocator, path: []const u8) !bool {
-    const file = try std.fs.cwd().openFile(path, .{});
-    defer file.close();
-
-    const content = try file.readToEndAlloc(allocator, 1024 * 1024);
+    const content = try readFileAllocCwd(allocator, path, 1024 * 1024);
     defer allocator.free(content);
 
     var in_interface = false;
@@ -909,10 +904,7 @@ const NGINX_MASKING_CONF = "/etc/nginx/sites-available/mtproto-masking";
 /// Strip legacy netns listen directives (e.g. `listen 10.200.200.1:8443 ssl;`)
 /// from the nginx masking config. Returns true if any lines were removed.
 fn cleanupNetnsNginxListen(allocator: std.mem.Allocator) bool {
-    const file = std.fs.cwd().openFile(NGINX_MASKING_CONF, .{}) catch return false;
-    defer file.close();
-
-    const content = file.readToEndAlloc(allocator, 256 * 1024) catch return false;
+    const content = readFileAllocCwd(allocator, NGINX_MASKING_CONF, 256 * 1024) catch return false;
     defer allocator.free(content);
 
     var output: std.ArrayList(u8) = .empty;
@@ -984,13 +976,13 @@ test "tunnel - installs Amnezia vpn link source directly" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
     const dest_path = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}/awg0.conf", .{tmp.sub_path});
 
     const kind = try installAwgConfigSource(std.testing.allocator, " \n" ++ test_amnezia_vpn_link ++ "\n", dest_path);
     try std.testing.expectEqual(AwgConfigKind.amnezia_vpn_link, kind);
 
-    const installed = try std.fs.cwd().readFileAlloc(std.testing.allocator, dest_path, 4096);
+    const installed = try std.Io.Dir.cwd().readFileAlloc(io(), dest_path, std.testing.allocator, .limited(4096));
     defer std.testing.allocator.free(installed);
 
     try std.testing.expect(std.mem.indexOf(u8, installed, "vpn://") == null);
@@ -1018,7 +1010,7 @@ test "tunnel - strips empty AWG assignments" {
         ,
     });
 
-    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
     const path = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}/{s}", .{ tmp.sub_path, name });
 
     try std.testing.expect(try stripAwgEmptyAssignments(std.testing.allocator, path));

--- a/src/ctl/uninstall.zig
+++ b/src/ctl/uninstall.zig
@@ -19,7 +19,7 @@ pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
     try execute(ui, allocator);
 }
 
-pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.ArgIterator) void {
+pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) void {
     var yes_flag = false;
 
     while (args.next()) |arg| {

--- a/src/ctl/update.zig
+++ b/src/ctl/update.zig
@@ -25,7 +25,7 @@ pub const UpdateOpts = struct {
 };
 
 /// Run update in CLI (non-interactive) mode.
-pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.ArgIterator) !void {
+pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) !void {
     var opts = UpdateOpts{};
 
     while (args.next()) |arg| {

--- a/src/ctl/update.zig
+++ b/src/ctl/update.zig
@@ -78,6 +78,18 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: UpdateOpts) !void {
         return;
     }
 
+    // ── Ensure signature verifier dependency ──
+    if (release.requiresSignatureVerification() and !sys.commandExists("minisign")) {
+        ui.step("Installing minisign for release signature verification...");
+        _ = sys.exec(allocator, &.{ "apt-get", "update", "-qq" }) catch {};
+        _ = sys.exec(allocator, &.{ "apt-get", "install", "-y", "minisign" }) catch {};
+        if (!sys.commandExists("minisign")) {
+            ui.fail("minisign is required for release signature verification");
+            return;
+        }
+        ui.ok("minisign installed");
+    }
+
     // ── Resolve release tag ──
     var tag = release.Tag{};
     {

--- a/src/linux_io.zig
+++ b/src/linux_io.zig
@@ -1,0 +1,16 @@
+const std = @import("std");
+
+pub fn writeAllFd(fd: std.posix.fd_t, bytes: []const u8) void {
+    var written: usize = 0;
+    while (written < bytes.len) {
+        const rc = std.os.linux.write(fd, bytes[written..].ptr, bytes.len - written);
+        switch (std.os.linux.errno(rc)) {
+            .SUCCESS => {
+                if (rc == 0) return;
+                written += rc;
+            },
+            .INTR => continue,
+            else => return,
+        }
+    }
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -11,6 +11,7 @@ const obfuscation = @import("protocol/obfuscation.zig");
 const tls = @import("protocol/tls.zig");
 const config = @import("config.zig");
 const proxy = @import("proxy/proxy.zig");
+const linux_io = @import("linux_io");
 const version_mod = @import("version");
 
 // Custom lock-free log function: formats into a stack buffer and writes
@@ -32,7 +33,7 @@ pub const std_options = std.Options{
 
 fn lockFreeLog(
     comptime message_level: std.log.Level,
-    comptime scope: @Type(.enum_literal),
+    comptime scope: @EnumLiteral(),
     comptime format: []const u8,
     args: anytype,
 ) void {
@@ -43,47 +44,48 @@ fn lockFreeLog(
     const prefix2 = comptime if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
     var buf: [4096]u8 = undefined;
     const msg = std.fmt.bufPrint(&buf, level_txt ++ prefix2 ++ format ++ "\n", args) catch return;
-    _ = std.posix.write(std.posix.STDERR_FILENO, msg) catch return;
+    linux_io.writeAllFd(std.posix.STDERR_FILENO, msg);
 }
 
 const log = std.log.scoped(.mtproto);
 
 pub const version = version_mod.version;
 
-// ============= Output Helpers (Zig 0.15 compatible) =============
+// ============= Output Helpers =============
 
 /// Write a formatted string to stdout via posix write.
 fn writeStdout(comptime fmt: []const u8, args: anytype) void {
     var buf: [4096]u8 = undefined;
     const slice = std.fmt.bufPrint(&buf, fmt, args) catch return;
-    _ = std.posix.write(std.posix.STDOUT_FILENO, slice) catch return;
+    linux_io.writeAllFd(std.posix.STDOUT_FILENO, slice);
 }
 
 /// Write a formatted string to stderr.
 fn writeStderr(comptime fmt: []const u8, args: anytype) void {
     var buf: [4096]u8 = undefined;
     const slice = std.fmt.bufPrint(&buf, fmt, args) catch return;
-    _ = std.posix.write(std.posix.STDERR_FILENO, slice) catch return;
+    linux_io.writeAllFd(std.posix.STDERR_FILENO, slice);
 }
 
 /// Write a hex byte to stdout.
 fn writeHexByte(byte: u8) void {
     const hex = "0123456789abcdef";
     const out = [2]u8{ hex[byte >> 4], hex[byte & 0x0f] };
-    _ = std.posix.write(std.posix.STDOUT_FILENO, &out) catch return;
+    linux_io.writeAllFd(std.posix.STDOUT_FILENO, &out);
 }
 
 /// Write raw string to stdout.
 fn writeRaw(s: []const u8) void {
-    _ = std.posix.write(std.posix.STDOUT_FILENO, s) catch return;
+    linux_io.writeAllFd(std.posix.STDOUT_FILENO, s);
 }
 
 // ============= Public IP Detection =============
 
 fn fetchUrlBytes(allocator: std.mem.Allocator, url: []const u8) ![]u8 {
     const uri = try std.Uri.parse(url);
+    const io = std.Io.Threaded.global_single_threaded.io();
 
-    var client: std.http.Client = .{ .allocator = allocator };
+    var client: std.http.Client = .{ .allocator = allocator, .io = io };
     defer client.deinit();
 
     var req = try client.request(.GET, uri, .{
@@ -202,14 +204,17 @@ const CapacityEstimate = struct {
 fn detectTotalRamBytes(allocator: std.mem.Allocator) ?u64 {
     if (builtin.os.tag != .linux) return null;
 
-    const file = std.fs.openFileAbsolute("/proc/meminfo", .{}) catch return null;
-    defer file.close();
-
-    const content = file.readToEndAlloc(allocator, 16 * 1024) catch return null;
-    defer allocator.free(content);
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const content = std.Io.Dir.openFileAbsolute(io, "/proc/meminfo", .{}) catch return null;
+    defer content.close(io);
+    var reader = content.reader(io, &.{});
+    const bytes = reader.interface.allocRemaining(allocator, .limited(16 * 1024)) catch return null;
+    const data = bytes;
+    defer allocator.free(data);
+    const content_bytes = data;
 
     const key = "MemTotal:";
-    var lines = std.mem.splitScalar(u8, content, '\n');
+    var lines = std.mem.splitScalar(u8, content_bytes, '\n');
     while (lines.next()) |line| {
         if (!std.mem.startsWith(u8, line, key)) continue;
 
@@ -432,13 +437,10 @@ fn printBanner(allocator: std.mem.Allocator, cfg: config.Config, capacity_estima
     writeRaw("  " ++ B ++ cyan ++ "⏳ Waiting for connections..." ++ R ++ "\n\n");
 }
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{ .thread_safe = false }){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
-
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
     // Parse config path from args
-    var args = try std.process.argsWithAllocator(allocator);
+    var args = try init.minimal.args.iterateAllocator(allocator);
     defer args.deinit();
     _ = args.next(); // skip program name
     const first_arg = args.next();

--- a/src/main.zig
+++ b/src/main.zig
@@ -43,7 +43,17 @@ fn lockFreeLog(
     const level_txt = comptime message_level.asText();
     const prefix2 = comptime if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
     var buf: [4096]u8 = undefined;
-    const msg = std.fmt.bufPrint(&buf, level_txt ++ prefix2 ++ format ++ "\n", args) catch return;
+    const msg = std.fmt.bufPrint(&buf, level_txt ++ prefix2 ++ format ++ "\n", args) catch |err| switch (err) {
+        error.NoSpaceLeft => blk: {
+            if (buf.len >= 2) {
+                buf[buf.len - 2] = '\n';
+                buf[buf.len - 1] = 0;
+                break :blk buf[0 .. buf.len - 1];
+            }
+            return;
+        },
+        else => return,
+    };
     linux_io.writeAllFd(std.posix.STDERR_FILENO, msg);
 }
 
@@ -65,13 +75,6 @@ fn writeStderr(comptime fmt: []const u8, args: anytype) void {
     var buf: [4096]u8 = undefined;
     const slice = std.fmt.bufPrint(&buf, fmt, args) catch return;
     linux_io.writeAllFd(std.posix.STDERR_FILENO, slice);
-}
-
-/// Write a hex byte to stdout.
-fn writeHexByte(byte: u8) void {
-    const hex = "0123456789abcdef";
-    const out = [2]u8{ hex[byte >> 4], hex[byte & 0x0f] };
-    linux_io.writeAllFd(std.posix.STDOUT_FILENO, &out);
 }
 
 /// Write raw string to stdout.
@@ -165,34 +168,6 @@ fn detectPublicIpFromServices(
         allocator.free(stdout);
     }
     return null;
-}
-
-fn encodeServerForProxyLink(server: []const u8, out: []u8) []const u8 {
-    var required_len: usize = 0;
-    for (server) |c| {
-        required_len += if (c == ':' or c == '[' or c == ']') 3 else 1;
-    }
-
-    // Keep original value if it does not fit to avoid silent truncation.
-    if (required_len > out.len) return server;
-
-    var pos: usize = 0;
-    for (server) |c| {
-        if (c == ':') {
-            @memcpy(out[pos..][0..3], "%3A");
-            pos += 3;
-        } else if (c == '[') {
-            @memcpy(out[pos..][0..3], "%5B");
-            pos += 3;
-        } else if (c == ']') {
-            @memcpy(out[pos..][0..3], "%5D");
-            pos += 3;
-        } else {
-            out[pos] = c;
-            pos += 1;
-        }
-    }
-    return out[0..pos];
 }
 
 const CapacityEstimate = struct {
@@ -325,7 +300,6 @@ fn printBanner(allocator: std.mem.Allocator, cfg: config.Config, capacity_estima
     const cyan = "\x1b[36m";
     const green = "\x1b[32m";
     const yellow = "\x1b[33m";
-    const magenta = "\x1b[35m";
     const white = "\x1b[97m";
     const red = "\x1b[31m";
 
@@ -389,48 +363,17 @@ fn printBanner(allocator: std.mem.Allocator, cfg: config.Config, capacity_estima
     writeStdout("  " ++ D ++ "───" ++ R ++ " " ++ B ++ cyan ++ "USERS" ++ R ++ " ({d}) " ++ D ++ "────────────────────────────────────" ++ R ++ "\n", .{cfg.users.count()});
     var it = @constCast(&cfg.users).iterator();
     while (it.next()) |entry| {
-        writeStdout("      " ++ green ++ "●" ++ R ++ " " ++ B ++ "{s}" ++ R ++ "  " ++ D, .{entry.key_ptr.*});
-        for (entry.value_ptr.*) |byte| {
-            writeHexByte(byte);
-        }
-        writeRaw(R ++ "\n");
+        writeStdout("      " ++ green ++ "●" ++ R ++ " " ++ B ++ "{s}" ++ R ++ "\n", .{entry.key_ptr.*});
     }
     writeRaw("\n");
 
-    // ─── LINKS ──────────────────────────────────────
-    writeRaw("  " ++ D ++ "───" ++ R ++ " " ++ B ++ cyan ++ "LINKS" ++ R ++ " " ++ D ++ "──────────────────────────────────────" ++ R ++ "\n");
+    // ─── SECURITY ───────────────────────────────────
+    writeRaw("  " ++ D ++ "───" ++ R ++ " " ++ B ++ cyan ++ "SECURITY" ++ R ++ " " ++ D ++ "───────────────────────────────────" ++ R ++ "\n");
     if (!has_ip) {
-        writeRaw("      " ++ red ++ "⚠  Could not detect IP. Replace <SERVER_IP> manually." ++ R ++ "\n");
+        writeRaw("      " ++ red ++ "⚠  Could not detect public IP automatically." ++ R ++ "\n");
     }
-
-    var encoded_ip_buf: [768]u8 = undefined;
-    const safe_server_ip = encodeServerForProxyLink(server_ip, &encoded_ip_buf);
-
-    var it2 = @constCast(&cfg.users).iterator();
-    while (it2.next()) |entry| {
-        writeStdout("      " ++ B ++ magenta ++ "{s}" ++ R ++ "\n", .{entry.key_ptr.*});
-
-        // tg:// deep link
-        writeStdout("      " ++ cyan ++ "tg://" ++ R ++ "proxy?server={s}&port={d}&secret=", .{ safe_server_ip, cfg.port });
-        writeRaw(green ++ "ee");
-        for (entry.value_ptr.*) |byte| {
-            writeHexByte(byte);
-        }
-        for (cfg.tls_domain) |byte| {
-            writeHexByte(byte);
-        }
-        writeRaw(R ++ "\n");
-
-        // t.me link
-        writeStdout("      " ++ D ++ "t.me/proxy?server={s}&port={d}&secret=ee", .{ safe_server_ip, cfg.port });
-        for (entry.value_ptr.*) |byte| {
-            writeHexByte(byte);
-        }
-        for (cfg.tls_domain) |byte| {
-            writeHexByte(byte);
-        }
-        writeRaw(R ++ "\n");
-    }
+    writeRaw("      " ++ D ++ "User secrets and proxy links are hidden in runtime logs." ++ R ++ "\n");
+    writeRaw("      " ++ D ++ "Use mtbuddy install output or trusted local tooling to generate links." ++ R ++ "\n");
 
     // Footer
     writeRaw("\n  " ++ D ++ "──────────────────────────────────────────────────" ++ R ++ "\n");
@@ -504,7 +447,7 @@ pub fn main(init: std.process.Init) !void {
     cfg.emitWarnings();
 
     // Create shared state (DI — no globals)
-    var state = proxy.ProxyState.init(allocator, cfg);
+    var state = try proxy.ProxyState.init(allocator, cfg);
     defer state.deinit();
 
     // Run the proxy

--- a/src/main.zig
+++ b/src/main.zig
@@ -179,6 +179,12 @@ const CapacityEstimate = struct {
 fn detectTotalRamBytes(allocator: std.mem.Allocator) ?u64 {
     if (builtin.os.tag != .linux) return null;
 
+    // Prefer sysinfo(2): no /proc dependency and works under stricter sandboxing.
+    if (detectTotalRamBytesSysinfo()) |total| {
+        return total;
+    }
+
+    // Fallback: parse /proc/meminfo.
     const io = std.Io.Threaded.global_single_threaded.io();
     const content = std.Io.Dir.openFileAbsolute(io, "/proc/meminfo", .{}) catch return null;
     defer content.close(io);
@@ -204,6 +210,19 @@ fn detectTotalRamBytes(allocator: std.mem.Allocator) ?u64 {
     }
 
     return null;
+}
+
+fn detectTotalRamBytesSysinfo() ?u64 {
+    if (builtin.os.tag != .linux) return null;
+
+    var info: std.os.linux.Sysinfo = undefined;
+    const rc = std.os.linux.sysinfo(&info);
+    if (std.os.linux.errno(rc) != .SUCCESS) return null;
+
+    const mem_unit: u128 = if (info.mem_unit == 0) 1 else info.mem_unit;
+    const total_bytes: u128 = @as(u128, info.totalram) * mem_unit;
+    if (total_bytes == 0 or total_bytes > std.math.maxInt(u64)) return null;
+    return @intCast(total_bytes);
 }
 
 fn estimateCapacity(cfg: *const config.Config, total_ram_bytes: u64) CapacityEstimate {
@@ -246,7 +265,7 @@ fn enforceCapacitySafety(cfg: *config.Config, capacity_estimate: ?CapacityEstima
         if (builtin.os.tag == .linux and !cfg.unsafe_override_limits) {
             const log_main = std.log.scoped(.config);
             log_main.warn(
-                "could not read /proc/meminfo; skipping max_connections safety clamp. " ++
+                "could not detect total RAM; skipping max_connections safety clamp. " ++
                     "set a conservative [server].max_connections to avoid OOM.",
                 .{},
             );

--- a/src/monitoring.zig
+++ b/src/monitoring.zig
@@ -424,8 +424,9 @@ test "metrics output contains required metrics" {
         .direct_users = std.StringHashMap(void).init(std.testing.allocator),
     };
     defer cfg.deinit(std.testing.allocator);
+    try cfg.users.put(try std.testing.allocator.dupe(u8, "test"), [_]u8{0x11} ** 16);
 
-    var state = proxy.ProxyState.init(std.testing.allocator, cfg);
+    var state = try proxy.ProxyState.init(std.testing.allocator, cfg);
     defer state.deinit();
 
     var buf: [32 * 1024]u8 = undefined;
@@ -443,8 +444,9 @@ test "metrics rejects unknown path" {
         .direct_users = std.StringHashMap(void).init(std.testing.allocator),
     };
     defer cfg.deinit(std.testing.allocator);
+    try cfg.users.put(try std.testing.allocator.dupe(u8, "test"), [_]u8{0x22} ** 16);
 
-    var state = proxy.ProxyState.init(std.testing.allocator, cfg);
+    var state = try proxy.ProxyState.init(std.testing.allocator, cfg);
     defer state.deinit();
 
     try std.testing.expect(!isGetMetrics("GET /nope HTTP/1.1\r\nHost: localhost\r\n\r\n"));

--- a/src/monitoring.zig
+++ b/src/monitoring.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const net = std.net;
+const net = std.Io.net;
 const posix = std.posix;
 const linux = std.os.linux;
 const proxy = @import("proxy/proxy.zig");
@@ -25,17 +25,14 @@ pub fn start(state: *proxy.ProxyState) !void {
 
     const host = state.config.metrics.effectiveHost();
     const port = state.config.metrics.port;
+    const io_ctx = std.Io.Threaded.global_single_threaded.io();
 
-    const addr_list = try net.getAddressList(std.heap.page_allocator, host, port);
-    defer addr_list.deinit();
-
-    if (addr_list.addrs.len == 0) return error.AddressNotAvailable;
-
-    var server = try addr_list.addrs[0].listen(.{
+    const listen_addr = try resolveFirstAddress(host, port);
+    var server = try listen_addr.listen(io_ctx, .{
         .reuse_address = true,
         .kernel_backlog = 64,
     });
-    errdefer server.deinit();
+    errdefer server.deinit(io_ctx);
 
     log.info("metrics endpoint listening on {s}:{d}", .{ host, port });
 
@@ -45,20 +42,59 @@ pub fn start(state: *proxy.ProxyState) !void {
 
 fn acceptLoop(state: *proxy.ProxyState, server: net.Server) void {
     var local_server = server;
-    defer local_server.deinit();
+    const io_ctx = std.Io.Threaded.global_single_threaded.io();
+    defer local_server.deinit(io_ctx);
 
     while (true) {
-        const conn = local_server.accept() catch |err| {
+        const conn = local_server.accept(io_ctx) catch |err| {
             log.warn("metrics accept failed: {any}", .{err});
-            std.Thread.sleep(200 * std.time.ns_per_ms);
+            sleepNs(200 * std.time.ns_per_ms);
             continue;
         };
-        handleConnection(state, conn.stream.handle);
+        handleConnection(state, conn.socket.handle);
+    }
+}
+
+fn resolveFirstAddress(host: []const u8, port: u16) !net.IpAddress {
+    if (net.IpAddress.parse(host, port)) |literal| return literal else |_| {}
+
+    const host_name = try net.HostName.init(host);
+    const io_ctx = std.Io.Threaded.global_single_threaded.io();
+
+    var results_buf: [8]net.HostName.LookupResult = undefined;
+    var results: std.Io.Queue(net.HostName.LookupResult) = .init(&results_buf);
+    try host_name.lookup(io_ctx, &results, .{ .port = port });
+
+    while (results.getOneUncancelable(io_ctx)) |entry| {
+        switch (entry) {
+            .address => |addr| return addr,
+            .canonical_name => {},
+        }
+    } else |err| switch (err) {
+        error.Closed => {},
+    }
+
+    return error.AddressNotAvailable;
+}
+
+fn sleepNs(ns: u64) void {
+    var req: posix.timespec = .{
+        .sec = @intCast(ns / std.time.ns_per_s),
+        .nsec = @intCast(ns % std.time.ns_per_s),
+    };
+    while (true) {
+        var rem: posix.timespec = undefined;
+        const rc = linux.nanosleep(&req, &rem);
+        switch (linux.errno(rc)) {
+            .SUCCESS => return,
+            .INTR => req = rem,
+            else => return,
+        }
     }
 }
 
 fn handleConnection(state: *proxy.ProxyState, fd: posix.fd_t) void {
-    defer posix.close(fd);
+    defer closeFd(fd);
 
     // Prevent slow clients from blocking the accept thread.
     if (builtin.os.tag == .linux) {
@@ -85,38 +121,54 @@ fn handleConnection(state: *proxy.ProxyState, fd: posix.fd_t) void {
     };
 }
 
+fn closeFd(fd: posix.fd_t) void {
+    while (true) {
+        switch (posix.errno(posix.system.close(fd))) {
+            .SUCCESS => return,
+            .INTR => continue,
+            else => return,
+        }
+    }
+}
+
 fn writeMetricsResponse(fd: posix.fd_t, state: *proxy.ProxyState) !void {
     var body_buf: [32 * 1024]u8 = undefined;
-    var body_stream = std.io.fixedBufferStream(&body_buf);
-    try writeMetrics(body_stream.writer(), state, collectProcessMetrics());
-    const body = body_stream.getWritten();
+    var body_writer: std.Io.Writer = .fixed(&body_buf);
+    try writeMetrics(&body_writer, state, collectProcessMetrics());
+    const body = body_writer.buffered();
 
     var header_buf: [256]u8 = undefined;
-    var header_stream = std.io.fixedBufferStream(&header_buf);
-    const w = header_stream.writer();
-    try w.print(
+    var header_writer: std.Io.Writer = .fixed(&header_buf);
+    try header_writer.print(
         "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Type: {s}\r\nContent-Length: {d}\r\n\r\n",
         .{ metrics_content_type, body.len },
     );
-    try writeAll(fd, header_stream.getWritten());
+    try writeAll(fd, header_writer.buffered());
     try writeAll(fd, body);
 }
 
 fn writeSimpleResponse(fd: posix.fd_t, status: []const u8, content_type: []const u8, body: []const u8) void {
     var buf: [512]u8 = undefined;
-    var stream = std.io.fixedBufferStream(&buf);
-    const w = stream.writer();
-    w.print(
+    var writer: std.Io.Writer = .fixed(&buf);
+    writer.print(
         "HTTP/1.1 {s}\r\nConnection: close\r\nContent-Type: {s}\r\nContent-Length: {d}\r\n\r\n{s}",
         .{ status, content_type, body.len, body },
     ) catch return;
-    writeAll(fd, stream.getWritten()) catch {};
+    writeAll(fd, writer.buffered()) catch {};
 }
 
 fn writeAll(fd: posix.fd_t, bytes: []const u8) !void {
     var off: usize = 0;
     while (off < bytes.len) {
-        off += try posix.write(fd, bytes[off..]);
+        const rc = linux.write(fd, bytes[off..].ptr, bytes.len - off);
+        switch (linux.errno(rc)) {
+            .SUCCESS => {
+                if (rc == 0) return error.WriteFailed;
+                off += rc;
+            },
+            .INTR => continue,
+            else => return error.WriteFailed,
+        }
     }
 }
 
@@ -332,12 +384,13 @@ fn readCpuSecondsTotal() ?f64 {
 }
 
 fn countOpenFds() ?u64 {
-    var dir = std.fs.openDirAbsolute("/proc/self/fd", .{ .iterate = true }) catch return null;
-    defer dir.close();
+    const io_ctx = std.Io.Threaded.global_single_threaded.io();
+    var dir = std.Io.Dir.openDirAbsolute(io_ctx, "/proc/self/fd", .{ .iterate = true }) catch return null;
+    defer dir.close(io_ctx);
 
     var it = dir.iterate();
     var count: u64 = 0;
-    while (it.next() catch return null) |_| {
+    while (it.next(io_ctx) catch return null) |_| {
         count += 1;
     }
     return count;
@@ -355,10 +408,14 @@ fn readMaxFds() ?u64 {
 }
 
 fn readFileAbsolute(path: []const u8, buffer: []u8) ?[]const u8 {
-    const file = std.fs.openFileAbsolute(path, .{}) catch return null;
-    defer file.close();
-    const len = file.readAll(buffer) catch return null;
-    return buffer[0..len];
+    const io_ctx = std.Io.Threaded.global_single_threaded.io();
+    var file = std.Io.Dir.openFileAbsolute(io_ctx, path, .{}) catch return null;
+    defer file.close(io_ctx);
+    var reader = file.reader(io_ctx, &.{});
+    const content = reader.interface.allocRemaining(std.heap.page_allocator, .limited(buffer.len)) catch return null;
+    defer std.heap.page_allocator.free(content);
+    @memcpy(buffer[0..content.len], content);
+    return buffer[0..content.len];
 }
 
 test "metrics output contains required metrics" {
@@ -372,9 +429,9 @@ test "metrics output contains required metrics" {
     defer state.deinit();
 
     var buf: [32 * 1024]u8 = undefined;
-    var stream = std.io.fixedBufferStream(&buf);
-    try writeMetrics(stream.writer(), &state, .{});
-    const out = stream.getWritten();
+    var writer: std.Io.Writer = .fixed(&buf);
+    try writeMetrics(&writer, &state, .{});
+    const out = writer.buffered();
     try std.testing.expect(std.mem.indexOf(u8, out, "mtproto_connections_active") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "mtproto_build_info") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "mtproto_client_to_upstream_bytes_total") != null);

--- a/src/protocol/constants.zig
+++ b/src/protocol/constants.zig
@@ -1,37 +1,46 @@
 //! Protocol constants and datacenter addresses for MTProto proxy.
 
 const std = @import("std");
+const net = std.Io.net;
+
+fn ip4(bytes: [4]u8, port: u16) net.IpAddress {
+    return .{ .ip4 = .{ .bytes = bytes, .port = port } };
+}
+
+fn ip6(bytes: [16]u8, port: u16) net.IpAddress {
+    return .{ .ip6 = .{ .bytes = bytes, .port = port } };
+}
 
 // ============= Telegram Datacenters =============
 
 pub const tg_datacenter_port: u16 = 443;
 
-pub const tg_datacenters_v4 = [5]std.net.Address{
-    std.net.Address.initIp4(.{ 149, 154, 175, 50 }, tg_datacenter_port),
-    std.net.Address.initIp4(.{ 149, 154, 167, 51 }, tg_datacenter_port),
-    std.net.Address.initIp4(.{ 149, 154, 175, 100 }, tg_datacenter_port),
-    std.net.Address.initIp4(.{ 149, 154, 167, 91 }, tg_datacenter_port),
-    std.net.Address.initIp4(.{ 149, 154, 171, 5 }, tg_datacenter_port),
+pub const tg_datacenters_v4 = [5]net.IpAddress{
+    ip4(.{ 149, 154, 175, 50 }, tg_datacenter_port),
+    ip4(.{ 149, 154, 167, 51 }, tg_datacenter_port),
+    ip4(.{ 149, 154, 175, 100 }, tg_datacenter_port),
+    ip4(.{ 149, 154, 167, 91 }, tg_datacenter_port),
+    ip4(.{ 149, 154, 171, 5 }, tg_datacenter_port),
 };
 
-pub const tg_datacenters_v6 = [5]std.net.Address{
-    std.net.Address.initIp6(.{ 0x20, 0x01, 0x0b, 0x28, 0xf2, 0x3d, 0xf0, 0x01, 0, 0, 0, 0, 0, 0, 0, 0x0a }, tg_datacenter_port, 0, 0),
-    std.net.Address.initIp6(.{ 0x20, 0x01, 0x06, 0x7c, 0x04, 0xe8, 0xf0, 0x02, 0, 0, 0, 0, 0, 0, 0, 0x0a }, tg_datacenter_port, 0, 0),
-    std.net.Address.initIp6(.{ 0x20, 0x01, 0x0b, 0x28, 0xf2, 0x3d, 0xf0, 0x03, 0, 0, 0, 0, 0, 0, 0, 0x0a }, tg_datacenter_port, 0, 0),
-    std.net.Address.initIp6(.{ 0x20, 0x01, 0x06, 0x7c, 0x04, 0xe8, 0xf0, 0x04, 0, 0, 0, 0, 0, 0, 0, 0x0a }, tg_datacenter_port, 0, 0),
-    std.net.Address.initIp6(.{ 0x20, 0x01, 0x0b, 0x28, 0xf2, 0x3f, 0xf0, 0x05, 0, 0, 0, 0, 0, 0, 0, 0x0a }, tg_datacenter_port, 0, 0),
+pub const tg_datacenters_v6 = [5]net.IpAddress{
+    ip6(.{ 0x20, 0x01, 0x0b, 0x28, 0xf2, 0x3d, 0xf0, 0x01, 0, 0, 0, 0, 0, 0, 0, 0x0a }, tg_datacenter_port),
+    ip6(.{ 0x20, 0x01, 0x06, 0x7c, 0x04, 0xe8, 0xf0, 0x02, 0, 0, 0, 0, 0, 0, 0, 0x0a }, tg_datacenter_port),
+    ip6(.{ 0x20, 0x01, 0x0b, 0x28, 0xf2, 0x3d, 0xf0, 0x03, 0, 0, 0, 0, 0, 0, 0, 0x0a }, tg_datacenter_port),
+    ip6(.{ 0x20, 0x01, 0x06, 0x7c, 0x04, 0xe8, 0xf0, 0x04, 0, 0, 0, 0, 0, 0, 0, 0x0a }, tg_datacenter_port),
+    ip6(.{ 0x20, 0x01, 0x0b, 0x28, 0xf2, 0x3f, 0xf0, 0x05, 0, 0, 0, 0, 0, 0, 0, 0x0a }, tg_datacenter_port),
 };
 
 pub const tg_middle_proxy_port: u16 = 8888;
 
 /// Default MiddleProxy endpoints per primary DC (1..5), regular (non-media) path.
 /// Refreshed at runtime from getProxyConfig when available.
-pub const tg_middle_proxies_v4 = [5]std.net.Address{
-    std.net.Address.initIp4(.{ 149, 154, 175, 50 }, tg_middle_proxy_port),
-    std.net.Address.initIp4(.{ 149, 154, 161, 144 }, tg_middle_proxy_port),
-    std.net.Address.initIp4(.{ 149, 154, 175, 100 }, tg_middle_proxy_port),
-    std.net.Address.initIp4(.{ 91, 108, 4, 169 }, tg_middle_proxy_port),
-    std.net.Address.initIp4(.{ 91, 108, 56, 170 }, tg_middle_proxy_port),
+pub const tg_middle_proxies_v4 = [5]net.IpAddress{
+    ip4(.{ 149, 154, 175, 50 }, tg_middle_proxy_port),
+    ip4(.{ 149, 154, 161, 144 }, tg_middle_proxy_port),
+    ip4(.{ 149, 154, 175, 100 }, tg_middle_proxy_port),
+    ip4(.{ 91, 108, 4, 169 }, tg_middle_proxy_port),
+    ip4(.{ 91, 108, 56, 170 }, tg_middle_proxy_port),
 };
 
 /// Default MiddleProxy endpoints per primary DC (1..5), media path (dc_idx < 0).
@@ -39,19 +48,19 @@ pub const tg_middle_proxies_v4 = [5]std.net.Address{
 /// client to a regular MP causes large file downloads to stall or silently
 /// drop. Keep these in sync with `proxy_for -N` lines in getProxyConfig.
 /// Refreshed at runtime from getProxyConfig when available.
-pub const tg_media_middle_proxies_v4 = [5]std.net.Address{
-    std.net.Address.initIp4(.{ 149, 154, 175, 50 }, tg_middle_proxy_port),
-    std.net.Address.initIp4(.{ 149, 154, 161, 184 }, tg_middle_proxy_port),
-    std.net.Address.initIp4(.{ 149, 154, 175, 100 }, tg_middle_proxy_port),
-    std.net.Address.initIp4(.{ 149, 154, 164, 250 }, tg_middle_proxy_port),
-    std.net.Address.initIp4(.{ 91, 108, 56, 170 }, tg_middle_proxy_port),
+pub const tg_media_middle_proxies_v4 = [5]net.IpAddress{
+    ip4(.{ 149, 154, 175, 50 }, tg_middle_proxy_port),
+    ip4(.{ 149, 154, 161, 184 }, tg_middle_proxy_port),
+    ip4(.{ 149, 154, 175, 100 }, tg_middle_proxy_port),
+    ip4(.{ 149, 154, 164, 250 }, tg_middle_proxy_port),
+    ip4(.{ 91, 108, 56, 170 }, tg_middle_proxy_port),
 };
 
 /// Resolves physical Datacenter IP by its index, handling special media DCs.
-pub fn getDcAddressV4(abs_dc: usize) std.net.Address {
+pub fn getDcAddressV4(abs_dc: usize) net.IpAddress {
     if (abs_dc == 203) {
         // Media DC 203 has a dedicated network, resolving to MiddleProxy IP
-        return std.net.Address.initIp4(.{ 91, 105, 192, 110 }, tg_datacenter_port);
+        return ip4(.{ 91, 105, 192, 110 }, tg_datacenter_port);
     }
     if (abs_dc >= 1 and abs_dc <= tg_datacenters_v4.len) {
         return tg_datacenters_v4[abs_dc - 1];
@@ -70,7 +79,7 @@ pub const ProtoTag = enum(u32) {
 
     pub fn fromBytes(bytes: [4]u8) ?ProtoTag {
         const val = std.mem.readInt(u32, &bytes, .little);
-        return std.meta.intToEnum(ProtoTag, val) catch null;
+        return std.enums.fromInt(ProtoTag, val);
     }
 
     pub fn toBytes(self: ProtoTag) [4]u8 {

--- a/src/protocol/middleproxy.zig
+++ b/src/protocol/middleproxy.zig
@@ -1,8 +1,12 @@
 const std = @import("std");
-const net = std.net;
+const net = std.Io.net;
 const posix = std.posix;
 const crypto = @import("../crypto/crypto.zig");
 const constants = @import("constants.zig");
+
+fn ip4(bytes: [4]u8, port: u16) net.IpAddress {
+    return .{ .ip4 = .{ .bytes = bytes, .port = port } };
+}
 
 pub const proxy_secret = [128]u8{
     0xc4, 0xf9, 0xfa, 0xca, 0x96, 0x78, 0xe6, 0xbb, 0x48, 0xad, 0x6c, 0x7e, 0x2c, 0xe5, 0xc0, 0xd2,
@@ -130,8 +134,8 @@ pub const MiddleProxyContext = struct {
         decryptor: crypto.AesCbc,
         conn_id: [8]u8,
         initial_seq_no: i32,
-        remote_addr: net.Address,
-        our_addr: net.Address,
+        remote_addr: net.IpAddress,
+        our_addr: net.IpAddress,
         proto_tag: constants.ProtoTag,
         ad_tag: ?[16]u8,
     ) !MiddleProxyContext {
@@ -155,37 +159,43 @@ pub const MiddleProxyContext = struct {
         decryptor: crypto.AesCbc,
         conn_id: [8]u8,
         initial_seq_no: i32,
-        remote_addr: net.Address,
-        our_addr: net.Address,
+        remote_addr: net.IpAddress,
+        our_addr: net.IpAddress,
         proto_tag: constants.ProtoTag,
         ad_tag: ?[16]u8,
         buffer_size: usize,
     ) !MiddleProxyContext {
         var rip: [20]u8 = undefined;
         var rport: u16 = 0;
-        if (remote_addr.any.family == posix.AF.INET) {
-            const ipv4_mapped = [_]u8{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff };
-            @memcpy(rip[0..12], &ipv4_mapped);
-            @memcpy(rip[12..16], std.mem.asBytes(&remote_addr.in.sa.addr));
-            rport = remote_addr.in.sa.port;
-        } else if (remote_addr.any.family == posix.AF.INET6) {
-            @memcpy(rip[0..16], &remote_addr.in6.sa.addr);
-            rport = remote_addr.in6.sa.port;
-        } else return error.UnsupportedAddressType;
-        std.mem.writeInt(u32, rip[16..20], std.mem.bigToNative(u16, rport), .little);
+        switch (remote_addr) {
+            .ip4 => |addr| {
+                const ipv4_mapped = [_]u8{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff };
+                @memcpy(rip[0..12], &ipv4_mapped);
+                @memcpy(rip[12..16], &addr.bytes);
+                rport = addr.port;
+            },
+            .ip6 => |addr| {
+                @memcpy(rip[0..16], &addr.bytes);
+                rport = addr.port;
+            },
+        }
+        std.mem.writeInt(u32, rip[16..20], rport, .little);
 
         var oip: [20]u8 = undefined;
         var oport: u16 = 0;
-        if (our_addr.any.family == posix.AF.INET) {
-            const ipv4_mapped = [_]u8{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff };
-            @memcpy(oip[0..12], &ipv4_mapped);
-            @memcpy(oip[12..16], std.mem.asBytes(&our_addr.in.sa.addr));
-            oport = our_addr.in.sa.port;
-        } else if (our_addr.any.family == posix.AF.INET6) {
-            @memcpy(oip[0..16], &our_addr.in6.sa.addr);
-            oport = our_addr.in6.sa.port;
-        } else return error.UnsupportedAddressType;
-        std.mem.writeInt(u32, oip[16..20], std.mem.bigToNative(u16, oport), .little);
+        switch (our_addr) {
+            .ip4 => |addr| {
+                const ipv4_mapped = [_]u8{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff };
+                @memcpy(oip[0..12], &ipv4_mapped);
+                @memcpy(oip[12..16], &addr.bytes);
+                oport = addr.port;
+            },
+            .ip6 => |addr| {
+                @memcpy(oip[0..16], &addr.bytes);
+                oport = addr.port;
+            },
+        }
+        std.mem.writeInt(u32, oip[16..20], oport, .little);
 
         const s2c_buf = try allocator.alloc(u8, buffer_size);
         errdefer allocator.free(s2c_buf);
@@ -451,9 +461,9 @@ pub const MiddleProxyContext = struct {
                 var pad_len: usize = 0;
                 var pad_buf: [15]u8 = undefined;
                 if (self.proto_tag == .secure) {
-                    pad_len = std.crypto.random.intRangeLessThan(usize, 0, 16);
+                    pad_len = crypto.randomRange(usize, 16);
                     if (pad_len > 0) {
-                        std.crypto.random.bytes(pad_buf[0..pad_len]);
+                        crypto.randomBytes(pad_buf[0..pad_len]);
                     }
                 }
 
@@ -527,8 +537,8 @@ test "encapsulated c2s keeps rpc_proxy_req header" {
         crypto.AesCbc.init(&key, &iv),
         [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 },
         -2,
-        std.net.Address.initIp4(.{ 10, 20, 30, 40 }, 12345),
-        std.net.Address.initIp4(.{ 91, 105, 192, 110 }, 443),
+        ip4(.{ 10, 20, 30, 40 }, 12345),
+        ip4(.{ 91, 105, 192, 110 }, 443),
         .intermediate,
         null,
     );
@@ -563,8 +573,8 @@ test "encapsulated c2s omits ad_tag block when absent" {
         crypto.AesCbc.init(&key, &iv),
         [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 },
         -2,
-        std.net.Address.initIp4(.{ 10, 20, 30, 40 }, 12345),
-        std.net.Address.initIp4(.{ 91, 105, 192, 110 }, 443),
+        ip4(.{ 10, 20, 30, 40 }, 12345),
+        ip4(.{ 91, 105, 192, 110 }, 443),
         .intermediate,
         null,
     );
@@ -599,8 +609,8 @@ test "encapsulate c2s rejects unaligned payload length" {
         crypto.AesCbc.init(&key, &iv),
         [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 },
         -2,
-        std.net.Address.initIp4(.{ 10, 20, 30, 40 }, 12345),
-        std.net.Address.initIp4(.{ 91, 105, 192, 110 }, 443),
+        ip4(.{ 10, 20, 30, 40 }, 12345),
+        ip4(.{ 91, 105, 192, 110 }, 443),
         .intermediate,
         null,
     );
@@ -628,8 +638,8 @@ test "encapsulated c2s includes ad_tag block when present" {
         crypto.AesCbc.init(&key, &iv),
         [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 },
         -2,
-        std.net.Address.initIp4(.{ 10, 20, 30, 40 }, 12345),
-        std.net.Address.initIp4(.{ 91, 105, 192, 110 }, 443),
+        ip4(.{ 10, 20, 30, 40 }, 12345),
+        ip4(.{ 91, 105, 192, 110 }, 443),
         .intermediate,
         ad_tag,
     );
@@ -670,8 +680,8 @@ test "decapsulate s2c skips noop padding words" {
         crypto.AesCbc.init(&key, &iv),
         [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 },
         -2,
-        std.net.Address.initIp4(.{ 10, 20, 30, 40 }, 12345),
-        std.net.Address.initIp4(.{ 91, 105, 192, 110 }, 443),
+        ip4(.{ 10, 20, 30, 40 }, 12345),
+        ip4(.{ 91, 105, 192, 110 }, 443),
         .intermediate,
         null,
     );
@@ -730,8 +740,8 @@ test "decapsulate s2c validates seq and checksum" {
         crypto.AesCbc.init(&key, &iv),
         [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 },
         -2,
-        std.net.Address.initIp4(.{ 10, 20, 30, 40 }, 12345),
-        std.net.Address.initIp4(.{ 91, 105, 192, 110 }, 443),
+        ip4(.{ 10, 20, 30, 40 }, 12345),
+        ip4(.{ 91, 105, 192, 110 }, 443),
         .intermediate,
         null,
     );
@@ -786,8 +796,8 @@ test "encapsulate c2s supports payloads larger than 64KiB" {
         crypto.AesCbc.init(&key, &iv),
         [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 },
         -2,
-        std.net.Address.initIp4(.{ 10, 20, 30, 40 }, 12345),
-        std.net.Address.initIp4(.{ 91, 105, 192, 110 }, 443),
+        ip4(.{ 10, 20, 30, 40 }, 12345),
+        ip4(.{ 91, 105, 192, 110 }, 443),
         .intermediate,
         null,
     );

--- a/src/protocol/tls.zig
+++ b/src/protocol/tls.zig
@@ -8,6 +8,13 @@ const constants = @import("constants.zig");
 const crypto = @import("../crypto/crypto.zig");
 const obfuscation = @import("obfuscation.zig");
 
+fn realtimeSeconds() i64 {
+    var ts: std.posix.timespec = undefined;
+    const rc = std.posix.system.clock_gettime(.REALTIME, &ts);
+    if (std.posix.errno(rc) != .SUCCESS) return 0;
+    return @intCast(ts.sec);
+}
+
 /// Re-export for convenience
 pub const UserSecret = obfuscation.UserSecret;
 
@@ -58,10 +65,7 @@ pub fn validateTlsHandshake(
     const HmacSha256 = std.crypto.auth.hmac.sha2.HmacSha256;
     const zero_digest = [_]u8{0} ** constants.tls_digest_len;
 
-    const now: i64 = if (!ignore_time_skew)
-        @intCast(std.time.timestamp())
-    else
-        0;
+    const now: i64 = if (!ignore_time_skew) realtimeSeconds() else 0;
 
     for (secrets) |entry| {
         var hmac = HmacSha256.init(&entry.secret);
@@ -217,7 +221,7 @@ const nginx_template: [nginx_template_len]u8 = blk: {
 };
 
 pub fn buildServerHelloTemplate(seed: ?u64) [nginx_template_len]u8 {
-    const actual_seed = seed orelse std.crypto.random.int(u64);
+    const actual_seed = seed orelse crypto.randomInt(u64);
     return buildNginxTemplate(actual_seed);
 }
 

--- a/src/proxy/connection_phase.zig
+++ b/src/proxy/connection_phase.zig
@@ -1,0 +1,81 @@
+const std = @import("std");
+const posix = std.posix;
+const linux = std.os.linux;
+
+pub const ConnectionPhase = enum {
+    idle,
+    reading_tls_header,
+    reading_client_hello_body,
+    writing_server_hello_first,
+    desync_wait,
+    writing_server_hello_rest,
+    reading_mtproto_tls_header,
+    reading_mtproto_tls_body,
+    connecting_upstream,
+    // SOCKS5 proxy handshake sub-phases
+    proxy_socks5_greeting,
+    proxy_socks5_greeting_resp,
+    proxy_socks5_auth,
+    proxy_socks5_auth_resp,
+    proxy_socks5_connect,
+    proxy_socks5_connect_resp,
+    // HTTP CONNECT proxy handshake sub-phases
+    proxy_http_connect,
+    proxy_http_connect_resp,
+    writing_dc_nonce,
+    middle_proxy_handshake,
+    relaying,
+    mask_relaying,
+    closing,
+};
+
+pub fn hasFatalEpollHangup(events: u32) bool {
+    return (events & (linux.EPOLL.ERR | linux.EPOLL.HUP | linux.EPOLL.RDHUP)) != 0;
+}
+
+/// Check if a phase is one of the proxy handshake sub-phases.
+pub fn isProxyHandshakePhase(phase: ConnectionPhase) bool {
+    return switch (phase) {
+        .proxy_socks5_greeting,
+        .proxy_socks5_greeting_resp,
+        .proxy_socks5_auth,
+        .proxy_socks5_auth_resp,
+        .proxy_socks5_connect,
+        .proxy_socks5_connect_resp,
+        .proxy_http_connect,
+        .proxy_http_connect_resp,
+        => true,
+        else => false,
+    };
+}
+
+pub fn shouldCloseOnFatalHangup(phase: ConnectionPhase, event_fd: posix.fd_t, upstream_fd: posix.fd_t) bool {
+    if (phase == .idle) return false;
+
+    // During connecting_upstream, EPOLLERR on upstream fd is expected and
+    // handled via onUpstreamWritable -> onUpstreamConnectComplete.
+    if (phase == .connecting_upstream and event_fd == upstream_fd) return false;
+
+    // During proxy handshake phases, upstream hangup is a proxy
+    // connect failure — let the handler deal with it.
+    if (isProxyHandshakePhase(phase) and event_fd == upstream_fd) return false;
+
+    return true;
+}
+
+test "epoll hangup helper" {
+    try std.testing.expect(hasFatalEpollHangup(linux.EPOLL.RDHUP));
+    try std.testing.expect(hasFatalEpollHangup(linux.EPOLL.HUP));
+    try std.testing.expect(hasFatalEpollHangup(linux.EPOLL.ERR));
+    try std.testing.expect(!hasFatalEpollHangup(linux.EPOLL.IN));
+}
+
+test "fatal hangup close policy distinguishes client/upstream while connecting" {
+    const client_fd: posix.fd_t = 41;
+    const upstream_fd: posix.fd_t = 42;
+
+    try std.testing.expect(shouldCloseOnFatalHangup(.connecting_upstream, client_fd, upstream_fd));
+    try std.testing.expect(!shouldCloseOnFatalHangup(.connecting_upstream, upstream_fd, upstream_fd));
+    try std.testing.expect(shouldCloseOnFatalHangup(.reading_tls_header, client_fd, upstream_fd));
+    try std.testing.expect(!shouldCloseOnFatalHangup(.idle, client_fd, upstream_fd));
+}

--- a/src/proxy/connection_pool.zig
+++ b/src/proxy/connection_pool.zig
@@ -1,0 +1,97 @@
+const std = @import("std");
+const posix = std.posix;
+
+pub fn ConnectionPool(comptime SlotType: type) type {
+    return struct {
+        const Self = @This();
+
+        allocator: std.mem.Allocator,
+        slots: []?*SlotType,
+        free_stack: []u32,
+        free_count: u32,
+        allocated_hi: u32,
+        fd_to_slot: std.AutoHashMapUnmanaged(posix.fd_t, u32) = .{},
+
+        pub fn init(allocator: std.mem.Allocator, capacity: u32) !Self {
+            const slots = try allocator.alloc(?*SlotType, capacity);
+            errdefer allocator.free(slots);
+
+            const free_stack = try allocator.alloc(u32, capacity);
+            errdefer allocator.free(free_stack);
+
+            for (slots) |*slot| {
+                slot.* = null;
+            }
+
+            var i: usize = 0;
+            while (i < capacity) : (i += 1) {
+                free_stack[i] = @intCast(capacity - 1 - i);
+            }
+
+            var pool = Self{
+                .allocator = allocator,
+                .slots = slots,
+                .free_stack = free_stack,
+                .free_count = capacity,
+                .allocated_hi = 0,
+                .fd_to_slot = .{},
+            };
+            try pool.fd_to_slot.ensureTotalCapacity(allocator, @as(u32, capacity * 2));
+            return pool;
+        }
+
+        pub fn deinit(self: *Self) void {
+            for (self.slots) |slot_opt| {
+                if (slot_opt) |slot_ptr| {
+                    self.allocator.destroy(slot_ptr);
+                }
+            }
+            self.fd_to_slot.deinit(self.allocator);
+            self.allocator.free(self.free_stack);
+            self.allocator.free(self.slots);
+        }
+
+        pub fn acquire(self: *Self) ?*SlotType {
+            if (self.free_count == 0) return null;
+            self.free_count -= 1;
+            const idx = self.free_stack[self.free_count];
+            if (self.slots[idx] == null) {
+                const fresh = self.allocator.create(SlotType) catch {
+                    self.free_stack[self.free_count] = idx;
+                    self.free_count += 1;
+                    return null;
+                };
+                fresh.* = .{};
+                self.slots[idx] = fresh;
+                const hi = idx + 1;
+                if (hi > self.allocated_hi) self.allocated_hi = hi;
+            }
+
+            const slot = self.slots[idx].?;
+            slot.* = .{};
+            slot.index = idx;
+            slot.client_queue.allocator = self.allocator;
+            slot.upstream_queue.allocator = self.allocator;
+            return slot;
+        }
+
+        pub fn release(self: *Self, slot: *SlotType) void {
+            self.free_stack[self.free_count] = slot.index;
+            self.free_count += 1;
+            slot.phase = .idle;
+        }
+
+        pub fn mapFd(self: *Self, fd: posix.fd_t, idx: u32) !void {
+            try self.fd_to_slot.put(self.allocator, fd, idx);
+        }
+
+        pub fn unmapFd(self: *Self, fd: posix.fd_t) void {
+            _ = self.fd_to_slot.remove(fd);
+        }
+
+        pub fn getByFd(self: *Self, fd: posix.fd_t) ?*SlotType {
+            const idx = self.fd_to_slot.get(fd) orelse return null;
+            return self.slots[idx];
+        }
+    };
+}

--- a/src/proxy/dc_nonce.zig
+++ b/src/proxy/dc_nonce.zig
@@ -1,0 +1,103 @@
+const std = @import("std");
+
+const constants = @import("../protocol/constants.zig");
+const crypto = @import("../crypto/crypto.zig");
+const obfuscation = @import("../protocol/obfuscation.zig");
+
+const log = std.log.scoped(.proxy);
+
+pub fn send(
+    loop: anytype,
+    slot: anytype,
+    comptime queue_upstream: fn (@TypeOf(loop), @TypeOf(slot), []const u8) anyerror!bool,
+    comptime close_slot: fn (@TypeOf(loop), @TypeOf(slot), []const u8) void,
+) void {
+    const params = slot.obf_params orelse {
+        close_slot(loop, slot, "missing obfuscation params");
+        return;
+    };
+
+    var tg_nonce = obfuscation.generateNonce();
+
+    if (slot.use_fast_mode) {
+        var client_s2c_key_iv: [constants.key_len + constants.iv_len]u8 = undefined;
+        @memcpy(client_s2c_key_iv[0..constants.key_len], &params.encrypt_key);
+        std.mem.writeInt(u128, client_s2c_key_iv[constants.key_len..][0..constants.iv_len], params.encrypt_iv, .big);
+        obfuscation.prepareTgNonce(&tg_nonce, params.proto_tag, &client_s2c_key_iv);
+    } else {
+        obfuscation.prepareTgNonce(&tg_nonce, params.proto_tag, null);
+    }
+
+    std.mem.writeInt(i16, tg_nonce[constants.dc_idx_pos..][0..2], params.dc_idx, .little);
+
+    const tg_enc_key_iv = tg_nonce[constants.skip_len..][0 .. constants.key_len + constants.iv_len];
+    var tg_enc_key: [constants.key_len]u8 = tg_enc_key_iv[0..constants.key_len].*;
+    var tg_enc_iv_bytes: [constants.iv_len]u8 = tg_enc_key_iv[constants.key_len..][0..constants.iv_len].*;
+    const tg_enc_iv = std.mem.readInt(u128, &tg_enc_iv_bytes, .big);
+
+    var tg_dec_key_iv: [constants.key_len + constants.iv_len]u8 = undefined;
+    for (0..tg_enc_key_iv.len) |i| {
+        tg_dec_key_iv[i] = tg_enc_key_iv[tg_enc_key_iv.len - 1 - i];
+    }
+    var tg_dec_key: [constants.key_len]u8 = tg_dec_key_iv[0..constants.key_len].*;
+    const tg_dec_iv = std.mem.readInt(u128, tg_dec_key_iv[constants.key_len..][0..constants.iv_len], .big);
+
+    var tg_encryptor = crypto.AesCtr.init(&tg_enc_key, tg_enc_iv);
+    var encrypted_nonce: [constants.handshake_len]u8 = undefined;
+    @memcpy(&encrypted_nonce, &tg_nonce);
+    tg_encryptor.apply(&encrypted_nonce);
+
+    var nonce_to_send: [constants.handshake_len]u8 = undefined;
+    @memcpy(nonce_to_send[0..constants.proto_tag_pos], tg_nonce[0..constants.proto_tag_pos]);
+    @memcpy(nonce_to_send[constants.proto_tag_pos..], encrypted_nonce[constants.proto_tag_pos..]);
+
+    if (queue_upstream(loop, slot, &nonce_to_send)) |_| {} else |err| {
+        log.debug("[{d}] queue dc nonce failed: {any}", .{ slot.conn_id, err });
+        close_slot(loop, slot, "queue dc nonce failed");
+        return;
+    }
+
+    // Promotion tag (optional), only for primary DC1..5.
+    if (loop.state.config.tag) |tag| {
+        const dc_abs = if (params.dc_idx > 0) @as(usize, @intCast(params.dc_idx)) else @as(usize, @abs(params.dc_idx));
+        if (dc_abs >= 1 and dc_abs <= constants.tg_datacenters_v4.len and dc_abs != 203) {
+            var promote_buf: [32]u8 = undefined;
+            var packet_len: usize = 0;
+
+            const rpc_id: u32 = 0xaeaf0c42;
+            var rpc_payload: [20]u8 = undefined;
+            std.mem.writeInt(u32, rpc_payload[0..4], rpc_id, .little);
+            @memcpy(rpc_payload[4..20], &tag);
+
+            switch (params.proto_tag) {
+                .abridged => {
+                    promote_buf[0] = 5;
+                    @memcpy(promote_buf[1..21], &rpc_payload);
+                    packet_len = 21;
+                },
+                .intermediate, .secure => {
+                    std.mem.writeInt(u32, promote_buf[0..4], 20, .little);
+                    @memcpy(promote_buf[4..24], &rpc_payload);
+                    packet_len = 24;
+                },
+            }
+
+            const tail = loop.state.allocator.alloc(u8, packet_len) catch {
+                close_slot(loop, slot, "alloc promotion tail failed");
+                return;
+            };
+            @memcpy(tail, promote_buf[0..packet_len]);
+            tg_encryptor.apply(tail);
+            slot.dc_initial_tail = tail;
+        }
+    }
+
+    slot.tg_encryptor = tg_encryptor;
+    slot.tg_decryptor = crypto.AesCtr.init(&tg_dec_key, tg_dec_iv);
+    slot.phase = .writing_dc_nonce;
+
+    @memset(&tg_enc_key, 0);
+    @memset(&tg_enc_iv_bytes, 0);
+    @memset(&tg_dec_key, 0);
+    @memset(&tg_dec_key_iv, 0);
+}

--- a/src/proxy/drs.zig
+++ b/src/proxy/drs.zig
@@ -1,0 +1,59 @@
+const std = @import("std");
+const constants = @import("../protocol/constants.zig");
+
+pub const DynamicRecordSizer = struct {
+    current_size: usize,
+    records_sent: u32,
+    bytes_sent: u64,
+    enabled: bool,
+
+    pub const initial_size: usize = 1369;
+    pub const full_size: usize = constants.max_tls_plaintext_size;
+    pub const ramp_record_threshold: u32 = 8;
+    pub const ramp_byte_threshold: u64 = 128 * 1024;
+
+    pub fn init(enabled: bool) DynamicRecordSizer {
+        // When DRS is disabled the user opted out of anti-DPI record-size
+        // masking, so there is no reason to keep clamping records to the
+        // probe-friendly 1369-byte size — doing so only hurts throughput.
+        // Start at the full TLS plaintext size and short-circuit ramp-up.
+        return .{
+            .current_size = if (enabled) initial_size else full_size,
+            .records_sent = 0,
+            .bytes_sent = 0,
+            .enabled = enabled,
+        };
+    }
+
+    pub fn nextRecordSize(self: *DynamicRecordSizer) usize {
+        return self.current_size;
+    }
+
+    pub fn recordSent(self: *DynamicRecordSizer, payload_len: usize) void {
+        if (!self.enabled) return;
+        self.records_sent += 1;
+        self.bytes_sent += @as(u64, @intCast(payload_len));
+        if (self.current_size == initial_size and
+            (self.records_sent >= ramp_record_threshold or self.bytes_sent >= ramp_byte_threshold))
+        {
+            self.current_size = full_size;
+        }
+    }
+};
+
+test "DRS disabled skips ramp and uses full TLS record size" {
+    // Regression: prior behaviour initialised `current_size` to the probe-
+    // friendly 1369-byte size even when the user disabled DRS, bottlenecking
+    // downstream throughput forever. Disabled DRS must start (and stay) at
+    // the full TLS plaintext size.
+    var drs = DynamicRecordSizer.init(false);
+    try std.testing.expectEqual(DynamicRecordSizer.full_size, drs.nextRecordSize());
+    for (0..32) |_| drs.recordSent(1369);
+    try std.testing.expectEqual(DynamicRecordSizer.full_size, drs.nextRecordSize());
+}
+
+test "DRS enabled ramps" {
+    var drs = DynamicRecordSizer.init(true);
+    for (0..8) |_| drs.recordSent(1369);
+    try std.testing.expectEqual(DynamicRecordSizer.full_size, drs.nextRecordSize());
+}

--- a/src/proxy/fd_limits.zig
+++ b/src/proxy/fd_limits.zig
@@ -1,0 +1,51 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const posix = std.posix;
+const linux = std.os.linux;
+
+const log = std.log.scoped(.proxy);
+
+const nofile_fd_overhead: usize = 512;
+
+pub fn requiredFdsForConnections(max_connections: u32) usize {
+    return @as(usize, max_connections) * 2 + nofile_fd_overhead;
+}
+
+pub fn maxConnectionsForNofile(soft_nofile: usize) u32 {
+    if (soft_nofile <= nofile_fd_overhead + 2) return 32;
+
+    const cap = (soft_nofile - nofile_fd_overhead) / 2;
+    const capped_u32: u32 = @intCast(@min(cap, @as(usize, std.math.maxInt(u32))));
+    return @max(@as(u32, 32), capped_u32);
+}
+
+pub fn getNofileSoftLimit() ?usize {
+    if (builtin.os.tag != .linux) return null;
+
+    var lim: linux.rlimit = undefined;
+    const rc = linux.getrlimit(.NOFILE, &lim);
+    switch (posix.errno(rc)) {
+        .SUCCESS => {},
+        else => return null,
+    }
+
+    return @intCast(lim.cur);
+}
+
+pub fn checkNofileLimit(required: usize, max_connections: u32) void {
+    const soft = getNofileSoftLimit() orelse return;
+
+    if (soft >= required) return;
+
+    log.warn("RLIMIT_NOFILE soft limit is {d}, recommended >= {d} for max_connections={d}", .{
+        soft,
+        required,
+        max_connections,
+    });
+}
+
+test "fd requirement helpers" {
+    try std.testing.expectEqual(@as(usize, 131582), requiredFdsForConnections(65535));
+    try std.testing.expectEqual(@as(u32, 65535), maxConnectionsForNofile(131582));
+    try std.testing.expectEqual(@as(u32, 32511), maxConnectionsForNofile(65535));
+}

--- a/src/proxy/http_connect.zig
+++ b/src/proxy/http_connect.zig
@@ -5,7 +5,11 @@
 //! handshake through the non-blocking epoll event loop.
 
 const std = @import("std");
-const net = std.net;
+const net = std.Io.net;
+
+fn ip4(bytes: [4]u8, port: u16) net.IpAddress {
+    return .{ .ip4 = .{ .bytes = bytes, .port = port } };
+}
 
 // ─── Request Building ────────────────────────────────────────
 
@@ -20,7 +24,7 @@ const net = std.net;
 /// Returns the slice of `buf` used, or empty on overflow.
 pub fn buildConnectRequest(
     buf: []u8,
-    addr: net.Address,
+    addr: net.IpAddress,
     username: ?[]const u8,
     password: ?[]const u8,
 ) []u8 {
@@ -145,46 +149,39 @@ fn copyInto(dst: []u8, src: []const u8) ?usize {
     return src.len;
 }
 
-fn formatAddress(addr: net.Address, buf: []u8) []const u8 {
-    if (addr.any.family == std.posix.AF.INET) {
-        const ip = std.mem.asBytes(&addr.in.sa.addr);
-        const port = std.mem.bigToNative(u16, addr.in.sa.port);
-        const str = std.fmt.bufPrint(buf, "{d}.{d}.{d}.{d}:{d}", .{
-            ip[0], ip[1], ip[2], ip[3], port,
-        }) catch return "";
-        return str;
-    } else if (addr.any.family == std.posix.AF.INET6) {
-        const port = std.mem.bigToNative(u16, addr.in6.sa.port);
-        // For IPv6, use bracket notation
-        var ip_buf: [46]u8 = undefined;
-        var ip_len: usize = 0;
-        const ip6 = &addr.in6.sa.addr;
+fn formatAddress(addr: net.IpAddress, buf: []u8) []const u8 {
+    return switch (addr) {
+        .ip4 => |a| std.fmt.bufPrint(buf, "{d}.{d}.{d}.{d}:{d}", .{
+            a.bytes[0], a.bytes[1], a.bytes[2], a.bytes[3], a.port,
+        }) catch "",
+        .ip6 => |a| blk: {
+            var ip_buf: [46]u8 = undefined;
+            var ip_len: usize = 0;
+            const ip6_bytes = &a.bytes;
 
-        // Simple hex format for IPv6
-        var i: usize = 0;
-        while (i < 16) : (i += 2) {
-            if (i > 0) {
-                ip_buf[ip_len] = ':';
-                ip_len += 1;
+            var i: usize = 0;
+            while (i < 16) : (i += 2) {
+                if (i > 0) {
+                    ip_buf[ip_len] = ':';
+                    ip_len += 1;
+                }
+                const word = @as(u16, ip6_bytes[i]) << 8 | @as(u16, ip6_bytes[i + 1]);
+                const hex = std.fmt.bufPrint(ip_buf[ip_len..], "{x}", .{word}) catch return "";
+                ip_len += hex.len;
             }
-            const word = @as(u16, ip6[i]) << 8 | @as(u16, ip6[i + 1]);
-            const hex = std.fmt.bufPrint(ip_buf[ip_len..], "{x}", .{word}) catch return "";
-            ip_len += hex.len;
-        }
 
-        const str = std.fmt.bufPrint(buf, "[{s}]:{d}", .{
-            ip_buf[0..ip_len], port,
-        }) catch return "";
-        return str;
-    }
-    return "";
+            break :blk std.fmt.bufPrint(buf, "[{s}]:{d}", .{
+                ip_buf[0..ip_len], a.port,
+            }) catch "";
+        },
+    };
 }
 
 // ─── Tests ───────────────────────────────────────────────────
 
 test "http_connect - build request without auth" {
     var buf: [1024]u8 = undefined;
-    const addr = net.Address.initIp4(.{ 149, 154, 167, 51 }, 443);
+    const addr = ip4(.{ 149, 154, 167, 51 }, 443);
     const msg = buildConnectRequest(&buf, addr, null, null);
 
     try std.testing.expect(msg.len > 0);
@@ -196,7 +193,7 @@ test "http_connect - build request without auth" {
 
 test "http_connect - build request with auth" {
     var buf: [1024]u8 = undefined;
-    const addr = net.Address.initIp4(.{ 149, 154, 167, 51 }, 443);
+    const addr = ip4(.{ 149, 154, 167, 51 }, 443);
     const msg = buildConnectRequest(&buf, addr, "admin", "fr6CgjUvxFEAn5vs");
 
     try std.testing.expect(msg.len > 0);
@@ -207,7 +204,7 @@ test "http_connect - build request with auth" {
 
 test "http_connect - build request with empty username skips auth" {
     var buf: [1024]u8 = undefined;
-    const addr = net.Address.initIp4(.{ 149, 154, 167, 51 }, 443);
+    const addr = ip4(.{ 149, 154, 167, 51 }, 443);
     const msg = buildConnectRequest(&buf, addr, "", "");
 
     try std.testing.expect(std.mem.indexOf(u8, msg, "Proxy-Authorization") == null);
@@ -250,7 +247,7 @@ test "http_connect - parse response with pipelined payload" {
 
 test "http_connect - address formatting ipv4" {
     var buf: [64]u8 = undefined;
-    const addr = net.Address.initIp4(.{ 10, 0, 0, 1 }, 8080);
+    const addr = ip4(.{ 10, 0, 0, 1 }, 8080);
     const str = formatAddress(addr, &buf);
     try std.testing.expectEqualStrings("10.0.0.1:8080", str);
 }

--- a/src/proxy/http_fetch.zig
+++ b/src/proxy/http_fetch.zig
@@ -1,0 +1,94 @@
+const std = @import("std");
+
+const log = std.log.scoped(.proxy);
+
+pub fn fetchUrlBytes(allocator: std.mem.Allocator, url: []const u8) ![]u8 {
+    const uri = try std.Uri.parse(url);
+
+    var client: std.http.Client = .{
+        .allocator = allocator,
+        .io = std.Io.Threaded.global_single_threaded.io(),
+    };
+    defer client.deinit();
+
+    var req = try client.request(.GET, uri, .{
+        .redirect_behavior = @enumFromInt(3),
+        .keep_alive = false,
+        .headers = .{
+            .accept_encoding = .{ .override = "identity" },
+        },
+    });
+    defer req.deinit();
+
+    try req.sendBodiless();
+
+    var redirect_buf: [8 * 1024]u8 = undefined;
+    var response = try req.receiveHead(&redirect_buf);
+    if (response.head.status.class() != .success) return error.HttpRequestFailed;
+
+    var transfer_buf: [4 * 1024]u8 = undefined;
+    const reader = response.reader(&transfer_buf);
+    return reader.allocRemaining(allocator, .limited(1 * 1024 * 1024));
+}
+
+/// Fetch a URL by shelling out to `curl`, binding the outgoing socket to the
+/// given network interface. This is the censorship-aware refresh path: when
+/// the proxy host sits in a network where `core.telegram.org` is unreachable
+/// over the default route, but the tunnel interface (e.g. AWG) provides a
+/// clean path, we use curl as an off-the-shelf HTTPS client without pulling
+/// a full TLS stack into the proxy binary.
+pub fn fetchUrlBytesViaInterface(
+    allocator: std.mem.Allocator,
+    url: []const u8,
+    interface: []const u8,
+) ![]u8 {
+    // curl requires --interface and its value as separate argv elements; the
+    // `--interface=<iface>` form is a common shell idiom but not supported by
+    // every curl version, hence the split.
+    const argv = [_][]const u8{
+        "curl",
+        "--silent",
+        "--fail",
+        "--show-error",
+        "--location",
+        "--max-time",
+        "10",
+        "--interface",
+        interface,
+        url,
+    };
+
+    var io_instance: std.Io.Threaded = .init(std.heap.page_allocator, .{});
+    defer io_instance.deinit();
+
+    const result = std.process.run(allocator, io_instance.io(), .{
+        .argv = &argv,
+        .stdout_limit = std.Io.Limit.limited(1 * 1024 * 1024),
+        .stderr_limit = std.Io.Limit.limited(1 * 1024 * 1024),
+    }) catch |err| {
+        log.warn("curl fallback failed to spawn: {any}", .{err});
+        return error.UnexpectedConnectFailure;
+    };
+    // Free stderr regardless of outcome; stdout is returned to the caller.
+    defer allocator.free(result.stderr);
+
+    switch (result.term) {
+        .exited => |code| {
+            if (code != 0) {
+                log.warn("curl {s} via {s} exited with {d}: {s}", .{
+                    url,                                        interface, code,
+                    std.mem.trim(u8, result.stderr, " \t\r\n"),
+                });
+                allocator.free(result.stdout);
+                return error.UnexpectedConnectFailure;
+            }
+        },
+        else => {
+            log.warn("curl {s} via {s} terminated abnormally", .{ url, interface });
+            allocator.free(result.stdout);
+            return error.UnexpectedConnectFailure;
+        },
+    }
+
+    return result.stdout;
+}

--- a/src/proxy/message_queue.zig
+++ b/src/proxy/message_queue.zig
@@ -1,0 +1,195 @@
+const std = @import("std");
+const posix = std.posix;
+
+const msg_block_size: usize = 2048;
+const msg_free_cap_per_queue: usize = 4;
+
+const MsgBlock = struct {
+    len: usize,
+    data: [msg_block_size]u8,
+};
+
+pub const MessageQueue = struct {
+    allocator: std.mem.Allocator,
+    free: std.ArrayListUnmanaged(*MsgBlock) = .empty,
+    blocks: std.ArrayListUnmanaged(*MsgBlock) = .empty,
+    head_idx: usize = 0,
+    offset: usize = 0,
+    total_len: usize = 0,
+
+    pub fn deinit(self: *MessageQueue) void {
+        self.clear();
+
+        for (self.free.items) |blk| self.allocator.destroy(blk);
+
+        self.free.deinit(self.allocator);
+        self.blocks.deinit(self.allocator);
+    }
+
+    pub fn clear(self: *MessageQueue) void {
+        for (self.blocks.items[self.head_idx..]) |blk| {
+            self.recycleBlock(blk);
+        }
+        self.blocks.clearRetainingCapacity();
+        self.head_idx = 0;
+        self.offset = 0;
+        self.total_len = 0;
+    }
+
+    pub fn isEmpty(self: *const MessageQueue) bool {
+        return self.total_len == 0;
+    }
+
+    pub fn appendCopy(self: *MessageQueue, data: []const u8) !void {
+        if (data.len == 0) return;
+
+        var off: usize = 0;
+
+        if (self.blocks.items.len > 0) {
+            const last_blk = self.blocks.items[self.blocks.items.len - 1];
+            if (last_blk.len < msg_block_size) {
+                const space = msg_block_size - last_blk.len;
+                const take = @min(space, data.len);
+                @memcpy(last_blk.data[last_blk.len .. last_blk.len + take], data[off .. off + take]);
+                last_blk.len += take;
+                self.total_len += take;
+                off += take;
+            }
+        }
+
+        while (off < data.len) {
+            const rem = data.len - off;
+            const take = @min(rem, msg_block_size);
+
+            const blk = try self.acquireBlock();
+            errdefer self.recycleBlock(blk);
+
+            blk.len = take;
+            @memcpy(blk.data[0..take], data[off .. off + take]);
+            try self.blocks.append(self.allocator, blk);
+            self.total_len += take;
+            off += take;
+        }
+    }
+
+    pub fn appendOwned(self: *MessageQueue, owned: []u8) !void {
+        defer self.allocator.free(owned);
+        try self.appendCopy(owned);
+    }
+
+    pub fn prepareIovecs(self: *const MessageQueue, out: []posix.iovec_const) usize {
+        if (self.head_idx >= self.blocks.items.len) return 0;
+
+        var count: usize = 0;
+        var local_off = self.offset;
+        for (self.blocks.items[self.head_idx..]) |blk| {
+            if (count >= out.len) break;
+
+            if (local_off >= blk.len) {
+                local_off -= blk.len;
+                continue;
+            }
+
+            out[count] = .{ .base = blk.data[local_off..blk.len].ptr, .len = blk.len - local_off };
+            count += 1;
+            local_off = 0;
+        }
+        return count;
+    }
+
+    pub fn consume(self: *MessageQueue, bytes: usize) !void {
+        if (bytes == 0 or self.total_len == 0) return;
+
+        var remaining = @min(bytes, self.total_len);
+        self.total_len -= remaining;
+
+        while (remaining > 0 and self.head_idx < self.blocks.items.len) {
+            const blk = self.blocks.items[self.head_idx];
+            const blk_left = blk.len - self.offset;
+
+            if (remaining < blk_left) {
+                self.offset += remaining;
+                remaining = 0;
+                break;
+            }
+
+            remaining -= blk_left;
+            self.offset = 0;
+            self.head_idx += 1;
+            self.recycleBlock(blk);
+        }
+
+        if (self.head_idx > 0 and (self.head_idx >= self.blocks.items.len or self.head_idx >= 64)) {
+            const rem = self.blocks.items.len - self.head_idx;
+            if (rem > 0) {
+                std.mem.copyForwards(*MsgBlock, self.blocks.items[0..rem], self.blocks.items[self.head_idx..]);
+            }
+            self.blocks.shrinkRetainingCapacity(rem);
+            self.head_idx = 0;
+        }
+
+        if (self.total_len == 0) {
+            self.head_idx = 0;
+            self.offset = 0;
+        }
+    }
+
+    fn acquireBlock(self: *MessageQueue) !*MsgBlock {
+        if (self.free.items.len > 0) {
+            return self.free.pop().?;
+        }
+
+        const blk = try self.allocator.create(MsgBlock);
+        blk.* = .{
+            .len = 0,
+            .data = undefined,
+        };
+        return blk;
+    }
+
+    fn recycleBlock(self: *MessageQueue, blk: *MsgBlock) void {
+        blk.len = 0;
+        if (self.free.items.len >= msg_free_cap_per_queue) {
+            self.allocator.destroy(blk);
+            return;
+        }
+
+        self.free.append(self.allocator, blk) catch {
+            self.allocator.destroy(blk);
+        };
+    }
+};
+
+test "message queue consume is stable" {
+    var q = MessageQueue{ .allocator = std.testing.allocator };
+    defer q.deinit();
+
+    try q.appendCopy("abc");
+    try q.appendCopy("defg");
+    try std.testing.expectEqual(@as(usize, 7), q.total_len);
+
+    try q.consume(2);
+    try std.testing.expectEqual(@as(usize, 5), q.total_len);
+
+    var iov: [8]posix.iovec_const = undefined;
+    const n = q.prepareIovecs(iov[0..]);
+    try std.testing.expect(n >= 1);
+    try std.testing.expectEqual(@as(u8, 'c'), iov[0].base[0]);
+
+    try q.consume(5);
+    try std.testing.expect(q.isEmpty());
+    try std.testing.expectEqual(@as(usize, 0), q.offset);
+    try std.testing.expectEqual(@as(usize, 0), q.head_idx);
+}
+
+test "message queue append fills tail block" {
+    var q = MessageQueue{ .allocator = std.testing.allocator };
+    defer q.deinit();
+
+    try q.appendCopy("abcde");
+    try q.appendCopy("fghij");
+
+    try std.testing.expectEqual(@as(usize, 10), q.total_len);
+    try std.testing.expectEqual(@as(usize, 1), q.blocks.items.len);
+    try std.testing.expectEqual(@as(usize, 10), q.blocks.items[0].len);
+}

--- a/src/proxy/middle_proxy_fallback.zig
+++ b/src/proxy/middle_proxy_fallback.zig
@@ -1,0 +1,69 @@
+const std = @import("std");
+
+const constants = @import("../protocol/constants.zig");
+const net_helpers = @import("net_helpers.zig");
+const socket_utils = @import("socket_utils.zig");
+
+const addressEql = net_helpers.addressEql;
+const formatAddress = socket_utils.formatAddress;
+
+const log = std.log.scoped(.proxy);
+
+pub fn fallbackToDirect(
+    loop: anytype,
+    slot: anytype,
+    comptime send_dc_nonce: fn (@TypeOf(loop), @TypeOf(slot)) void,
+    comptime cleanup_failed_upstream_connect: fn (@TypeOf(loop), @TypeOf(slot)) void,
+    comptime set_single_upstream_candidate: fn (@TypeOf(loop), @TypeOf(slot), @TypeOf(slot.direct_fallback_addr.?)) anyerror!void,
+    comptime start_direct_connect: fn (@TypeOf(loop), @TypeOf(slot), @TypeOf(slot.direct_fallback_addr.?)) anyerror!void,
+) bool {
+    if (slot.direct_fallback_addr == null or slot.direct_fallback_used) return false;
+
+    _ = slot.obf_params orelse return false;
+    slot.direct_fallback_used = true;
+    _ = loop.state.stats_mp_fallback.fetchAdd(1, .monotonic);
+    slot.use_middle_proxy = false;
+    slot.mp_step = .none;
+    slot.mp_enc = null;
+    slot.mp_dec = null;
+
+    slot.use_fast_mode = loop.state.config.fast_mode and
+        (slot.dc_abs >= 1 and slot.dc_abs <= constants.tg_datacenters_v4.len);
+
+    // Reset nonce path state to cleanly re-send direct nonce.
+    if (slot.dc_initial_tail) |tail| {
+        loop.state.allocator.free(tail);
+        slot.dc_initial_tail = null;
+    }
+    if (slot.tg_encryptor) |*enc| enc.wipe();
+    if (slot.tg_decryptor) |*dec| dec.wipe();
+    slot.tg_encryptor = null;
+    slot.tg_decryptor = null;
+
+    // If current connected endpoint is already the direct fallback, continue inline.
+    const fallback = slot.direct_fallback_addr.?;
+    if (slot.current_upstream_addr) |cur| {
+        if (addressEql(cur, fallback)) {
+            send_dc_nonce(loop, slot);
+            return true;
+        }
+    }
+
+    // Otherwise reconnect to direct fallback endpoint.
+    cleanup_failed_upstream_connect(loop, slot);
+    slot.upstream_candidate_next = 1;
+
+    set_single_upstream_candidate(loop, slot, fallback) catch {
+        return false;
+    };
+
+    start_direct_connect(loop, slot, fallback) catch |err| {
+        log.warn("[{d}] direct fallback connect start failed: {any}", .{ slot.conn_id, err });
+        return false;
+    };
+
+    var fb_buf: [64]u8 = undefined;
+    const fb_str = formatAddress(fallback, &fb_buf);
+    log.warn("[{d}] middle-proxy handshake failed, reconnecting direct to {s}", .{ slot.conn_id, fb_str });
+    return true;
+}

--- a/src/proxy/middle_proxy_frames.zig
+++ b/src/proxy/middle_proxy_frames.zig
@@ -1,0 +1,200 @@
+const std = @import("std");
+const posix = std.posix;
+
+const middleproxy = @import("../protocol/middleproxy.zig");
+
+const log = std.log.scoped(.proxy);
+
+pub fn readReset(slot: anytype, encrypted: bool) void {
+    slot.mp_frame_have = 0;
+    slot.mp_frame_total_len = 0;
+    slot.mp_frame_padded_len = 0;
+    slot.mp_frame_encrypted = encrypted;
+    slot.mp_frame_first_decrypted = false;
+    slot.mp_frame_need = if (encrypted) 16 else 4;
+}
+
+pub fn ensureFrameBuf(slot: anytype, allocator: std.mem.Allocator, comptime frame_buf_size: usize) ![]u8 {
+    if (slot.mp_frame_buf) |buf| return buf;
+    const buf = try allocator.alloc(u8, frame_buf_size);
+    slot.mp_frame_buf = buf;
+    return buf;
+}
+
+pub fn writeFrame(
+    slot: anytype,
+    allocator: std.mem.Allocator,
+    payload: []const u8,
+    encrypted: bool,
+    comptime frame_buf_size: usize,
+    comptime queue_upstream: fn (@TypeOf(slot), std.mem.Allocator, []const u8) anyerror!bool,
+) !void {
+    var plain: [frame_buf_size]u8 = undefined;
+    const total_len: usize = payload.len + 12;
+    if (total_len > plain.len) return error.BadMiddleProxyFrameSize;
+
+    std.mem.writeInt(u32, plain[0..4], @intCast(total_len), .little);
+    std.mem.writeInt(i32, plain[4..8], slot.mp_write_seq_no, .little);
+    slot.mp_write_seq_no += 1;
+
+    @memcpy(plain[8 .. 8 + payload.len], payload);
+    const checksum = middleproxy.crc32(plain[0 .. 8 + payload.len]);
+    std.mem.writeInt(u32, plain[8 + payload.len ..][0..4], checksum, .little);
+
+    var frame_len = total_len;
+    if (encrypted) {
+        const pad = (16 - (frame_len % 16)) % 16;
+        if (frame_len + pad > plain.len) return error.BadMiddleProxyFrameSize;
+        var i: usize = 0;
+        while (i < pad) : (i += 4) {
+            std.mem.writeInt(u32, plain[frame_len + i ..][0..4], 4, .little);
+        }
+        frame_len += pad;
+        try slot.mp_enc.?.encryptInPlace(plain[0..frame_len]);
+    }
+
+    _ = try queue_upstream(slot, allocator, plain[0..frame_len]);
+}
+
+pub fn tryReadFrame(
+    slot: anytype,
+    allocator: std.mem.Allocator,
+    encrypted: bool,
+    comptime frame_buf_size: usize,
+) !?[]const u8 {
+    const frame_buf = try ensureFrameBuf(slot, allocator, frame_buf_size);
+
+    while (true) {
+        if (slot.mp_frame_need == 0) {
+            readReset(slot, encrypted);
+        }
+
+        if (slot.mp_frame_have < slot.mp_frame_need) {
+            const n = posix.read(slot.upstream_fd, frame_buf[slot.mp_frame_have..slot.mp_frame_need]) catch |err| {
+                if (err == error.WouldBlock) return null;
+                log.debug("[{d}] mp read error: step={s} encrypted={} have={d} need={d} err={any}", .{
+                    slot.conn_id,
+                    @tagName(slot.mp_step),
+                    encrypted,
+                    slot.mp_frame_have,
+                    slot.mp_frame_need,
+                    err,
+                });
+                return err;
+            };
+            if (n == 0) {
+                log.debug("[{d}] mp upstream eof: step={s} encrypted={} have={d} need={d}", .{
+                    slot.conn_id,
+                    @tagName(slot.mp_step),
+                    encrypted,
+                    slot.mp_frame_have,
+                    slot.mp_frame_need,
+                });
+                return error.EndOfStream;
+            }
+            slot.mp_frame_have += n;
+            if (slot.mp_frame_have < slot.mp_frame_need) return null;
+        }
+
+        if (!encrypted) {
+            if (slot.mp_frame_total_len == 0) {
+                slot.mp_frame_total_len = std.mem.readInt(u32, frame_buf[0..4], .little);
+                if (slot.mp_frame_total_len < 12 or slot.mp_frame_total_len > frame_buf.len) {
+                    log.debug("[{d}] mp plain frame size invalid: total_len={d} have={d} need={d}", .{
+                        slot.conn_id,
+                        slot.mp_frame_total_len,
+                        slot.mp_frame_have,
+                        slot.mp_frame_need,
+                    });
+                    return error.BadMiddleProxyFrameSize;
+                }
+                slot.mp_frame_need = slot.mp_frame_total_len;
+                continue;
+            }
+        } else {
+            if (!slot.mp_frame_first_decrypted) {
+                slot.mp_dec.?.decryptInPlace(frame_buf[0..16]) catch |err| {
+                    log.debug("[{d}] mp decrypt first block failed: step={s} err={any}", .{
+                        slot.conn_id,
+                        @tagName(slot.mp_step),
+                        err,
+                    });
+                    return err;
+                };
+                slot.mp_frame_first_decrypted = true;
+                slot.mp_frame_total_len = std.mem.readInt(u32, frame_buf[0..4], .little);
+                if (slot.mp_frame_total_len < 12 or slot.mp_frame_total_len > (1 << 24)) {
+                    const first4_le = std.mem.readInt(u32, frame_buf[0..4], .little);
+                    const first4_be = std.mem.readInt(u32, frame_buf[0..4], .big);
+                    log.debug("[{d}] mp encrypted frame size invalid: total_len={d} first4_le=0x{x} first4_be=0x{x}", .{
+                        slot.conn_id,
+                        slot.mp_frame_total_len,
+                        first4_le,
+                        first4_be,
+                    });
+                    return error.BadMiddleProxyFrameSize;
+                }
+                slot.mp_frame_padded_len = if (slot.mp_frame_total_len % 16 == 0)
+                    slot.mp_frame_total_len
+                else
+                    slot.mp_frame_total_len + (16 - (slot.mp_frame_total_len % 16));
+                if (slot.mp_frame_padded_len > frame_buf.len) {
+                    log.debug("[{d}] mp encrypted padded size invalid: total_len={d} padded_len={d} frame_buf={d}", .{
+                        slot.conn_id,
+                        slot.mp_frame_total_len,
+                        slot.mp_frame_padded_len,
+                        frame_buf.len,
+                    });
+                    return error.BadMiddleProxyFrameSize;
+                }
+                slot.mp_frame_need = slot.mp_frame_padded_len;
+                if (slot.mp_frame_have < slot.mp_frame_need) return null;
+            }
+
+            if (slot.mp_frame_padded_len > 16) {
+                slot.mp_dec.?.decryptInPlace(frame_buf[16..slot.mp_frame_padded_len]) catch |err| {
+                    log.debug("[{d}] mp decrypt payload failed: step={s} padded_len={d} err={any}", .{
+                        slot.conn_id,
+                        @tagName(slot.mp_step),
+                        slot.mp_frame_padded_len,
+                        err,
+                    });
+                    return err;
+                };
+            }
+        }
+
+        const frame = frame_buf[0..slot.mp_frame_total_len];
+        const msg_seq = std.mem.readInt(i32, frame[4..8], .little);
+        if (msg_seq != slot.mp_read_seq_no) {
+            log.debug("[{d}] mp seq mismatch: got={d} expected={d} step={s}", .{
+                slot.conn_id,
+                msg_seq,
+                slot.mp_read_seq_no,
+                @tagName(slot.mp_step),
+            });
+            return error.BadMiddleProxySeqNo;
+        }
+        slot.mp_read_seq_no += 1;
+
+        const expected_checksum = std.mem.readInt(u32, frame[frame.len - 4 ..][0..4], .little);
+        const computed_checksum = middleproxy.crc32(frame[0 .. frame.len - 4]);
+        if (expected_checksum != computed_checksum) {
+            log.debug("[{d}] mp checksum mismatch: expected=0x{x} computed=0x{x} frame_len={d}", .{
+                slot.conn_id,
+                expected_checksum,
+                computed_checksum,
+                frame.len,
+            });
+            return error.BadMiddleProxyChecksum;
+        }
+
+        // Copy payload into front of frame_buf so caller can consume before reset.
+        const payload_len = frame.len - 12;
+        std.mem.copyForwards(u8, frame_buf[0..payload_len], frame[8 .. frame.len - 4]);
+        const payload = frame_buf[0..payload_len];
+
+        readReset(slot, encrypted);
+        return payload;
+    }
+}

--- a/src/proxy/middle_proxy_handshake.zig
+++ b/src/proxy/middle_proxy_handshake.zig
@@ -1,0 +1,309 @@
+const std = @import("std");
+
+const crypto = @import("../crypto/crypto.zig");
+const middleproxy = @import("../protocol/middleproxy.zig");
+const middle_proxy_frames = @import("middle_proxy_frames.zig");
+const net_helpers = @import("net_helpers.zig");
+const network_detect = @import("network_detect.zig");
+const socket_utils = @import("socket_utils.zig");
+
+const ip4 = net_helpers.ip4;
+const localSocketAddress = socket_utils.localSocketAddress;
+const realtimeSeconds = socket_utils.realtimeSeconds;
+const ipv4NetworkToHostBytes = network_detect.ipv4NetworkToHostBytes;
+
+const log = std.log.scoped(.proxy);
+
+fn hasUpstreamPending(slot: anytype) bool {
+    return !slot.upstream_queue.isEmpty();
+}
+
+pub fn begin(
+    loop: anytype,
+    slot: anytype,
+    comptime write_frame: fn (@TypeOf(loop), @TypeOf(slot), []const u8, bool) anyerror!void,
+    comptime lock_shared: fn (@TypeOf(loop)) void,
+    comptime unlock_shared: fn (@TypeOf(loop)) void,
+    comptime close_slot: fn (@TypeOf(loop), @TypeOf(slot), []const u8) void,
+) void {
+    slot.phase = .middle_proxy_handshake;
+    slot.mp_step = .sending_rpc_nonce;
+    slot.mp_write_seq_no = -2;
+    slot.mp_read_seq_no = -2;
+    slot.mp_frame_have = 0;
+    slot.mp_frame_need = 0;
+    slot.mp_enc = null;
+    slot.mp_dec = null;
+
+    crypto.randomBytes(&slot.mp_nonce);
+    const ts: u32 = @intCast(@mod(realtimeSeconds(), 4294967296));
+    slot.mp_timestamp = ts;
+
+    var crypto_ts: [4]u8 = undefined;
+    std.mem.writeInt(u32, &crypto_ts, ts, .little);
+
+    var msg: [32]u8 = undefined;
+    @memcpy(msg[0..4], &middleproxy.rpc_nonce_req);
+    lock_shared(loop);
+    // Defensive copy: refresh rejects secrets shorter than 16 bytes, but
+    // if that invariant is ever broken we must avoid a length-mismatched
+    // memcpy panic when filling the 4-byte key selector field.
+    @memset(msg[4..8], 0);
+    if (loop.state.middle_proxy_secret_len > 0) msg[4] = loop.state.middle_proxy_secret[0];
+    if (loop.state.middle_proxy_secret_len > 1) msg[5] = loop.state.middle_proxy_secret[1];
+    if (loop.state.middle_proxy_secret_len > 2) msg[6] = loop.state.middle_proxy_secret[2];
+    if (loop.state.middle_proxy_secret_len > 3) msg[7] = loop.state.middle_proxy_secret[3];
+    unlock_shared(loop);
+    @memcpy(msg[8..12], &middleproxy.rpc_crypto_aes);
+    @memcpy(msg[12..16], &crypto_ts);
+    @memcpy(msg[16..32], &slot.mp_nonce);
+
+    write_frame(loop, slot, msg[0..], false) catch {
+        close_slot(loop, slot, "mp send nonce failed");
+        return;
+    };
+
+    if (!hasUpstreamPending(slot)) {
+        slot.mp_step = .waiting_rpc_nonce_response;
+        middle_proxy_frames.readReset(slot, false);
+    }
+}
+
+pub fn onWritable(slot: anytype) void {
+    if (hasUpstreamPending(slot)) return;
+
+    switch (slot.mp_step) {
+        .sending_rpc_nonce => {
+            slot.mp_step = .waiting_rpc_nonce_response;
+            middle_proxy_frames.readReset(slot, false);
+        },
+        .sending_rpc_handshake => {
+            slot.mp_step = .waiting_rpc_handshake_response;
+            middle_proxy_frames.readReset(slot, true);
+        },
+        else => {},
+    }
+}
+
+pub fn onReadable(
+    loop: anytype,
+    slot: anytype,
+    comptime read_frame: fn (@TypeOf(loop), @TypeOf(slot), bool) anyerror!?[]const u8,
+    comptime write_frame: fn (@TypeOf(loop), @TypeOf(slot), []const u8, bool) anyerror!void,
+    comptime lock_shared: fn (@TypeOf(loop)) void,
+    comptime unlock_shared: fn (@TypeOf(loop)) void,
+    comptime start_relay: fn (@TypeOf(loop), @TypeOf(slot)) void,
+    comptime close_slot: fn (@TypeOf(loop), @TypeOf(slot), []const u8) void,
+    comptime fallback_to_direct: fn (@TypeOf(loop), @TypeOf(slot)) bool,
+) void {
+    switch (slot.mp_step) {
+        .waiting_rpc_nonce_response => {
+            const payload = read_frame(loop, slot, false) catch |err| {
+                log.debug("[{d}] mp nonce frame read failed: {any}", .{ slot.conn_id, err });
+                close_slot(loop, slot, "mp read nonce ans failed");
+                return;
+            } orelse return;
+
+            if (payload.len != 32) {
+                close_slot(loop, slot, "mp bad nonce ans len");
+                return;
+            }
+            if (!std.mem.eql(u8, payload[0..4], &middleproxy.rpc_nonce_req)) {
+                close_slot(loop, slot, "mp bad nonce ans type");
+                return;
+            }
+
+            lock_shared(loop);
+            const key_sel = loop.state.middle_proxy_secret[0..@min(@as(usize, 4), loop.state.middle_proxy_secret_len)];
+            const secret_slice = loop.state.middle_proxy_secret[0..loop.state.middle_proxy_secret_len];
+            if (!std.mem.eql(u8, payload[4..8], key_sel)) {
+                unlock_shared(loop);
+                close_slot(loop, slot, "mp key selector mismatch");
+                return;
+            }
+            if (!std.mem.eql(u8, payload[8..12], &middleproxy.rpc_crypto_aes)) {
+                unlock_shared(loop);
+                close_slot(loop, slot, "mp crypto schema mismatch");
+                return;
+            }
+
+            slot.mp_rpc_nonce_ans = payload[16..32][0..16].*;
+
+            var ts_arr: [4]u8 = undefined;
+            std.mem.writeInt(u32, &ts_arr, slot.mp_timestamp, .little);
+
+            const tg_addr = slot.current_upstream_addr orelse {
+                unlock_shared(loop);
+                close_slot(loop, slot, "mp missing logical upstream addr");
+                return;
+            };
+
+            const local_addr = localSocketAddress(slot.upstream_fd) catch {
+                unlock_shared(loop);
+                close_slot(loop, slot, "mp getsockname failed");
+                return;
+            };
+            var middle_local_addr = local_addr;
+
+            var tg_port: [2]u8 = undefined;
+            var my_port: [2]u8 = undefined;
+            var tg_ip_v4_opt: ?[4]u8 = null;
+            var my_ip_v4_opt: ?[4]u8 = null;
+            var tg_ip_v6_opt: ?[16]u8 = null;
+            var my_ip_v6_opt: ?[16]u8 = null;
+
+            const local_port = local_addr.getPort();
+            std.mem.writeInt(u16, &my_port, local_port, .little);
+
+            switch (tg_addr) {
+                .ip4 => |tg4| {
+                    var tg_ip_v4 = tg4.bytes;
+                    std.mem.reverse(u8, &tg_ip_v4);
+                    tg_ip_v4_opt = tg_ip_v4;
+
+                    if (loop.state.middle_proxy_nat_ip4) |nat_ip| {
+                        const my_ip_v4 = ipv4NetworkToHostBytes(nat_ip);
+                        my_ip_v4_opt = my_ip_v4;
+                        middle_local_addr = ip4(nat_ip, local_port);
+                    }
+
+                    std.mem.writeInt(u16, &tg_port, tg4.port, .little);
+                },
+                .ip6 => |tg6| {
+                    tg_ip_v6_opt = tg6.bytes;
+
+                    switch (local_addr) {
+                        .ip6 => |loc6| my_ip_v6_opt = loc6.bytes,
+                        .ip4 => {},
+                    }
+
+                    std.mem.writeInt(u16, &tg_port, tg6.port, .little);
+                },
+            }
+
+            const tg_ip_v4_ptr: ?*const [4]u8 = if (tg_ip_v4_opt) |*ip| ip else null;
+            const my_ip_v4_ptr: ?*const [4]u8 = if (my_ip_v4_opt) |*ip| ip else null;
+            const my_ip_v6_ptr: ?*const [16]u8 = if (my_ip_v6_opt) |*ip| ip else null;
+            const tg_ip_v6_ptr: ?*const [16]u8 = if (tg_ip_v6_opt) |*ip| ip else null;
+
+            const enc_keys = middleproxy.getAesKeyAndIv(
+                &slot.mp_rpc_nonce_ans,
+                &slot.mp_nonce,
+                &ts_arr,
+                tg_ip_v4_ptr,
+                &my_port,
+                "CLIENT",
+                my_ip_v4_ptr,
+                &tg_port,
+                secret_slice,
+                my_ip_v6_ptr,
+                tg_ip_v6_ptr,
+            );
+
+            const dec_keys = middleproxy.getAesKeyAndIv(
+                &slot.mp_rpc_nonce_ans,
+                &slot.mp_nonce,
+                &ts_arr,
+                tg_ip_v4_ptr,
+                &my_port,
+                "SERVER",
+                my_ip_v4_ptr,
+                &tg_port,
+                secret_slice,
+                my_ip_v6_ptr,
+                tg_ip_v6_ptr,
+            );
+            unlock_shared(loop);
+
+            slot.mp_enc = crypto.AesCbc.init(&enc_keys[0], &enc_keys[1]);
+            slot.mp_dec = crypto.AesCbc.init(&dec_keys[0], &dec_keys[1]);
+
+            var hs_msg: [32]u8 = undefined;
+            @memcpy(hs_msg[0..4], &middleproxy.rpc_handshake);
+            @memset(hs_msg[4..8], 0);
+            @memcpy(hs_msg[8..20], "IPIPPRPDTIME");
+            @memcpy(hs_msg[20..32], "IPIPPRPDTIME");
+
+            write_frame(loop, slot, hs_msg[0..], true) catch {
+                if (!fallback_to_direct(loop, slot)) {
+                    close_slot(loop, slot, "mp send handshake failed");
+                }
+                return;
+            };
+
+            slot.mp_step = if (hasUpstreamPending(slot)) .sending_rpc_handshake else .waiting_rpc_handshake_response;
+            if (!hasUpstreamPending(slot)) {
+                middle_proxy_frames.readReset(slot, true);
+            }
+        },
+
+        .waiting_rpc_handshake_response => {
+            const payload = read_frame(loop, slot, true) catch |err| {
+                log.debug("[{d}] mp handshake frame read failed: {any}", .{ slot.conn_id, err });
+                if (!fallback_to_direct(loop, slot)) {
+                    close_slot(loop, slot, "mp read handshake ans failed");
+                }
+                return;
+            } orelse return;
+
+            if (payload.len != 32) {
+                if (!fallback_to_direct(loop, slot)) {
+                    close_slot(loop, slot, "mp bad handshake ans len");
+                }
+                return;
+            }
+            if (!std.mem.eql(u8, payload[0..4], &middleproxy.rpc_handshake)) {
+                if (!fallback_to_direct(loop, slot)) {
+                    close_slot(loop, slot, "mp bad handshake ans type");
+                }
+                return;
+            }
+            if (!std.mem.eql(u8, payload[20..32], "IPIPPRPDTIME")) {
+                if (!fallback_to_direct(loop, slot)) {
+                    close_slot(loop, slot, "mp bad handshake pid");
+                }
+                return;
+            }
+
+            const local_addr = localSocketAddress(slot.upstream_fd) catch {
+                if (!fallback_to_direct(loop, slot)) {
+                    close_slot(loop, slot, "mp getsockname failed");
+                }
+                return;
+            };
+
+            var middle_local_addr = local_addr;
+            if (loop.state.middle_proxy_nat_ip4) |nat_ip| {
+                switch (local_addr) {
+                    .ip4 => |la4| middle_local_addr = ip4(nat_ip, la4.port),
+                    .ip6 => {},
+                }
+            }
+
+            var conn_id: [8]u8 = undefined;
+            crypto.randomBytes(&conn_id);
+
+            slot.middle_ctx = middleproxy.MiddleProxyContext.initWithBuffer(
+                loop.state.allocator,
+                slot.mp_enc.?,
+                slot.mp_dec.?,
+                conn_id,
+                slot.mp_write_seq_no,
+                slot.peer_addr,
+                middle_local_addr,
+                slot.proto_tag,
+                loop.state.config.tag,
+                loop.state.config.middleProxyBufferBytes(),
+            ) catch {
+                if (!fallback_to_direct(loop, slot)) {
+                    close_slot(loop, slot, "mp context init failed");
+                }
+                return;
+            };
+
+            slot.mp_step = .done;
+            start_relay(loop, slot);
+        },
+        else => {},
+    }
+}

--- a/src/proxy/middle_proxy_routing.zig
+++ b/src/proxy/middle_proxy_routing.zig
@@ -1,0 +1,380 @@
+const std = @import("std");
+const posix = std.posix;
+const net = std.Io.net;
+const Address = net.IpAddress;
+
+const constants = @import("../protocol/constants.zig");
+const Config = @import("../config.zig").Config;
+
+pub const DcConnectPlan = struct {
+    candidates: [16]Address = undefined,
+    count: usize = 0,
+    use_middle_proxy: bool = false,
+    is_media_path: bool = false,
+    direct_fallback: ?Address = null,
+};
+
+pub const MiddleProxySnapshot = struct {
+    addrs_primary: [5]Address,
+    addrs_media_primary: [5]Address,
+    addr_203: Address,
+    addrs_dc4: [16]Address,
+    addrs_dc4_len: usize,
+    addrs_media_dc4: [16]Address,
+    addrs_media_dc4_len: usize,
+    addrs_203: [8]Address,
+    addrs_203_len: usize,
+    secret: [256]u8,
+    secret_len: usize,
+
+    /// Pick the single primary endpoint for (dc_abs, media?). Media-path
+    /// traffic (client sent dc_idx<0) must go to the media MP fleet.
+    pub fn getForDc(self: *const MiddleProxySnapshot, dc_abs: usize, media: bool) ?Address {
+        if (dc_abs == 203) return self.addr_203;
+        if (dc_abs >= 1 and dc_abs <= self.addrs_primary.len) {
+            if (media) return self.addrs_media_primary[dc_abs - 1];
+            return self.addrs_primary[dc_abs - 1];
+        }
+        return null;
+    }
+};
+
+pub const DcSignFilter = enum {
+    any, // accept proxy_for with dc == target_dc (any sign) — legacy
+    positive_only, // only `proxy_for  N  addr;` — regular traffic
+    negative_only, // only `proxy_for -N  addr;` — media traffic (dc_idx < 0)
+};
+
+fn addressEql(a: Address, b: Address) bool {
+    return net.IpAddress.eql(&a, &b);
+}
+
+fn isSameIpEndpoint(a: Address, b: Address) bool {
+    return addressEql(a, b);
+}
+
+fn appendUniqueAddress(addrs: *[16]Address, count: *usize, addr: Address) void {
+    if (count.* >= addrs.len) return;
+    for (addrs[0..count.*]) |existing| {
+        if (isSameIpEndpoint(existing, addr)) return;
+    }
+    addrs[count.*] = addr;
+    count.* += 1;
+}
+
+pub fn buildDcConnectPlan(
+    cfg: *const Config,
+    dc_abs: usize,
+    dc_idx: i16,
+    snapshot: ?*const MiddleProxySnapshot,
+    user_name: []const u8,
+) DcConnectPlan {
+    var plan = DcConnectPlan{};
+    plan.is_media_path = (dc_idx < 0) or (dc_abs == 203);
+
+    if (cfg.datacenter_override) |override| {
+        plan.candidates[0] = override;
+        plan.count = 1;
+        plan.use_middle_proxy = false;
+        plan.direct_fallback = null;
+        return plan;
+    }
+
+    if (cfg.userBypassesMiddleProxy(user_name)) {
+        plan.candidates[0] = constants.getDcAddressV4(dc_abs);
+        plan.count = 1;
+        plan.use_middle_proxy = false;
+        plan.direct_fallback = null;
+        return plan;
+    }
+
+    var middle_addr: ?Address = null;
+    if (snapshot) |snap| {
+        middle_addr = snap.getForDc(dc_abs, plan.is_media_path);
+        if (middle_addr == null and plan.is_media_path) {
+            // Media pool is empty in this snapshot (e.g. first run, refresh
+            // hasn't succeeded yet and bundled media list is mis-seeded).
+            // Fall back to the regular MP — connections still complete, just
+            // without media-optimized routing.
+            middle_addr = snap.getForDc(dc_abs, false);
+        }
+    }
+
+    const force_media_middle_proxy = cfg.force_media_middle_proxy and plan.is_media_path and middle_addr != null;
+    plan.use_middle_proxy = if (force_media_middle_proxy)
+        true
+    else
+        cfg.use_middle_proxy and middle_addr != null;
+
+    if (!plan.use_middle_proxy) {
+        plan.candidates[0] = constants.getDcAddressV4(dc_abs);
+        plan.count = 1;
+        plan.direct_fallback = null;
+        return plan;
+    }
+
+    if (snapshot) |snap| {
+        if (dc_abs == 4) {
+            if (plan.is_media_path and snap.addrs_media_dc4_len > 0) {
+                var n: usize = 0;
+                while (n < snap.addrs_media_dc4_len and plan.count < plan.candidates.len) : (n += 1) {
+                    appendUniqueAddress(&plan.candidates, &plan.count, snap.addrs_media_dc4[n]);
+                }
+            } else if (snap.addrs_dc4_len > 0) {
+                var n: usize = 0;
+                while (n < snap.addrs_dc4_len and plan.count < plan.candidates.len) : (n += 1) {
+                    appendUniqueAddress(&plan.candidates, &plan.count, snap.addrs_dc4[n]);
+                }
+            }
+        } else if (dc_abs == 203 and snap.addrs_203_len > 0) {
+            var n: usize = 0;
+            while (n < snap.addrs_203_len and plan.count < plan.candidates.len) : (n += 1) {
+                appendUniqueAddress(&plan.candidates, &plan.count, snap.addrs_203[n]);
+            }
+        }
+    }
+
+    if (plan.count == 0 and middle_addr != null) {
+        appendUniqueAddress(&plan.candidates, &plan.count, middle_addr.?);
+    }
+
+    if (plan.count == 0) {
+        // Safety fallback: if cache has no middle-proxy endpoint for this DC,
+        // avoid dropping valid users and go direct.
+        plan.use_middle_proxy = false;
+        plan.candidates[0] = constants.getDcAddressV4(dc_abs);
+        plan.count = 1;
+        plan.direct_fallback = null;
+        return plan;
+    }
+
+    // If middle-proxy connect/handshake fails, retry the same DC via direct mode.
+    // This keeps media paths functional in environments where middle-proxy transport
+    // itself is degraded (for example due to strict NAT behavior in upstream tunnels).
+    plan.direct_fallback = constants.getDcAddressV4(dc_abs);
+    return plan;
+}
+
+fn parseIpAndPortAddress(text: []const u8) !Address {
+    return net.IpAddress.parseLiteral(text);
+}
+
+pub fn parseMiddleProxyAddressesForDc(
+    config_text: []const u8,
+    target_dc: i16,
+    sign: DcSignFilter,
+    out: []Address,
+) usize {
+    if (out.len == 0) return 0;
+
+    var lines = std.mem.splitScalar(u8, config_text, '\n');
+    var count: usize = 0;
+
+    while (lines.next()) |raw_line| {
+        var line = std.mem.trim(u8, raw_line, &[_]u8{ ' ', '\t', '\r' });
+        if (line.len == 0 or line[0] == '#') continue;
+        if (line[line.len - 1] == ';') line = line[0 .. line.len - 1];
+
+        var parts = std.mem.tokenizeAny(u8, line, " \t");
+        const keyword = parts.next() orelse continue;
+        if (!std.mem.eql(u8, keyword, "proxy_for")) continue;
+
+        const dc_text = parts.next() orelse continue;
+        const host_port = parts.next() orelse continue;
+
+        const dc_idx = std.fmt.parseInt(i16, dc_text, 10) catch continue;
+        const abs_target: i16 = if (target_dc < 0) -target_dc else target_dc;
+        switch (sign) {
+            .any => if (dc_idx != abs_target and dc_idx != -abs_target) continue,
+            .positive_only => if (dc_idx != abs_target) continue,
+            .negative_only => if (dc_idx != -abs_target) continue,
+        }
+
+        const parsed = parseIpAndPortAddress(host_port) catch continue;
+
+        var dup = false;
+        for (out[0..count]) |existing| {
+            if (addressEql(existing, parsed)) {
+                dup = true;
+                break;
+            }
+        }
+        if (dup) continue;
+
+        out[count] = parsed;
+        count += 1;
+        if (count == out.len) break;
+    }
+
+    return count;
+}
+
+pub fn parseMiddleProxyAddressForDc(config_text: []const u8, target_dc: i16) ?Address {
+    var one: [1]Address = undefined;
+    const sign: DcSignFilter = if (target_dc < 0) .negative_only else .positive_only;
+    const n = parseMiddleProxyAddressesForDc(config_text, target_dc, sign, &one);
+    if (n == 0) return null;
+    return one[0];
+}
+
+pub fn trySelectReachableMiddleProxy(candidates: []const Address, timeout_ms: i32) ?Address {
+    for (candidates) |addr| {
+        if (isAddressReachable(addr, timeout_ms)) return addr;
+    }
+    return null;
+}
+
+pub fn addressesEqual(a: []const Address, b: []const Address) bool {
+    if (a.len != b.len) return false;
+    for (a, b) |lhs, rhs| {
+        if (!addressEql(lhs, rhs)) return false;
+    }
+    return true;
+}
+
+fn closeFd(fd: posix.fd_t) void {
+    while (true) {
+        switch (posix.errno(posix.system.close(fd))) {
+            .SUCCESS => return,
+            .INTR => continue,
+            else => return,
+        }
+    }
+}
+
+fn connectSockaddr(fd: posix.fd_t, addr: *const posix.sockaddr, addr_len: posix.socklen_t) !void {
+    while (true) switch (posix.errno(posix.system.connect(fd, addr, addr_len))) {
+        .SUCCESS => return,
+        .INTR => continue,
+        .ADDRNOTAVAIL => return error.AddressUnavailable,
+        .AFNOSUPPORT => return error.AddressFamilyUnsupported,
+        .AGAIN, .INPROGRESS => return error.WouldBlock,
+        .ALREADY => return error.ConnectionPending,
+        .CONNREFUSED => return error.ConnectionRefused,
+        .CONNRESET => return error.ConnectionResetByPeer,
+        .HOSTUNREACH => return error.HostUnreachable,
+        .NETUNREACH => return error.NetworkUnreachable,
+        .TIMEDOUT => return error.Timeout,
+        else => |err| return posix.unexpectedErrno(err),
+    };
+}
+
+fn isAddressReachable(address: Address, timeout_ms: i32) bool {
+    const sock_flags = posix.SOCK.STREAM | posix.SOCK.CLOEXEC | posix.SOCK.NONBLOCK;
+    const family: posix.sa_family_t = switch (address) {
+        .ip4 => posix.AF.INET,
+        .ip6 => posix.AF.INET6,
+    };
+    const fd = fd: {
+        const rc = posix.system.socket(family, sock_flags, posix.IPPROTO.TCP);
+        if (posix.errno(rc) != .SUCCESS) return false;
+        break :fd @as(posix.fd_t, @intCast(rc));
+    };
+    defer closeFd(fd);
+
+    switch (address) {
+        .ip4 => |ip4_addr| {
+            var sa: posix.sockaddr.in = .{
+                .family = posix.AF.INET,
+                .port = std.mem.nativeToBig(u16, ip4_addr.port),
+                .addr = @bitCast(ip4_addr.bytes),
+            };
+            connectSockaddr(fd, @ptrCast(&sa), @sizeOf(posix.sockaddr.in)) catch |err| switch (err) {
+                error.WouldBlock, error.ConnectionPending => {},
+                else => return false,
+            };
+        },
+        .ip6 => |ip6_addr| {
+            var sa: posix.sockaddr.in6 = .{
+                .family = posix.AF.INET6,
+                .port = std.mem.nativeToBig(u16, ip6_addr.port),
+                .flowinfo = ip6_addr.flow,
+                .addr = ip6_addr.bytes,
+                .scope_id = ip6_addr.interface.index,
+            };
+            connectSockaddr(fd, @ptrCast(&sa), @sizeOf(posix.sockaddr.in6)) catch |err| switch (err) {
+                error.WouldBlock, error.ConnectionPending => {},
+                else => return false,
+            };
+        },
+    }
+
+    var fds = [_]posix.pollfd{.{ .fd = fd, .events = posix.POLL.OUT, .revents = 0 }};
+    const ready = posix.poll(&fds, timeout_ms) catch return false;
+    if (ready == 0) return false;
+    const revents = fds[0].revents;
+    if ((revents & posix.POLL.OUT) == 0) return false;
+    if ((revents & (posix.POLL.ERR | posix.POLL.HUP | posix.POLL.NVAL)) != 0) return false;
+    return true;
+}
+
+test "parse middle proxy address for dc203" {
+    const cfg =
+        "# force_probability 10 10\n" ++
+        "default 2;\n" ++
+        "proxy_for 1 149.154.175.50:8888;\n" ++
+        "proxy_for 203 91.105.192.110:443;\n" ++
+        "proxy_for -203 91.105.192.110:443;\n";
+
+    const addr = parseMiddleProxyAddressForDc(cfg, 203) orelse return error.TestExpectedEqual;
+    try std.testing.expect(switch (addr) {
+        .ip4 => true,
+        .ip6 => false,
+    });
+    try std.testing.expectEqual(@as(u16, 443), addr.getPort());
+}
+
+test "direct users bypass middle-proxy routing" {
+    const cfg_text =
+        \\[general]
+        \\use_middle_proxy = true
+        \\[access.users]
+        \\admin = "00112233445566778899aabbccddeeff"
+        \\regular = "ffeeddccbbaa99887766554433221100"
+        \\[access.direct_users]
+        \\admin = true
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, cfg_text);
+    defer cfg.deinit(std.testing.allocator);
+
+    const mp_dc4: Address = .{ .ip4 = .{ .bytes = .{ 11, 11, 11, 11 }, .port = 443 } };
+    const mp_dc203: Address = .{ .ip4 = .{ .bytes = .{ 12, 12, 12, 12 }, .port = 443 } };
+    const snapshot = MiddleProxySnapshot{
+        .addrs_primary = .{
+            constants.tg_middle_proxies_v4[0],
+            constants.tg_middle_proxies_v4[1],
+            constants.tg_middle_proxies_v4[2],
+            mp_dc4,
+            constants.tg_middle_proxies_v4[4],
+        },
+        .addrs_media_primary = constants.tg_media_middle_proxies_v4,
+        .addr_203 = mp_dc203,
+        .addrs_dc4 = [_]Address{mp_dc4} ++ ([_]Address{mp_dc4} ** 15),
+        .addrs_dc4_len = 1,
+        .addrs_media_dc4 = [_]Address{constants.tg_media_middle_proxies_v4[3]} ++ ([_]Address{constants.tg_media_middle_proxies_v4[3]} ** 15),
+        .addrs_media_dc4_len = 1,
+        .addrs_203 = [_]Address{mp_dc203} ++ ([_]Address{mp_dc203} ** 7),
+        .addrs_203_len = 1,
+        .secret = [_]u8{0} ** 256,
+        .secret_len = 16,
+    };
+
+    const regular_plan = buildDcConnectPlan(&cfg, 4, 4, &snapshot, "regular");
+    try std.testing.expect(regular_plan.use_middle_proxy);
+    try std.testing.expect(regular_plan.direct_fallback != null);
+    try std.testing.expect(addressEql(regular_plan.candidates[0], mp_dc4));
+
+    const admin_plan = buildDcConnectPlan(&cfg, 4, 4, &snapshot, "admin");
+    try std.testing.expect(!admin_plan.use_middle_proxy);
+    try std.testing.expect(admin_plan.direct_fallback == null);
+    try std.testing.expect(addressEql(admin_plan.candidates[0], constants.getDcAddressV4(4)));
+
+    const regular_media = buildDcConnectPlan(&cfg, 203, -203, &snapshot, "regular");
+    try std.testing.expect(regular_media.use_middle_proxy);
+    try std.testing.expect(addressEql(regular_media.candidates[0], mp_dc203));
+
+    const admin_media = buildDcConnectPlan(&cfg, 203, -203, &snapshot, "admin");
+    try std.testing.expect(!admin_media.use_middle_proxy);
+    try std.testing.expect(addressEql(admin_media.candidates[0], constants.getDcAddressV4(203)));
+}

--- a/src/proxy/net_helpers.zig
+++ b/src/proxy/net_helpers.zig
@@ -1,0 +1,71 @@
+const std = @import("std");
+const net = std.Io.net;
+
+pub const Address = net.IpAddress;
+
+pub const AddressList = struct {
+    allocator: std.mem.Allocator,
+    addrs: []Address,
+
+    pub fn deinit(self: *const AddressList) void {
+        self.allocator.free(self.addrs);
+    }
+};
+
+pub fn ip4(bytes: [4]u8, port: u16) Address {
+    return .{ .ip4 = .{ .bytes = bytes, .port = port } };
+}
+
+pub fn ip6(bytes: [16]u8, port: u16, flow: u32, scope_id: u32) Address {
+    return .{ .ip6 = .{
+        .bytes = bytes,
+        .port = port,
+        .flow = flow,
+        .interface = .{ .index = scope_id },
+    } };
+}
+
+pub fn isIpv6(addr: Address) bool {
+    return switch (addr) {
+        .ip6 => true,
+        .ip4 => false,
+    };
+}
+
+pub fn addressEql(a: Address, b: Address) bool {
+    return net.IpAddress.eql(&a, &b);
+}
+
+pub fn getAddressList(allocator: std.mem.Allocator, host: []const u8, port: u16) !AddressList {
+    if (net.IpAddress.parse(host, port)) |literal| {
+        const addrs = try allocator.alloc(Address, 1);
+        addrs[0] = literal;
+        return .{ .allocator = allocator, .addrs = addrs };
+    } else |_| {}
+
+    const host_name = try net.HostName.init(host);
+    const io_ctx = std.Io.Threaded.global_single_threaded.io();
+
+    var results_buf: [32]net.HostName.LookupResult = undefined;
+    var results: std.Io.Queue(net.HostName.LookupResult) = .init(&results_buf);
+
+    try host_name.lookup(io_ctx, &results, .{ .port = port });
+
+    var addrs: std.ArrayList(Address) = .empty;
+    defer addrs.deinit(allocator);
+
+    while (results.getOneUncancelable(io_ctx)) |entry| {
+        switch (entry) {
+            .address => |addr| try addrs.append(allocator, addr),
+            .canonical_name => {},
+        }
+    } else |err| switch (err) {
+        error.Closed => {},
+    }
+
+    if (addrs.items.len == 0) return error.NoAddressReturned;
+    return .{
+        .allocator = allocator,
+        .addrs = try addrs.toOwnedSlice(allocator),
+    };
+}

--- a/src/proxy/network_detect.zig
+++ b/src/proxy/network_detect.zig
@@ -1,0 +1,216 @@
+const std = @import("std");
+const net = std.Io.net;
+
+const Address = net.IpAddress;
+
+fn ip4(bytes: [4]u8, port: u16) Address {
+    return .{ .ip4 = .{ .bytes = bytes, .port = port } };
+}
+
+pub fn parseIpv4Literal(text: []const u8) ?[4]u8 {
+    var parts = std.mem.splitScalar(u8, text, '.');
+    var out: [4]u8 = undefined;
+    var i: usize = 0;
+    while (parts.next()) |p| {
+        if (i >= 4 or p.len == 0) return null;
+        const n = std.fmt.parseInt(u16, p, 10) catch return null;
+        if (n > 255) return null;
+        out[i] = @intCast(n);
+        i += 1;
+    }
+    if (i != 4) return null;
+    return out;
+}
+
+/// Parse a user-supplied bind address string into an Address.
+/// Accepts IPv4 literals like "1.2.3.4" and IPv6 literals like "::1".
+pub fn parseListenAddress(text: []const u8, port: u16) ?Address {
+    // Try IPv4 first
+    if (parseIpv4Literal(text)) |ip4_bytes| {
+        return ip4(ip4_bytes, port);
+    }
+    // Try IPv6 (may or may not have brackets)
+    var ip6_str = text;
+    if (ip6_str.len >= 2 and ip6_str[0] == '[' and ip6_str[ip6_str.len - 1] == ']') {
+        ip6_str = ip6_str[1 .. ip6_str.len - 1];
+    }
+    return net.IpAddress.parseIp6(ip6_str, port) catch return null;
+}
+
+pub fn isRunningInNonInitNetns() bool {
+    var self_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    var init_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const io_ctx = std.Io.Threaded.global_single_threaded.io();
+
+    const self_len = std.Io.Dir.readLinkAbsolute(io_ctx, "/proc/self/ns/net", &self_buf) catch return false;
+    const init_len = std.Io.Dir.readLinkAbsolute(io_ctx, "/proc/1/ns/net", &init_buf) catch return false;
+    const self_ns = self_buf[0..self_len];
+    const init_ns = init_buf[0..init_len];
+
+    return !std.mem.eql(u8, self_ns, init_ns);
+}
+
+pub fn parseEndpointHost(endpoint: []const u8) ?[]const u8 {
+    const trimmed = std.mem.trim(u8, endpoint, &[_]u8{ ' ', '\t', '\r', '\n' });
+    if (trimmed.len == 0) return null;
+
+    if (trimmed[0] == '[') {
+        const close_idx = std.mem.indexOfScalar(u8, trimmed, ']') orelse return null;
+        const host = trimmed[1..close_idx];
+        if (host.len == 0) return null;
+        return host;
+    }
+
+    if (std.mem.lastIndexOfScalar(u8, trimmed, ':')) |sep| {
+        if (sep == 0) return null;
+        return std.mem.trim(u8, trimmed[0..sep], &[_]u8{ ' ', '\t', '\r', '\n' });
+    }
+
+    return trimmed;
+}
+
+fn resolveHostAddresses(allocator: std.mem.Allocator, host: []const u8, port: u16) ![]Address {
+    if (net.IpAddress.parse(host, port)) |literal| {
+        const addrs = try allocator.alloc(Address, 1);
+        addrs[0] = literal;
+        return addrs;
+    } else |_| {}
+
+    const host_name = try net.HostName.init(host);
+    const io_ctx = std.Io.Threaded.global_single_threaded.io();
+
+    var results_buf: [32]net.HostName.LookupResult = undefined;
+    var results: std.Io.Queue(net.HostName.LookupResult) = .init(&results_buf);
+
+    try host_name.lookup(io_ctx, &results, .{ .port = port });
+
+    var addrs: std.ArrayList(Address) = .empty;
+    defer addrs.deinit(allocator);
+
+    while (results.getOneUncancelable(io_ctx)) |entry| {
+        switch (entry) {
+            .address => |addr| try addrs.append(allocator, addr),
+            .canonical_name => {},
+        }
+    } else |_| {}
+
+    if (addrs.items.len == 0) return error.NoAddressReturned;
+    return try addrs.toOwnedSlice(allocator);
+}
+
+pub fn resolveHostnameIpv4(allocator: std.mem.Allocator, host: []const u8) ?[4]u8 {
+    const addrs = resolveHostAddresses(allocator, host, 443) catch return null;
+    defer allocator.free(addrs);
+
+    for (addrs) |addr| {
+        switch (addr) {
+            .ip4 => |ip4_addr| return ip4_addr.bytes,
+            .ip6 => {},
+        }
+    }
+
+    return null;
+}
+
+pub fn parseAwgEndpointIpv4FromConfig(allocator: std.mem.Allocator, content: []const u8) ?[4]u8 {
+    var in_peer = false;
+    var lines = std.mem.splitScalar(u8, content, '\n');
+
+    while (lines.next()) |raw_line| {
+        const line_no_cr = std.mem.trim(u8, raw_line, "\r");
+        const line = std.mem.trim(u8, line_no_cr, &[_]u8{ ' ', '\t' });
+        if (line.len == 0 or line[0] == '#' or line[0] == ';') continue;
+
+        if (line[0] == '[' and line[line.len - 1] == ']') {
+            in_peer = std.ascii.eqlIgnoreCase(line, "[Peer]");
+            continue;
+        }
+        if (!in_peer) continue;
+
+        const eq_pos = std.mem.indexOfScalar(u8, line, '=') orelse continue;
+        const key = std.mem.trim(u8, line[0..eq_pos], &[_]u8{ ' ', '\t' });
+        if (!std.ascii.eqlIgnoreCase(key, "Endpoint")) continue;
+
+        var value = std.mem.trim(u8, line[eq_pos + 1 ..], &[_]u8{ ' ', '\t' });
+        if (std.mem.indexOfScalar(u8, value, '#')) |idx| value = value[0..idx];
+        if (std.mem.indexOfScalar(u8, value, ';')) |idx| value = value[0..idx];
+        value = std.mem.trim(u8, value, &[_]u8{ ' ', '\t' });
+        const host = parseEndpointHost(value) orelse continue;
+
+        if (parseIpv4Literal(host)) |ip| return ip;
+        if (resolveHostnameIpv4(allocator, host)) |resolved_ip| return resolved_ip;
+    }
+
+    return null;
+}
+
+pub fn detectAwgEndpointIpv4(allocator: std.mem.Allocator) ?[4]u8 {
+    const paths = [_][]const u8{
+        "/etc/amnezia/amneziawg/awg0.conf",
+        "/etc/amnezia/amneziawg/wg0.conf",
+        "/etc/wireguard/wg0.conf",
+    };
+
+    for (paths) |path| {
+        const io_ctx = std.Io.Threaded.global_single_threaded.io();
+        const content = std.Io.Dir.cwd().readFileAlloc(io_ctx, path, allocator, .limited(64 * 1024)) catch continue;
+        defer allocator.free(content);
+
+        if (parseAwgEndpointIpv4FromConfig(allocator, content)) |ip| return ip;
+    }
+
+    return null;
+}
+
+pub fn detectPublicIpv4(allocator: std.mem.Allocator, comptime fetchBytes: anytype) ?[4]u8 {
+    const services = [_][]const u8{
+        "https://api.ipify.org",
+        "https://ifconfig.me",
+        "https://ipv4.icanhazip.com",
+    };
+
+    for (services) |url| {
+        const stdout = fetchBytes(allocator, url) catch continue;
+        const trimmed = std.mem.trim(u8, stdout, &[_]u8{ ' ', '\t', '\r', '\n' });
+        const parsed = parseIpv4Literal(trimmed);
+        allocator.free(stdout);
+        if (parsed) |ip| return ip;
+    }
+
+    return null;
+}
+
+pub fn formatIpv4Bytes(ip: [4]u8, buf: *[16]u8) []const u8 {
+    return std.fmt.bufPrint(buf, "{d}.{d}.{d}.{d}", .{ ip[0], ip[1], ip[2], ip[3] }) catch "?.?.?.?";
+}
+
+pub fn ipv4NetworkToHostBytes(ip: [4]u8) [4]u8 {
+    return .{ ip[3], ip[2], ip[1], ip[0] };
+}
+
+test "parse ipv4 literal" {
+    const parsed = parseIpv4Literal("179.43.141.146") orelse return error.TestExpectedEqual;
+    try std.testing.expectEqual([4]u8{ 179, 43, 141, 146 }, parsed);
+    try std.testing.expect(parseIpv4Literal("179.43.141") == null);
+    try std.testing.expect(parseIpv4Literal("179.43.141.999") == null);
+}
+
+test "parse endpoint host" {
+    try std.testing.expectEqualStrings("179.43.141.146", parseEndpointHost("179.43.141.146:41182").?);
+    try std.testing.expectEqualStrings("vpn.example.com", parseEndpointHost("vpn.example.com:51820").?);
+    try std.testing.expectEqualStrings("2001:db8::1", parseEndpointHost("[2001:db8::1]:41182").?);
+}
+
+test "parse awg endpoint ipv4 from config" {
+    const content =
+        \\[Interface]
+        \\Address = 100.83.12.60/32
+        \\
+        \\[Peer]
+        \\PublicKey = x
+        \\Endpoint = 179.43.141.146:41182
+    ;
+
+    const parsed = parseAwgEndpointIpv4FromConfig(std.testing.allocator, content) orelse return error.TestExpectedEqual;
+    try std.testing.expectEqual([4]u8{ 179, 43, 141, 146 }, parsed);
+}

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -5,7 +5,8 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
-const net = std.net;
+const net = std.Io.net;
+const Address = net.IpAddress;
 const posix = std.posix;
 const linux = std.os.linux;
 
@@ -19,6 +20,50 @@ const upstream_mod = @import("upstream.zig");
 const tunnel_mod = @import("../tunnel.zig");
 const socks5 = @import("socks5.zig");
 const http_connect = @import("http_connect.zig");
+const SubnetRateLimit = @import("subnet_rate_limit.zig").SubnetRateLimit;
+const DynamicRecordSizer = @import("drs.zig").DynamicRecordSizer;
+const ReplayCache = @import("replay_cache.zig").ReplayCache;
+const MessageQueue = @import("message_queue.zig").MessageQueue;
+const queue_io = @import("queue_io.zig");
+const middle_proxy_routing = @import("middle_proxy_routing.zig");
+const socket_utils = @import("socket_utils.zig");
+const network_detect = @import("network_detect.zig");
+const http_fetch = @import("http_fetch.zig");
+const fd_limits = @import("fd_limits.zig");
+const connection_phase = @import("connection_phase.zig");
+const net_helpers = @import("net_helpers.zig");
+const connection_pool_mod = @import("connection_pool.zig");
+const relay_steps = @import("relay_steps.zig");
+const middle_proxy_frames = @import("middle_proxy_frames.zig");
+const middle_proxy_handshake = @import("middle_proxy_handshake.zig");
+const proxy_upstream_handshake = @import("proxy_upstream_handshake.zig");
+const middle_proxy_fallback = @import("middle_proxy_fallback.zig");
+const dc_nonce = @import("dc_nonce.zig");
+const upstream_failover = @import("upstream_failover.zig");
+
+test {
+    // Keep extracted proxy submodule tests in the default `zig build test` run.
+    _ = @import("subnet_rate_limit.zig");
+    _ = @import("drs.zig");
+    _ = @import("replay_cache.zig");
+    _ = @import("message_queue.zig");
+    _ = @import("queue_io.zig");
+    _ = @import("middle_proxy_routing.zig");
+    _ = @import("socket_utils.zig");
+    _ = @import("network_detect.zig");
+    _ = @import("http_fetch.zig");
+    _ = @import("fd_limits.zig");
+    _ = @import("connection_phase.zig");
+    _ = @import("net_helpers.zig");
+    _ = @import("connection_pool.zig");
+    _ = @import("relay_steps.zig");
+    _ = @import("middle_proxy_frames.zig");
+    _ = @import("middle_proxy_handshake.zig");
+    _ = @import("proxy_upstream_handshake.zig");
+    _ = @import("middle_proxy_fallback.zig");
+    _ = @import("dc_nonce.zig");
+    _ = @import("upstream_failover.zig");
+}
 
 const log = std.log.scoped(.proxy);
 
@@ -31,7 +76,6 @@ const accept_batch_limit: usize = 256;
 const stats_log_interval_s: i64 = 10;
 const stats_log_interval_ns: i128 = @as(i128, stats_log_interval_s) * std.time.ns_per_s;
 const timer_scan_budget: usize = 512;
-const nofile_fd_overhead: usize = 512;
 const middle_proxy_config_url = "https://core.telegram.org/getProxyConfig";
 const middle_proxy_secret_url = "https://core.telegram.org/getProxySecret";
 const middle_proxy_update_period_ns: u64 = 24 * 60 * 60 * std.time.ns_per_s;
@@ -42,293 +86,29 @@ const mp_handshake_frame_buf_size: usize = 2048;
 const read_buf_size: usize = 32 * 1024;
 const max_pipelined_handshake_bytes: usize = 128 * 1024;
 
-/// Per-/24 (IPv4) or /48 (IPv6) subnet rate limiter.
-/// Fixed-size open-addressed hash table — zero heap allocation.
-/// Token bucket per subnet: each second refills up to max_per_sec tokens.
-const SubnetRateLimit = struct {
-    const BUCKETS = 65536;
-    const MAX_PROBES = 8;
-    const stale_after_s: i64 = 60;
-
-    const Entry = struct {
-        used: bool = false,
-        subnet_key: u32 = 0,
-        tokens: u8 = 0,
-        last_refill_s: i64 = 0,
-    };
-
-    hash_seed: u64 = 0,
-    entries: [BUCKETS]Entry = [_]Entry{.{}} ** BUCKETS,
-
-    fn init() SubnetRateLimit {
-        return .{
-            .hash_seed = std.crypto.random.int(u64),
-        };
-    }
-
-    fn indexFor(self: *const SubnetRateLimit, key: u32) usize {
-        var x = self.hash_seed ^ @as(u64, key);
-        x +%= 0x9E3779B97F4A7C15;
-        x ^= x >> 30;
-        x *%= 0xBF58476D1CE4E5B9;
-        x ^= x >> 27;
-        x *%= 0x94D049BB133111EB;
-        x ^= x >> 31;
-        return @as(usize, @intCast(x & (BUCKETS - 1)));
-    }
-
-    fn findEntry(self: *SubnetRateLimit, key: u32) ?*Entry {
-        const start = self.indexFor(key);
-        var probe: usize = 0;
-        while (probe < MAX_PROBES) : (probe += 1) {
-            const idx = (start + probe) & (BUCKETS - 1);
-            const e = &self.entries[idx];
-            if (!e.used) return null;
-            if (e.subnet_key == key) return e;
-        }
-        return null;
-    }
-
-    /// Returns true if the connection is allowed, false if rate-limited.
-    fn check(self: *SubnetRateLimit, addr: net.Address, max_per_sec: u8) bool {
-        if (max_per_sec == 0) return true;
-        const key = subnetKey(addr);
-        const now_s = @divTrunc(std.time.milliTimestamp(), 1000);
-
-        const start = self.indexFor(key);
-        var first_stale_idx: ?usize = null;
-        var oldest_idx: usize = start;
-        var oldest_ts: i64 = std.math.maxInt(i64);
-
-        var probe: usize = 0;
-        while (probe < MAX_PROBES) : (probe += 1) {
-            const idx = (start + probe) & (BUCKETS - 1);
-            const e = &self.entries[idx];
-
-            if (!e.used) {
-                e.* = .{ .used = true, .subnet_key = key, .tokens = max_per_sec -| 1, .last_refill_s = now_s };
-                return true;
-            }
-
-            if (e.subnet_key == key) {
-                // Refill tokens based on elapsed seconds
-                const elapsed = now_s - e.last_refill_s;
-                if (elapsed > 0) {
-                    const refill: u16 = @intCast(@min(elapsed, 255));
-                    const topped = @as(u16, e.tokens) + refill * @as(u16, max_per_sec);
-                    e.tokens = @intCast(@min(@as(u16, max_per_sec), topped));
-                    e.last_refill_s = now_s;
-                }
-
-                if (e.tokens > 0) {
-                    e.tokens -= 1;
-                    return true;
-                }
-                return false;
-            }
-
-            if (now_s - e.last_refill_s > stale_after_s and first_stale_idx == null) {
-                first_stale_idx = idx;
-            }
-            if (e.last_refill_s < oldest_ts) {
-                oldest_ts = e.last_refill_s;
-                oldest_idx = idx;
-            }
-        }
-
-        const victim_idx = first_stale_idx orelse oldest_idx;
-        self.entries[victim_idx] = .{ .used = true, .subnet_key = key, .tokens = max_per_sec -| 1, .last_refill_s = now_s };
-        return true;
-    }
-
-    fn subnetKey(addr: net.Address) u32 {
-        if (addr.any.family == posix.AF.INET) {
-            // /24 subnet: mask off last octet
-            const ip_bytes = std.mem.asBytes(&addr.in.sa.addr);
-            return @as(u32, ip_bytes[0]) << 16 | @as(u32, ip_bytes[1]) << 8 | @as(u32, ip_bytes[2]);
-        } else if (addr.any.family == posix.AF.INET6) {
-            const ip6 = &addr.in6.sa.addr;
-
-            // Detect IPv4-mapped IPv6 (::ffff:a.b.c.d).
-            // On dual-stack [::] listeners every IPv4 client arrives in this form;
-            // without this branch all IPv4 clients would collapse to key 0 and the
-            // entire IPv4 internet would share a single /24 token bucket.
-            const is_ipv4_mapped = std.mem.eql(u8, ip6[0..10], &[_]u8{0} ** 10) and
-                ip6[10] == 0xff and ip6[11] == 0xff;
-            if (is_ipv4_mapped) {
-                // Apply IPv4 /24 logic on the embedded IPv4 octets (bytes 12..14).
-                return @as(u32, ip6[12]) << 16 | @as(u32, ip6[13]) << 8 | @as(u32, ip6[14]);
-            }
-
-            // Native IPv6 /48 subnet: hash first 6 bytes into u32.
-            return @as(u32, ip6[0]) << 24 | @as(u32, ip6[1]) << 16 | @as(u32, ip6[2]) << 8 | @as(u32, ip6[3]) ^ (@as(u32, ip6[4]) << 8 | @as(u32, ip6[5]));
-        }
-        return 0;
-    }
-};
-
-const MsgBlock = struct {
-    len: usize,
-    data: [msg_block_size]u8,
-};
-
-const msg_block_size: usize = 2048;
-const msg_free_cap_per_queue: usize = 4;
-const max_scatter_parts: usize = 64;
 const upstream_candidates_inline_cap: usize = 4;
 
-fn hasFatalEpollHangup(events: u32) bool {
-    return (events & (linux.EPOLL.ERR | linux.EPOLL.HUP | linux.EPOLL.RDHUP)) != 0;
-}
+const CompatRwLock = struct {
+    mutex: std.Io.Mutex = .init,
 
-const MessageQueue = struct {
-    allocator: std.mem.Allocator,
-    free: std.ArrayListUnmanaged(*MsgBlock) = .{},
-    blocks: std.ArrayListUnmanaged(*MsgBlock) = .{},
-    head_idx: usize = 0,
-    offset: usize = 0,
-    total_len: usize = 0,
-
-    fn deinit(self: *MessageQueue) void {
-        self.clear();
-
-        for (self.free.items) |blk| self.allocator.destroy(blk);
-
-        self.free.deinit(self.allocator);
-        self.blocks.deinit(self.allocator);
+    fn io() std.Io {
+        return std.Io.Threaded.global_single_threaded.io();
     }
 
-    fn clear(self: *MessageQueue) void {
-        for (self.blocks.items[self.head_idx..]) |blk| {
-            self.recycleBlock(blk);
-        }
-        self.blocks.clearRetainingCapacity();
-        self.head_idx = 0;
-        self.offset = 0;
-        self.total_len = 0;
+    fn lock(self: *CompatRwLock) void {
+        self.mutex.lockUncancelable(io());
     }
 
-    fn isEmpty(self: *const MessageQueue) bool {
-        return self.total_len == 0;
+    fn unlock(self: *CompatRwLock) void {
+        self.mutex.unlock(io());
     }
 
-    fn appendCopy(self: *MessageQueue, data: []const u8) !void {
-        if (data.len == 0) return;
-
-        var off: usize = 0;
-
-        if (self.blocks.items.len > 0) {
-            const last_blk = self.blocks.items[self.blocks.items.len - 1];
-            if (last_blk.len < msg_block_size) {
-                const space = msg_block_size - last_blk.len;
-                const take = @min(space, data.len);
-                @memcpy(last_blk.data[last_blk.len .. last_blk.len + take], data[off .. off + take]);
-                last_blk.len += take;
-                self.total_len += take;
-                off += take;
-            }
-        }
-
-        while (off < data.len) {
-            const rem = data.len - off;
-            const take = @min(rem, msg_block_size);
-
-            const blk = try self.acquireBlock();
-            errdefer self.recycleBlock(blk);
-
-            blk.len = take;
-            @memcpy(blk.data[0..take], data[off .. off + take]);
-            try self.blocks.append(self.allocator, blk);
-            self.total_len += take;
-            off += take;
-        }
+    fn lockShared(self: *CompatRwLock) void {
+        self.mutex.lockUncancelable(io());
     }
 
-    fn appendOwned(self: *MessageQueue, owned: []u8) !void {
-        defer self.allocator.free(owned);
-        try self.appendCopy(owned);
-    }
-
-    fn prepareIovecs(self: *const MessageQueue, out: []posix.iovec_const) usize {
-        if (self.head_idx >= self.blocks.items.len) return 0;
-
-        var count: usize = 0;
-        var local_off = self.offset;
-        for (self.blocks.items[self.head_idx..]) |blk| {
-            if (count >= out.len) break;
-
-            if (local_off >= blk.len) {
-                local_off -= blk.len;
-                continue;
-            }
-
-            out[count] = .{ .base = blk.data[local_off..blk.len].ptr, .len = blk.len - local_off };
-            count += 1;
-            local_off = 0;
-        }
-        return count;
-    }
-
-    fn consume(self: *MessageQueue, bytes: usize) !void {
-        if (bytes == 0 or self.total_len == 0) return;
-
-        var remaining = @min(bytes, self.total_len);
-        self.total_len -= remaining;
-
-        while (remaining > 0 and self.head_idx < self.blocks.items.len) {
-            const blk = self.blocks.items[self.head_idx];
-            const blk_left = blk.len - self.offset;
-
-            if (remaining < blk_left) {
-                self.offset += remaining;
-                remaining = 0;
-                break;
-            }
-
-            remaining -= blk_left;
-            self.offset = 0;
-            self.head_idx += 1;
-            self.recycleBlock(blk);
-        }
-
-        if (self.head_idx > 0 and (self.head_idx >= self.blocks.items.len or self.head_idx >= 64)) {
-            const rem = self.blocks.items.len - self.head_idx;
-            if (rem > 0) {
-                std.mem.copyForwards(*MsgBlock, self.blocks.items[0..rem], self.blocks.items[self.head_idx..]);
-            }
-            self.blocks.shrinkRetainingCapacity(rem);
-            self.head_idx = 0;
-        }
-
-        if (self.total_len == 0) {
-            self.head_idx = 0;
-            self.offset = 0;
-        }
-    }
-
-    fn acquireBlock(self: *MessageQueue) !*MsgBlock {
-        if (self.free.items.len > 0) {
-            return self.free.pop().?;
-        }
-
-        const blk = try self.allocator.create(MsgBlock);
-        blk.* = .{
-            .len = 0,
-            .data = undefined,
-        };
-        return blk;
-    }
-
-    fn recycleBlock(self: *MessageQueue, blk: *MsgBlock) void {
-        blk.len = 0;
-        if (self.free.items.len >= msg_free_cap_per_queue) {
-            self.allocator.destroy(blk);
-            return;
-        }
-
-        self.free.append(self.allocator, blk) catch {
-            self.allocator.destroy(blk);
-        };
+    fn unlockShared(self: *CompatRwLock) void {
+        self.mutex.unlock(io());
     }
 };
 
@@ -337,63 +117,6 @@ const UpstreamKind = enum {
     dc,
     mask,
 };
-
-const ConnectionPhase = enum {
-    idle,
-    reading_tls_header,
-    reading_client_hello_body,
-    writing_server_hello_first,
-    desync_wait,
-    writing_server_hello_rest,
-    reading_mtproto_tls_header,
-    reading_mtproto_tls_body,
-    connecting_upstream,
-    // SOCKS5 proxy handshake sub-phases
-    proxy_socks5_greeting,
-    proxy_socks5_greeting_resp,
-    proxy_socks5_auth,
-    proxy_socks5_auth_resp,
-    proxy_socks5_connect,
-    proxy_socks5_connect_resp,
-    // HTTP CONNECT proxy handshake sub-phases
-    proxy_http_connect,
-    proxy_http_connect_resp,
-    writing_dc_nonce,
-    middle_proxy_handshake,
-    relaying,
-    mask_relaying,
-    closing,
-};
-
-fn shouldCloseOnFatalHangup(phase: ConnectionPhase, event_fd: posix.fd_t, upstream_fd: posix.fd_t) bool {
-    if (phase == .idle) return false;
-
-    // During connecting_upstream, EPOLLERR on upstream fd is expected and
-    // handled via onUpstreamWritable -> onUpstreamConnectComplete.
-    if (phase == .connecting_upstream and event_fd == upstream_fd) return false;
-
-    // During proxy handshake phases, upstream hangup is a proxy
-    // connect failure — let the handler deal with it.
-    if (isProxyHandshakePhase(phase) and event_fd == upstream_fd) return false;
-
-    return true;
-}
-
-/// Check if a phase is one of the proxy handshake sub-phases.
-fn isProxyHandshakePhase(phase: ConnectionPhase) bool {
-    return switch (phase) {
-        .proxy_socks5_greeting,
-        .proxy_socks5_greeting_resp,
-        .proxy_socks5_auth,
-        .proxy_socks5_auth_resp,
-        .proxy_socks5_connect,
-        .proxy_socks5_connect_resp,
-        .proxy_http_connect,
-        .proxy_http_connect_resp,
-        => true,
-        else => false,
-    };
-}
 
 const MiddleProxyHandshakeStep = enum {
     none,
@@ -404,133 +127,53 @@ const MiddleProxyHandshakeStep = enum {
     done,
 };
 
-const RelayProgress = enum {
-    none,
-    partial,
-    forwarded,
-};
+const DcConnectPlan = middle_proxy_routing.DcConnectPlan;
+const buildDcConnectPlan = middle_proxy_routing.buildDcConnectPlan;
+const parseMiddleProxyAddressesForDc = middle_proxy_routing.parseMiddleProxyAddressesForDc;
+const trySelectReachableMiddleProxy = middle_proxy_routing.trySelectReachableMiddleProxy;
+const addressesEqual = middle_proxy_routing.addressesEqual;
 
-const DcConnectPlan = struct {
-    candidates: [16]net.Address = undefined,
-    count: usize = 0,
-    use_middle_proxy: bool = false,
-    is_media_path: bool = false,
-    direct_fallback: ?net.Address = null,
-};
+const realtimeSeconds = socket_utils.realtimeSeconds;
+const nowMs = socket_utils.nowMs;
+const nowNs = socket_utils.nowNs;
+const sleepNs = socket_utils.sleepNs;
+const closeFd = socket_utils.closeFd;
+const checkSocketConnectError = socket_utils.checkSocketConnectError;
+const acceptClient = socket_utils.acceptClient;
+const localSocketAddress = socket_utils.localSocketAddress;
+const setNonBlocking = socket_utils.setNonBlocking;
+const secondsToMs = socket_utils.secondsToMs;
+const setTcpNoDelay = socket_utils.setTcpNoDelay;
+const configureRelaySocket = socket_utils.configureRelaySocket;
+const formatAddress = socket_utils.formatAddress;
 
-const DynamicRecordSizer = struct {
-    current_size: usize,
-    records_sent: u32,
-    bytes_sent: u64,
-    enabled: bool,
+const parseIpv4Literal = network_detect.parseIpv4Literal;
+const parseListenAddress = network_detect.parseListenAddress;
+const isRunningInNonInitNetns = network_detect.isRunningInNonInitNetns;
+const detectAwgEndpointIpv4 = network_detect.detectAwgEndpointIpv4;
+const formatIpv4Bytes = network_detect.formatIpv4Bytes;
+const ipv4NetworkToHostBytes = network_detect.ipv4NetworkToHostBytes;
+const fetchUrlBytes = http_fetch.fetchUrlBytes;
+const fetchUrlBytesViaInterface = http_fetch.fetchUrlBytesViaInterface;
+const requiredFdsForConnections = fd_limits.requiredFdsForConnections;
+const maxConnectionsForNofile = fd_limits.maxConnectionsForNofile;
+const getNofileSoftLimit = fd_limits.getNofileSoftLimit;
+const checkNofileLimit = fd_limits.checkNofileLimit;
+const epollCreate = socket_utils.epollCreate;
+const ConnectionPhase = connection_phase.ConnectionPhase;
+const hasFatalEpollHangup = connection_phase.hasFatalEpollHangup;
+const shouldCloseOnFatalHangup = connection_phase.shouldCloseOnFatalHangup;
+const RelayProgress = relay_steps.RelayProgress;
+const AddressList = net_helpers.AddressList;
+const ip4 = net_helpers.ip4;
+const ip6 = net_helpers.ip6;
+const isIpv6 = net_helpers.isIpv6;
+const addressEql = net_helpers.addressEql;
+const getAddressList = net_helpers.getAddressList;
 
-    const initial_size: usize = 1369;
-    const full_size: usize = constants.max_tls_plaintext_size;
-    const ramp_record_threshold: u32 = 8;
-    const ramp_byte_threshold: u64 = 128 * 1024;
-
-    fn init(enabled: bool) DynamicRecordSizer {
-        // When DRS is disabled the user opted out of anti-DPI record-size
-        // masking, so there is no reason to keep clamping records to the
-        // probe-friendly 1369-byte size — doing so only hurts throughput.
-        // Start at the full TLS plaintext size and short-circuit ramp-up.
-        return .{
-            .current_size = if (enabled) initial_size else full_size,
-            .records_sent = 0,
-            .bytes_sent = 0,
-            .enabled = enabled,
-        };
-    }
-
-    fn nextRecordSize(self: *DynamicRecordSizer) usize {
-        return self.current_size;
-    }
-
-    fn recordSent(self: *DynamicRecordSizer, payload_len: usize) void {
-        if (!self.enabled) return;
-        self.records_sent += 1;
-        self.bytes_sent += @as(u64, @intCast(payload_len));
-        if (self.current_size == initial_size and
-            (self.records_sent >= ramp_record_threshold or self.bytes_sent >= ramp_byte_threshold))
-        {
-            self.current_size = full_size;
-        }
-    }
-};
-
-const ReplayCache = struct {
-    const BUCKETS = 8192;
-    const MAX_PROBES = 8;
-    const stale_after_s: i64 = 60 * 60;
-
-    const Entry = struct {
-        used: bool = false,
-        key: u64 = 0,
-        last_seen_s: i64 = 0,
-    };
-
-    hash_seed: u64 = 0,
-    entries: [BUCKETS]Entry = [_]Entry{.{}} ** BUCKETS,
-
-    fn init() ReplayCache {
-        return .{
-            .hash_seed = std.crypto.random.int(u64),
-        };
-    }
-
-    fn digestKey(digest: *const [32]u8) u64 {
-        return std.mem.readInt(u64, digest[0..8], .little);
-    }
-
-    fn indexFor(self: *const ReplayCache, key: u64) usize {
-        var x = self.hash_seed ^ key;
-        x +%= 0x9E3779B97F4A7C15;
-        x ^= x >> 30;
-        x *%= 0xBF58476D1CE4E5B9;
-        x ^= x >> 27;
-        x *%= 0x94D049BB133111EB;
-        x ^= x >> 31;
-        return @as(usize, @intCast(x & (BUCKETS - 1)));
-    }
-
-    pub fn checkAndInsert(self: *ReplayCache, digest: *const [32]u8) bool {
-        const key = digestKey(digest);
-        const now_s = @divTrunc(std.time.milliTimestamp(), 1000);
-        const start = self.indexFor(key);
-
-        var first_stale_idx: ?usize = null;
-        var oldest_idx: usize = start;
-        var oldest_ts: i64 = std.math.maxInt(i64);
-
-        var probe: usize = 0;
-        while (probe < MAX_PROBES) : (probe += 1) {
-            const idx = (start + probe) & (BUCKETS - 1);
-            const e = &self.entries[idx];
-
-            if (!e.used) {
-                e.* = .{ .used = true, .key = key, .last_seen_s = now_s };
-                return false;
-            }
-
-            if (e.key == key) {
-                e.last_seen_s = now_s;
-                return true;
-            }
-
-            if (now_s - e.last_seen_s > stale_after_s and first_stale_idx == null) {
-                first_stale_idx = idx;
-            }
-            if (e.last_seen_s < oldest_ts) {
-                oldest_ts = e.last_seen_s;
-                oldest_idx = idx;
-            }
-        }
-
-        const victim_idx = first_stale_idx orelse oldest_idx;
-        self.entries[victim_idx] = .{ .used = true, .key = key, .last_seen_s = now_s };
-        return false;
-    }
-};
+fn detectPublicIpv4(allocator: std.mem.Allocator) ?[4]u8 {
+    return network_detect.detectPublicIpv4(allocator, fetchUrlBytes);
+}
 
 const ConnectionSlot = struct {
     index: u32 = 0,
@@ -539,7 +182,7 @@ const ConnectionSlot = struct {
     client_fd: posix.fd_t = -1,
     upstream_fd: posix.fd_t = -1,
     upstream_kind: UpstreamKind = .none,
-    peer_addr: net.Address = undefined,
+    peer_addr: Address = undefined,
 
     phase: ConnectionPhase = .idle,
     active_reserved: bool = false,
@@ -590,13 +233,13 @@ const ConnectionSlot = struct {
     use_middle_proxy: bool = false,
     is_media_path: bool = false,
 
-    upstream_candidates_inline: [upstream_candidates_inline_cap]net.Address = undefined,
-    upstream_candidates_heap: ?[]net.Address = null,
+    upstream_candidates_inline: [upstream_candidates_inline_cap]Address = undefined,
+    upstream_candidates_heap: ?[]Address = null,
     upstream_candidate_count: u8 = 0,
     upstream_candidate_next: u8 = 0,
-    direct_fallback_addr: ?net.Address = null,
+    direct_fallback_addr: ?Address = null,
     direct_fallback_used: bool = false,
-    current_upstream_addr: ?net.Address = null,
+    current_upstream_addr: ?Address = null,
 
     // Pending initial bytes for direct DC path (promotion tag)
     dc_initial_tail: ?[]u8 = null,
@@ -651,7 +294,7 @@ const ConnectionSlot = struct {
     proxy_handshake_buf: [1024]u8 = undefined,
     proxy_handshake_pos: u16 = 0,
     proxy_handshake_len: u16 = 0,
-    proxy_target_addr: ?net.Address = null,
+    proxy_target_addr: ?Address = null,
 
     // Current epoll interests
     client_interest_in: bool = false,
@@ -748,14 +391,14 @@ const ConnectionSlot = struct {
         return self.client_hello_inline[0..self.client_hello_len];
     }
 
-    fn upstreamCandidates(self: *const ConnectionSlot) []const net.Address {
+    fn upstreamCandidates(self: *const ConnectionSlot) []const Address {
         const count: usize = self.upstream_candidate_count;
         if (count == 0) return &.{};
         if (self.upstream_candidates_heap) |buf| return buf[0..count];
         return self.upstream_candidates_inline[0..count];
     }
 
-    fn setUpstreamCandidates(self: *ConnectionSlot, allocator: std.mem.Allocator, candidates: []const net.Address) !void {
+    fn setUpstreamCandidates(self: *ConnectionSlot, allocator: std.mem.Allocator, candidates: []const Address) !void {
         if (self.upstream_candidates_heap) |buf| {
             allocator.free(buf);
             self.upstream_candidates_heap = null;
@@ -772,7 +415,7 @@ const ConnectionSlot = struct {
             return;
         }
 
-        const heap = try allocator.alloc(net.Address, candidates.len);
+        const heap = try allocator.alloc(Address, candidates.len);
         errdefer allocator.free(heap);
 
         @memcpy(heap, candidates);
@@ -788,7 +431,7 @@ pub const BenchCandidatePath = struct {
         self.slot.resetOwnedBuffers(allocator);
     }
 
-    pub fn apply(self: *BenchCandidatePath, allocator: std.mem.Allocator, candidates: []const net.Address) !usize {
+    pub fn apply(self: *BenchCandidatePath, allocator: std.mem.Allocator, candidates: []const Address) !usize {
         if (candidates.len == 0) return error.BenchEmptyCandidates;
 
         try self.slot.setUpstreamCandidates(allocator, candidates);
@@ -800,96 +443,7 @@ pub const BenchCandidatePath = struct {
     }
 };
 
-const ConnectionPool = struct {
-    allocator: std.mem.Allocator,
-    slots: []?*ConnectionSlot,
-    free_stack: []u32,
-    free_count: u32,
-    allocated_hi: u32,
-    fd_to_slot: std.AutoHashMapUnmanaged(posix.fd_t, u32) = .{},
-
-    fn init(allocator: std.mem.Allocator, capacity: u32) !ConnectionPool {
-        const slots = try allocator.alloc(?*ConnectionSlot, capacity);
-        errdefer allocator.free(slots);
-
-        const free_stack = try allocator.alloc(u32, capacity);
-        errdefer allocator.free(free_stack);
-
-        for (slots) |*slot| {
-            slot.* = null;
-        }
-
-        var i: usize = 0;
-        while (i < capacity) : (i += 1) {
-            free_stack[i] = @intCast(capacity - 1 - i);
-        }
-
-        var pool = ConnectionPool{
-            .allocator = allocator,
-            .slots = slots,
-            .free_stack = free_stack,
-            .free_count = capacity,
-            .allocated_hi = 0,
-            .fd_to_slot = .{},
-        };
-        try pool.fd_to_slot.ensureTotalCapacity(allocator, @as(u32, capacity * 2));
-        return pool;
-    }
-
-    fn deinit(self: *ConnectionPool) void {
-        for (self.slots) |slot_opt| {
-            if (slot_opt) |slot_ptr| {
-                self.allocator.destroy(slot_ptr);
-            }
-        }
-        self.fd_to_slot.deinit(self.allocator);
-        self.allocator.free(self.free_stack);
-        self.allocator.free(self.slots);
-    }
-
-    fn acquire(self: *ConnectionPool) ?*ConnectionSlot {
-        if (self.free_count == 0) return null;
-        self.free_count -= 1;
-        const idx = self.free_stack[self.free_count];
-        if (self.slots[idx] == null) {
-            const fresh = self.allocator.create(ConnectionSlot) catch {
-                self.free_stack[self.free_count] = idx;
-                self.free_count += 1;
-                return null;
-            };
-            fresh.* = .{};
-            self.slots[idx] = fresh;
-            const hi = idx + 1;
-            if (hi > self.allocated_hi) self.allocated_hi = hi;
-        }
-
-        const slot = self.slots[idx].?;
-        slot.* = .{};
-        slot.index = idx;
-        slot.client_queue.allocator = self.allocator;
-        slot.upstream_queue.allocator = self.allocator;
-        return slot;
-    }
-
-    fn release(self: *ConnectionPool, slot: *ConnectionSlot) void {
-        self.free_stack[self.free_count] = slot.index;
-        self.free_count += 1;
-        slot.phase = .idle;
-    }
-
-    fn mapFd(self: *ConnectionPool, fd: posix.fd_t, idx: u32) !void {
-        try self.fd_to_slot.put(self.allocator, fd, idx);
-    }
-
-    fn unmapFd(self: *ConnectionPool, fd: posix.fd_t) void {
-        _ = self.fd_to_slot.remove(fd);
-    }
-
-    fn getByFd(self: *ConnectionPool, fd: posix.fd_t) ?*ConnectionSlot {
-        const idx = self.fd_to_slot.get(fd) orelse return null;
-        return self.slots[idx];
-    }
-};
+const ConnectionPool = connection_pool_mod.ConnectionPool(ConnectionSlot);
 
 pub const ProxyState = struct {
     pub const UserMetrics = struct {
@@ -940,7 +494,7 @@ pub const ProxyState = struct {
     handshakes_inflight: std.atomic.Value(u32),
     accept_paused: std.atomic.Value(bool),
     saturation_paused: std.atomic.Value(bool),
-    mask_addr: ?net.Address,
+    mask_addr: ?Address,
     replay_cache: ReplayCache,
     tls_server_hello_template: [tls.server_hello_template_len]u8,
 
@@ -952,20 +506,20 @@ pub const ProxyState = struct {
     stats_hs_timeout: std.atomic.Value(u64),
     stats_mp_fallback: std.atomic.Value(u64),
 
-    middle_proxy_lock: std.Thread.RwLock = .{},
+    middle_proxy_lock: CompatRwLock = .{},
     // Regular (non-media) primary endpoints per DC 1..5. Matches `proxy_for N`
     // lines in Telegram's getProxyConfig.
-    middle_proxy_addrs_primary: [5]net.Address,
+    middle_proxy_addrs_primary: [5]Address,
     // Media primary endpoints per DC 1..5 (matches `proxy_for -N`). Telegram
     // serves large-file traffic on a dedicated MP fleet; routing a media
     // client through a regular MP causes downloads to stall.
-    middle_proxy_addrs_media_primary: [5]net.Address,
-    middle_proxy_addr_203: net.Address,
-    middle_proxy_addrs_dc4: [16]net.Address,
+    middle_proxy_addrs_media_primary: [5]Address,
+    middle_proxy_addr_203: Address,
+    middle_proxy_addrs_dc4: [16]Address,
     middle_proxy_addrs_dc4_len: usize,
-    middle_proxy_addrs_media_dc4: [16]net.Address,
+    middle_proxy_addrs_media_dc4: [16]Address,
     middle_proxy_addrs_media_dc4_len: usize,
-    middle_proxy_addrs_203: [8]net.Address,
+    middle_proxy_addrs_203: [8]Address,
     middle_proxy_addrs_203_len: usize,
     middle_proxy_secret: [256]u8,
     middle_proxy_secret_len: usize,
@@ -990,13 +544,13 @@ pub const ProxyState = struct {
             }) catch continue;
         }
 
-        var resolved_addr: ?net.Address = null;
+        var resolved_addr: ?Address = null;
         if (cfg.mask) {
             const mask_target = if (cfg.mask_port == 443) cfg.tls_domain else "127.0.0.1";
             if (cfg.mask_port != 443) {
                 log.info("mask_port={d} configured, using local mask target 127.0.0.1", .{cfg.mask_port});
             }
-            const list = net.getAddressList(allocator, mask_target, cfg.mask_port) catch |err| blk: {
+            const list = getAddressList(allocator, mask_target, cfg.mask_port) catch |err| blk: {
                 log.err("Failed to resolve mask target '{s}': {any}", .{ mask_target, err });
                 break :blk null;
             };
@@ -1058,7 +612,7 @@ pub const ProxyState = struct {
             .config = cfg,
             .user_secrets = secrets.toOwnedSlice(allocator) catch &.{},
             .user_metrics = user_metrics.toOwnedSlice(allocator) catch &.{},
-            .start_time_seconds = std.time.timestamp(),
+            .start_time_seconds = realtimeSeconds(),
             .connection_count = std.atomic.Value(u64).init(0),
             .closed_count = std.atomic.Value(u64).init(0),
             .client_to_upstream_bytes_total = std.atomic.Value(u64).init(0),
@@ -1079,11 +633,11 @@ pub const ProxyState = struct {
             .middle_proxy_addrs_primary = constants.tg_middle_proxies_v4,
             .middle_proxy_addrs_media_primary = constants.tg_media_middle_proxies_v4,
             .middle_proxy_addr_203 = constants.getDcAddressV4(203),
-            .middle_proxy_addrs_dc4 = [_]net.Address{constants.tg_middle_proxies_v4[3]} ++ ([_]net.Address{constants.tg_middle_proxies_v4[3]} ** 15),
+            .middle_proxy_addrs_dc4 = [_]Address{constants.tg_middle_proxies_v4[3]} ++ ([_]Address{constants.tg_middle_proxies_v4[3]} ** 15),
             .middle_proxy_addrs_dc4_len = 1,
-            .middle_proxy_addrs_media_dc4 = [_]net.Address{constants.tg_media_middle_proxies_v4[3]} ++ ([_]net.Address{constants.tg_media_middle_proxies_v4[3]} ** 15),
+            .middle_proxy_addrs_media_dc4 = [_]Address{constants.tg_media_middle_proxies_v4[3]} ++ ([_]Address{constants.tg_media_middle_proxies_v4[3]} ** 15),
             .middle_proxy_addrs_media_dc4_len = 1,
-            .middle_proxy_addrs_203 = [_]net.Address{constants.getDcAddressV4(203)} ++ ([_]net.Address{constants.getDcAddressV4(203)} ** 7),
+            .middle_proxy_addrs_203 = [_]Address{constants.getDcAddressV4(203)} ++ ([_]Address{constants.getDcAddressV4(203)} ** 7),
             .middle_proxy_addrs_203_len = 1,
             .middle_proxy_secret = default_middle_proxy_secret,
             .middle_proxy_secret_len = middleproxy.proxy_secret.len,
@@ -1094,7 +648,7 @@ pub const ProxyState = struct {
                     .socks5 => {
                         if (cfg.upstream_proxy_host) |host| {
                             if (cfg.upstream_proxy_port > 0) {
-                                const proxy_list = net.getAddressList(allocator, host, cfg.upstream_proxy_port) catch |err| {
+                                const proxy_list = getAddressList(allocator, host, cfg.upstream_proxy_port) catch |err| {
                                     log.err("Failed to resolve SOCKS5 proxy host '{s}:{d}': {any}", .{ host, cfg.upstream_proxy_port, err });
                                     break :upblk upstream_mod.Upstream.initDirect();
                                 };
@@ -1115,7 +669,7 @@ pub const ProxyState = struct {
                     .http => {
                         if (cfg.upstream_proxy_host) |host| {
                             if (cfg.upstream_proxy_port > 0) {
-                                const proxy_list = net.getAddressList(allocator, host, cfg.upstream_proxy_port) catch |err| {
+                                const proxy_list = getAddressList(allocator, host, cfg.upstream_proxy_port) catch |err| {
                                     log.err("Failed to resolve HTTP proxy host '{s}:{d}': {any}", .{ host, cfg.upstream_proxy_port, err });
                                     break :upblk upstream_mod.Upstream.initDirect();
                                 };
@@ -1177,7 +731,7 @@ pub const ProxyState = struct {
     }
 
     pub fn getMetricsSnapshot(self: *const ProxyState) MetricsSnapshot {
-        const now = std.time.timestamp();
+        const now = realtimeSeconds();
         const accepted_total = self.connection_count.load(.monotonic);
         return .{
             .start_time_seconds = self.start_time_seconds,
@@ -1210,6 +764,7 @@ pub const ProxyState = struct {
 
     pub fn run(self: *ProxyState) !void {
         if (builtin.os.tag != .linux) return error.UnsupportedOperatingSystem;
+        const io_ctx = std.Io.Threaded.global_single_threaded.io();
 
         var ipv6_ok = true;
         var server: net.Server = undefined;
@@ -1220,29 +775,29 @@ pub const ProxyState = struct {
                 log.err("Invalid bind_address '{s}', cannot start", .{bind_str});
                 return error.InvalidBindAddress;
             };
-            ipv6_ok = (parsed.any.family == std.posix.AF.INET6);
-            server = try parsed.listen(.{
+            ipv6_ok = isIpv6(parsed);
+            server = try parsed.listen(io_ctx, .{
                 .reuse_address = true,
                 .kernel_backlog = @intCast(self.config.backlog),
             });
             log.info("Listening on {s}:{d} (epoll, single-thread)", .{ bind_str, self.config.port });
         } else {
             // Default: try [::] (dual-stack), fall back to 0.0.0.0
-            const address = net.Address.initIp6(
+            const address = ip6(
                 .{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
                 self.config.port,
                 0,
                 0,
             );
-            server = address.listen(.{
+            server = address.listen(io_ctx, .{
                 .reuse_address = true,
                 .kernel_backlog = @intCast(self.config.backlog),
             }) catch |err| blk: {
-                if (err == error.AddressFamilyNotSupported) {
+                if (err == error.AddressFamilyUnsupported) {
                     ipv6_ok = false;
                     log.warn("IPv6 not available, falling back to IPv4 (0.0.0.0)", .{});
-                    const address_v4 = net.Address.initIp4(.{ 0, 0, 0, 0 }, self.config.port);
-                    break :blk try address_v4.listen(.{
+                    const address_v4 = ip4(.{ 0, 0, 0, 0 }, self.config.port);
+                    break :blk try address_v4.listen(io_ctx, .{
                         .reuse_address = true,
                         .kernel_backlog = @intCast(self.config.backlog),
                     });
@@ -1256,9 +811,9 @@ pub const ProxyState = struct {
                 log.info("Listening on 0.0.0.0:{d} (epoll, single-thread)", .{self.config.port});
             }
         }
-        defer server.deinit();
+        defer server.deinit(io_ctx);
 
-        setNonBlocking(server.stream.handle);
+        setNonBlocking(server.socket.handle);
 
         if (self.config.use_middle_proxy and self.config.datacenter_override == null) {
             self.refreshMiddleProxyInfo() catch |err| {
@@ -1299,37 +854,12 @@ pub const ProxyState = struct {
             try @import("../monitoring.zig").start(self);
         }
 
-        var loop = try EventLoop.init(self, server.stream.handle);
+        var loop = try EventLoop.init(self, server.socket.handle);
         defer loop.deinit();
         try loop.run();
     }
 
-    const MiddleProxySnapshot = struct {
-        addrs_primary: [5]net.Address,
-        addrs_media_primary: [5]net.Address,
-        addr_203: net.Address,
-        addrs_dc4: [16]net.Address,
-        addrs_dc4_len: usize,
-        addrs_media_dc4: [16]net.Address,
-        addrs_media_dc4_len: usize,
-        addrs_203: [8]net.Address,
-        addrs_203_len: usize,
-        secret: [256]u8,
-        secret_len: usize,
-
-        /// Pick the single primary endpoint for (dc_abs, media?). Media-path
-        /// traffic (client sent dc_idx<0) must go to the media MP fleet —
-        /// regular MPs will accept the handshake but throttle/stall large
-        /// transfers, which is exactly the "media тупит" symptom.
-        fn getForDc(self: *const MiddleProxySnapshot, dc_abs: usize, media: bool) ?net.Address {
-            if (dc_abs == 203) return self.addr_203;
-            if (dc_abs >= 1 and dc_abs <= self.addrs_primary.len) {
-                if (media) return self.addrs_media_primary[dc_abs - 1];
-                return self.addrs_primary[dc_abs - 1];
-            }
-            return null;
-        }
-    };
+    const MiddleProxySnapshot = middle_proxy_routing.MiddleProxySnapshot;
 
     fn getMiddleProxySnapshot(self: *ProxyState) MiddleProxySnapshot {
         self.middle_proxy_lock.lockShared();
@@ -1387,7 +917,7 @@ pub const ProxyState = struct {
         };
         var retry_idx: usize = 0;
         while (retry_idx < short_retries.len) : (retry_idx += 1) {
-            std.Thread.sleep(short_retries[retry_idx]);
+            sleepNs(short_retries[retry_idx]);
             if (self.refreshMiddleProxyInfo()) |_| {
                 break;
             } else |err| {
@@ -1400,7 +930,7 @@ pub const ProxyState = struct {
         }
 
         while (true) {
-            std.Thread.sleep(middle_proxy_update_period_ns);
+            sleepNs(middle_proxy_update_period_ns);
             self.refreshMiddleProxyInfo() catch |err| {
                 if (isMiddleProxyRefreshNetworkError(err)) {
                     log.info("Middle-proxy refresh unavailable ({s}), keeping current cache", .{@errorName(err)});
@@ -1435,17 +965,17 @@ pub const ProxyState = struct {
         const cfg_bytes = self.fetchMiddleProxyAsset(temp_alloc, middle_proxy_config_url) catch |err| return err;
         const next_secret = self.fetchMiddleProxyAsset(temp_alloc, middle_proxy_secret_url) catch |err| return err;
 
-        var next_primary: [5]?net.Address = [_]?net.Address{null} ** 5;
-        var next_media_primary: [5]?net.Address = [_]?net.Address{null} ** 5;
-        var next_dc4_candidates: [16]net.Address = undefined;
+        var next_primary: [5]?Address = [_]?Address{null} ** 5;
+        var next_media_primary: [5]?Address = [_]?Address{null} ** 5;
+        var next_dc4_candidates: [16]Address = undefined;
         var next_dc4_candidates_len: usize = 0;
-        var next_media_dc4_candidates: [16]net.Address = undefined;
+        var next_media_dc4_candidates: [16]Address = undefined;
         var next_media_dc4_candidates_len: usize = 0;
         for (0..next_primary.len) |i| {
             const dc_num: i16 = @intCast(i + 1);
 
             // Regular (positive dc_idx) — used for non-media traffic.
-            var candidates: [16]net.Address = undefined;
+            var candidates: [16]Address = undefined;
             const count = parseMiddleProxyAddressesForDc(cfg_bytes, dc_num, .positive_only, &candidates);
 
             if (i == 3 and count > 0) {
@@ -1466,7 +996,7 @@ pub const ProxyState = struct {
             // Media (negative dc_idx) — Telegram uses a separate MP fleet for
             // large file routing. Mixing the two causes media downloads to
             // stall (what looks like "tormozit" on photo/video load).
-            var media_candidates: [16]net.Address = undefined;
+            var media_candidates: [16]Address = undefined;
             const media_count = parseMiddleProxyAddressesForDc(cfg_bytes, dc_num, .negative_only, &media_candidates);
 
             if (i == 3 and media_count > 0) {
@@ -1485,9 +1015,9 @@ pub const ProxyState = struct {
                 media_candidates[0];
         }
 
-        var candidates_203: [8]net.Address = undefined;
+        var candidates_203: [8]Address = undefined;
         const count_203 = parseMiddleProxyAddressesForDc(cfg_bytes, 203, .any, &candidates_203);
-        var next_203_candidates: [8]net.Address = undefined;
+        var next_203_candidates: [8]Address = undefined;
         var next_203_candidates_len: usize = 0;
         if (count_203 > 0) {
             const c203_n = @min(count_203, next_203_candidates.len);
@@ -1507,13 +1037,13 @@ pub const ProxyState = struct {
 
         for (0..next_primary.len) |i| {
             if (next_primary[i]) |addr| {
-                if (!self.middle_proxy_addrs_primary[i].eql(addr)) {
+                if (!addressEql(self.middle_proxy_addrs_primary[i], addr)) {
                     self.middle_proxy_addrs_primary[i] = addr;
                     changed = true;
                 }
             }
             if (next_media_primary[i]) |addr| {
-                if (!self.middle_proxy_addrs_media_primary[i].eql(addr)) {
+                if (!addressEql(self.middle_proxy_addrs_media_primary[i], addr)) {
                     self.middle_proxy_addrs_media_primary[i] = addr;
                     changed = true;
                 }
@@ -1531,7 +1061,7 @@ pub const ProxyState = struct {
         }
 
         if (next_addr_203) |addr| {
-            if (!self.middle_proxy_addr_203.eql(addr)) {
+            if (!addressEql(self.middle_proxy_addr_203, addr)) {
                 self.middle_proxy_addr_203 = addr;
                 changed = true;
             }
@@ -1603,7 +1133,7 @@ const EventLoop = struct {
 
     fn init(state: *ProxyState, listen_fd: posix.fd_t) !EventLoop {
         const epoll_fd = try epollCreate();
-        errdefer posix.close(epoll_fd);
+        errdefer closeFd(epoll_fd);
 
         var loop = EventLoop{
             .state = state,
@@ -1614,7 +1144,7 @@ const EventLoop = struct {
             .accept_resume_ns = 0,
             .saturation_paused = false,
             .timer_scan_cursor = 0,
-            .stats_next_log_ns = std.time.nanoTimestamp() + stats_log_interval_ns,
+            .stats_next_log_ns = nowNs() + stats_log_interval_ns,
             .accepted_since_log = 0,
             .closed_since_log = 0,
             .subnet_limiter = SubnetRateLimit.init(),
@@ -1625,7 +1155,7 @@ const EventLoop = struct {
             .prev_hs_timeout = 0,
             .prev_mp_fallback = 0,
             .shared_read_buf = undefined,
-            .desync_wait_slots = .{},
+            .desync_wait_slots = .empty,
             .mp_c2s_scratch = null,
             .mp_s2c_scratch = null,
         };
@@ -1649,13 +1179,13 @@ const EventLoop = struct {
         self.desync_wait_slots.deinit(self.state.allocator);
 
         self.pool.deinit();
-        posix.close(self.epoll_fd);
+        closeFd(self.epoll_fd);
     }
 
     fn run(self: *EventLoop) !void {
         var events: [256]linux.epoll_event = undefined;
         const timer_tick_ns: i128 = 5 * std.time.ns_per_ms;
-        var next_timer_tick_ns: i128 = std.time.nanoTimestamp();
+        var next_timer_tick_ns: i128 = nowNs();
 
         while (true) {
             var current_wait_ms: i32 = event_loop_wait_ms;
@@ -1687,7 +1217,7 @@ const EventLoop = struct {
 
             self.processDesyncWaits();
 
-            const now_ns = std.time.nanoTimestamp();
+            const now_ns = nowNs();
             if (self.accept_paused and now_ns >= self.accept_resume_ns) {
                 self.resumeAccepting();
             }
@@ -1760,12 +1290,8 @@ const EventLoop = struct {
 
         var accepted_this_round: usize = 0;
         while (accepted_this_round < accept_batch_limit) {
-            var client_addr: net.Address = undefined;
-            var client_len: posix.socklen_t = @sizeOf(net.Address);
-            const cfd = posix.accept(self.listen_fd, &client_addr.any, &client_len, posix.SOCK.CLOEXEC | posix.SOCK.NONBLOCK) catch |err| {
+            const accepted = acceptClient(self.listen_fd) catch |err| {
                 switch (err) {
-                    error.WouldBlock => return,
-
                     // TCP three-way-handshake aborts between the kernel's
                     // accept queue and our accept() call. These are benign —
                     // bubbling them up causes the whole batch to abort and
@@ -1784,9 +1310,12 @@ const EventLoop = struct {
                         self.pauseAccepting(err);
                         return;
                     },
-                    else => return err,
+                    else => return error.UnexpectedAccept,
                 }
             };
+            if (accepted == null) return;
+            const cfd = accepted.?.fd;
+            const client_addr = accepted.?.addr;
             accepted_this_round += 1;
 
             // Ensure desync byte-splitting is not coalesced by Nagle during early handshake.
@@ -1795,7 +1324,7 @@ const EventLoop = struct {
             // Per-/24 subnet rate limit (before we allocate any slot)
             if (!self.subnet_limiter.check(client_addr, self.state.config.rate_limit_per_subnet)) {
                 _ = self.state.stats_dropped_rate_limit.fetchAdd(1, .monotonic);
-                posix.close(cfd);
+                closeFd(cfd);
                 continue;
             }
 
@@ -1803,7 +1332,7 @@ const EventLoop = struct {
             if (active_before >= self.state.config.max_connections) {
                 _ = self.state.active_connections.fetchSub(1, .monotonic);
                 _ = self.state.stats_dropped_cap.fetchAdd(1, .monotonic);
-                posix.close(cfd);
+                closeFd(cfd);
                 continue;
             }
 
@@ -1815,14 +1344,14 @@ const EventLoop = struct {
                 _ = self.state.handshakes_inflight.fetchSub(1, .monotonic);
                 _ = self.state.active_connections.fetchSub(1, .monotonic);
                 _ = self.state.stats_dropped_hs_budget.fetchAdd(1, .monotonic);
-                posix.close(cfd);
+                closeFd(cfd);
                 continue;
             }
 
             const slot = self.pool.acquire() orelse {
                 _ = self.state.handshakes_inflight.fetchSub(1, .monotonic);
                 _ = self.state.active_connections.fetchSub(1, .monotonic);
-                posix.close(cfd);
+                closeFd(cfd);
                 continue;
             };
 
@@ -1834,7 +1363,7 @@ const EventLoop = struct {
             slot.client_fd = cfd;
             slot.peer_addr = client_addr;
             slot.phase = .reading_tls_header;
-            slot.created_at_ms = std.time.milliTimestamp();
+            slot.created_at_ms = nowMs();
             slot.last_activity_ms = slot.created_at_ms;
             slot.drs = DynamicRecordSizer.init(self.state.config.drs);
 
@@ -1928,7 +1457,7 @@ const EventLoop = struct {
     }
 
     fn pauseAccepting(self: *EventLoop, err: anyerror) void {
-        self.accept_resume_ns = std.time.nanoTimestamp() + accept_backoff_ns;
+        self.accept_resume_ns = nowNs() + accept_backoff_ns;
         if (self.accept_paused) return;
 
         self.modFd(self.listen_fd, false, false) catch |mod_err| {
@@ -1950,7 +1479,7 @@ const EventLoop = struct {
         if (!self.accept_paused) return;
 
         self.modFd(self.listen_fd, true, false) catch |err| {
-            self.accept_resume_ns = std.time.nanoTimestamp() + accept_backoff_ns;
+            self.accept_resume_ns = nowNs() + accept_backoff_ns;
             log.warn("failed to resume accepts; retry in {d}ms: {any}", .{ accept_backoff_ms, err });
             return;
         };
@@ -1995,7 +1524,7 @@ const EventLoop = struct {
     }
 
     fn onClientReadable(self: *EventLoop, slot: *ConnectionSlot) void {
-        slot.last_activity_ms = std.time.milliTimestamp();
+        slot.last_activity_ms = nowMs();
 
         switch (slot.phase) {
             .reading_tls_header => self.readTlsHeader(slot),
@@ -2017,14 +1546,14 @@ const EventLoop = struct {
             return;
         }
         if (had_pending and !slot.hasClientPending()) {
-            slot.last_activity_ms = std.time.milliTimestamp();
+            slot.last_activity_ms = nowMs();
         }
 
         switch (slot.phase) {
             .writing_server_hello_first => {
                 if (!slot.hasClientPending()) {
                     slot.phase = .desync_wait;
-                    slot.desync_deadline_ns = std.time.nanoTimestamp() + (3 * std.time.ns_per_ms);
+                    slot.desync_deadline_ns = nowNs() + (3 * std.time.ns_per_ms);
                     self.enqueueDesyncWait(slot) catch {
                         self.closeSlot(slot, "desync wait queue failed");
                         return;
@@ -2048,7 +1577,7 @@ const EventLoop = struct {
     }
 
     fn onUpstreamReadable(self: *EventLoop, slot: *ConnectionSlot) void {
-        slot.last_activity_ms = std.time.milliTimestamp();
+        slot.last_activity_ms = nowMs();
 
         switch (slot.phase) {
             .proxy_socks5_greeting_resp,
@@ -2081,7 +1610,7 @@ const EventLoop = struct {
                 }
 
                 if (!slot.hasUpstreamPending()) {
-                    slot.last_activity_ms = std.time.milliTimestamp();
+                    slot.last_activity_ms = nowMs();
                     // Write complete, switch to reading response
                     switch (slot.phase) {
                         .proxy_socks5_greeting => slot.phase = .proxy_socks5_greeting_resp,
@@ -2101,7 +1630,7 @@ const EventLoop = struct {
                     return;
                 }
                 if (had_pending and !slot.hasUpstreamPending()) {
-                    slot.last_activity_ms = std.time.milliTimestamp();
+                    slot.last_activity_ms = nowMs();
                 }
 
                 if (slot.phase == .writing_dc_nonce and !slot.hasUpstreamPending()) {
@@ -2149,7 +1678,7 @@ const EventLoop = struct {
     fn processDesyncWaits(self: *EventLoop) void {
         if (self.desync_wait_slots.items.len == 0) return;
 
-        const now_ns = std.time.nanoTimestamp();
+        const now_ns = nowNs();
         var write_idx: usize = 0;
         var read_idx: usize = 0;
 
@@ -2203,10 +1732,10 @@ const EventLoop = struct {
                 return;
             }
             if (slot.first_byte_at_ms == 0) {
-                slot.first_byte_at_ms = std.time.milliTimestamp();
+                slot.first_byte_at_ms = nowMs();
             }
             slot.tls_hdr_pos += @intCast(n);
-            slot.last_activity_ms = std.time.milliTimestamp();
+            slot.last_activity_ms = nowMs();
         }
 
         if (!tls.isTlsHandshake(slot.tls_hdr_buf[0..])) {
@@ -2255,7 +1784,7 @@ const EventLoop = struct {
                 return;
             }
             slot.tls_body_pos += @intCast(n);
-            slot.last_activity_ms = std.time.milliTimestamp();
+            slot.last_activity_ms = nowMs();
         }
 
         const client_hello = hello_buf[0..slot.client_hello_len];
@@ -2531,13 +2060,13 @@ const EventLoop = struct {
         try self.startConnectUpstream(slot, addr, .mask);
     }
 
-    fn startConnectUpstream(self: *EventLoop, slot: *ConnectionSlot, addr: net.Address, kind: UpstreamKind) !void {
+    fn startConnectUpstream(self: *EventLoop, slot: *ConnectionSlot, addr: Address, kind: UpstreamKind) !void {
         const connect_result = if (kind == .mask) blk: {
             const direct = upstream_mod.Upstream.initDirect();
             break :blk try direct.connect(addr);
         } else try self.state.upstream.connect(addr);
         const fd = connect_result.fd;
-        errdefer posix.close(fd);
+        errdefer closeFd(fd);
 
         try self.addFd(fd, false, true);
         errdefer _ = self.delFd(fd) catch {};
@@ -2568,10 +2097,11 @@ const EventLoop = struct {
     }
 
     fn onUpstreamConnectComplete(self: *EventLoop, slot: *ConnectionSlot) void {
-        if (posix.getsockoptError(slot.upstream_fd)) |_| {} else |err| {
+        if (checkSocketConnectError(slot.upstream_fd)) |_| {} else |err| {
+            const failed_kind = slot.upstream_kind;
             self.cleanupFailedUpstreamConnect(slot);
 
-            if (slot.upstream_kind == .dc and self.tryNextDcEndpoint(slot, err)) {
+            if (failed_kind == .dc and self.tryNextDcEndpoint(slot, err)) {
                 return;
             }
 
@@ -2628,255 +2158,41 @@ const EventLoop = struct {
         self.sendDcNonce(slot);
     }
 
-    // ─── SOCKS5 Proxy Handshake ─────────────────────────────────
-
     fn startSocks5Handshake(self: *EventLoop, slot: *ConnectionSlot) void {
-        const needs_auth = self.state.upstream.socks5.needsAuth();
-        const msg = socks5.buildGreeting(&slot.proxy_handshake_buf, needs_auth);
-        if (msg.len == 0) {
-            self.closeSlot(slot, "socks5 greeting build failed");
-            return;
-        }
-
-        if (queueUpstream(slot, self.state.allocator, msg)) |_| {} else |err| {
-            log.debug("[{d}] socks5 greeting queue error: {any}", .{ slot.conn_id, err });
-            self.closeSlot(slot, "socks5 greeting queue failed");
-            return;
-        }
-
-        slot.phase = if (slot.hasUpstreamPending())
-            .proxy_socks5_greeting
-        else
-            .proxy_socks5_greeting_resp;
-        slot.proxy_handshake_pos = 0;
+        return proxy_upstream_handshake.startSocks5(
+            self,
+            slot,
+            proxyHandshakeQueueUpstream,
+            proxyHandshakeCloseSlot,
+        );
     }
 
     fn onProxySocks5Readable(self: *EventLoop, slot: *ConnectionSlot) void {
-        // Read into proxy_handshake_buf at current pos
-        const pos: usize = slot.proxy_handshake_pos;
-        const space = slot.proxy_handshake_buf[pos..];
-        if (space.len == 0) {
-            self.closeSlot(slot, "socks5 response buffer overflow");
-            return;
-        }
-
-        const n = posix.read(slot.upstream_fd, space) catch |err| {
-            log.debug("[{d}] socks5 read error: {any}", .{ slot.conn_id, err });
-            if (err == error.WouldBlock) return;
-            self.closeSlot(slot, "socks5 read failed");
-            return;
-        };
-
-        if (n == 0) {
-            self.closeSlot(slot, "socks5 proxy closed connection");
-            return;
-        }
-
-        slot.proxy_handshake_pos += @intCast(n);
-        const have = slot.proxy_handshake_buf[0..slot.proxy_handshake_pos];
-
-        switch (slot.phase) {
-            .proxy_socks5_greeting_resp => {
-                if (have.len < socks5.greeting_response_len) return; // need more
-
-                const method = socks5.parseGreetingResponse(have) orelse {
-                    self.closeSlot(slot, "socks5 invalid greeting response");
-                    return;
-                };
-
-                switch (method) {
-                    .no_auth => {
-                        self.socks5SendConnect(slot);
-                    },
-                    .username_password => {
-                        self.socks5SendAuth(slot);
-                    },
-                    .no_acceptable => {
-                        log.debug("[{d}] socks5 proxy rejected all auth methods", .{slot.conn_id});
-                        self.closeSlot(slot, "socks5 no acceptable auth");
-                    },
-                }
-            },
-            .proxy_socks5_auth_resp => {
-                if (have.len < socks5.auth_response_len) return; // need more
-
-                const ok = socks5.parseAuthResponse(have) orelse {
-                    self.closeSlot(slot, "socks5 invalid auth response");
-                    return;
-                };
-
-                if (!ok) {
-                    log.debug("[{d}] socks5 authentication failed", .{slot.conn_id});
-                    self.closeSlot(slot, "socks5 auth rejected");
-                    return;
-                }
-
-                self.socks5SendConnect(slot);
-            },
-            .proxy_socks5_connect_resp => {
-                const result = socks5.parseConnectResponse(have) orelse return; // need more
-
-                if (result.reply != .succeeded) {
-                    log.debug("[{d}] socks5 CONNECT failed: reply={d}", .{
-                        slot.conn_id, @intFromEnum(result.reply),
-                    });
-                    self.closeSlot(slot, "socks5 connect rejected");
-                    return;
-                }
-
-                // Telegram DCs (and MiddleProxies) never speak first after a
-                // SOCKS5 CONNECT success — they wait for our 64-byte handshake
-                // nonce. Any bytes piggy-backed onto the SOCKS5 reply are either
-                // garbage from a misbehaving upstream or an active MITM probe.
-                //
-                // Critically, `slot.pipelined_data` is the *client-side* pipeline
-                // buffer: on startRelay it is fed through `client_decryptor.apply`.
-                // Mixing upstream bytes into it desynchronises the client CTR
-                // stream (and, with MiddleProxy, encapsulates garbage into a
-                // valid RPC_PROXY_REQ frame). Drop the connection instead.
-                if (have.len > result.consumed) {
-                    log.warn("[{d}] socks5 upstream sent {d} unsolicited bytes after CONNECT success", .{
-                        slot.conn_id, have.len - result.consumed,
-                    });
-                    self.closeSlot(slot, "socks5 unsolicited upstream data");
-                    return;
-                }
-
-                // SOCKS5 handshake complete — proceed to DC path
-                self.proxyHandshakeComplete(slot);
-            },
-            else => {},
-        }
+        return proxy_upstream_handshake.onSocks5Readable(
+            self,
+            slot,
+            proxyHandshakeQueueUpstream,
+            proxyHandshakeCloseSlot,
+            proxyHandshakeCompleteCallback,
+        );
     }
-
-    fn socks5SendAuth(self: *EventLoop, slot: *ConnectionSlot) void {
-        const username = self.state.upstream.proxyUsername() orelse "";
-        const password = self.state.upstream.proxyPassword() orelse "";
-
-        const msg = socks5.buildAuthRequest(&slot.proxy_handshake_buf, username, password);
-        if (msg.len == 0) {
-            self.closeSlot(slot, "socks5 auth request build failed");
-            return;
-        }
-
-        if (queueUpstream(slot, self.state.allocator, msg)) |_| {} else |err| {
-            log.debug("[{d}] socks5 auth queue error: {any}", .{ slot.conn_id, err });
-            self.closeSlot(slot, "socks5 auth queue failed");
-            return;
-        }
-
-        slot.phase = if (slot.hasUpstreamPending())
-            .proxy_socks5_auth
-        else
-            .proxy_socks5_auth_resp;
-        slot.proxy_handshake_pos = 0;
-    }
-
-    fn socks5SendConnect(self: *EventLoop, slot: *ConnectionSlot) void {
-        const target = slot.proxy_target_addr orelse {
-            self.closeSlot(slot, "socks5 no target addr");
-            return;
-        };
-
-        const msg = socks5.buildConnectRequest(&slot.proxy_handshake_buf, target);
-        if (msg.len == 0) {
-            self.closeSlot(slot, "socks5 connect request build failed");
-            return;
-        }
-
-        if (queueUpstream(slot, self.state.allocator, msg)) |_| {} else |err| {
-            log.debug("[{d}] socks5 connect queue error: {any}", .{ slot.conn_id, err });
-            self.closeSlot(slot, "socks5 connect queue failed");
-            return;
-        }
-
-        slot.phase = if (slot.hasUpstreamPending())
-            .proxy_socks5_connect
-        else
-            .proxy_socks5_connect_resp;
-        slot.proxy_handshake_pos = 0;
-    }
-
-    // ─── HTTP CONNECT Proxy Handshake ───────────────────────────
 
     fn startHttpConnectHandshake(self: *EventLoop, slot: *ConnectionSlot) void {
-        const target = slot.proxy_target_addr orelse {
-            self.closeSlot(slot, "http proxy no target addr");
-            return;
-        };
-
-        const username = self.state.upstream.proxyUsername();
-        const password = self.state.upstream.proxyPassword();
-
-        const msg = http_connect.buildConnectRequest(
-            &slot.proxy_handshake_buf,
-            target,
-            username,
-            password,
+        return proxy_upstream_handshake.startHttpConnect(
+            self,
+            slot,
+            proxyHandshakeQueueUpstream,
+            proxyHandshakeCloseSlot,
         );
-        if (msg.len == 0) {
-            self.closeSlot(slot, "http connect request build failed");
-            return;
-        }
-
-        if (queueUpstream(slot, self.state.allocator, msg)) |_| {} else |err| {
-            log.debug("[{d}] http connect queue error: {any}", .{ slot.conn_id, err });
-            self.closeSlot(slot, "http connect queue failed");
-            return;
-        }
-
-        slot.phase = if (slot.hasUpstreamPending())
-            .proxy_http_connect
-        else
-            .proxy_http_connect_resp;
-        slot.proxy_handshake_pos = 0;
     }
 
     fn onProxyHttpConnectReadable(self: *EventLoop, slot: *ConnectionSlot) void {
-        const pos: usize = slot.proxy_handshake_pos;
-        const space = slot.proxy_handshake_buf[pos..];
-        if (space.len == 0) {
-            self.closeSlot(slot, "http connect response buffer overflow");
-            return;
-        }
-
-        const n = posix.read(slot.upstream_fd, space) catch |err| {
-            log.debug("[{d}] http connect read error: {any}", .{ slot.conn_id, err });
-            if (err == error.WouldBlock) return;
-            self.closeSlot(slot, "http connect read failed");
-            return;
-        };
-
-        if (n == 0) {
-            self.closeSlot(slot, "http proxy closed connection");
-            return;
-        }
-
-        slot.proxy_handshake_pos += @intCast(n);
-        const have = slot.proxy_handshake_buf[0..slot.proxy_handshake_pos];
-
-        const result = http_connect.parseResponse(have) orelse return; // need more
-
-        if (result.status < 200 or result.status >= 300) {
-            log.debug("[{d}] HTTP CONNECT failed: status={d}", .{ slot.conn_id, result.status });
-            self.closeSlot(slot, "http connect rejected");
-            return;
-        }
-
-        // Same invariant as SOCKS5: the DC never speaks first. Any bytes the
-        // HTTP proxy appended after the "200 OK" line would be wrongly routed
-        // through the *client* decryption path in startRelay, corrupting the
-        // CTR stream. Reject the upstream.
-        if (have.len > result.header_end) {
-            log.warn("[{d}] http connect upstream sent {d} unsolicited bytes after 2xx", .{
-                slot.conn_id, have.len - result.header_end,
-            });
-            self.closeSlot(slot, "http connect unsolicited upstream data");
-            return;
-        }
-
-        // HTTP CONNECT handshake complete — proceed to DC path
-        self.proxyHandshakeComplete(slot);
+        return proxy_upstream_handshake.onHttpConnectReadable(
+            self,
+            slot,
+            proxyHandshakeCloseSlot,
+            proxyHandshakeCompleteCallback,
+        );
     }
 
     // ─── Common: proxy handshake → DC path transition ───────────
@@ -2899,7 +2215,7 @@ const EventLoop = struct {
             const fd = slot.upstream_fd;
             _ = self.delFd(fd) catch {};
             self.pool.unmapFd(fd);
-            posix.close(fd);
+            closeFd(fd);
             slot.upstream_fd = -1;
         }
         slot.upstream_kind = .none;
@@ -2908,194 +2224,32 @@ const EventLoop = struct {
     }
 
     fn tryNextDcEndpoint(self: *EventLoop, slot: *ConnectionSlot, err: anyerror) bool {
-        const attempt_addr = slot.current_upstream_addr;
-        const candidates = slot.upstreamCandidates();
-        if (candidates.len == 0) return false;
-        const candidate_count = candidates.len;
-
-        const next_u: usize = slot.upstream_candidate_next;
-        if (next_u < candidates.len) {
-            const next_idx = next_u;
-            const next_addr = candidates[next_idx];
-            slot.upstream_candidate_next += 1;
-            self.startConnectUpstream(slot, next_addr, .dc) catch |next_err| {
-                log.warn("[{d}] dc connect candidate {d}/{d} failed immediately: {any}", .{
-                    slot.conn_id,
-                    next_idx + 1,
-                    candidate_count,
-                    next_err,
-                });
-                return self.tryNextDcEndpoint(slot, next_err);
-            };
-
-            if (attempt_addr) |addr| {
-                var prev_buf: [64]u8 = undefined;
-                const prev_str = formatAddress(addr, &prev_buf);
-                log.warn("[{d}] dc connect failed ({any}), retry candidate {d}/{d} after {s}", .{
-                    slot.conn_id,
-                    err,
-                    next_idx + 1,
-                    candidate_count,
-                    prev_str,
-                });
-            }
-            return true;
-        }
-
-        if (!slot.direct_fallback_used and slot.direct_fallback_addr != null and slot.use_middle_proxy) {
-            slot.direct_fallback_used = true;
-            slot.use_middle_proxy = false;
-            const fallback = slot.direct_fallback_addr.?;
-            slot.upstream_candidate_next = 1;
-
-            var one = [_]net.Address{fallback};
-            slot.setUpstreamCandidates(self.state.allocator, one[0..]) catch {
-                return false;
-            };
-
-            self.startConnectUpstream(slot, fallback, .dc) catch |fallback_err| {
-                log.warn("[{d}] direct fallback connect failed: {any}", .{ slot.conn_id, fallback_err });
-                return false;
-            };
-
-            var fb_buf: [64]u8 = undefined;
-            const fb_str = formatAddress(fallback, &fb_buf);
-            log.warn("[{d}] middle-proxy exhausted, fallback to direct {s}", .{ slot.conn_id, fb_str });
-            return true;
-        }
-
-        if (slot.is_media_path) {
-            log.warn("[{d}] media path connect failed after all candidates: {any}", .{ slot.conn_id, err });
-        }
-        return false;
+        return upstream_failover.tryNextDcEndpoint(
+            self,
+            slot,
+            err,
+            startConnectUpstreamDc,
+            mpFallbackSetSingleUpstreamCandidate,
+        );
     }
 
     fn sendDcNonce(self: *EventLoop, slot: *ConnectionSlot) void {
-        const params = slot.obf_params orelse {
-            self.closeSlot(slot, "missing obfuscation params");
-            return;
-        };
-
-        var tg_nonce = obfuscation.generateNonce();
-
-        if (slot.use_fast_mode) {
-            var client_s2c_key_iv: [constants.key_len + constants.iv_len]u8 = undefined;
-            @memcpy(client_s2c_key_iv[0..constants.key_len], &params.encrypt_key);
-            std.mem.writeInt(u128, client_s2c_key_iv[constants.key_len..][0..constants.iv_len], params.encrypt_iv, .big);
-            obfuscation.prepareTgNonce(&tg_nonce, params.proto_tag, &client_s2c_key_iv);
-        } else {
-            obfuscation.prepareTgNonce(&tg_nonce, params.proto_tag, null);
-        }
-
-        std.mem.writeInt(i16, tg_nonce[constants.dc_idx_pos..][0..2], params.dc_idx, .little);
-
-        const tg_enc_key_iv = tg_nonce[constants.skip_len..][0 .. constants.key_len + constants.iv_len];
-        var tg_enc_key: [constants.key_len]u8 = tg_enc_key_iv[0..constants.key_len].*;
-        var tg_enc_iv_bytes: [constants.iv_len]u8 = tg_enc_key_iv[constants.key_len..][0..constants.iv_len].*;
-        const tg_enc_iv = std.mem.readInt(u128, &tg_enc_iv_bytes, .big);
-
-        var tg_dec_key_iv: [constants.key_len + constants.iv_len]u8 = undefined;
-        for (0..tg_enc_key_iv.len) |i| {
-            tg_dec_key_iv[i] = tg_enc_key_iv[tg_enc_key_iv.len - 1 - i];
-        }
-        var tg_dec_key: [constants.key_len]u8 = tg_dec_key_iv[0..constants.key_len].*;
-        const tg_dec_iv = std.mem.readInt(u128, tg_dec_key_iv[constants.key_len..][0..constants.iv_len], .big);
-
-        var tg_encryptor = crypto.AesCtr.init(&tg_enc_key, tg_enc_iv);
-        var encrypted_nonce: [constants.handshake_len]u8 = undefined;
-        @memcpy(&encrypted_nonce, &tg_nonce);
-        tg_encryptor.apply(&encrypted_nonce);
-
-        var nonce_to_send: [constants.handshake_len]u8 = undefined;
-        @memcpy(nonce_to_send[0..constants.proto_tag_pos], tg_nonce[0..constants.proto_tag_pos]);
-        @memcpy(nonce_to_send[constants.proto_tag_pos..], encrypted_nonce[constants.proto_tag_pos..]);
-
-        if (queueUpstream(slot, self.state.allocator, &nonce_to_send)) |_| {} else |err| {
-            log.debug("[{d}] queue dc nonce failed: {any}", .{ slot.conn_id, err });
-            self.closeSlot(slot, "queue dc nonce failed");
-            return;
-        }
-
-        // Promotion tag (optional), only for primary DC1..5
-        if (self.state.config.tag) |tag| {
-            const dc_abs = if (params.dc_idx > 0) @as(usize, @intCast(params.dc_idx)) else @as(usize, @abs(params.dc_idx));
-            if (dc_abs >= 1 and dc_abs <= constants.tg_datacenters_v4.len and dc_abs != 203) {
-                var promote_buf: [32]u8 = undefined;
-                var packet_len: usize = 0;
-
-                const rpc_id: u32 = 0xaeaf0c42;
-                var rpc_payload: [20]u8 = undefined;
-                std.mem.writeInt(u32, rpc_payload[0..4], rpc_id, .little);
-                @memcpy(rpc_payload[4..20], &tag);
-
-                switch (params.proto_tag) {
-                    .abridged => {
-                        promote_buf[0] = 5;
-                        @memcpy(promote_buf[1..21], &rpc_payload);
-                        packet_len = 21;
-                    },
-                    .intermediate, .secure => {
-                        std.mem.writeInt(u32, promote_buf[0..4], 20, .little);
-                        @memcpy(promote_buf[4..24], &rpc_payload);
-                        packet_len = 24;
-                    },
-                }
-
-                const tail = self.state.allocator.alloc(u8, packet_len) catch {
-                    self.closeSlot(slot, "alloc promotion tail failed");
-                    return;
-                };
-                @memcpy(tail, promote_buf[0..packet_len]);
-                tg_encryptor.apply(tail);
-                slot.dc_initial_tail = tail;
-            }
-        }
-
-        slot.tg_encryptor = tg_encryptor;
-        slot.tg_decryptor = crypto.AesCtr.init(&tg_dec_key, tg_dec_iv);
-        slot.phase = .writing_dc_nonce;
-
-        @memset(&tg_enc_key, 0);
-        @memset(&tg_enc_iv_bytes, 0);
-        @memset(&tg_dec_key, 0);
-        @memset(&tg_dec_key_iv, 0);
+        return dc_nonce.send(
+            self,
+            slot,
+            proxyHandshakeQueueUpstream,
+            proxyHandshakeCloseSlot,
+        );
     }
 
     fn startRelay(self: *EventLoop, slot: *ConnectionSlot) void {
-        // Handshake complete — release from handshake budget
-        _ = self.state.handshakes_inflight.fetchSub(1, .monotonic);
-        slot.phase = .relaying;
-
-        if (slot.pipelined_data) |buf| {
-            if (slot.client_decryptor) |*dec| dec.apply(buf);
-
-            if (slot.middle_ctx) |*mp| {
-                const scratch = self.ensureMpC2sScratch() catch {
-                    self.closeSlot(slot, "alloc middleproxy c2s scratch failed");
-                    return;
-                };
-                const out_data = mp.encapsulateC2S(buf, scratch) catch {
-                    self.closeSlot(slot, "encapsulate pipelined middleproxy payload failed");
-                    return;
-                };
-                if (out_data.len > 0) {
-                    _ = queueUpstream(slot, self.state.allocator, out_data) catch {
-                        self.closeSlot(slot, "queue pipelined middleproxy payload failed");
-                        return;
-                    };
-                }
-            } else if (slot.tg_encryptor) |*enc| {
-                enc.apply(buf);
-                _ = queueUpstream(slot, self.state.allocator, buf) catch {
-                    self.closeSlot(slot, "queue pipelined direct payload failed");
-                    return;
-                };
-            }
-
-            slot.c2s_bytes += buf.len;
-            self.state.allocator.free(buf);
-            slot.pipelined_data = null;
-        }
+        return relay_steps.startRelay(
+            self,
+            slot,
+            relayEnsureMpC2sScratch,
+            proxyHandshakeQueueUpstream,
+            proxyHandshakeCloseSlot,
+        );
     }
 
     fn relayClientToUpstream(self: *EventLoop, slot: *ConnectionSlot) void {
@@ -3119,7 +2273,7 @@ const EventLoop = struct {
             return;
         };
         if (progress == .forwarded or progress == .partial) {
-            slot.last_activity_ms = std.time.milliTimestamp();
+            slot.last_activity_ms = nowMs();
         }
     }
 
@@ -3144,565 +2298,93 @@ const EventLoop = struct {
             return;
         };
         if (progress == .forwarded or progress == .partial) {
-            slot.last_activity_ms = std.time.milliTimestamp();
+            slot.last_activity_ms = nowMs();
         }
     }
 
     fn relayRawClientToUpstream(self: *EventLoop, slot: *ConnectionSlot) void {
-        if (slot.hasUpstreamPending()) return;
-
-        const read_buf = self.shared_read_buf[0..];
-
-        const n = posix.read(slot.client_fd, read_buf) catch |err| {
-            if (err == error.WouldBlock) return;
-            self.closeSlot(slot, "mask relay c2s read error");
-            return;
-        };
-        if (n == 0) {
-            self.closeSlot(slot, "mask relay c2s eof");
-            return;
-        }
-
-        _ = queueUpstream(slot, self.state.allocator, read_buf[0..n]) catch {
-            self.closeSlot(slot, "mask relay c2s queue error");
-            return;
-        };
-        slot.last_activity_ms = std.time.milliTimestamp();
+        return relay_steps.relayRawClientToUpstream(
+            self,
+            slot,
+            self.shared_read_buf[0..],
+            proxyHandshakeQueueUpstream,
+            proxyHandshakeCloseSlot,
+        );
     }
 
     fn relayRawUpstreamToClient(self: *EventLoop, slot: *ConnectionSlot) void {
-        if (slot.hasClientPending()) return;
-
-        const read_buf = self.shared_read_buf[0..];
-
-        const n = posix.read(slot.upstream_fd, read_buf) catch |err| {
-            if (err == error.WouldBlock) return;
-            self.closeSlot(slot, "mask relay s2c read error");
-            return;
-        };
-        if (n == 0) {
-            self.closeSlot(slot, "mask relay s2c eof");
-            return;
-        }
-
-        _ = queueClient(slot, self.state.allocator, read_buf[0..n]) catch {
-            self.closeSlot(slot, "mask relay s2c queue error");
-            return;
-        };
-        slot.last_activity_ms = std.time.milliTimestamp();
+        return relay_steps.relayRawUpstreamToClient(
+            self,
+            slot,
+            self.shared_read_buf[0..],
+            relayQueueClient,
+            proxyHandshakeCloseSlot,
+        );
     }
 
     fn middleProxyBegin(self: *EventLoop, slot: *ConnectionSlot) void {
-        slot.phase = .middle_proxy_handshake;
-        slot.mp_step = .sending_rpc_nonce;
-        slot.mp_write_seq_no = -2;
-        slot.mp_read_seq_no = -2;
-        slot.mp_frame_have = 0;
-        slot.mp_frame_need = 0;
-        slot.mp_enc = null;
-        slot.mp_dec = null;
-
-        crypto.randomBytes(&slot.mp_nonce);
-        const ts: u32 = @intCast(@mod(std.time.timestamp(), 4294967296));
-        slot.mp_timestamp = ts;
-
-        var crypto_ts: [4]u8 = undefined;
-        std.mem.writeInt(u32, &crypto_ts, ts, .little);
-
-        var msg: [32]u8 = undefined;
-        @memcpy(msg[0..4], &middleproxy.rpc_nonce_req);
-        self.state.middle_proxy_lock.lockShared();
-        // Defensive copy: refresh rejects secrets shorter than 16 bytes, but
-        // if that invariant is ever broken we must avoid a length-mismatched
-        // memcpy panic when filling the 4-byte key selector field.
-        @memset(msg[4..8], 0);
-        if (self.state.middle_proxy_secret_len > 0) msg[4] = self.state.middle_proxy_secret[0];
-        if (self.state.middle_proxy_secret_len > 1) msg[5] = self.state.middle_proxy_secret[1];
-        if (self.state.middle_proxy_secret_len > 2) msg[6] = self.state.middle_proxy_secret[2];
-        if (self.state.middle_proxy_secret_len > 3) msg[7] = self.state.middle_proxy_secret[3];
-        self.state.middle_proxy_lock.unlockShared();
-        @memcpy(msg[8..12], &middleproxy.rpc_crypto_aes);
-        @memcpy(msg[12..16], &crypto_ts);
-        @memcpy(msg[16..32], &slot.mp_nonce);
-
-        self.mpWriteFrame(slot, msg[0..], false) catch {
-            self.closeSlot(slot, "mp send nonce failed");
-            return;
-        };
-
-        if (!slot.hasUpstreamPending()) {
-            slot.mp_step = .waiting_rpc_nonce_response;
-            mpReadReset(slot, false);
-        }
+        return middle_proxy_handshake.begin(
+            self,
+            slot,
+            mpHandshakeWriteFrame,
+            mpLockMiddleProxyShared,
+            mpUnlockMiddleProxyShared,
+            mpHandshakeCloseSlot,
+        );
     }
 
     fn middleProxyOnWritable(self: *EventLoop, slot: *ConnectionSlot) void {
         _ = self;
-        if (slot.hasUpstreamPending()) return;
-
-        switch (slot.mp_step) {
-            .sending_rpc_nonce => {
-                slot.mp_step = .waiting_rpc_nonce_response;
-                mpReadReset(slot, false);
-            },
-            .sending_rpc_handshake => {
-                slot.mp_step = .waiting_rpc_handshake_response;
-                mpReadReset(slot, true);
-            },
-            else => {},
-        }
+        return middle_proxy_handshake.onWritable(slot);
     }
 
     fn middleProxyOnReadable(self: *EventLoop, slot: *ConnectionSlot) void {
-        switch (slot.mp_step) {
-            .waiting_rpc_nonce_response => {
-                const payload = self.mpTryReadFrame(slot, false) catch |err| {
-                    log.debug("[{d}] mp nonce frame read failed: {any}", .{ slot.conn_id, err });
-                    self.closeSlot(slot, "mp read nonce ans failed");
-                    return;
-                } orelse return;
-
-                if (payload.len != 32) {
-                    self.closeSlot(slot, "mp bad nonce ans len");
-                    return;
-                }
-                if (!std.mem.eql(u8, payload[0..4], &middleproxy.rpc_nonce_req)) {
-                    self.closeSlot(slot, "mp bad nonce ans type");
-                    return;
-                }
-
-                self.state.middle_proxy_lock.lockShared();
-                const key_sel = self.state.middle_proxy_secret[0..@min(@as(usize, 4), self.state.middle_proxy_secret_len)];
-                const secret_slice = self.state.middle_proxy_secret[0..self.state.middle_proxy_secret_len];
-                if (!std.mem.eql(u8, payload[4..8], key_sel)) {
-                    self.state.middle_proxy_lock.unlockShared();
-                    self.closeSlot(slot, "mp key selector mismatch");
-                    return;
-                }
-                if (!std.mem.eql(u8, payload[8..12], &middleproxy.rpc_crypto_aes)) {
-                    self.state.middle_proxy_lock.unlockShared();
-                    self.closeSlot(slot, "mp crypto schema mismatch");
-                    return;
-                }
-
-                slot.mp_rpc_nonce_ans = payload[16..32][0..16].*;
-
-                var ts_arr: [4]u8 = undefined;
-                std.mem.writeInt(u32, &ts_arr, slot.mp_timestamp, .little);
-
-                const tg_addr = slot.current_upstream_addr orelse {
-                    self.state.middle_proxy_lock.unlockShared();
-                    self.closeSlot(slot, "mp missing logical upstream addr");
-                    return;
-                };
-
-                var local_addr: net.Address = undefined;
-                var local_len: posix.socklen_t = @sizeOf(net.Address);
-                posix.getsockname(slot.upstream_fd, &local_addr.any, &local_len) catch {
-                    self.state.middle_proxy_lock.unlockShared();
-                    self.closeSlot(slot, "mp getsockname failed");
-                    return;
-                };
-                var middle_local_addr = local_addr;
-
-                var tg_port: [2]u8 = undefined;
-                var my_port: [2]u8 = undefined;
-                var tg_ip_v4_opt: ?[4]u8 = null;
-                var my_ip_v4_opt: ?[4]u8 = null;
-                var tg_ip_v6_opt: ?[16]u8 = null;
-                var my_ip_v6_opt: ?[16]u8 = null;
-
-                const local_port = switch (local_addr.any.family) {
-                    posix.AF.INET => std.mem.bigToNative(u16, local_addr.in.sa.port),
-                    posix.AF.INET6 => std.mem.bigToNative(u16, local_addr.in6.sa.port),
-                    else => {
-                        self.state.middle_proxy_lock.unlockShared();
-                        self.closeSlot(slot, "mp unsupported local addr family");
-                        return;
-                    },
-                };
-                std.mem.writeInt(u16, &my_port, local_port, .little);
-
-                if (tg_addr.any.family == posix.AF.INET) {
-                    var tg_ip_v4: [4]u8 = undefined;
-                    @memcpy(&tg_ip_v4, std.mem.asBytes(&tg_addr.in.sa.addr));
-                    std.mem.reverse(u8, &tg_ip_v4);
-                    tg_ip_v4_opt = tg_ip_v4;
-
-                    if (self.state.middle_proxy_nat_ip4) |nat_ip| {
-                        const my_ip_v4 = ipv4NetworkToHostBytes(nat_ip);
-                        my_ip_v4_opt = my_ip_v4;
-                        middle_local_addr = net.Address.initIp4(nat_ip, local_port);
-                    }
-
-                    std.mem.writeInt(u16, &tg_port, std.mem.bigToNative(u16, tg_addr.in.sa.port), .little);
-                } else if (tg_addr.any.family == posix.AF.INET6) {
-                    var tg_ip_v6: [16]u8 = undefined;
-                    @memcpy(&tg_ip_v6, &tg_addr.in6.sa.addr);
-                    tg_ip_v6_opt = tg_ip_v6;
-
-                    if (local_addr.any.family == posix.AF.INET6) {
-                        var my_ip_v6: [16]u8 = undefined;
-                        @memcpy(&my_ip_v6, &local_addr.in6.sa.addr);
-                        my_ip_v6_opt = my_ip_v6;
-                    }
-
-                    std.mem.writeInt(u16, &tg_port, std.mem.bigToNative(u16, tg_addr.in6.sa.port), .little);
-                } else {
-                    self.state.middle_proxy_lock.unlockShared();
-                    self.closeSlot(slot, "mp unsupported upstream addr family");
-                    return;
-                }
-
-                const tg_ip_v4_ptr: ?*const [4]u8 = if (tg_ip_v4_opt) |*ip| ip else null;
-                const my_ip_v4_ptr: ?*const [4]u8 = if (my_ip_v4_opt) |*ip| ip else null;
-                const my_ip_v6_ptr: ?*const [16]u8 = if (my_ip_v6_opt) |*ip| ip else null;
-                const tg_ip_v6_ptr: ?*const [16]u8 = if (tg_ip_v6_opt) |*ip| ip else null;
-
-                const enc_keys = middleproxy.getAesKeyAndIv(
-                    &slot.mp_rpc_nonce_ans,
-                    &slot.mp_nonce,
-                    &ts_arr,
-                    tg_ip_v4_ptr,
-                    &my_port,
-                    "CLIENT",
-                    my_ip_v4_ptr,
-                    &tg_port,
-                    secret_slice,
-                    my_ip_v6_ptr,
-                    tg_ip_v6_ptr,
-                );
-
-                const dec_keys = middleproxy.getAesKeyAndIv(
-                    &slot.mp_rpc_nonce_ans,
-                    &slot.mp_nonce,
-                    &ts_arr,
-                    tg_ip_v4_ptr,
-                    &my_port,
-                    "SERVER",
-                    my_ip_v4_ptr,
-                    &tg_port,
-                    secret_slice,
-                    my_ip_v6_ptr,
-                    tg_ip_v6_ptr,
-                );
-                self.state.middle_proxy_lock.unlockShared();
-
-                slot.mp_enc = crypto.AesCbc.init(&enc_keys[0], &enc_keys[1]);
-                slot.mp_dec = crypto.AesCbc.init(&dec_keys[0], &dec_keys[1]);
-
-                var hs_msg: [32]u8 = undefined;
-                @memcpy(hs_msg[0..4], &middleproxy.rpc_handshake);
-                @memset(hs_msg[4..8], 0);
-                @memcpy(hs_msg[8..20], "IPIPPRPDTIME");
-                @memcpy(hs_msg[20..32], "IPIPPRPDTIME");
-
-                self.mpWriteFrame(slot, hs_msg[0..], true) catch {
-                    if (!self.fallbackFromMiddleProxyToDirect(slot)) {
-                        self.closeSlot(slot, "mp send handshake failed");
-                    }
-                    return;
-                };
-
-                slot.mp_step = if (slot.hasUpstreamPending()) .sending_rpc_handshake else .waiting_rpc_handshake_response;
-                if (!slot.hasUpstreamPending()) {
-                    mpReadReset(slot, true);
-                }
-            },
-
-            .waiting_rpc_handshake_response => {
-                const payload = self.mpTryReadFrame(slot, true) catch |err| {
-                    log.debug("[{d}] mp handshake frame read failed: {any}", .{ slot.conn_id, err });
-                    if (!self.fallbackFromMiddleProxyToDirect(slot)) {
-                        self.closeSlot(slot, "mp read handshake ans failed");
-                    }
-                    return;
-                } orelse return;
-
-                if (payload.len != 32) {
-                    if (!self.fallbackFromMiddleProxyToDirect(slot)) {
-                        self.closeSlot(slot, "mp bad handshake ans len");
-                    }
-                    return;
-                }
-                if (!std.mem.eql(u8, payload[0..4], &middleproxy.rpc_handshake)) {
-                    if (!self.fallbackFromMiddleProxyToDirect(slot)) {
-                        self.closeSlot(slot, "mp bad handshake ans type");
-                    }
-                    return;
-                }
-                if (!std.mem.eql(u8, payload[20..32], "IPIPPRPDTIME")) {
-                    if (!self.fallbackFromMiddleProxyToDirect(slot)) {
-                        self.closeSlot(slot, "mp bad handshake pid");
-                    }
-                    return;
-                }
-
-                var local_addr: net.Address = undefined;
-                var local_len: posix.socklen_t = @sizeOf(net.Address);
-                posix.getsockname(slot.upstream_fd, &local_addr.any, &local_len) catch {
-                    if (!self.fallbackFromMiddleProxyToDirect(slot)) {
-                        self.closeSlot(slot, "mp getsockname failed");
-                    }
-                    return;
-                };
-
-                var middle_local_addr = local_addr;
-                if (self.state.middle_proxy_nat_ip4) |nat_ip| {
-                    if (local_addr.any.family == posix.AF.INET) {
-                        middle_local_addr = net.Address.initIp4(nat_ip, std.mem.bigToNative(u16, local_addr.in.sa.port));
-                    }
-                }
-
-                var conn_id: [8]u8 = undefined;
-                crypto.randomBytes(&conn_id);
-
-                slot.middle_ctx = middleproxy.MiddleProxyContext.initWithBuffer(
-                    self.state.allocator,
-                    slot.mp_enc.?,
-                    slot.mp_dec.?,
-                    conn_id,
-                    slot.mp_write_seq_no,
-                    slot.peer_addr,
-                    middle_local_addr,
-                    slot.proto_tag,
-                    self.state.config.tag,
-                    self.state.config.middleProxyBufferBytes(),
-                ) catch {
-                    if (!self.fallbackFromMiddleProxyToDirect(slot)) {
-                        self.closeSlot(slot, "mp context init failed");
-                    }
-                    return;
-                };
-
-                slot.mp_step = .done;
-                self.startRelay(slot);
-            },
-            else => {},
-        }
+        return middle_proxy_handshake.onReadable(
+            self,
+            slot,
+            mpHandshakeReadFrame,
+            mpHandshakeWriteFrame,
+            mpLockMiddleProxyShared,
+            mpUnlockMiddleProxyShared,
+            mpHandshakeStartRelay,
+            mpHandshakeCloseSlot,
+            mpHandshakeFallbackToDirect,
+        );
     }
 
     fn fallbackFromMiddleProxyToDirect(self: *EventLoop, slot: *ConnectionSlot) bool {
-        if (slot.direct_fallback_addr == null or slot.direct_fallback_used) return false;
-
-        _ = slot.obf_params orelse return false;
-        slot.direct_fallback_used = true;
-        _ = self.state.stats_mp_fallback.fetchAdd(1, .monotonic);
-        slot.use_middle_proxy = false;
-        slot.mp_step = .none;
-        slot.mp_enc = null;
-        slot.mp_dec = null;
-
-        slot.use_fast_mode = self.state.config.fast_mode and
-            (slot.dc_abs >= 1 and slot.dc_abs <= constants.tg_datacenters_v4.len);
-
-        // Reset nonce path state to cleanly re-send direct nonce.
-        if (slot.dc_initial_tail) |tail| {
-            self.state.allocator.free(tail);
-            slot.dc_initial_tail = null;
-        }
-        if (slot.tg_encryptor) |*enc| enc.wipe();
-        if (slot.tg_decryptor) |*dec| dec.wipe();
-        slot.tg_encryptor = null;
-        slot.tg_decryptor = null;
-
-        // If current connected endpoint is already the direct fallback, continue inline.
-        const fallback = slot.direct_fallback_addr.?;
-        if (slot.current_upstream_addr) |cur| {
-            if (isSameIpEndpoint(cur, fallback)) {
-                self.sendDcNonce(slot);
-                return true;
-            }
-        }
-
-        // Otherwise reconnect to direct fallback endpoint.
-        self.cleanupFailedUpstreamConnect(slot);
-        slot.upstream_candidate_next = 1;
-
-        var one = [_]net.Address{fallback};
-        slot.setUpstreamCandidates(self.state.allocator, one[0..]) catch {
-            return false;
-        };
-
-        self.startConnectUpstream(slot, fallback, .dc) catch |err| {
-            log.warn("[{d}] direct fallback connect start failed: {any}", .{ slot.conn_id, err });
-            return false;
-        };
-
-        var fb_buf: [64]u8 = undefined;
-        const fb_str = formatAddress(fallback, &fb_buf);
-        log.warn("[{d}] middle-proxy handshake failed, reconnecting direct to {s}", .{ slot.conn_id, fb_str });
-        return true;
+        return middle_proxy_fallback.fallbackToDirect(
+            self,
+            slot,
+            mpFallbackSendDcNonce,
+            mpFallbackCleanupFailedUpstreamConnect,
+            mpFallbackSetSingleUpstreamCandidate,
+            mpFallbackStartDirectConnect,
+        );
     }
 
     fn mpWriteFrame(self: *EventLoop, slot: *ConnectionSlot, payload: []const u8, encrypted: bool) !void {
-        var plain: [mp_handshake_frame_buf_size]u8 = undefined;
-        const total_len: usize = payload.len + 12;
-        if (total_len > plain.len) return error.BadMiddleProxyFrameSize;
-
-        std.mem.writeInt(u32, plain[0..4], @intCast(total_len), .little);
-        std.mem.writeInt(i32, plain[4..8], slot.mp_write_seq_no, .little);
-        slot.mp_write_seq_no += 1;
-
-        @memcpy(plain[8 .. 8 + payload.len], payload);
-        const checksum = middleproxy.crc32(plain[0 .. 8 + payload.len]);
-        std.mem.writeInt(u32, plain[8 + payload.len ..][0..4], checksum, .little);
-
-        var frame_len = total_len;
-        if (encrypted) {
-            const pad = (16 - (frame_len % 16)) % 16;
-            if (frame_len + pad > plain.len) return error.BadMiddleProxyFrameSize;
-            var i: usize = 0;
-            while (i < pad) : (i += 4) {
-                std.mem.writeInt(u32, plain[frame_len + i ..][0..4], 4, .little);
-            }
-            frame_len += pad;
-            try slot.mp_enc.?.encryptInPlace(plain[0..frame_len]);
-        }
-
-        _ = try queueUpstream(slot, self.state.allocator, plain[0..frame_len]);
+        return middle_proxy_frames.writeFrame(
+            slot,
+            self.state.allocator,
+            payload,
+            encrypted,
+            mp_handshake_frame_buf_size,
+            slotQueueUpstream,
+        );
     }
 
     fn mpTryReadFrame(self: *EventLoop, slot: *ConnectionSlot, encrypted: bool) !?[]const u8 {
-        const frame_buf = try ensureMpFrameBuf(slot, self.state.allocator);
-
-        while (true) {
-            if (slot.mp_frame_need == 0) {
-                mpReadReset(slot, encrypted);
-            }
-
-            if (slot.mp_frame_have < slot.mp_frame_need) {
-                const n = posix.read(slot.upstream_fd, frame_buf[slot.mp_frame_have..slot.mp_frame_need]) catch |err| {
-                    if (err == error.WouldBlock) return null;
-                    log.debug("[{d}] mp read error: step={s} encrypted={} have={d} need={d} err={any}", .{
-                        slot.conn_id,
-                        @tagName(slot.mp_step),
-                        encrypted,
-                        slot.mp_frame_have,
-                        slot.mp_frame_need,
-                        err,
-                    });
-                    return err;
-                };
-                if (n == 0) {
-                    log.debug("[{d}] mp upstream eof: step={s} encrypted={} have={d} need={d}", .{
-                        slot.conn_id,
-                        @tagName(slot.mp_step),
-                        encrypted,
-                        slot.mp_frame_have,
-                        slot.mp_frame_need,
-                    });
-                    return error.EndOfStream;
-                }
-                slot.mp_frame_have += n;
-                if (slot.mp_frame_have < slot.mp_frame_need) return null;
-            }
-
-            if (!encrypted) {
-                if (slot.mp_frame_total_len == 0) {
-                    slot.mp_frame_total_len = std.mem.readInt(u32, frame_buf[0..4], .little);
-                    if (slot.mp_frame_total_len < 12 or slot.mp_frame_total_len > frame_buf.len) {
-                        log.debug("[{d}] mp plain frame size invalid: total_len={d} have={d} need={d}", .{
-                            slot.conn_id,
-                            slot.mp_frame_total_len,
-                            slot.mp_frame_have,
-                            slot.mp_frame_need,
-                        });
-                        return error.BadMiddleProxyFrameSize;
-                    }
-                    slot.mp_frame_need = slot.mp_frame_total_len;
-                    continue;
-                }
-            } else {
-                if (!slot.mp_frame_first_decrypted) {
-                    slot.mp_dec.?.decryptInPlace(frame_buf[0..16]) catch |err| {
-                        log.debug("[{d}] mp decrypt first block failed: step={s} err={any}", .{
-                            slot.conn_id,
-                            @tagName(slot.mp_step),
-                            err,
-                        });
-                        return err;
-                    };
-                    slot.mp_frame_first_decrypted = true;
-                    slot.mp_frame_total_len = std.mem.readInt(u32, frame_buf[0..4], .little);
-                    if (slot.mp_frame_total_len < 12 or slot.mp_frame_total_len > (1 << 24)) {
-                        const first4_le = std.mem.readInt(u32, frame_buf[0..4], .little);
-                        const first4_be = std.mem.readInt(u32, frame_buf[0..4], .big);
-                        log.debug("[{d}] mp encrypted frame size invalid: total_len={d} first4_le=0x{x} first4_be=0x{x}", .{
-                            slot.conn_id,
-                            slot.mp_frame_total_len,
-                            first4_le,
-                            first4_be,
-                        });
-                        return error.BadMiddleProxyFrameSize;
-                    }
-                    slot.mp_frame_padded_len = if (slot.mp_frame_total_len % 16 == 0)
-                        slot.mp_frame_total_len
-                    else
-                        slot.mp_frame_total_len + (16 - (slot.mp_frame_total_len % 16));
-                    if (slot.mp_frame_padded_len > frame_buf.len) {
-                        log.debug("[{d}] mp encrypted padded size invalid: total_len={d} padded_len={d} frame_buf={d}", .{
-                            slot.conn_id,
-                            slot.mp_frame_total_len,
-                            slot.mp_frame_padded_len,
-                            frame_buf.len,
-                        });
-                        return error.BadMiddleProxyFrameSize;
-                    }
-                    slot.mp_frame_need = slot.mp_frame_padded_len;
-                    if (slot.mp_frame_have < slot.mp_frame_need) return null;
-                }
-
-                if (slot.mp_frame_padded_len > 16) {
-                    slot.mp_dec.?.decryptInPlace(frame_buf[16..slot.mp_frame_padded_len]) catch |err| {
-                        log.debug("[{d}] mp decrypt payload failed: step={s} padded_len={d} err={any}", .{
-                            slot.conn_id,
-                            @tagName(slot.mp_step),
-                            slot.mp_frame_padded_len,
-                            err,
-                        });
-                        return err;
-                    };
-                }
-            }
-
-            const frame = frame_buf[0..slot.mp_frame_total_len];
-            const msg_seq = std.mem.readInt(i32, frame[4..8], .little);
-            if (msg_seq != slot.mp_read_seq_no) {
-                log.debug("[{d}] mp seq mismatch: got={d} expected={d} step={s}", .{
-                    slot.conn_id,
-                    msg_seq,
-                    slot.mp_read_seq_no,
-                    @tagName(slot.mp_step),
-                });
-                return error.BadMiddleProxySeqNo;
-            }
-            slot.mp_read_seq_no += 1;
-
-            const expected_checksum = std.mem.readInt(u32, frame[frame.len - 4 ..][0..4], .little);
-            const computed_checksum = middleproxy.crc32(frame[0 .. frame.len - 4]);
-            if (expected_checksum != computed_checksum) {
-                log.debug("[{d}] mp checksum mismatch: expected=0x{x} computed=0x{x} frame_len={d}", .{
-                    slot.conn_id,
-                    expected_checksum,
-                    computed_checksum,
-                    frame.len,
-                });
-                return error.BadMiddleProxyChecksum;
-            }
-
-            // Copy payload into front of frame_buf so caller can consume before reset.
-            const payload_len = frame.len - 12;
-            std.mem.copyForwards(u8, frame_buf[0..payload_len], frame[8 .. frame.len - 4]);
-            const payload = frame_buf[0..payload_len];
-
-            mpReadReset(slot, encrypted);
-            return payload;
-        }
+        return middle_proxy_frames.tryReadFrame(
+            slot,
+            self.state.allocator,
+            encrypted,
+            mp_handshake_frame_buf_size,
+        );
     }
 
     fn runTimers(self: *EventLoop) void {
-        const now_ms = std.time.milliTimestamp();
+        const now_ms = nowMs();
 
         const hi: usize = @intCast(self.pool.allocated_hi);
         if (hi == 0) return;
@@ -3886,14 +2568,14 @@ const EventLoop = struct {
         if (slot.client_fd != -1) {
             _ = self.delFd(slot.client_fd) catch {};
             self.pool.unmapFd(slot.client_fd);
-            posix.close(slot.client_fd);
+            closeFd(slot.client_fd);
             slot.client_fd = -1;
         }
 
         if (slot.upstream_fd != -1) {
             _ = self.delFd(slot.upstream_fd) catch {};
             self.pool.unmapFd(slot.upstream_fd);
-            posix.close(slot.upstream_fd);
+            closeFd(slot.upstream_fd);
             slot.upstream_fd = -1;
         }
 
@@ -3981,710 +2663,15 @@ const EventLoop = struct {
 };
 
 fn relayClientToUpstreamStep(slot: *ConnectionSlot, allocator: std.mem.Allocator, mp_c2s_scratch: ?[]u8, read_buf: []u8) !RelayProgress {
-    var consumed_any = false;
-
-    while (true) {
-        if (slot.relay_tls_hdr_pos < tls_header_len) {
-            const n = posix.read(slot.client_fd, slot.relay_tls_hdr[slot.relay_tls_hdr_pos..]) catch |err| {
-                if (err == error.WouldBlock) return if (consumed_any) .partial else .none;
-                return err;
-            };
-            if (n == 0) return error.EndOfStream;
-            consumed_any = true;
-            slot.relay_tls_hdr_pos += @intCast(n);
-
-            if (slot.relay_tls_hdr_pos < tls_header_len) return .partial;
-
-            slot.relay_record_type = slot.relay_tls_hdr[0];
-            slot.relay_tls_body_len = std.mem.readInt(u16, slot.relay_tls_hdr[3..5], .big);
-            slot.relay_tls_body_pos = 0;
-
-            if (slot.relay_record_type == constants.tls_record_alert) return error.ConnectionReset;
-            if (slot.relay_record_type != constants.tls_record_change_cipher and
-                slot.relay_record_type != constants.tls_record_application)
-            {
-                return error.ConnectionReset;
-            }
-            if (slot.relay_tls_body_len == 0 or slot.relay_tls_body_len > constants.max_tls_ciphertext_size) {
-                return error.ConnectionReset;
-            }
-        }
-
-        const remaining = slot.relay_tls_body_len - slot.relay_tls_body_pos;
-        if (remaining == 0) {
-            slot.relay_tls_hdr_pos = 0;
-            slot.relay_tls_body_pos = 0;
-            slot.relay_tls_body_len = 0;
-            if (consumed_any) return .partial;
-            continue;
-        }
-
-        const want = @min(@as(usize, remaining), read_buf.len);
-        const n = posix.read(slot.client_fd, read_buf[0..want]) catch |err| {
-            if (err == error.WouldBlock) return if (consumed_any) .partial else .none;
-            return err;
-        };
-        if (n == 0) return error.EndOfStream;
-
-        consumed_any = true;
-        slot.relay_tls_body_pos += @intCast(n);
-
-        if (slot.relay_record_type == constants.tls_record_change_cipher) {
-            if (slot.relay_tls_body_pos == slot.relay_tls_body_len) {
-                slot.relay_tls_hdr_pos = 0;
-                slot.relay_tls_body_pos = 0;
-                slot.relay_tls_body_len = 0;
-            }
-            return .partial;
-        }
-
-        const payload = read_buf[0..n];
-        if (slot.client_decryptor) |*dec| dec.apply(payload);
-
-        if (slot.middle_ctx) |*mp| {
-            const scratch = mp_c2s_scratch orelse return error.MissingMiddleProxyScratch;
-            const out_data = try mp.encapsulateC2S(payload, scratch);
-            if (out_data.len > 0) {
-                _ = try queueUpstream(slot, allocator, out_data);
-            }
-        } else if (slot.tg_encryptor) |*enc| {
-            enc.apply(payload);
-            _ = try queueUpstream(slot, allocator, payload);
-        }
-
-        slot.c2s_bytes += payload.len;
-
-        if (slot.relay_tls_body_pos == slot.relay_tls_body_len) {
-            slot.relay_tls_hdr_pos = 0;
-            slot.relay_tls_body_pos = 0;
-            slot.relay_tls_body_len = 0;
-            return .forwarded;
-        }
-
-        return .partial;
-    }
+    return relay_steps.relayClientToUpstreamStep(slot, allocator, mp_c2s_scratch, read_buf, queueUpstream);
 }
 
 fn relayUpstreamToClientStep(slot: *ConnectionSlot, allocator: std.mem.Allocator, mp_s2c_scratch: ?[]u8, read_buf: []u8) !RelayProgress {
-    const n = posix.read(slot.upstream_fd, read_buf) catch |err| {
-        if (err == error.WouldBlock) return .none;
-        return err;
-    };
-    if (n == 0) return error.EndOfStream;
-
-    const raw = read_buf[0..n];
-
-    if (slot.middle_ctx) |*mp| {
-        const scratch = mp_s2c_scratch orelse return error.MissingMiddleProxyScratch;
-        const payload = try mp.decapsulateS2C(raw, scratch);
-        if (payload.len == 0) return .partial;
-        if (slot.client_encryptor) |*enc| enc.apply(payload);
-        try queueTlsAppRecords(slot, allocator, payload);
-        slot.s2c_bytes += payload.len;
-        return .forwarded;
-    }
-
-    if (!slot.use_fast_mode) {
-        if (slot.tg_decryptor) |*dec| dec.apply(raw);
-        if (slot.client_encryptor) |*enc| enc.apply(raw);
-    }
-
-    try queueTlsAppRecords(slot, allocator, raw);
-    slot.s2c_bytes += raw.len;
-    return .forwarded;
+    return relay_steps.relayUpstreamToClientStep(slot, allocator, mp_s2c_scratch, read_buf, queueTlsAppRecords);
 }
 
 fn queueTlsAppRecords(slot: *ConnectionSlot, allocator: std.mem.Allocator, payload: []u8) !void {
-    var off: usize = 0;
-    var header: [tls_header_len]u8 = undefined;
-
-    while (off < payload.len) {
-        const chunk_len = @min(payload.len - off, slot.drs.nextRecordSize());
-
-        header[0] = constants.tls_record_application;
-        header[1] = constants.tls_version[0];
-        header[2] = constants.tls_version[1];
-        std.mem.writeInt(u16, header[3..5], @intCast(chunk_len), .big);
-
-        _ = try slotQueueClientPair(slot, allocator, header[0..], payload[off .. off + chunk_len]);
-        slot.drs.recordSent(chunk_len);
-        off += chunk_len;
-    }
-}
-
-fn epollCreate() !posix.fd_t {
-    const rc = linux.epoll_create1(linux.EPOLL.CLOEXEC);
-    switch (posix.errno(rc)) {
-        .SUCCESS => return @intCast(rc),
-        else => |err| return posix.unexpectedErrno(err),
-    }
-}
-
-fn requiredFdsForConnections(max_connections: u32) usize {
-    return @as(usize, max_connections) * 2 + nofile_fd_overhead;
-}
-
-fn maxConnectionsForNofile(soft_nofile: usize) u32 {
-    if (soft_nofile <= nofile_fd_overhead + 2) return 32;
-
-    const cap = (soft_nofile - nofile_fd_overhead) / 2;
-    const capped_u32: u32 = @intCast(@min(cap, @as(usize, std.math.maxInt(u32))));
-    return @max(@as(u32, 32), capped_u32);
-}
-
-fn getNofileSoftLimit() ?usize {
-    if (builtin.os.tag != .linux) return null;
-
-    var lim: linux.rlimit = undefined;
-    const rc = linux.getrlimit(.NOFILE, &lim);
-    switch (posix.errno(rc)) {
-        .SUCCESS => {},
-        else => return null,
-    }
-
-    return @intCast(lim.cur);
-}
-
-fn checkNofileLimit(required: usize, max_connections: u32) void {
-    const soft = getNofileSoftLimit() orelse return;
-
-    if (soft >= required) return;
-
-    log.warn("RLIMIT_NOFILE soft limit is {d}, recommended >= {d} for max_connections={d}", .{
-        soft,
-        required,
-        max_connections,
-    });
-}
-
-fn setNonBlocking(fd: posix.fd_t) void {
-    var fl_flags = posix.fcntl(fd, posix.F.GETFL, 0) catch return;
-    const nonblock: @TypeOf(fl_flags) = @bitCast(@as(u64, @as(u32, @bitCast(posix.O{ .NONBLOCK = true }))));
-    fl_flags |= nonblock;
-    _ = posix.fcntl(fd, posix.F.SETFL, fl_flags) catch return;
-}
-
-fn secondsToMs(sec: u32) i64 {
-    return @as(i64, @intCast(sec)) * std.time.ms_per_s;
-}
-
-fn setSendTimeout(fd: posix.fd_t, timeout_sec: u32) void {
-    const tv = posix.timeval{ .sec = @intCast(timeout_sec), .usec = 0 };
-    posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.SNDTIMEO, std.mem.asBytes(&tv)) catch return;
-}
-
-fn setTcpKeepalive(fd: posix.fd_t) void {
-    const sol_tcp: i32 = 6;
-
-    const enable: c_int = 1;
-    posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.KEEPALIVE, std.mem.asBytes(&enable)) catch return;
-
-    const idle: c_int = 60;
-    posix.setsockopt(fd, sol_tcp, 4, std.mem.asBytes(&idle)) catch return;
-
-    const interval: c_int = 10;
-    posix.setsockopt(fd, sol_tcp, 5, std.mem.asBytes(&interval)) catch return;
-
-    const count: c_int = 3;
-    posix.setsockopt(fd, sol_tcp, 6, std.mem.asBytes(&count)) catch return;
-}
-
-fn setTcpNoDelay(fd: posix.fd_t) void {
-    const enable: c_int = 1;
-    posix.setsockopt(fd, posix.IPPROTO.TCP, posix.TCP.NODELAY, std.mem.asBytes(&enable)) catch return;
-}
-
-fn configureRelaySocket(fd: posix.fd_t) void {
-    setTcpNoDelay(fd);
-    setTcpKeepalive(fd);
-    setSendTimeout(fd, 30);
-}
-
-fn formatAddress(addr: net.Address, buf: *[64]u8) []const u8 {
-    switch (addr.any.family) {
-        posix.AF.INET => {
-            return std.fmt.bufPrint(buf, "[ipv4]:{d}", .{
-                std.mem.bigToNative(u16, addr.in.sa.port),
-            }) catch "?";
-        },
-        posix.AF.INET6 => {
-            const bytes: *const [16]u8 = @ptrCast(&addr.in6.sa.addr);
-            const is_ipv4_mapped = std.mem.eql(u8, bytes[0..10], &[_]u8{0} ** 10) and
-                std.mem.eql(u8, bytes[10..12], &[_]u8{ 0xff, 0xff });
-
-            if (is_ipv4_mapped) {
-                return std.fmt.bufPrint(buf, "[ipv4]:{d}", .{
-                    std.mem.bigToNative(u16, addr.in6.sa.port),
-                }) catch "?";
-            }
-            return std.fmt.bufPrint(buf, "[ipv6]:{d}", .{
-                std.mem.bigToNative(u16, addr.in6.sa.port),
-            }) catch "?";
-        },
-        else => return "?",
-    }
-}
-
-fn ensureMpFrameBuf(slot: *ConnectionSlot, allocator: std.mem.Allocator) ![]u8 {
-    if (slot.mp_frame_buf) |buf| return buf;
-    const buf = try allocator.alloc(u8, mp_handshake_frame_buf_size);
-    slot.mp_frame_buf = buf;
-    return buf;
-}
-
-fn fetchUrlBytes(allocator: std.mem.Allocator, url: []const u8) ![]u8 {
-    const uri = try std.Uri.parse(url);
-
-    var client: std.http.Client = .{ .allocator = allocator };
-    defer client.deinit();
-
-    var req = try client.request(.GET, uri, .{
-        .redirect_behavior = @enumFromInt(3),
-        .keep_alive = false,
-        .headers = .{
-            .accept_encoding = .{ .override = "identity" },
-        },
-    });
-    defer req.deinit();
-
-    try req.sendBodiless();
-
-    var redirect_buf: [8 * 1024]u8 = undefined;
-    var response = try req.receiveHead(&redirect_buf);
-    if (response.head.status.class() != .success) return error.HttpRequestFailed;
-
-    var transfer_buf: [4 * 1024]u8 = undefined;
-    const reader = response.reader(&transfer_buf);
-    return reader.allocRemaining(allocator, .limited(1 * 1024 * 1024));
-}
-
-/// Fetch a URL by shelling out to `curl`, binding the outgoing socket to the
-/// given network interface. This is the censorship-aware refresh path: when
-/// the proxy host sits in a network where `core.telegram.org` is unreachable
-/// over the default route, but the tunnel interface (e.g. AWG) provides a
-/// clean path, we use curl as an off-the-shelf HTTPS client without pulling
-/// a full TLS stack into the proxy binary.
-fn fetchUrlBytesViaInterface(
-    allocator: std.mem.Allocator,
-    url: []const u8,
-    interface: []const u8,
-) ![]u8 {
-    // curl requires --interface and its value as separate argv elements; the
-    // `--interface=<iface>` form is a common shell idiom but not supported by
-    // every curl version, hence the split.
-    const argv = [_][]const u8{
-        "curl",
-        "--silent",
-        "--fail",
-        "--show-error",
-        "--location",
-        "--max-time",
-        "10",
-        "--interface",
-        interface,
-        url,
-    };
-
-    const result = std.process.Child.run(.{
-        .allocator = allocator,
-        .argv = &argv,
-        .max_output_bytes = 1 * 1024 * 1024,
-    }) catch |err| {
-        log.warn("curl fallback failed to spawn: {any}", .{err});
-        return error.UnexpectedConnectFailure;
-    };
-    // Free stderr regardless of outcome; stdout is returned to the caller.
-    defer allocator.free(result.stderr);
-
-    switch (result.term) {
-        .Exited => |code| {
-            if (code != 0) {
-                log.warn("curl {s} via {s} exited with {d}: {s}", .{
-                    url, interface, code,
-                    std.mem.trim(u8, result.stderr, " \t\r\n"),
-                });
-                allocator.free(result.stdout);
-                return error.UnexpectedConnectFailure;
-            }
-        },
-        else => {
-            log.warn("curl {s} via {s} terminated abnormally", .{ url, interface });
-            allocator.free(result.stdout);
-            return error.UnexpectedConnectFailure;
-        },
-    }
-
-    return result.stdout;
-}
-
-fn parseIpv4Literal(text: []const u8) ?[4]u8 {
-    var parts = std.mem.splitScalar(u8, text, '.');
-    var ip: [4]u8 = undefined;
-    var idx: usize = 0;
-
-    while (parts.next()) |part| {
-        if (idx >= ip.len or part.len == 0 or part.len > 3) return null;
-        const octet = std.fmt.parseInt(u16, part, 10) catch return null;
-        if (octet > 255) return null;
-        ip[idx] = @intCast(octet);
-        idx += 1;
-    }
-
-    if (idx != ip.len) return null;
-    return ip;
-}
-
-/// Parse a user-supplied bind address string into a net.Address.
-/// Accepts IPv4 literals like "1.2.3.4" and IPv6 literals like "::1".
-fn parseListenAddress(text: []const u8, port: u16) ?net.Address {
-    // Try IPv4 first
-    if (parseIpv4Literal(text)) |ip4| {
-        return net.Address.initIp4(ip4, port);
-    }
-    // Try IPv6 (may or may not have brackets)
-    var ip6_str = text;
-    if (ip6_str.len >= 2 and ip6_str[0] == '[' and ip6_str[ip6_str.len - 1] == ']') {
-        ip6_str = ip6_str[1 .. ip6_str.len - 1];
-    }
-    return net.Address.parseIp6(ip6_str, port) catch return null;
-}
-
-fn isRunningInNonInitNetns() bool {
-    var self_buf: [std.fs.max_path_bytes]u8 = undefined;
-    var init_buf: [std.fs.max_path_bytes]u8 = undefined;
-
-    const self_ns = std.fs.readLinkAbsolute("/proc/self/ns/net", &self_buf) catch return false;
-    const init_ns = std.fs.readLinkAbsolute("/proc/1/ns/net", &init_buf) catch return false;
-
-    return !std.mem.eql(u8, self_ns, init_ns);
-}
-
-fn parseEndpointHost(endpoint: []const u8) ?[]const u8 {
-    const trimmed = std.mem.trim(u8, endpoint, &[_]u8{ ' ', '\t', '\r', '\n' });
-    if (trimmed.len == 0) return null;
-
-    if (trimmed[0] == '[') {
-        const close_idx = std.mem.indexOfScalar(u8, trimmed, ']') orelse return null;
-        const host = trimmed[1..close_idx];
-        if (host.len == 0) return null;
-        return host;
-    }
-
-    if (std.mem.lastIndexOfScalar(u8, trimmed, ':')) |sep| {
-        if (sep == 0) return null;
-        return std.mem.trim(u8, trimmed[0..sep], &[_]u8{ ' ', '\t', '\r', '\n' });
-    }
-
-    return trimmed;
-}
-
-fn resolveHostnameIpv4(allocator: std.mem.Allocator, host: []const u8) ?[4]u8 {
-    var list = net.getAddressList(allocator, host, 443) catch return null;
-    defer list.deinit();
-
-    for (list.addrs) |addr| {
-        if (addr.any.family == posix.AF.INET) {
-            var ip: [4]u8 = undefined;
-            @memcpy(&ip, std.mem.asBytes(&addr.in.sa.addr));
-            std.mem.reverse(u8, &ip);
-            return ip;
-        }
-    }
-
-    return null;
-}
-
-fn parseAwgEndpointIpv4FromConfig(allocator: std.mem.Allocator, content: []const u8) ?[4]u8 {
-    var in_peer = false;
-    var lines = std.mem.splitScalar(u8, content, '\n');
-
-    while (lines.next()) |raw_line| {
-        const line_no_cr = std.mem.trimRight(u8, raw_line, "\r");
-        const line = std.mem.trim(u8, line_no_cr, &[_]u8{ ' ', '\t' });
-        if (line.len == 0 or line[0] == '#' or line[0] == ';') continue;
-
-        if (line[0] == '[' and line[line.len - 1] == ']') {
-            in_peer = std.ascii.eqlIgnoreCase(line, "[Peer]");
-            continue;
-        }
-        if (!in_peer) continue;
-
-        const eq_pos = std.mem.indexOfScalar(u8, line, '=') orelse continue;
-        const key = std.mem.trim(u8, line[0..eq_pos], &[_]u8{ ' ', '\t' });
-        if (!std.ascii.eqlIgnoreCase(key, "Endpoint")) continue;
-
-        var value = std.mem.trim(u8, line[eq_pos + 1 ..], &[_]u8{ ' ', '\t' });
-        if (std.mem.indexOfScalar(u8, value, '#')) |idx| value = value[0..idx];
-        if (std.mem.indexOfScalar(u8, value, ';')) |idx| value = value[0..idx];
-        value = std.mem.trim(u8, value, &[_]u8{ ' ', '\t' });
-        const host = parseEndpointHost(value) orelse continue;
-
-        if (parseIpv4Literal(host)) |ip| return ip;
-        if (resolveHostnameIpv4(allocator, host)) |resolved_ip| return resolved_ip;
-    }
-
-    return null;
-}
-
-fn detectAwgEndpointIpv4(allocator: std.mem.Allocator) ?[4]u8 {
-    const paths = [_][]const u8{
-        "/etc/amnezia/amneziawg/awg0.conf",
-        "/etc/amnezia/amneziawg/wg0.conf",
-        "/etc/wireguard/wg0.conf",
-    };
-
-    for (paths) |path| {
-        const file = std.fs.openFileAbsolute(path, .{}) catch continue;
-        defer file.close();
-
-        const content = file.readToEndAlloc(allocator, 64 * 1024) catch continue;
-        defer allocator.free(content);
-
-        if (parseAwgEndpointIpv4FromConfig(allocator, content)) |ip| return ip;
-    }
-
-    return null;
-}
-
-fn detectPublicIpv4(allocator: std.mem.Allocator) ?[4]u8 {
-    const services = [_][]const u8{
-        "https://api.ipify.org",
-        "https://ifconfig.me",
-        "https://ipv4.icanhazip.com",
-    };
-
-    for (services) |url| {
-        const stdout = fetchUrlBytes(allocator, url) catch continue;
-        const trimmed = std.mem.trim(u8, stdout, &[_]u8{ ' ', '\t', '\r', '\n' });
-        const parsed = parseIpv4Literal(trimmed);
-        allocator.free(stdout);
-        if (parsed) |ip| return ip;
-    }
-
-    return null;
-}
-
-fn formatIpv4Bytes(ip: [4]u8, buf: *[16]u8) []const u8 {
-    return std.fmt.bufPrint(buf, "{d}.{d}.{d}.{d}", .{ ip[0], ip[1], ip[2], ip[3] }) catch "?.?.?.?";
-}
-
-fn ipv4NetworkToHostBytes(ip: [4]u8) [4]u8 {
-    return .{ ip[3], ip[2], ip[1], ip[0] };
-}
-
-fn isSameIpEndpoint(a: net.Address, b: net.Address) bool {
-    if (a.any.family != b.any.family) return false;
-
-    if (a.any.family == posix.AF.INET) {
-        return a.in.sa.addr == b.in.sa.addr and a.in.sa.port == b.in.sa.port;
-    }
-
-    if (a.any.family == posix.AF.INET6) {
-        return std.mem.eql(u8, &a.in6.sa.addr, &b.in6.sa.addr) and a.in6.sa.port == b.in6.sa.port;
-    }
-
-    return false;
-}
-
-fn appendUniqueAddress(addrs: *[16]net.Address, count: *usize, addr: net.Address) void {
-    if (count.* >= addrs.len) return;
-    for (addrs[0..count.*]) |existing| {
-        if (isSameIpEndpoint(existing, addr)) return;
-    }
-    addrs[count.*] = addr;
-    count.* += 1;
-}
-
-fn buildDcConnectPlan(
-    cfg: *const Config,
-    dc_abs: usize,
-    dc_idx: i16,
-    snapshot: ?*const ProxyState.MiddleProxySnapshot,
-    user_name: []const u8,
-) DcConnectPlan {
-    var plan = DcConnectPlan{};
-    plan.is_media_path = (dc_idx < 0) or (dc_abs == 203);
-
-    if (cfg.datacenter_override) |override| {
-        plan.candidates[0] = override;
-        plan.count = 1;
-        plan.use_middle_proxy = false;
-        plan.direct_fallback = null;
-        return plan;
-    }
-
-    if (cfg.userBypassesMiddleProxy(user_name)) {
-        plan.candidates[0] = constants.getDcAddressV4(dc_abs);
-        plan.count = 1;
-        plan.use_middle_proxy = false;
-        plan.direct_fallback = null;
-        return plan;
-    }
-
-    var middle_addr: ?net.Address = null;
-    if (snapshot) |snap| {
-        middle_addr = snap.getForDc(dc_abs, plan.is_media_path);
-        if (middle_addr == null and plan.is_media_path) {
-            // Media pool is empty in this snapshot (e.g. first run, refresh
-            // hasn't succeeded yet and bundled media list is mis-seeded).
-            // Fall back to the regular MP — connections still complete, just
-            // without media-optimized routing.
-            middle_addr = snap.getForDc(dc_abs, false);
-        }
-    }
-
-    const force_media_middle_proxy = cfg.force_media_middle_proxy and plan.is_media_path and middle_addr != null;
-    plan.use_middle_proxy = if (force_media_middle_proxy)
-        true
-    else
-        cfg.use_middle_proxy and middle_addr != null;
-
-    if (!plan.use_middle_proxy) {
-        plan.candidates[0] = constants.getDcAddressV4(dc_abs);
-        plan.count = 1;
-        plan.direct_fallback = null;
-        return plan;
-    }
-
-    if (snapshot) |snap| {
-        if (dc_abs == 4) {
-            if (plan.is_media_path and snap.addrs_media_dc4_len > 0) {
-                var n: usize = 0;
-                while (n < snap.addrs_media_dc4_len and plan.count < plan.candidates.len) : (n += 1) {
-                    appendUniqueAddress(&plan.candidates, &plan.count, snap.addrs_media_dc4[n]);
-                }
-            } else if (snap.addrs_dc4_len > 0) {
-                var n: usize = 0;
-                while (n < snap.addrs_dc4_len and plan.count < plan.candidates.len) : (n += 1) {
-                    appendUniqueAddress(&plan.candidates, &plan.count, snap.addrs_dc4[n]);
-                }
-            }
-        } else if (dc_abs == 203 and snap.addrs_203_len > 0) {
-            var n: usize = 0;
-            while (n < snap.addrs_203_len and plan.count < plan.candidates.len) : (n += 1) {
-                appendUniqueAddress(&plan.candidates, &plan.count, snap.addrs_203[n]);
-            }
-        }
-    }
-
-    if (plan.count == 0 and middle_addr != null) {
-        appendUniqueAddress(&plan.candidates, &plan.count, middle_addr.?);
-    }
-
-    if (plan.count == 0) {
-        // Safety fallback: if cache has no middle-proxy endpoint for this DC,
-        // avoid dropping valid users and go direct.
-        plan.use_middle_proxy = false;
-        plan.candidates[0] = constants.getDcAddressV4(dc_abs);
-        plan.count = 1;
-        plan.direct_fallback = null;
-        return plan;
-    }
-
-    // If middle-proxy connect/handshake fails, retry the same DC via direct mode.
-    // This keeps media paths functional in environments where middle-proxy transport
-    // itself is degraded (for example due to strict NAT behavior in upstream tunnels).
-    plan.direct_fallback = constants.getDcAddressV4(dc_abs);
-    return plan;
-}
-
-const DcSignFilter = enum {
-    any, // accept proxy_for with dc == target_dc (any sign) — legacy
-    positive_only, // only `proxy_for  N  addr;` — regular traffic
-    negative_only, // only `proxy_for -N  addr;` — media traffic (dc_idx < 0)
-};
-
-fn parseMiddleProxyAddressesForDc(
-    config_text: []const u8,
-    target_dc: i16,
-    sign: DcSignFilter,
-    out: []net.Address,
-) usize {
-    if (out.len == 0) return 0;
-
-    var lines = std.mem.splitScalar(u8, config_text, '\n');
-    var count: usize = 0;
-
-    while (lines.next()) |raw_line| {
-        var line = std.mem.trim(u8, raw_line, &[_]u8{ ' ', '\t', '\r' });
-        if (line.len == 0 or line[0] == '#') continue;
-        if (line[line.len - 1] == ';') line = line[0 .. line.len - 1];
-
-        var parts = std.mem.tokenizeAny(u8, line, " \t");
-        const keyword = parts.next() orelse continue;
-        if (!std.mem.eql(u8, keyword, "proxy_for")) continue;
-
-        const dc_text = parts.next() orelse continue;
-        const host_port = parts.next() orelse continue;
-
-        const dc_idx = std.fmt.parseInt(i16, dc_text, 10) catch continue;
-        const abs_target: i16 = if (target_dc < 0) -target_dc else target_dc;
-        switch (sign) {
-            .any => if (dc_idx != abs_target and dc_idx != -abs_target) continue,
-            .positive_only => if (dc_idx != abs_target) continue,
-            .negative_only => if (dc_idx != -abs_target) continue,
-        }
-
-        const parsed = net.Address.parseIpAndPort(host_port) catch continue;
-
-        var dup = false;
-        for (out[0..count]) |existing| {
-            if (existing.eql(parsed)) {
-                dup = true;
-                break;
-            }
-        }
-        if (dup) continue;
-
-        out[count] = parsed;
-        count += 1;
-        if (count == out.len) break;
-    }
-
-    return count;
-}
-
-fn trySelectReachableMiddleProxy(candidates: []const net.Address, timeout_ms: i32) ?net.Address {
-    for (candidates) |addr| {
-        if (isAddressReachable(addr, timeout_ms)) return addr;
-    }
-    return null;
-}
-
-fn addressesEqual(a: []const net.Address, b: []const net.Address) bool {
-    if (a.len != b.len) return false;
-    for (a, b) |lhs, rhs| {
-        if (!lhs.eql(rhs)) return false;
-    }
-    return true;
-}
-
-fn isAddressReachable(address: net.Address, timeout_ms: i32) bool {
-    const sock_flags = posix.SOCK.STREAM | posix.SOCK.CLOEXEC | posix.SOCK.NONBLOCK;
-    const fd = posix.socket(address.any.family, sock_flags, posix.IPPROTO.TCP) catch return false;
-    defer posix.close(fd);
-
-    posix.connect(fd, &address.any, address.getOsSockLen()) catch |err| switch (err) {
-        error.WouldBlock, error.ConnectionPending => {},
-        else => return false,
-    };
-
-    var fds = [_]posix.pollfd{.{ .fd = fd, .events = posix.POLL.OUT, .revents = 0 }};
-    const ready = posix.poll(&fds, timeout_ms) catch return false;
-    if (ready == 0) return false;
-    const revents = fds[0].revents;
-    if ((revents & posix.POLL.OUT) == 0) return false;
-    if ((revents & (posix.POLL.ERR | posix.POLL.HUP | posix.POLL.NVAL)) != 0) return false;
-    posix.getsockoptError(fd) catch return false;
-    return true;
-}
-
-fn parseMiddleProxyAddressForDc(config_text: []const u8, target_dc: i16) ?net.Address {
-    var one: [1]net.Address = undefined;
-    const sign: DcSignFilter = if (target_dc < 0) .negative_only else .positive_only;
-    const n = parseMiddleProxyAddressesForDc(config_text, target_dc, sign, &one);
-    if (n == 0) return null;
-    return one[0];
+    return relay_steps.queueTlsAppRecords(slot, allocator, payload, slotQueueClientPair);
 }
 
 /// Dummy counter for slots that don't yet have traffic counters attached
@@ -4692,150 +2679,9 @@ fn parseMiddleProxyAddressForDc(config_text: []const u8, target_dc: i16) ?net.Ad
 /// silently absorbed so the data path never errors out on missing metrics.
 var noop_counter = std.atomic.Value(u64).init(0);
 
-fn noteTraffic(counter: *std.atomic.Value(u64), bytes: usize) void {
-    if (bytes == 0) return;
-    _ = counter.fetchAdd(@intCast(bytes), .monotonic);
-}
-
-fn noteTrafficOptional(counter: ?*std.atomic.Value(u64), bytes: usize) void {
-    if (counter) |ptr| noteTraffic(ptr, bytes);
-}
-
-fn queueOrWriteMsg(fd: posix.fd_t, queue: *MessageQueue, data: []const u8, counter: *std.atomic.Value(u64), user_counter: ?*std.atomic.Value(u64)) !bool {
-    if (data.len == 0) return true;
-
-    if (queue.isEmpty()) {
-        const n = posix.write(fd, data) catch |err| {
-            if (err == error.WouldBlock) {
-                try queue.appendCopy(data);
-                return false;
-            }
-            return err;
-        };
-
-        noteTraffic(counter, n);
-        noteTrafficOptional(user_counter, n);
-        if (n == data.len) return true;
-        try queue.appendCopy(data[n..]);
-        return false;
-    }
-
-    try queue.appendCopy(data);
-    return false;
-}
-
-fn queueOrWriteMsgPair(fd: posix.fd_t, queue: *MessageQueue, first: []const u8, second: []const u8, counter: *std.atomic.Value(u64), user_counter: ?*std.atomic.Value(u64)) !bool {
-    if (first.len == 0 and second.len == 0) return true;
-
-    if (queue.isEmpty()) {
-        var iovecs: [2]posix.iovec_const = undefined;
-        var n_iov: usize = 0;
-        if (first.len > 0) {
-            iovecs[n_iov] = .{ .base = first.ptr, .len = first.len };
-            n_iov += 1;
-        }
-        if (second.len > 0) {
-            iovecs[n_iov] = .{ .base = second.ptr, .len = second.len };
-            n_iov += 1;
-        }
-
-        const total_len = first.len + second.len;
-        const n = posix.writev(fd, iovecs[0..n_iov]) catch |err| {
-            if (err == error.WouldBlock) {
-                try queue.appendCopy(first);
-                try queue.appendCopy(second);
-                return false;
-            }
-            return err;
-        };
-
-        if (n == 0) return error.ConnectionReset;
-        noteTraffic(counter, n);
-        noteTrafficOptional(user_counter, n);
-        if (n == total_len) return true;
-
-        if (n < first.len) {
-            try queue.appendCopy(first[n..]);
-            try queue.appendCopy(second);
-            return false;
-        }
-
-        const consumed_second = n - first.len;
-        if (consumed_second < second.len) {
-            try queue.appendCopy(second[consumed_second..]);
-        }
-        return false;
-    }
-
-    try queue.appendCopy(first);
-    try queue.appendCopy(second);
-    return false;
-}
-
-fn queueOrWriteOwnedMsg(fd: posix.fd_t, queue: *MessageQueue, owned: []u8, counter: *std.atomic.Value(u64), user_counter: ?*std.atomic.Value(u64)) !bool {
-    if (owned.len == 0) {
-        queue.allocator.free(owned);
-        return true;
-    }
-
-    if (queue.isEmpty()) {
-        const n = posix.write(fd, owned) catch |err| {
-            if (err == error.WouldBlock) {
-                try queue.appendOwned(owned);
-                return false;
-            }
-            queue.allocator.free(owned);
-            return err;
-        };
-
-        noteTraffic(counter, n);
-        noteTrafficOptional(user_counter, n);
-        if (n == owned.len) {
-            queue.allocator.free(owned);
-            return true;
-        }
-
-        const remaining = owned[n..];
-        try queue.appendCopy(remaining);
-        queue.allocator.free(owned);
-        return false;
-    }
-
-    try queue.appendOwned(owned);
-    return false;
-}
-
-fn flushQueue(fd: posix.fd_t, queue: *MessageQueue, counter: *std.atomic.Value(u64), user_counter: ?*std.atomic.Value(u64)) !bool {
-    if (queue.isEmpty()) return true;
-
-    var iovecs: [max_scatter_parts]posix.iovec_const = undefined;
-
-    while (!queue.isEmpty()) {
-        const n_iov = queue.prepareIovecs(iovecs[0..]);
-        if (n_iov == 0) return true;
-
-        var total_req: usize = 0;
-        for (iovecs[0..n_iov]) |iov| total_req += iov.len;
-
-        const n = posix.writev(fd, iovecs[0..n_iov]) catch |err| {
-            if (err == error.WouldBlock) return false;
-            return err;
-        };
-
-        if (n == 0) return error.ConnectionReset;
-        noteTraffic(counter, n);
-        noteTrafficOptional(user_counter, n);
-        try queue.consume(n);
-
-        if (n < total_req) return false;
-    }
-
-    return true;
-}
-
 fn slotQueueClient(slot: *ConnectionSlot, allocator: std.mem.Allocator, data: []const u8) !bool {
     _ = allocator;
-    return queueOrWriteMsg(
+    return queue_io.queueOrWriteMsg(
         slot.client_fd,
         &slot.client_queue,
         data,
@@ -4846,7 +2692,7 @@ fn slotQueueClient(slot: *ConnectionSlot, allocator: std.mem.Allocator, data: []
 
 fn slotQueueClientPair(slot: *ConnectionSlot, allocator: std.mem.Allocator, first: []const u8, second: []const u8) !bool {
     _ = allocator;
-    return queueOrWriteMsgPair(
+    return queue_io.queueOrWriteMsgPair(
         slot.client_fd,
         &slot.client_queue,
         first,
@@ -4858,7 +2704,7 @@ fn slotQueueClientPair(slot: *ConnectionSlot, allocator: std.mem.Allocator, firs
 
 fn slotQueueClientOwned(slot: *ConnectionSlot, allocator: std.mem.Allocator, owned: []u8) !bool {
     _ = allocator;
-    return queueOrWriteOwnedMsg(
+    return queue_io.queueOrWriteOwnedMsg(
         slot.client_fd,
         &slot.client_queue,
         owned,
@@ -4869,7 +2715,7 @@ fn slotQueueClientOwned(slot: *ConnectionSlot, allocator: std.mem.Allocator, own
 
 fn slotQueueUpstream(slot: *ConnectionSlot, allocator: std.mem.Allocator, data: []const u8) !bool {
     _ = allocator;
-    return queueOrWriteMsg(
+    return queue_io.queueOrWriteMsg(
         slot.upstream_fd,
         &slot.upstream_queue,
         data,
@@ -4880,7 +2726,7 @@ fn slotQueueUpstream(slot: *ConnectionSlot, allocator: std.mem.Allocator, data: 
 
 fn slotFlushClientPending(slot: *ConnectionSlot, allocator: std.mem.Allocator) !bool {
     _ = allocator;
-    return flushQueue(
+    return queue_io.flushQueue(
         slot.client_fd,
         &slot.client_queue,
         slot.traffic_upstream_to_client_counter orelse &noop_counter,
@@ -4890,7 +2736,7 @@ fn slotFlushClientPending(slot: *ConnectionSlot, allocator: std.mem.Allocator) !
 
 fn slotFlushUpstreamPending(slot: *ConnectionSlot, allocator: std.mem.Allocator) !bool {
     _ = allocator;
-    return flushQueue(
+    return queue_io.flushQueue(
         slot.upstream_fd,
         &slot.upstream_queue,
         slot.traffic_client_to_upstream_counter orelse &noop_counter,
@@ -4899,12 +2745,7 @@ fn slotFlushUpstreamPending(slot: *ConnectionSlot, allocator: std.mem.Allocator)
 }
 
 fn slotMpReadReset(slot: *ConnectionSlot, encrypted: bool) void {
-    slot.mp_frame_have = 0;
-    slot.mp_frame_total_len = 0;
-    slot.mp_frame_padded_len = 0;
-    slot.mp_frame_encrypted = encrypted;
-    slot.mp_frame_first_decrypted = false;
-    slot.mp_frame_need = if (encrypted) 16 else 4;
+    return middle_proxy_frames.readReset(slot, encrypted);
 }
 
 // Method forwarding helpers (keeps call sites readable)
@@ -4932,284 +2773,73 @@ fn mpReadReset(self: *ConnectionSlot, encrypted: bool) void {
     return slotMpReadReset(self, encrypted);
 }
 
-test "parse middle proxy address for dc203" {
-    const cfg =
-        "# force_probability 10 10\n" ++
-        "default 2;\n" ++
-        "proxy_for 1 149.154.175.50:8888;\n" ++
-        "proxy_for 203 91.105.192.110:443;\n" ++
-        "proxy_for -203 91.105.192.110:443;\n";
-
-    const addr = parseMiddleProxyAddressForDc(cfg, 203) orelse return error.TestExpectedEqual;
-    try std.testing.expect(addr.any.family == posix.AF.INET);
-    try std.testing.expectEqual(@as(u16, 443), std.mem.bigToNative(u16, addr.in.sa.port));
+fn proxyHandshakeQueueUpstream(loop: *EventLoop, slot: *ConnectionSlot, data: []const u8) !bool {
+    return queueUpstream(slot, loop.state.allocator, data);
 }
 
-test "direct users bypass middle-proxy routing" {
-    const cfg_text =
-        \\[general]
-        \\use_middle_proxy = true
-        \\[access.users]
-        \\admin = "00112233445566778899aabbccddeeff"
-        \\regular = "ffeeddccbbaa99887766554433221100"
-        \\[access.direct_users]
-        \\admin = true
-    ;
-
-    var cfg = try Config.parse(std.testing.allocator, cfg_text);
-    defer cfg.deinit(std.testing.allocator);
-
-    const mp_dc4 = net.Address.initIp4(.{ 11, 11, 11, 11 }, 443);
-    const mp_dc203 = net.Address.initIp4(.{ 12, 12, 12, 12 }, 443);
-    const snapshot = ProxyState.MiddleProxySnapshot{
-        .addrs_primary = .{
-            constants.tg_middle_proxies_v4[0],
-            constants.tg_middle_proxies_v4[1],
-            constants.tg_middle_proxies_v4[2],
-            mp_dc4,
-            constants.tg_middle_proxies_v4[4],
-        },
-        .addrs_media_primary = constants.tg_media_middle_proxies_v4,
-        .addr_203 = mp_dc203,
-        .addrs_dc4 = [_]net.Address{mp_dc4} ++ ([_]net.Address{mp_dc4} ** 15),
-        .addrs_dc4_len = 1,
-        .addrs_media_dc4 = [_]net.Address{constants.tg_media_middle_proxies_v4[3]} ++ ([_]net.Address{constants.tg_media_middle_proxies_v4[3]} ** 15),
-        .addrs_media_dc4_len = 1,
-        .addrs_203 = [_]net.Address{mp_dc203} ++ ([_]net.Address{mp_dc203} ** 7),
-        .addrs_203_len = 1,
-        .secret = [_]u8{0} ** 256,
-        .secret_len = 16,
-    };
-
-    const regular_plan = buildDcConnectPlan(&cfg, 4, 4, &snapshot, "regular");
-    try std.testing.expect(regular_plan.use_middle_proxy);
-    try std.testing.expect(regular_plan.direct_fallback != null);
-    try std.testing.expect(regular_plan.candidates[0].eql(mp_dc4));
-
-    const admin_plan = buildDcConnectPlan(&cfg, 4, 4, &snapshot, "admin");
-    try std.testing.expect(!admin_plan.use_middle_proxy);
-    try std.testing.expect(admin_plan.direct_fallback == null);
-    try std.testing.expect(admin_plan.candidates[0].eql(constants.getDcAddressV4(4)));
-
-    const regular_media = buildDcConnectPlan(&cfg, 203, -203, &snapshot, "regular");
-    try std.testing.expect(regular_media.use_middle_proxy);
-    try std.testing.expect(regular_media.candidates[0].eql(mp_dc203));
-
-    const admin_media = buildDcConnectPlan(&cfg, 203, -203, &snapshot, "admin");
-    try std.testing.expect(!admin_media.use_middle_proxy);
-    try std.testing.expect(admin_media.candidates[0].eql(constants.getDcAddressV4(203)));
+fn proxyHandshakeCloseSlot(loop: *EventLoop, slot: *ConnectionSlot, reason: []const u8) void {
+    return loop.closeSlot(slot, reason);
 }
 
-test "DRS disabled skips ramp and uses full TLS record size" {
-    // Regression: prior behaviour initialised `current_size` to the probe-
-    // friendly 1369-byte size even when the user disabled DRS, bottlenecking
-    // downstream throughput forever. Disabled DRS must start (and stay) at
-    // the full TLS plaintext size.
-    var drs = DynamicRecordSizer.init(false);
-    try std.testing.expectEqual(DynamicRecordSizer.full_size, drs.nextRecordSize());
-    for (0..32) |_| drs.recordSent(1369);
-    try std.testing.expectEqual(DynamicRecordSizer.full_size, drs.nextRecordSize());
+fn proxyHandshakeCompleteCallback(loop: *EventLoop, slot: *ConnectionSlot) void {
+    return loop.proxyHandshakeComplete(slot);
 }
 
-test "DRS enabled ramps" {
-    var drs = DynamicRecordSizer.init(true);
-    for (0..8) |_| drs.recordSent(1369);
-    try std.testing.expectEqual(DynamicRecordSizer.full_size, drs.nextRecordSize());
+fn relayEnsureMpC2sScratch(loop: *EventLoop) ![]u8 {
+    return loop.ensureMpC2sScratch();
 }
 
-test "message queue consume is stable" {
-    var q = MessageQueue{ .allocator = std.testing.allocator };
-    defer q.deinit();
-
-    try q.appendCopy("abc");
-    try q.appendCopy("defg");
-    try std.testing.expectEqual(@as(usize, 7), q.total_len);
-
-    try q.consume(2);
-    try std.testing.expectEqual(@as(usize, 5), q.total_len);
-
-    var iov: [8]posix.iovec_const = undefined;
-    const n = q.prepareIovecs(iov[0..]);
-    try std.testing.expect(n >= 1);
-    try std.testing.expectEqual(@as(u8, 'c'), iov[0].base[0]);
-
-    try q.consume(5);
-    try std.testing.expect(q.isEmpty());
-    try std.testing.expectEqual(@as(usize, 0), q.offset);
-    try std.testing.expectEqual(@as(usize, 0), q.head_idx);
+fn relayQueueClient(loop: *EventLoop, slot: *ConnectionSlot, data: []const u8) !bool {
+    return queueClient(slot, loop.state.allocator, data);
 }
 
-test "message queue append fills tail block" {
-    var q = MessageQueue{ .allocator = std.testing.allocator };
-    defer q.deinit();
-
-    try q.appendCopy("abcde");
-    try q.appendCopy("fghij");
-
-    try std.testing.expectEqual(@as(usize, 10), q.total_len);
-    try std.testing.expectEqual(@as(usize, 1), q.blocks.items.len);
-    try std.testing.expectEqual(@as(usize, 10), q.blocks.items[0].len);
+fn startConnectUpstreamDc(loop: *EventLoop, slot: *ConnectionSlot, addr: Address) !void {
+    return loop.startConnectUpstream(slot, addr, .dc);
 }
 
-test "epoll hangup helper" {
-    try std.testing.expect(hasFatalEpollHangup(linux.EPOLL.RDHUP));
-    try std.testing.expect(hasFatalEpollHangup(linux.EPOLL.HUP));
-    try std.testing.expect(hasFatalEpollHangup(linux.EPOLL.ERR));
-    try std.testing.expect(!hasFatalEpollHangup(linux.EPOLL.IN));
+fn mpFallbackSendDcNonce(loop: *EventLoop, slot: *ConnectionSlot) void {
+    return loop.sendDcNonce(slot);
 }
 
-test "fatal hangup close policy distinguishes client/upstream while connecting" {
-    const client_fd: posix.fd_t = 41;
-    const upstream_fd: posix.fd_t = 42;
-
-    try std.testing.expect(shouldCloseOnFatalHangup(.connecting_upstream, client_fd, upstream_fd));
-    try std.testing.expect(!shouldCloseOnFatalHangup(.connecting_upstream, upstream_fd, upstream_fd));
-    try std.testing.expect(shouldCloseOnFatalHangup(.reading_tls_header, client_fd, upstream_fd));
-    try std.testing.expect(!shouldCloseOnFatalHangup(.idle, client_fd, upstream_fd));
+fn mpFallbackCleanupFailedUpstreamConnect(loop: *EventLoop, slot: *ConnectionSlot) void {
+    return loop.cleanupFailedUpstreamConnect(slot);
 }
 
-test "fd requirement helpers" {
-    try std.testing.expectEqual(@as(usize, 131582), requiredFdsForConnections(65535));
-    try std.testing.expectEqual(@as(u32, 65535), maxConnectionsForNofile(131582));
-    try std.testing.expectEqual(@as(u32, 32511), maxConnectionsForNofile(65535));
+fn mpFallbackSetSingleUpstreamCandidate(loop: *EventLoop, slot: *ConnectionSlot, addr: Address) !void {
+    var one = [_]Address{addr};
+    try slot.setUpstreamCandidates(loop.state.allocator, one[0..]);
 }
 
-test "parse ipv4 literal" {
-    const parsed = parseIpv4Literal("179.43.141.146") orelse return error.TestExpectedEqual;
-    try std.testing.expectEqual([4]u8{ 179, 43, 141, 146 }, parsed);
-    try std.testing.expect(parseIpv4Literal("179.43.141") == null);
-    try std.testing.expect(parseIpv4Literal("179.43.141.999") == null);
+fn mpFallbackStartDirectConnect(loop: *EventLoop, slot: *ConnectionSlot, addr: Address) !void {
+    return loop.startConnectUpstream(slot, addr, .dc);
 }
 
-test "parse endpoint host" {
-    try std.testing.expectEqualStrings("179.43.141.146", parseEndpointHost("179.43.141.146:41182").?);
-    try std.testing.expectEqualStrings("vpn.example.com", parseEndpointHost("vpn.example.com:51820").?);
-    try std.testing.expectEqualStrings("2001:db8::1", parseEndpointHost("[2001:db8::1]:41182").?);
+fn mpHandshakeReadFrame(loop: *EventLoop, slot: *ConnectionSlot, encrypted: bool) !?[]const u8 {
+    return loop.mpTryReadFrame(slot, encrypted);
 }
 
-test "parse awg endpoint ipv4 from config" {
-    const content =
-        \\[Interface]
-        \\Address = 100.83.12.60/32
-        \\
-        \\[Peer]
-        \\PublicKey = x
-        \\Endpoint = 179.43.141.146:41182
-    ;
-
-    const parsed = parseAwgEndpointIpv4FromConfig(std.testing.allocator, content) orelse return error.TestExpectedEqual;
-    try std.testing.expectEqual([4]u8{ 179, 43, 141, 146 }, parsed);
+fn mpHandshakeWriteFrame(loop: *EventLoop, slot: *ConnectionSlot, payload: []const u8, encrypted: bool) !void {
+    return loop.mpWriteFrame(slot, payload, encrypted);
 }
 
-test "subnet rate limit - subnet key groups /24 IPv4" {
-    // 10.0.1.5 and 10.0.1.200 should have the same /24 key
-    const addr1 = net.Address.initIp4(.{ 10, 0, 1, 5 }, 443);
-    const addr2 = net.Address.initIp4(.{ 10, 0, 1, 200 }, 443);
-    const addr3 = net.Address.initIp4(.{ 10, 0, 2, 5 }, 443);
-
-    const key1 = SubnetRateLimit.subnetKey(addr1);
-    const key2 = SubnetRateLimit.subnetKey(addr2);
-    const key3 = SubnetRateLimit.subnetKey(addr3);
-
-    try std.testing.expectEqual(key1, key2); // same /24
-    try std.testing.expect(key1 != key3); // different /24
+fn mpLockMiddleProxyShared(loop: *EventLoop) void {
+    loop.state.middle_proxy_lock.lockShared();
 }
 
-test "subnet rate limit - IPv4-mapped IPv6 keys match native IPv4 /24" {
-    // On dual-stack [::] listeners IPv4 clients arrive as ::ffff:a.b.c.d.
-    // Regression: prior to the mapped-detection branch every mapped address
-    // produced key = 0, collapsing the whole IPv4 internet into one bucket.
-    const native_v4 = net.Address.initIp4(.{ 203, 0, 113, 42 }, 443);
-
-    const mapped_bytes = [_]u8{0} ** 10 ++ [_]u8{ 0xff, 0xff } ++ [_]u8{ 203, 0, 113, 42 };
-    const mapped = net.Address.initIp6(mapped_bytes, 443, 0, 0);
-
-    const k_native = SubnetRateLimit.subnetKey(native_v4);
-    const k_mapped = SubnetRateLimit.subnetKey(mapped);
-    try std.testing.expectEqual(k_native, k_mapped);
-
-    // Two different mapped /24s must diverge (otherwise we'd still have the
-    // global IPv4 collision after the fix).
-    const mapped_other_bytes = [_]u8{0} ** 10 ++ [_]u8{ 0xff, 0xff } ++ [_]u8{ 198, 51, 100, 1 };
-    const mapped_other = net.Address.initIp6(mapped_other_bytes, 443, 0, 0);
-    try std.testing.expect(SubnetRateLimit.subnetKey(mapped_other) != k_mapped);
-
-    // Native IPv6 path must stay on the /48 hash (not collide with mapped form).
-    const native6_bytes = [_]u8{ 0x20, 0x01, 0x0d, 0xb8 } ++ [_]u8{0} ** 12;
-    const native6 = net.Address.initIp6(native6_bytes, 443, 0, 0);
-    try std.testing.expect(SubnetRateLimit.subnetKey(native6) != k_mapped);
+fn mpUnlockMiddleProxyShared(loop: *EventLoop) void {
+    loop.state.middle_proxy_lock.unlockShared();
 }
 
-test "subnet rate limit - allows up to max then blocks" {
-    var limiter = SubnetRateLimit{};
-    const addr = net.Address.initIp4(.{ 192, 168, 1, 100 }, 443);
-
-    // max_per_sec = 3 → should allow 3 then block
-    // First call resets entry with tokens = max-1 = 2, returns true
-    try std.testing.expect(limiter.check(addr, 3));
-    // Two more with existing tokens
-    try std.testing.expect(limiter.check(addr, 3));
-    try std.testing.expect(limiter.check(addr, 3));
-    // Now should be blocked
-    try std.testing.expect(!limiter.check(addr, 3));
-    try std.testing.expect(!limiter.check(addr, 3));
+fn mpHandshakeStartRelay(loop: *EventLoop, slot: *ConnectionSlot) void {
+    return loop.startRelay(slot);
 }
 
-test "subnet rate limit - disabled when max_per_sec is 0" {
-    var limiter = SubnetRateLimit{};
-    const addr = net.Address.initIp4(.{ 1, 2, 3, 4 }, 443);
-
-    // With max_per_sec = 0, always allows
-    for (0..100) |_| {
-        try std.testing.expect(limiter.check(addr, 0));
-    }
+fn mpHandshakeCloseSlot(loop: *EventLoop, slot: *ConnectionSlot, reason: []const u8) void {
+    return loop.closeSlot(slot, reason);
 }
 
-test "subnet rate limit - stale entry resets" {
-    var limiter = SubnetRateLimit{};
-    const addr = net.Address.initIp4(.{ 10, 20, 30, 40 }, 443);
-
-    // Drain tokens
-    _ = limiter.check(addr, 1);
-    try std.testing.expect(!limiter.check(addr, 1));
-
-    // Make entry stale (>60s old)
-    const key = SubnetRateLimit.subnetKey(addr);
-    const entry = limiter.findEntry(key) orelse return error.TestExpectedEqual;
-    entry.last_refill_s -= SubnetRateLimit.stale_after_s + 1;
-
-    // Should reset and allow again
-    try std.testing.expect(limiter.check(addr, 1));
-}
-
-test "subnet rate limit - different subnets are independent" {
-    var limiter = SubnetRateLimit{};
-    const addr_a = net.Address.initIp4(.{ 10, 0, 1, 100 }, 443);
-    const addr_b = net.Address.initIp4(.{ 10, 0, 2, 100 }, 443);
-
-    // Drain subnet A
-    _ = limiter.check(addr_a, 1);
-    try std.testing.expect(!limiter.check(addr_a, 1));
-
-    // Subnet B should still work
-    try std.testing.expect(limiter.check(addr_b, 1));
-}
-
-test "replay cache detects duplicate digest" {
-    var cache = ReplayCache.init();
-    const digest = [_]u8{0xAB} ** 32;
-
-    try std.testing.expect(!cache.checkAndInsert(&digest));
-    try std.testing.expect(cache.checkAndInsert(&digest));
-}
-
-test "replay cache accepts distinct digests" {
-    var cache = ReplayCache.init();
-    const digest_a = [_]u8{0x11} ** 32;
-    const digest_b = [_]u8{0x22} ** 32;
-
-    try std.testing.expect(!cache.checkAndInsert(&digest_a));
-    try std.testing.expect(!cache.checkAndInsert(&digest_b));
+fn mpHandshakeFallbackToDirect(loop: *EventLoop, slot: *ConnectionSlot) bool {
+    return loop.fallbackFromMiddleProxyToDirect(slot);
 }
 
 test "handshakeInProgress - phases" {

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -291,7 +291,7 @@ const ConnectionSlot = struct {
     mp_frame_first_decrypted: bool = false,
 
     // Non-blocking proxy handshake state (SOCKS5 / HTTP CONNECT)
-    proxy_handshake_buf: [1024]u8 = undefined,
+    proxy_handshake_buf: [http_connect.max_response_size]u8 = undefined,
     proxy_handshake_pos: u16 = 0,
     proxy_handshake_len: u16 = 0,
     proxy_target_addr: ?Address = null,
@@ -524,24 +524,30 @@ pub const ProxyState = struct {
     middle_proxy_secret: [256]u8,
     middle_proxy_secret_len: usize,
     middle_proxy_nat_ip4: ?[4]u8,
+    middle_proxy_updater_shutdown: std.atomic.Value(bool),
+    middle_proxy_updater_thread: ?std.Thread,
     upstream: upstream_mod.Upstream,
     tunnel_info: tunnel_mod.Tunnel,
 
-    pub fn init(allocator: std.mem.Allocator, cfg: Config) ProxyState {
+    pub fn init(allocator: std.mem.Allocator, cfg: Config) !ProxyState {
+        if (cfg.users.count() == 0) return error.NoUsersConfigured;
+
         var secrets: std.ArrayList(obfuscation.UserSecret) = .empty;
+        errdefer secrets.deinit(allocator);
         var user_metrics: std.ArrayList(UserMetrics) = .empty;
+        errdefer user_metrics.deinit(allocator);
         var it = @constCast(&cfg.users).iterator();
         while (it.next()) |entry| {
-            secrets.append(allocator, .{
+            try secrets.append(allocator, .{
                 .name = entry.key_ptr.*,
                 .secret = entry.value_ptr.*,
-            }) catch continue;
-            user_metrics.append(allocator, .{
+            });
+            try user_metrics.append(allocator, .{
                 .name = entry.key_ptr.*,
                 .connections_active = std.atomic.Value(u32).init(0),
                 .client_to_upstream_bytes_total = std.atomic.Value(u64).init(0),
                 .upstream_to_client_bytes_total = std.atomic.Value(u64).init(0),
-            }) catch continue;
+            });
         }
 
         var resolved_addr: ?Address = null;
@@ -607,11 +613,16 @@ pub const ProxyState = struct {
             }
         }
 
+        const user_secrets = try secrets.toOwnedSlice(allocator);
+        errdefer allocator.free(user_secrets);
+        const user_metrics_owned = try user_metrics.toOwnedSlice(allocator);
+        errdefer allocator.free(user_metrics_owned);
+
         return .{
             .allocator = allocator,
             .config = cfg,
-            .user_secrets = secrets.toOwnedSlice(allocator) catch &.{},
-            .user_metrics = user_metrics.toOwnedSlice(allocator) catch &.{},
+            .user_secrets = user_secrets,
+            .user_metrics = user_metrics_owned,
             .start_time_seconds = realtimeSeconds(),
             .connection_count = std.atomic.Value(u64).init(0),
             .closed_count = std.atomic.Value(u64).init(0),
@@ -642,6 +653,8 @@ pub const ProxyState = struct {
             .middle_proxy_secret = default_middle_proxy_secret,
             .middle_proxy_secret_len = middleproxy.proxy_secret.len,
             .middle_proxy_nat_ip4 = detected_nat_ip4,
+            .middle_proxy_updater_shutdown = std.atomic.Value(bool).init(false),
+            .middle_proxy_updater_thread = null,
             .upstream = upblk: {
                 switch (cfg.upstream_mode) {
                     .tunnel => break :upblk upstream_mod.Upstream.initDirectWithMark(tunnel_socket_mark),
@@ -649,8 +662,11 @@ pub const ProxyState = struct {
                         if (cfg.upstream_proxy_host) |host| {
                             if (cfg.upstream_proxy_port > 0) {
                                 const proxy_list = getAddressList(allocator, host, cfg.upstream_proxy_port) catch |err| {
-                                    log.err("Failed to resolve SOCKS5 proxy host '{s}:{d}': {any}", .{ host, cfg.upstream_proxy_port, err });
-                                    break :upblk upstream_mod.Upstream.initDirect();
+                                    if (cfg.allow_direct_fallback) {
+                                        log.err("Failed to resolve SOCKS5 proxy host '{s}:{d}': {any}", .{ host, cfg.upstream_proxy_port, err });
+                                        break :upblk upstream_mod.Upstream.initDirect();
+                                    }
+                                    return error.InvalidSocks5UpstreamConfig;
                                 };
                                 defer proxy_list.deinit();
                                 if (proxy_list.addrs.len > 0) {
@@ -663,6 +679,7 @@ pub const ProxyState = struct {
                                 }
                             }
                         }
+                        if (!cfg.allow_direct_fallback) return error.InvalidSocks5UpstreamConfig;
                         log.warn("upstream.type=socks5 but proxy host/port not configured; falling back to direct", .{});
                         break :upblk upstream_mod.Upstream.initDirect();
                     },
@@ -670,8 +687,11 @@ pub const ProxyState = struct {
                         if (cfg.upstream_proxy_host) |host| {
                             if (cfg.upstream_proxy_port > 0) {
                                 const proxy_list = getAddressList(allocator, host, cfg.upstream_proxy_port) catch |err| {
-                                    log.err("Failed to resolve HTTP proxy host '{s}:{d}': {any}", .{ host, cfg.upstream_proxy_port, err });
-                                    break :upblk upstream_mod.Upstream.initDirect();
+                                    if (cfg.allow_direct_fallback) {
+                                        log.err("Failed to resolve HTTP proxy host '{s}:{d}': {any}", .{ host, cfg.upstream_proxy_port, err });
+                                        break :upblk upstream_mod.Upstream.initDirect();
+                                    }
+                                    return error.InvalidHttpUpstreamConfig;
                                 };
                                 defer proxy_list.deinit();
                                 if (proxy_list.addrs.len > 0) {
@@ -684,6 +704,7 @@ pub const ProxyState = struct {
                                 }
                             }
                         }
+                        if (!cfg.allow_direct_fallback) return error.InvalidHttpUpstreamConfig;
                         log.warn("upstream.type=http but proxy host/port not configured; falling back to direct", .{});
                         break :upblk upstream_mod.Upstream.initDirect();
                     },
@@ -719,6 +740,11 @@ pub const ProxyState = struct {
     }
 
     pub fn deinit(self: *ProxyState) void {
+        self.middle_proxy_updater_shutdown.store(true, .release);
+        if (self.middle_proxy_updater_thread) |thread| {
+            thread.join();
+            self.middle_proxy_updater_thread = null;
+        }
         self.allocator.free(self.user_secrets);
         self.allocator.free(self.user_metrics);
     }
@@ -824,8 +850,9 @@ pub const ProxyState = struct {
                 }
             };
 
+            self.middle_proxy_updater_shutdown.store(false, .release);
             if (std.Thread.spawn(.{}, ProxyState.middleProxyUpdaterMain, .{self})) |updater| {
-                updater.detach();
+                self.middle_proxy_updater_thread = updater;
             } else |err| {
                 log.warn("Middle-proxy updater thread failed to start: {any}", .{err});
             }
@@ -917,7 +944,7 @@ pub const ProxyState = struct {
         };
         var retry_idx: usize = 0;
         while (retry_idx < short_retries.len) : (retry_idx += 1) {
-            sleepNs(short_retries[retry_idx]);
+            if (self.waitForUpdaterDelay(short_retries[retry_idx])) return;
             if (self.refreshMiddleProxyInfo()) |_| {
                 break;
             } else |err| {
@@ -929,8 +956,8 @@ pub const ProxyState = struct {
             }
         }
 
-        while (true) {
-            sleepNs(middle_proxy_update_period_ns);
+        while (!self.middle_proxy_updater_shutdown.load(.acquire)) {
+            if (self.waitForUpdaterDelay(middle_proxy_update_period_ns)) return;
             self.refreshMiddleProxyInfo() catch |err| {
                 if (isMiddleProxyRefreshNetworkError(err)) {
                     log.info("Middle-proxy refresh unavailable ({s}), keeping current cache", .{@errorName(err)});
@@ -939,6 +966,18 @@ pub const ProxyState = struct {
                 }
             };
         }
+    }
+
+    fn waitForUpdaterDelay(self: *ProxyState, total_ns: u64) bool {
+        const step_ns: u64 = std.time.ns_per_s;
+        var remaining = total_ns;
+        while (remaining > 0) {
+            if (self.middle_proxy_updater_shutdown.load(.acquire)) return true;
+            const chunk = @min(remaining, step_ns);
+            sleepNs(chunk);
+            remaining -= chunk;
+        }
+        return self.middle_proxy_updater_shutdown.load(.acquire);
     }
 
     fn isMiddleProxyRefreshNetworkError(err: anyerror) bool {

--- a/src/proxy/proxy_upstream_handshake.zig
+++ b/src/proxy/proxy_upstream_handshake.zig
@@ -1,0 +1,289 @@
+const std = @import("std");
+const posix = std.posix;
+
+const http_connect = @import("http_connect.zig");
+const socks5 = @import("socks5.zig");
+
+const log = std.log.scoped(.proxy);
+
+fn hasUpstreamPending(slot: anytype) bool {
+    return !slot.upstream_queue.isEmpty();
+}
+
+fn sendSocks5Auth(
+    loop: anytype,
+    slot: anytype,
+    comptime queue_upstream: fn (@TypeOf(loop), @TypeOf(slot), []const u8) anyerror!bool,
+    comptime close_slot: fn (@TypeOf(loop), @TypeOf(slot), []const u8) void,
+) void {
+    const username = loop.state.upstream.proxyUsername() orelse "";
+    const password = loop.state.upstream.proxyPassword() orelse "";
+
+    const msg = socks5.buildAuthRequest(&slot.proxy_handshake_buf, username, password);
+    if (msg.len == 0) {
+        close_slot(loop, slot, "socks5 auth request build failed");
+        return;
+    }
+
+    if (queue_upstream(loop, slot, msg)) |_| {} else |err| {
+        log.debug("[{d}] socks5 auth queue error: {any}", .{ slot.conn_id, err });
+        close_slot(loop, slot, "socks5 auth queue failed");
+        return;
+    }
+
+    slot.phase = if (hasUpstreamPending(slot))
+        .proxy_socks5_auth
+    else
+        .proxy_socks5_auth_resp;
+    slot.proxy_handshake_pos = 0;
+}
+
+fn sendSocks5Connect(
+    loop: anytype,
+    slot: anytype,
+    comptime queue_upstream: fn (@TypeOf(loop), @TypeOf(slot), []const u8) anyerror!bool,
+    comptime close_slot: fn (@TypeOf(loop), @TypeOf(slot), []const u8) void,
+) void {
+    const target = slot.proxy_target_addr orelse {
+        close_slot(loop, slot, "socks5 no target addr");
+        return;
+    };
+
+    const msg = socks5.buildConnectRequest(&slot.proxy_handshake_buf, target);
+    if (msg.len == 0) {
+        close_slot(loop, slot, "socks5 connect request build failed");
+        return;
+    }
+
+    if (queue_upstream(loop, slot, msg)) |_| {} else |err| {
+        log.debug("[{d}] socks5 connect queue error: {any}", .{ slot.conn_id, err });
+        close_slot(loop, slot, "socks5 connect queue failed");
+        return;
+    }
+
+    slot.phase = if (hasUpstreamPending(slot))
+        .proxy_socks5_connect
+    else
+        .proxy_socks5_connect_resp;
+    slot.proxy_handshake_pos = 0;
+}
+
+pub fn startSocks5(
+    loop: anytype,
+    slot: anytype,
+    comptime queue_upstream: fn (@TypeOf(loop), @TypeOf(slot), []const u8) anyerror!bool,
+    comptime close_slot: fn (@TypeOf(loop), @TypeOf(slot), []const u8) void,
+) void {
+    const needs_auth = loop.state.upstream.socks5.needsAuth();
+    const msg = socks5.buildGreeting(&slot.proxy_handshake_buf, needs_auth);
+    if (msg.len == 0) {
+        close_slot(loop, slot, "socks5 greeting build failed");
+        return;
+    }
+
+    if (queue_upstream(loop, slot, msg)) |_| {} else |err| {
+        log.debug("[{d}] socks5 greeting queue error: {any}", .{ slot.conn_id, err });
+        close_slot(loop, slot, "socks5 greeting queue failed");
+        return;
+    }
+
+    slot.phase = if (hasUpstreamPending(slot))
+        .proxy_socks5_greeting
+    else
+        .proxy_socks5_greeting_resp;
+    slot.proxy_handshake_pos = 0;
+}
+
+pub fn onSocks5Readable(
+    loop: anytype,
+    slot: anytype,
+    comptime queue_upstream: fn (@TypeOf(loop), @TypeOf(slot), []const u8) anyerror!bool,
+    comptime close_slot: fn (@TypeOf(loop), @TypeOf(slot), []const u8) void,
+    comptime handshake_complete: fn (@TypeOf(loop), @TypeOf(slot)) void,
+) void {
+    // Read into proxy_handshake_buf at current pos
+    const pos: usize = slot.proxy_handshake_pos;
+    const space = slot.proxy_handshake_buf[pos..];
+    if (space.len == 0) {
+        close_slot(loop, slot, "socks5 response buffer overflow");
+        return;
+    }
+
+    const n = posix.read(slot.upstream_fd, space) catch |err| {
+        log.debug("[{d}] socks5 read error: {any}", .{ slot.conn_id, err });
+        if (err == error.WouldBlock) return;
+        close_slot(loop, slot, "socks5 read failed");
+        return;
+    };
+
+    if (n == 0) {
+        close_slot(loop, slot, "socks5 proxy closed connection");
+        return;
+    }
+
+    slot.proxy_handshake_pos += @intCast(n);
+    const have = slot.proxy_handshake_buf[0..slot.proxy_handshake_pos];
+
+    switch (slot.phase) {
+        .proxy_socks5_greeting_resp => {
+            if (have.len < socks5.greeting_response_len) return; // need more
+
+            const method = socks5.parseGreetingResponse(have) orelse {
+                close_slot(loop, slot, "socks5 invalid greeting response");
+                return;
+            };
+
+            switch (method) {
+                .no_auth => {
+                    sendSocks5Connect(loop, slot, queue_upstream, close_slot);
+                },
+                .username_password => {
+                    sendSocks5Auth(loop, slot, queue_upstream, close_slot);
+                },
+                .no_acceptable => {
+                    log.debug("[{d}] socks5 proxy rejected all auth methods", .{slot.conn_id});
+                    close_slot(loop, slot, "socks5 no acceptable auth");
+                },
+            }
+        },
+        .proxy_socks5_auth_resp => {
+            if (have.len < socks5.auth_response_len) return; // need more
+
+            const ok = socks5.parseAuthResponse(have) orelse {
+                close_slot(loop, slot, "socks5 invalid auth response");
+                return;
+            };
+
+            if (!ok) {
+                log.debug("[{d}] socks5 authentication failed", .{slot.conn_id});
+                close_slot(loop, slot, "socks5 auth rejected");
+                return;
+            }
+
+            sendSocks5Connect(loop, slot, queue_upstream, close_slot);
+        },
+        .proxy_socks5_connect_resp => {
+            const result = socks5.parseConnectResponse(have) orelse return; // need more
+
+            if (result.reply != .succeeded) {
+                log.debug("[{d}] socks5 CONNECT failed: reply={d}", .{
+                    slot.conn_id, @intFromEnum(result.reply),
+                });
+                close_slot(loop, slot, "socks5 connect rejected");
+                return;
+            }
+
+            // Telegram DCs (and MiddleProxies) never speak first after a
+            // SOCKS5 CONNECT success — they wait for our 64-byte handshake
+            // nonce. Any bytes piggy-backed onto the SOCKS5 reply are either
+            // garbage from a misbehaving upstream or an active MITM probe.
+            //
+            // Critically, `slot.pipelined_data` is the *client-side* pipeline
+            // buffer: on startRelay it is fed through `client_decryptor.apply`.
+            // Mixing upstream bytes into it desynchronises the client CTR
+            // stream (and, with MiddleProxy, encapsulates garbage into a
+            // valid RPC_PROXY_REQ frame). Drop the connection instead.
+            if (have.len > result.consumed) {
+                log.warn("[{d}] socks5 upstream sent {d} unsolicited bytes after CONNECT success", .{
+                    slot.conn_id, have.len - result.consumed,
+                });
+                close_slot(loop, slot, "socks5 unsolicited upstream data");
+                return;
+            }
+
+            // SOCKS5 handshake complete — proceed to DC path
+            handshake_complete(loop, slot);
+        },
+        else => {},
+    }
+}
+
+pub fn startHttpConnect(
+    loop: anytype,
+    slot: anytype,
+    comptime queue_upstream: fn (@TypeOf(loop), @TypeOf(slot), []const u8) anyerror!bool,
+    comptime close_slot: fn (@TypeOf(loop), @TypeOf(slot), []const u8) void,
+) void {
+    const target = slot.proxy_target_addr orelse {
+        close_slot(loop, slot, "http proxy no target addr");
+        return;
+    };
+
+    const username = loop.state.upstream.proxyUsername();
+    const password = loop.state.upstream.proxyPassword();
+
+    const msg = http_connect.buildConnectRequest(
+        &slot.proxy_handshake_buf,
+        target,
+        username,
+        password,
+    );
+    if (msg.len == 0) {
+        close_slot(loop, slot, "http connect request build failed");
+        return;
+    }
+
+    if (queue_upstream(loop, slot, msg)) |_| {} else |err| {
+        log.debug("[{d}] http connect queue error: {any}", .{ slot.conn_id, err });
+        close_slot(loop, slot, "http connect queue failed");
+        return;
+    }
+
+    slot.phase = if (hasUpstreamPending(slot))
+        .proxy_http_connect
+    else
+        .proxy_http_connect_resp;
+    slot.proxy_handshake_pos = 0;
+}
+
+pub fn onHttpConnectReadable(
+    loop: anytype,
+    slot: anytype,
+    comptime close_slot: fn (@TypeOf(loop), @TypeOf(slot), []const u8) void,
+    comptime handshake_complete: fn (@TypeOf(loop), @TypeOf(slot)) void,
+) void {
+    const pos: usize = slot.proxy_handshake_pos;
+    const space = slot.proxy_handshake_buf[pos..];
+    if (space.len == 0) {
+        close_slot(loop, slot, "http connect response buffer overflow");
+        return;
+    }
+
+    const n = posix.read(slot.upstream_fd, space) catch |err| {
+        log.debug("[{d}] http connect read error: {any}", .{ slot.conn_id, err });
+        if (err == error.WouldBlock) return;
+        close_slot(loop, slot, "http connect read failed");
+        return;
+    };
+
+    if (n == 0) {
+        close_slot(loop, slot, "http proxy closed connection");
+        return;
+    }
+
+    slot.proxy_handshake_pos += @intCast(n);
+    const have = slot.proxy_handshake_buf[0..slot.proxy_handshake_pos];
+
+    const result = http_connect.parseResponse(have) orelse return; // need more
+
+    if (result.status < 200 or result.status >= 300) {
+        log.debug("[{d}] HTTP CONNECT failed: status={d}", .{ slot.conn_id, result.status });
+        close_slot(loop, slot, "http connect rejected");
+        return;
+    }
+
+    // Same invariant as SOCKS5: the DC never speaks first. Any bytes the
+    // HTTP proxy appended after the "200 OK" line would be wrongly routed
+    // through the *client* decryption path in startRelay, corrupting the
+    // CTR stream. Reject the upstream.
+    if (have.len > result.header_end) {
+        log.warn("[{d}] http connect upstream sent {d} unsolicited bytes after 2xx", .{
+            slot.conn_id, have.len - result.header_end,
+        });
+        close_slot(loop, slot, "http connect unsolicited upstream data");
+        return;
+    }
+
+    // HTTP CONNECT handshake complete — proceed to DC path
+    handshake_complete(loop, slot);
+}

--- a/src/proxy/queue_io.zig
+++ b/src/proxy/queue_io.zig
@@ -1,0 +1,197 @@
+const std = @import("std");
+const posix = std.posix;
+
+const MessageQueue = @import("message_queue.zig").MessageQueue;
+
+const max_scatter_parts: usize = 64;
+
+fn writeFd(fd: posix.fd_t, data: []const u8) !usize {
+    while (true) {
+        const rc = posix.system.write(fd, data.ptr, data.len);
+        switch (posix.errno(rc)) {
+            .SUCCESS => return @intCast(rc),
+            .INTR => continue,
+            .AGAIN => return error.WouldBlock,
+            .CONNRESET, .PIPE => return error.ConnectionReset,
+            else => return error.UnexpectedWrite,
+        }
+    }
+}
+
+fn writevFd(fd: posix.fd_t, iovecs: []const posix.iovec_const) !usize {
+    while (true) {
+        const rc = posix.system.writev(fd, iovecs.ptr, @intCast(iovecs.len));
+        switch (posix.errno(rc)) {
+            .SUCCESS => return @intCast(rc),
+            .INTR => continue,
+            .AGAIN => return error.WouldBlock,
+            .CONNRESET, .PIPE => return error.ConnectionReset,
+            else => return error.UnexpectedWritev,
+        }
+    }
+}
+
+fn noteTraffic(counter: *std.atomic.Value(u64), bytes: usize) void {
+    if (bytes == 0) return;
+    _ = counter.fetchAdd(@intCast(bytes), .monotonic);
+}
+
+fn noteTrafficOptional(counter: ?*std.atomic.Value(u64), bytes: usize) void {
+    if (counter) |ptr| noteTraffic(ptr, bytes);
+}
+
+pub fn queueOrWriteMsg(
+    fd: posix.fd_t,
+    queue: *MessageQueue,
+    data: []const u8,
+    counter: *std.atomic.Value(u64),
+    user_counter: ?*std.atomic.Value(u64),
+) !bool {
+    if (data.len == 0) return true;
+
+    if (queue.isEmpty()) {
+        const n = writeFd(fd, data) catch |err| {
+            if (err == error.WouldBlock) {
+                try queue.appendCopy(data);
+                return false;
+            }
+            return err;
+        };
+
+        noteTraffic(counter, n);
+        noteTrafficOptional(user_counter, n);
+        if (n == data.len) return true;
+        try queue.appendCopy(data[n..]);
+        return false;
+    }
+
+    try queue.appendCopy(data);
+    return false;
+}
+
+pub fn queueOrWriteMsgPair(
+    fd: posix.fd_t,
+    queue: *MessageQueue,
+    first: []const u8,
+    second: []const u8,
+    counter: *std.atomic.Value(u64),
+    user_counter: ?*std.atomic.Value(u64),
+) !bool {
+    if (first.len == 0 and second.len == 0) return true;
+
+    if (queue.isEmpty()) {
+        var iovecs: [2]posix.iovec_const = undefined;
+        var n_iov: usize = 0;
+        if (first.len > 0) {
+            iovecs[n_iov] = .{ .base = first.ptr, .len = first.len };
+            n_iov += 1;
+        }
+        if (second.len > 0) {
+            iovecs[n_iov] = .{ .base = second.ptr, .len = second.len };
+            n_iov += 1;
+        }
+
+        const total_len = first.len + second.len;
+        const n = writevFd(fd, iovecs[0..n_iov]) catch |err| {
+            if (err == error.WouldBlock) {
+                try queue.appendCopy(first);
+                try queue.appendCopy(second);
+                return false;
+            }
+            return err;
+        };
+
+        if (n == 0) return error.ConnectionReset;
+        noteTraffic(counter, n);
+        noteTrafficOptional(user_counter, n);
+        if (n == total_len) return true;
+
+        if (n < first.len) {
+            try queue.appendCopy(first[n..]);
+            try queue.appendCopy(second);
+            return false;
+        }
+
+        const consumed_second = n - first.len;
+        if (consumed_second < second.len) {
+            try queue.appendCopy(second[consumed_second..]);
+        }
+        return false;
+    }
+
+    try queue.appendCopy(first);
+    try queue.appendCopy(second);
+    return false;
+}
+
+pub fn queueOrWriteOwnedMsg(
+    fd: posix.fd_t,
+    queue: *MessageQueue,
+    owned: []u8,
+    counter: *std.atomic.Value(u64),
+    user_counter: ?*std.atomic.Value(u64),
+) !bool {
+    if (owned.len == 0) {
+        queue.allocator.free(owned);
+        return true;
+    }
+
+    if (queue.isEmpty()) {
+        const n = writeFd(fd, owned) catch |err| {
+            if (err == error.WouldBlock) {
+                try queue.appendOwned(owned);
+                return false;
+            }
+            queue.allocator.free(owned);
+            return err;
+        };
+
+        noteTraffic(counter, n);
+        noteTrafficOptional(user_counter, n);
+        if (n == owned.len) {
+            queue.allocator.free(owned);
+            return true;
+        }
+
+        const remaining = owned[n..];
+        try queue.appendCopy(remaining);
+        queue.allocator.free(owned);
+        return false;
+    }
+
+    try queue.appendOwned(owned);
+    return false;
+}
+
+pub fn flushQueue(
+    fd: posix.fd_t,
+    queue: *MessageQueue,
+    counter: *std.atomic.Value(u64),
+    user_counter: ?*std.atomic.Value(u64),
+) !bool {
+    if (queue.isEmpty()) return true;
+
+    var iovecs: [max_scatter_parts]posix.iovec_const = undefined;
+
+    while (!queue.isEmpty()) {
+        const n_iov = queue.prepareIovecs(iovecs[0..]);
+        if (n_iov == 0) return true;
+
+        var total_req: usize = 0;
+        for (iovecs[0..n_iov]) |iov| total_req += iov.len;
+
+        const n = writevFd(fd, iovecs[0..n_iov]) catch |err| {
+            if (err == error.WouldBlock) return false;
+            return err;
+        };
+
+        if (n == 0) return error.ConnectionReset;
+        noteTraffic(counter, n);
+        noteTrafficOptional(user_counter, n);
+        try queue.consume(n);
+
+        if (n < total_req) return false;
+    }
+
+    return true;
+}

--- a/src/proxy/relay_steps.zig
+++ b/src/proxy/relay_steps.zig
@@ -1,0 +1,256 @@
+const std = @import("std");
+const posix = std.posix;
+const constants = @import("../protocol/constants.zig");
+const socket_utils = @import("socket_utils.zig");
+
+const nowMs = socket_utils.nowMs;
+
+pub const RelayProgress = enum {
+    none,
+    partial,
+    forwarded,
+};
+
+pub fn relayClientToUpstreamStep(
+    slot: anytype,
+    allocator: std.mem.Allocator,
+    mp_c2s_scratch: ?[]u8,
+    read_buf: []u8,
+    comptime queue_upstream: fn (@TypeOf(slot), std.mem.Allocator, []const u8) anyerror!bool,
+) !RelayProgress {
+    var consumed_any = false;
+
+    while (true) {
+        if (slot.relay_tls_hdr_pos < 5) {
+            const n = posix.read(slot.client_fd, slot.relay_tls_hdr[slot.relay_tls_hdr_pos..]) catch |err| {
+                if (err == error.WouldBlock) return if (consumed_any) .partial else .none;
+                return err;
+            };
+            if (n == 0) return error.EndOfStream;
+            consumed_any = true;
+            slot.relay_tls_hdr_pos += @intCast(n);
+
+            if (slot.relay_tls_hdr_pos < 5) return .partial;
+
+            slot.relay_record_type = slot.relay_tls_hdr[0];
+            slot.relay_tls_body_len = std.mem.readInt(u16, slot.relay_tls_hdr[3..5], .big);
+            slot.relay_tls_body_pos = 0;
+
+            if (slot.relay_record_type == constants.tls_record_alert) return error.ConnectionReset;
+            if (slot.relay_record_type != constants.tls_record_change_cipher and
+                slot.relay_record_type != constants.tls_record_application)
+            {
+                return error.ConnectionReset;
+            }
+            if (slot.relay_tls_body_len == 0 or slot.relay_tls_body_len > constants.max_tls_ciphertext_size) {
+                return error.ConnectionReset;
+            }
+        }
+
+        const remaining = slot.relay_tls_body_len - slot.relay_tls_body_pos;
+        if (remaining == 0) {
+            slot.relay_tls_hdr_pos = 0;
+            slot.relay_tls_body_pos = 0;
+            slot.relay_tls_body_len = 0;
+            if (consumed_any) return .partial;
+            continue;
+        }
+
+        const want = @min(@as(usize, remaining), read_buf.len);
+        const n = posix.read(slot.client_fd, read_buf[0..want]) catch |err| {
+            if (err == error.WouldBlock) return if (consumed_any) .partial else .none;
+            return err;
+        };
+        if (n == 0) return error.EndOfStream;
+
+        consumed_any = true;
+        slot.relay_tls_body_pos += @intCast(n);
+
+        if (slot.relay_record_type == constants.tls_record_change_cipher) {
+            if (slot.relay_tls_body_pos == slot.relay_tls_body_len) {
+                slot.relay_tls_hdr_pos = 0;
+                slot.relay_tls_body_pos = 0;
+                slot.relay_tls_body_len = 0;
+            }
+            return .partial;
+        }
+
+        const payload = read_buf[0..n];
+        if (slot.client_decryptor) |*dec| dec.apply(payload);
+
+        if (slot.middle_ctx) |*mp| {
+            const scratch = mp_c2s_scratch orelse return error.MissingMiddleProxyScratch;
+            const out_data = try mp.encapsulateC2S(payload, scratch);
+            if (out_data.len > 0) {
+                _ = try queue_upstream(slot, allocator, out_data);
+            }
+        } else if (slot.tg_encryptor) |*enc| {
+            enc.apply(payload);
+            _ = try queue_upstream(slot, allocator, payload);
+        }
+
+        slot.c2s_bytes += payload.len;
+
+        if (slot.relay_tls_body_pos == slot.relay_tls_body_len) {
+            slot.relay_tls_hdr_pos = 0;
+            slot.relay_tls_body_pos = 0;
+            slot.relay_tls_body_len = 0;
+            return .forwarded;
+        }
+
+        return .partial;
+    }
+}
+
+pub fn relayUpstreamToClientStep(
+    slot: anytype,
+    allocator: std.mem.Allocator,
+    mp_s2c_scratch: ?[]u8,
+    read_buf: []u8,
+    comptime queue_tls_records: fn (@TypeOf(slot), std.mem.Allocator, []u8) anyerror!void,
+) !RelayProgress {
+    const n = posix.read(slot.upstream_fd, read_buf) catch |err| {
+        if (err == error.WouldBlock) return .none;
+        return err;
+    };
+    if (n == 0) return error.EndOfStream;
+
+    const raw = read_buf[0..n];
+
+    if (slot.middle_ctx) |*mp| {
+        const scratch = mp_s2c_scratch orelse return error.MissingMiddleProxyScratch;
+        const payload = try mp.decapsulateS2C(raw, scratch);
+        if (payload.len == 0) return .partial;
+        if (slot.client_encryptor) |*enc| enc.apply(payload);
+        try queue_tls_records(slot, allocator, payload);
+        slot.s2c_bytes += payload.len;
+        return .forwarded;
+    }
+
+    if (!slot.use_fast_mode) {
+        if (slot.tg_decryptor) |*dec| dec.apply(raw);
+        if (slot.client_encryptor) |*enc| enc.apply(raw);
+    }
+
+    try queue_tls_records(slot, allocator, raw);
+    slot.s2c_bytes += raw.len;
+    return .forwarded;
+}
+
+pub fn queueTlsAppRecords(
+    slot: anytype,
+    allocator: std.mem.Allocator,
+    payload: []u8,
+    comptime queue_client_pair: fn (@TypeOf(slot), std.mem.Allocator, []const u8, []const u8) anyerror!bool,
+) !void {
+    var off: usize = 0;
+    var header: [5]u8 = undefined;
+
+    while (off < payload.len) {
+        const chunk_len = @min(payload.len - off, slot.drs.nextRecordSize());
+
+        header[0] = constants.tls_record_application;
+        header[1] = constants.tls_version[0];
+        header[2] = constants.tls_version[1];
+        std.mem.writeInt(u16, header[3..5], @intCast(chunk_len), .big);
+
+        _ = try queue_client_pair(slot, allocator, header[0..], payload[off .. off + chunk_len]);
+        slot.drs.recordSent(chunk_len);
+        off += chunk_len;
+    }
+}
+
+pub fn startRelay(
+    loop: anytype,
+    slot: anytype,
+    comptime ensure_mp_c2s_scratch: fn (@TypeOf(loop)) anyerror![]u8,
+    comptime queue_upstream: fn (@TypeOf(loop), @TypeOf(slot), []const u8) anyerror!bool,
+    comptime close_slot: fn (@TypeOf(loop), @TypeOf(slot), []const u8) void,
+) void {
+    // Handshake complete — release from handshake budget.
+    _ = loop.state.handshakes_inflight.fetchSub(1, .monotonic);
+    slot.phase = .relaying;
+
+    if (slot.pipelined_data) |buf| {
+        if (slot.client_decryptor) |*dec| dec.apply(buf);
+
+        if (slot.middle_ctx) |*mp| {
+            const scratch = ensure_mp_c2s_scratch(loop) catch {
+                close_slot(loop, slot, "alloc middleproxy c2s scratch failed");
+                return;
+            };
+            const out_data = mp.encapsulateC2S(buf, scratch) catch {
+                close_slot(loop, slot, "encapsulate pipelined middleproxy payload failed");
+                return;
+            };
+            if (out_data.len > 0) {
+                _ = queue_upstream(loop, slot, out_data) catch {
+                    close_slot(loop, slot, "queue pipelined middleproxy payload failed");
+                    return;
+                };
+            }
+        } else if (slot.tg_encryptor) |*enc| {
+            enc.apply(buf);
+            _ = queue_upstream(loop, slot, buf) catch {
+                close_slot(loop, slot, "queue pipelined direct payload failed");
+                return;
+            };
+        }
+
+        slot.c2s_bytes += buf.len;
+        loop.state.allocator.free(buf);
+        slot.pipelined_data = null;
+    }
+}
+
+pub fn relayRawClientToUpstream(
+    loop: anytype,
+    slot: anytype,
+    read_buf: []u8,
+    comptime queue_upstream: fn (@TypeOf(loop), @TypeOf(slot), []const u8) anyerror!bool,
+    comptime close_slot: fn (@TypeOf(loop), @TypeOf(slot), []const u8) void,
+) void {
+    if (!slot.upstream_queue.isEmpty()) return;
+
+    const n = posix.read(slot.client_fd, read_buf) catch |err| {
+        if (err == error.WouldBlock) return;
+        close_slot(loop, slot, "mask relay c2s read error");
+        return;
+    };
+    if (n == 0) {
+        close_slot(loop, slot, "mask relay c2s eof");
+        return;
+    }
+
+    _ = queue_upstream(loop, slot, read_buf[0..n]) catch {
+        close_slot(loop, slot, "mask relay c2s queue error");
+        return;
+    };
+    slot.last_activity_ms = nowMs();
+}
+
+pub fn relayRawUpstreamToClient(
+    loop: anytype,
+    slot: anytype,
+    read_buf: []u8,
+    comptime queue_client: fn (@TypeOf(loop), @TypeOf(slot), []const u8) anyerror!bool,
+    comptime close_slot: fn (@TypeOf(loop), @TypeOf(slot), []const u8) void,
+) void {
+    if (!slot.client_queue.isEmpty()) return;
+
+    const n = posix.read(slot.upstream_fd, read_buf) catch |err| {
+        if (err == error.WouldBlock) return;
+        close_slot(loop, slot, "mask relay s2c read error");
+        return;
+    };
+    if (n == 0) {
+        close_slot(loop, slot, "mask relay s2c eof");
+        return;
+    }
+
+    _ = queue_client(loop, slot, read_buf[0..n]) catch {
+        close_slot(loop, slot, "mask relay s2c queue error");
+        return;
+    };
+    slot.last_activity_ms = nowMs();
+}

--- a/src/proxy/replay_cache.zig
+++ b/src/proxy/replay_cache.zig
@@ -1,0 +1,103 @@
+const std = @import("std");
+const posix = std.posix;
+const crypto = @import("../crypto/crypto.zig");
+
+fn nowSeconds() i64 {
+    var ts: posix.timespec = undefined;
+    const rc = posix.system.clock_gettime(.MONOTONIC, &ts);
+    if (posix.errno(rc) != .SUCCESS) return 0;
+    return @intCast(ts.sec);
+}
+
+pub const ReplayCache = struct {
+    const BUCKETS = 8192;
+    const MAX_PROBES = 8;
+    const stale_after_s: i64 = 60 * 60;
+
+    const Entry = struct {
+        used: bool = false,
+        key: u64 = 0,
+        last_seen_s: i64 = 0,
+    };
+
+    hash_seed: u64 = 0,
+    entries: [BUCKETS]Entry = [_]Entry{.{}} ** BUCKETS,
+
+    pub fn init() ReplayCache {
+        return .{
+            .hash_seed = crypto.randomInt(u64),
+        };
+    }
+
+    fn digestKey(digest: *const [32]u8) u64 {
+        return std.mem.readInt(u64, digest[0..8], .little);
+    }
+
+    fn indexFor(self: *const ReplayCache, key: u64) usize {
+        var x = self.hash_seed ^ key;
+        x +%= 0x9E3779B97F4A7C15;
+        x ^= x >> 30;
+        x *%= 0xBF58476D1CE4E5B9;
+        x ^= x >> 27;
+        x *%= 0x94D049BB133111EB;
+        x ^= x >> 31;
+        return @as(usize, @intCast(x & (BUCKETS - 1)));
+    }
+
+    /// Returns true if this digest was already seen (duplicate replay),
+    /// false when inserted as a new digest.
+    pub fn checkAndInsert(self: *ReplayCache, digest: *const [32]u8) bool {
+        const key = digestKey(digest);
+        const now_s = nowSeconds();
+        const start = self.indexFor(key);
+
+        var first_stale_idx: ?usize = null;
+        var oldest_idx: usize = start;
+        var oldest_ts: i64 = std.math.maxInt(i64);
+
+        var probe: usize = 0;
+        while (probe < MAX_PROBES) : (probe += 1) {
+            const idx = (start + probe) & (BUCKETS - 1);
+            const e = &self.entries[idx];
+
+            if (!e.used) {
+                e.* = .{ .used = true, .key = key, .last_seen_s = now_s };
+                return false;
+            }
+
+            if (e.key == key) {
+                e.last_seen_s = now_s;
+                return true;
+            }
+
+            if (now_s - e.last_seen_s > stale_after_s and first_stale_idx == null) {
+                first_stale_idx = idx;
+            }
+            if (e.last_seen_s < oldest_ts) {
+                oldest_ts = e.last_seen_s;
+                oldest_idx = idx;
+            }
+        }
+
+        const victim_idx = first_stale_idx orelse oldest_idx;
+        self.entries[victim_idx] = .{ .used = true, .key = key, .last_seen_s = now_s };
+        return false;
+    }
+};
+
+test "replay cache detects duplicate digest" {
+    var cache = ReplayCache.init();
+    const digest = [_]u8{0xAB} ** 32;
+
+    try std.testing.expect(!cache.checkAndInsert(&digest));
+    try std.testing.expect(cache.checkAndInsert(&digest));
+}
+
+test "replay cache accepts distinct digests" {
+    var cache = ReplayCache.init();
+    const digest_a = [_]u8{0x11} ** 32;
+    const digest_b = [_]u8{0x22} ** 32;
+
+    try std.testing.expect(!cache.checkAndInsert(&digest_a));
+    try std.testing.expect(!cache.checkAndInsert(&digest_b));
+}

--- a/src/proxy/socket_utils.zig
+++ b/src/proxy/socket_utils.zig
@@ -1,0 +1,229 @@
+const std = @import("std");
+const posix = std.posix;
+const linux = std.os.linux;
+const net = std.Io.net;
+const Address = net.IpAddress;
+
+pub const AcceptError = error{
+    ConnectionAborted,
+    ConnectionResetByPeer,
+    ProcessFdQuotaExceeded,
+    SystemFdQuotaExceeded,
+    SystemResources,
+    UnexpectedAccept,
+};
+
+pub const AcceptResult = struct {
+    fd: posix.fd_t,
+    addr: Address,
+};
+
+pub fn epollCreate() !posix.fd_t {
+    const rc = linux.epoll_create1(linux.EPOLL.CLOEXEC);
+    switch (posix.errno(rc)) {
+        .SUCCESS => return @intCast(rc),
+        else => |err| return posix.unexpectedErrno(err),
+    }
+}
+
+pub fn realtimeSeconds() i64 {
+    var ts: posix.timespec = undefined;
+    const rc = posix.system.clock_gettime(.REALTIME, &ts);
+    if (posix.errno(rc) == .SUCCESS) return @intCast(ts.sec);
+    return @divTrunc(nowMs(), 1000);
+}
+
+pub fn nowMs() i64 {
+    var ts: posix.timespec = undefined;
+    const rc = posix.system.clock_gettime(.MONOTONIC, &ts);
+    if (posix.errno(rc) == .SUCCESS) {
+        return @as(i64, @intCast(ts.sec)) * std.time.ms_per_s +
+            @as(i64, @intCast(@divTrunc(ts.nsec, std.time.ns_per_ms)));
+    }
+    return 0;
+}
+
+pub fn nowNs() i128 {
+    var ts: posix.timespec = undefined;
+    const rc = posix.system.clock_gettime(.MONOTONIC, &ts);
+    if (posix.errno(rc) == .SUCCESS) {
+        return @as(i128, @intCast(ts.sec)) * std.time.ns_per_s + @as(i128, @intCast(ts.nsec));
+    }
+    return @as(i128, nowMs()) * std.time.ns_per_ms;
+}
+
+pub fn sleepNs(ns: u64) void {
+    var req: posix.timespec = .{
+        .sec = @intCast(ns / std.time.ns_per_s),
+        .nsec = @intCast(ns % std.time.ns_per_s),
+    };
+    while (true) {
+        var rem: posix.timespec = undefined;
+        const rc = posix.system.nanosleep(&req, &rem);
+        switch (posix.errno(rc)) {
+            .SUCCESS => return,
+            .INTR => req = rem,
+            else => return,
+        }
+    }
+}
+
+pub fn closeFd(fd: posix.fd_t) void {
+    while (true) {
+        switch (posix.errno(posix.system.close(fd))) {
+            .SUCCESS => return,
+            .INTR => continue,
+            else => return,
+        }
+    }
+}
+
+pub fn connectSockaddr(fd: posix.fd_t, addr: *const posix.sockaddr, addr_len: posix.socklen_t) !void {
+    while (true) switch (posix.errno(posix.system.connect(fd, addr, addr_len))) {
+        .SUCCESS => return,
+        .INTR => continue,
+        .ADDRNOTAVAIL => return error.AddressUnavailable,
+        .AFNOSUPPORT => return error.AddressFamilyUnsupported,
+        .AGAIN, .INPROGRESS => return error.WouldBlock,
+        .ALREADY => return error.ConnectionPending,
+        .CONNREFUSED => return error.ConnectionRefused,
+        .CONNRESET => return error.ConnectionResetByPeer,
+        .HOSTUNREACH => return error.HostUnreachable,
+        .NETUNREACH => return error.NetworkUnreachable,
+        .TIMEDOUT => return error.Timeout,
+        else => |err| return posix.unexpectedErrno(err),
+    };
+}
+
+pub fn checkSocketConnectError(fd: posix.fd_t) !void {
+    var so_error: i32 = 0;
+    var opt_len: linux.socklen_t = @sizeOf(i32);
+    const so_error_opt: u32 = 4; // SO_ERROR
+    const rc = linux.getsockopt(fd, posix.SOL.SOCKET, so_error_opt, std.mem.asBytes(&so_error).ptr, &opt_len);
+    if (linux.errno(rc) != .SUCCESS) return error.Unexpected;
+    if (so_error == 0) return;
+    return error.ConnectionRefused;
+}
+
+pub fn addressFromSockaddrStorage(storage: *const posix.sockaddr.storage) ?Address {
+    return switch (storage.family) {
+        posix.AF.INET => blk: {
+            const sa4: *const posix.sockaddr.in = @ptrCast(storage);
+            break :blk .{
+                .ip4 = .{
+                    .bytes = @bitCast(sa4.addr),
+                    .port = std.mem.bigToNative(u16, sa4.port),
+                },
+            };
+        },
+        posix.AF.INET6 => blk: {
+            const sa6: *const posix.sockaddr.in6 = @ptrCast(storage);
+            break :blk .{
+                .ip6 = .{
+                    .bytes = sa6.addr,
+                    .port = std.mem.bigToNative(u16, sa6.port),
+                    .flow = sa6.flowinfo,
+                    .interface = .{ .index = sa6.scope_id },
+                },
+            };
+        },
+        else => null,
+    };
+}
+
+pub fn acceptClient(listen_fd: posix.fd_t) AcceptError!?AcceptResult {
+    while (true) {
+        var storage: posix.sockaddr.storage = undefined;
+        var addr_len: posix.socklen_t = @sizeOf(posix.sockaddr.storage);
+        const rc = linux.accept4(listen_fd, @ptrCast(&storage), &addr_len, posix.SOCK.CLOEXEC | posix.SOCK.NONBLOCK);
+        switch (linux.errno(rc)) {
+            .SUCCESS => {
+                const fd: posix.fd_t = @intCast(rc);
+                const addr = addressFromSockaddrStorage(&storage) orelse {
+                    closeFd(fd);
+                    continue;
+                };
+                return .{ .fd = fd, .addr = addr };
+            },
+            .INTR => continue,
+            .AGAIN => return null,
+            .CONNABORTED => return error.ConnectionAborted,
+            .CONNRESET => return error.ConnectionResetByPeer,
+            .MFILE => return error.ProcessFdQuotaExceeded,
+            .NFILE => return error.SystemFdQuotaExceeded,
+            .NOBUFS, .NOMEM => return error.SystemResources,
+            else => return error.UnexpectedAccept,
+        }
+    }
+}
+
+pub fn localSocketAddress(fd: posix.fd_t) !Address {
+    var storage: posix.sockaddr.storage = undefined;
+    var addr_len: posix.socklen_t = @sizeOf(posix.sockaddr.storage);
+    while (true) {
+        const rc = posix.system.getsockname(fd, @ptrCast(&storage), &addr_len);
+        switch (posix.errno(rc)) {
+            .SUCCESS => return addressFromSockaddrStorage(&storage) orelse error.UnsupportedAddressFamily,
+            .INTR => continue,
+            else => return error.GetSockNameFailed,
+        }
+    }
+}
+
+pub fn setNonBlocking(fd: posix.fd_t) void {
+    var fl_flags = posix.system.fcntl(fd, posix.F.GETFL, @as(usize, 0));
+    if (posix.errno(fl_flags) != .SUCCESS) return;
+    fl_flags |= @as(usize, 1 << @bitOffsetOf(posix.O, "NONBLOCK"));
+    if (posix.errno(posix.system.fcntl(fd, posix.F.SETFL, fl_flags)) != .SUCCESS) return;
+}
+
+pub fn secondsToMs(sec: u32) i64 {
+    return @as(i64, @intCast(sec)) * std.time.ms_per_s;
+}
+
+pub fn setSendTimeout(fd: posix.fd_t, timeout_sec: u32) void {
+    const tv = posix.timeval{ .sec = @intCast(timeout_sec), .usec = 0 };
+    posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.SNDTIMEO, std.mem.asBytes(&tv)) catch return;
+}
+
+pub fn setTcpKeepalive(fd: posix.fd_t) void {
+    const sol_tcp: i32 = 6;
+
+    const enable: c_int = 1;
+    posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.KEEPALIVE, std.mem.asBytes(&enable)) catch return;
+
+    const idle: c_int = 60;
+    posix.setsockopt(fd, sol_tcp, 4, std.mem.asBytes(&idle)) catch return;
+
+    const interval: c_int = 10;
+    posix.setsockopt(fd, sol_tcp, 5, std.mem.asBytes(&interval)) catch return;
+
+    const count: c_int = 3;
+    posix.setsockopt(fd, sol_tcp, 6, std.mem.asBytes(&count)) catch return;
+}
+
+pub fn setTcpNoDelay(fd: posix.fd_t) void {
+    const enable: c_int = 1;
+    posix.setsockopt(fd, posix.IPPROTO.TCP, posix.TCP.NODELAY, std.mem.asBytes(&enable)) catch return;
+}
+
+pub fn configureRelaySocket(fd: posix.fd_t) void {
+    setTcpNoDelay(fd);
+    setTcpKeepalive(fd);
+    setSendTimeout(fd, 30);
+}
+
+pub fn formatAddress(addr: Address, buf: *[64]u8) []const u8 {
+    return switch (addr) {
+        .ip4 => |ip4_addr| std.fmt.bufPrint(buf, "[ipv4]:{d}", .{ip4_addr.port}) catch "?",
+        .ip6 => |ip6_addr| blk: {
+            const bytes = &ip6_addr.bytes;
+            const is_ipv4_mapped = std.mem.eql(u8, bytes[0..10], &[_]u8{0} ** 10) and
+                std.mem.eql(u8, bytes[10..12], &[_]u8{ 0xff, 0xff });
+            if (is_ipv4_mapped) {
+                break :blk std.fmt.bufPrint(buf, "[ipv4]:{d}", .{ip6_addr.port}) catch "?";
+            }
+            break :blk std.fmt.bufPrint(buf, "[ipv6]:{d}", .{ip6_addr.port}) catch "?";
+        },
+    };
+}

--- a/src/proxy/socks5.zig
+++ b/src/proxy/socks5.zig
@@ -5,7 +5,7 @@
 //! handshake through the non-blocking epoll event loop.
 
 const std = @import("std");
-const net = std.net;
+const net = std.Io.net;
 
 // ─── Constants ───────────────────────────────────────────────
 
@@ -70,7 +70,7 @@ pub fn buildGreeting(buf: []u8, use_auth: bool) []u8 {
 pub fn parseGreetingResponse(data: []const u8) ?Method {
     if (data.len < 2) return null;
     if (data[0] != version) return null;
-    return std.meta.intToEnum(Method, data[1]) catch .no_acceptable;
+    return std.enums.fromInt(Method, data[1]) orelse .no_acceptable;
 }
 
 /// Minimum bytes needed for greeting response.
@@ -111,8 +111,9 @@ pub const auth_response_len: usize = 2;
 
 /// Build a SOCKS5 CONNECT request to the given target address.
 /// Returns the slice of `buf` that was written, or empty on overflow.
-pub fn buildConnectRequest(buf: []u8, addr: net.Address) []u8 {
-    if (addr.any.family == std.posix.AF.INET) {
+pub fn buildConnectRequest(buf: []u8, addr: net.IpAddress) []u8 {
+    switch (addr) {
+        .ip4 => |ip4| {
         // VER(1) + CMD(1) + RSV(1) + ATYP(1) + IPv4(4) + PORT(2) = 10
         const total: usize = 10;
         if (buf.len < total) return buf[0..0];
@@ -122,16 +123,16 @@ pub fn buildConnectRequest(buf: []u8, addr: net.Address) []u8 {
         buf[2] = 0x00; // reserved
         buf[3] = @intFromEnum(AddressType.ipv4);
 
-        const ip_bytes = std.mem.asBytes(&addr.in.sa.addr);
-        @memcpy(buf[4..8], ip_bytes);
+            @memcpy(buf[4..8], &ip4.bytes);
 
-        const port = addr.in.sa.port; // network byte order already
+            const port = std.mem.nativeToBig(u16, ip4.port);
         const port_bytes = std.mem.asBytes(&port);
         buf[8] = port_bytes[0];
         buf[9] = port_bytes[1];
 
         return buf[0..total];
-    } else if (addr.any.family == std.posix.AF.INET6) {
+        },
+        .ip6 => |ip6| {
         // VER(1) + CMD(1) + RSV(1) + ATYP(1) + IPv6(16) + PORT(2) = 22
         const total: usize = 22;
         if (buf.len < total) return buf[0..0];
@@ -141,16 +142,16 @@ pub fn buildConnectRequest(buf: []u8, addr: net.Address) []u8 {
         buf[2] = 0x00; // reserved
         buf[3] = @intFromEnum(AddressType.ipv6);
 
-        @memcpy(buf[4..20], &addr.in6.sa.addr);
+            @memcpy(buf[4..20], &ip6.bytes);
 
-        const port = addr.in6.sa.port;
+            const port = std.mem.nativeToBig(u16, ip6.port);
         const port_bytes = std.mem.asBytes(&port);
         buf[20] = port_bytes[0];
         buf[21] = port_bytes[1];
 
         return buf[0..total];
+        },
     }
-    return buf[0..0];
 }
 
 /// Parse a SOCKS5 CONNECT response.
@@ -249,7 +250,10 @@ test "socks5 - parse auth response" {
 test "socks5 - connect request ipv4" {
     var buf: [64]u8 = undefined;
     // Construct an IPv4 address: 149.154.167.51:443
-    const addr = net.Address.initIp4(.{ 149, 154, 167, 51 }, 443);
+    const addr: net.IpAddress = .{ .ip4 = .{
+        .bytes = .{ 149, 154, 167, 51 },
+        .port = 443,
+    } };
     const msg = buildConnectRequest(&buf, addr);
 
     try std.testing.expectEqual(@as(usize, 10), msg.len);

--- a/src/proxy/subnet_rate_limit.zig
+++ b/src/proxy/subnet_rate_limit.zig
@@ -1,0 +1,243 @@
+const std = @import("std");
+const posix = std.posix;
+const crypto = @import("../crypto/crypto.zig");
+
+const Address = std.Io.net.IpAddress;
+
+fn nowSeconds() i64 {
+    var ts: posix.timespec = undefined;
+    const rc = posix.system.clock_gettime(.MONOTONIC, &ts);
+    if (posix.errno(rc) != .SUCCESS) return 0;
+    return @intCast(ts.sec);
+}
+
+/// Per-/24 (IPv4) or /48 (IPv6) subnet rate limiter.
+/// Fixed-size open-addressed hash table — zero heap allocation.
+/// Token bucket per subnet: each second refills up to max_per_sec tokens.
+pub const SubnetRateLimit = struct {
+    pub const BUCKETS = 65536;
+    pub const MAX_PROBES = 8;
+    pub const stale_after_s: i64 = 60;
+
+    pub const Entry = struct {
+        used: bool = false,
+        subnet_key: u32 = 0,
+        tokens: u8 = 0,
+        last_refill_s: i64 = 0,
+    };
+
+    hash_seed: u64 = 0,
+    entries: [BUCKETS]Entry = [_]Entry{.{}} ** BUCKETS,
+
+    pub fn init() SubnetRateLimit {
+        return .{
+            .hash_seed = crypto.randomInt(u64),
+        };
+    }
+
+    fn indexFor(self: *const SubnetRateLimit, key: u32) usize {
+        var x = self.hash_seed ^ @as(u64, key);
+        x +%= 0x9E3779B97F4A7C15;
+        x ^= x >> 30;
+        x *%= 0xBF58476D1CE4E5B9;
+        x ^= x >> 27;
+        x *%= 0x94D049BB133111EB;
+        x ^= x >> 31;
+        return @as(usize, @intCast(x & (BUCKETS - 1)));
+    }
+
+    pub fn findEntry(self: *SubnetRateLimit, key: u32) ?*Entry {
+        const start = self.indexFor(key);
+        var probe: usize = 0;
+        while (probe < MAX_PROBES) : (probe += 1) {
+            const idx = (start + probe) & (BUCKETS - 1);
+            const e = &self.entries[idx];
+            if (!e.used) return null;
+            if (e.subnet_key == key) return e;
+        }
+        return null;
+    }
+
+    /// Returns true if the connection is allowed, false if rate-limited.
+    pub fn check(self: *SubnetRateLimit, addr: Address, max_per_sec: u8) bool {
+        if (max_per_sec == 0) return true;
+        const key = subnetKey(addr);
+        const now_s = nowSeconds();
+
+        const start = self.indexFor(key);
+        var first_stale_idx: ?usize = null;
+        var oldest_idx: usize = start;
+        var oldest_ts: i64 = std.math.maxInt(i64);
+
+        var probe: usize = 0;
+        while (probe < MAX_PROBES) : (probe += 1) {
+            const idx = (start + probe) & (BUCKETS - 1);
+            const e = &self.entries[idx];
+
+            if (!e.used) {
+                e.* = .{ .used = true, .subnet_key = key, .tokens = max_per_sec -| 1, .last_refill_s = now_s };
+                return true;
+            }
+
+            if (e.subnet_key == key) {
+                const elapsed = now_s - e.last_refill_s;
+                if (elapsed > 0) {
+                    const refill: u16 = @intCast(@min(elapsed, 255));
+                    const topped = @as(u16, e.tokens) + refill * @as(u16, max_per_sec);
+                    e.tokens = @intCast(@min(@as(u16, max_per_sec), topped));
+                    e.last_refill_s = now_s;
+                }
+
+                if (e.tokens > 0) {
+                    e.tokens -= 1;
+                    return true;
+                }
+                return false;
+            }
+
+            if (now_s - e.last_refill_s > stale_after_s and first_stale_idx == null) {
+                first_stale_idx = idx;
+            }
+            if (e.last_refill_s < oldest_ts) {
+                oldest_ts = e.last_refill_s;
+                oldest_idx = idx;
+            }
+        }
+
+        const victim_idx = first_stale_idx orelse oldest_idx;
+        self.entries[victim_idx] = .{ .used = true, .subnet_key = key, .tokens = max_per_sec -| 1, .last_refill_s = now_s };
+        return true;
+    }
+
+    pub fn subnetKey(addr: Address) u32 {
+        return switch (addr) {
+            .ip4 => |ip4_addr| @as(u32, ip4_addr.bytes[0]) << 16 |
+                @as(u32, ip4_addr.bytes[1]) << 8 |
+                @as(u32, ip4_addr.bytes[2]),
+            .ip6 => |ip6_addr| blk: {
+                const ip6_bytes = &ip6_addr.bytes;
+
+                const is_ipv4_mapped = std.mem.eql(u8, ip6_bytes[0..10], &[_]u8{0} ** 10) and
+                    ip6_bytes[10] == 0xff and ip6_bytes[11] == 0xff;
+                if (is_ipv4_mapped) {
+                    break :blk @as(u32, ip6_bytes[12]) << 16 |
+                        @as(u32, ip6_bytes[13]) << 8 |
+                        @as(u32, ip6_bytes[14]);
+                }
+
+                break :blk @as(u32, ip6_bytes[0]) << 24 |
+                    @as(u32, ip6_bytes[1]) << 16 |
+                    @as(u32, ip6_bytes[2]) << 8 |
+                    @as(u32, ip6_bytes[3]) ^
+                    (@as(u32, ip6_bytes[4]) << 8 | @as(u32, ip6_bytes[5]));
+            },
+        };
+    }
+};
+
+fn ip4(bytes: [4]u8, port: u16) Address {
+    return .{ .ip4 = .{ .bytes = bytes, .port = port } };
+}
+
+fn ip6(bytes: [16]u8, port: u16, flow: u32, scope_id: u32) Address {
+    return .{ .ip6 = .{
+        .bytes = bytes,
+        .port = port,
+        .flow = flow,
+        .interface = .{ .index = scope_id },
+    } };
+}
+
+test "subnet rate limit - subnet key groups /24 IPv4" {
+    // 10.0.1.5 and 10.0.1.200 should have the same /24 key
+    const addr1 = ip4(.{ 10, 0, 1, 5 }, 443);
+    const addr2 = ip4(.{ 10, 0, 1, 200 }, 443);
+    const addr3 = ip4(.{ 10, 0, 2, 5 }, 443);
+
+    const key1 = SubnetRateLimit.subnetKey(addr1);
+    const key2 = SubnetRateLimit.subnetKey(addr2);
+    const key3 = SubnetRateLimit.subnetKey(addr3);
+
+    try std.testing.expectEqual(key1, key2); // same /24
+    try std.testing.expect(key1 != key3); // different /24
+}
+
+test "subnet rate limit - IPv4-mapped IPv6 keys match native IPv4 /24" {
+    // On dual-stack [::] listeners IPv4 clients arrive as ::ffff:a.b.c.d.
+    // Regression: prior to the mapped-detection branch every mapped address
+    // produced key = 0, collapsing the whole IPv4 internet into one bucket.
+    const native_v4 = ip4(.{ 203, 0, 113, 42 }, 443);
+
+    const mapped_bytes = [_]u8{0} ** 10 ++ [_]u8{ 0xff, 0xff } ++ [_]u8{ 203, 0, 113, 42 };
+    const mapped = ip6(mapped_bytes, 443, 0, 0);
+
+    const k_native = SubnetRateLimit.subnetKey(native_v4);
+    const k_mapped = SubnetRateLimit.subnetKey(mapped);
+    try std.testing.expectEqual(k_native, k_mapped);
+
+    // Two different mapped /24s must diverge (otherwise we'd still have the
+    // global IPv4 collision after the fix).
+    const mapped_other_bytes = [_]u8{0} ** 10 ++ [_]u8{ 0xff, 0xff } ++ [_]u8{ 198, 51, 100, 1 };
+    const mapped_other = ip6(mapped_other_bytes, 443, 0, 0);
+    try std.testing.expect(SubnetRateLimit.subnetKey(mapped_other) != k_mapped);
+
+    // Native IPv6 path must stay on the /48 hash (not collide with mapped form).
+    const native6_bytes = [_]u8{ 0x20, 0x01, 0x0d, 0xb8 } ++ [_]u8{0} ** 12;
+    const native6 = ip6(native6_bytes, 443, 0, 0);
+    try std.testing.expect(SubnetRateLimit.subnetKey(native6) != k_mapped);
+}
+
+test "subnet rate limit - allows up to max then blocks" {
+    var limiter = SubnetRateLimit{};
+    const addr = ip4(.{ 192, 168, 1, 100 }, 443);
+
+    // max_per_sec = 3 → should allow 3 then block
+    // First call resets entry with tokens = max-1 = 2, returns true
+    try std.testing.expect(limiter.check(addr, 3));
+    // Two more with existing tokens
+    try std.testing.expect(limiter.check(addr, 3));
+    try std.testing.expect(limiter.check(addr, 3));
+    // Now should be blocked
+    try std.testing.expect(!limiter.check(addr, 3));
+    try std.testing.expect(!limiter.check(addr, 3));
+}
+
+test "subnet rate limit - disabled when max_per_sec is 0" {
+    var limiter = SubnetRateLimit{};
+    const addr = ip4(.{ 1, 2, 3, 4 }, 443);
+
+    // With max_per_sec = 0, always allows
+    for (0..100) |_| {
+        try std.testing.expect(limiter.check(addr, 0));
+    }
+}
+
+test "subnet rate limit - stale entry resets" {
+    var limiter = SubnetRateLimit{};
+    const addr = ip4(.{ 10, 20, 30, 40 }, 443);
+
+    // Drain tokens
+    _ = limiter.check(addr, 1);
+    try std.testing.expect(!limiter.check(addr, 1));
+
+    // Make entry stale (>60s old)
+    const key = SubnetRateLimit.subnetKey(addr);
+    const entry = limiter.findEntry(key) orelse return error.TestExpectedEqual;
+    entry.last_refill_s -= SubnetRateLimit.stale_after_s + 1;
+
+    // Should reset and allow again
+    try std.testing.expect(limiter.check(addr, 1));
+}
+
+test "subnet rate limit - different subnets are independent" {
+    var limiter = SubnetRateLimit{};
+    const addr_a = ip4(.{ 10, 0, 1, 100 }, 443);
+    const addr_b = ip4(.{ 10, 0, 2, 100 }, 443);
+
+    // Drain subnet A
+    _ = limiter.check(addr_a, 1);
+    try std.testing.expect(!limiter.check(addr_a, 1));
+
+    // Subnet B should still work
+    try std.testing.expect(limiter.check(addr_b, 1));
+}

--- a/src/proxy/upstream.zig
+++ b/src/proxy/upstream.zig
@@ -18,11 +18,92 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
-const net = std.net;
+const net = std.Io.net;
 const posix = std.posix;
 const tunnel_mod = @import("../tunnel.zig");
+const Address = net.IpAddress;
 
 pub const Tunnel = tunnel_mod.Tunnel;
+
+const SocketAddr = union(enum) {
+    ip4: posix.sockaddr.in,
+    ip6: posix.sockaddr.in6,
+};
+
+fn socketFamily(addr: Address) posix.sa_family_t {
+    return switch (addr) {
+        .ip4 => posix.AF.INET,
+        .ip6 => posix.AF.INET6,
+    };
+}
+
+fn toSocketAddr(addr: Address) SocketAddr {
+    return switch (addr) {
+        .ip4 => |ip4| .{ .ip4 = .{
+            .family = posix.AF.INET,
+            .port = std.mem.nativeToBig(u16, ip4.port),
+            .addr = @bitCast(ip4.bytes),
+        } },
+        .ip6 => |ip6| .{ .ip6 = .{
+            .family = posix.AF.INET6,
+            .port = std.mem.nativeToBig(u16, ip6.port),
+            .flowinfo = ip6.flow,
+            .addr = ip6.bytes,
+            .scope_id = ip6.interface.index,
+        } },
+    };
+}
+
+fn connectSocket(fd: posix.fd_t, addr: Address) !void {
+    var sa = toSocketAddr(addr);
+    switch (sa) {
+        .ip4 => |*a| try connectSockaddr(fd, @ptrCast(&a.*), @sizeOf(posix.sockaddr.in)),
+        .ip6 => |*a| try connectSockaddr(fd, @ptrCast(&a.*), @sizeOf(posix.sockaddr.in6)),
+    }
+}
+
+fn createTcpSocket(family: posix.sa_family_t) !posix.fd_t {
+    const flags = posix.SOCK.STREAM | posix.SOCK.NONBLOCK | posix.SOCK.CLOEXEC;
+    while (true) {
+        const rc = posix.system.socket(family, flags, posix.IPPROTO.TCP);
+        switch (posix.errno(rc)) {
+            .SUCCESS => return @intCast(rc),
+            .INTR => continue,
+            .AFNOSUPPORT => return error.AddressFamilyUnsupported,
+            .MFILE => return error.ProcessFdQuotaExceeded,
+            .NFILE => return error.SystemFdQuotaExceeded,
+            .NOBUFS, .NOMEM => return error.SystemResources,
+            .PROTONOSUPPORT => return error.ProtocolUnsupportedByAddressFamily,
+            .PROTOTYPE => return error.SocketModeUnsupported,
+            else => |err| return posix.unexpectedErrno(err),
+        }
+    }
+}
+
+fn closeFd(fd: posix.fd_t) void {
+    while (true) switch (posix.errno(posix.system.close(fd))) {
+        .SUCCESS => return,
+        .INTR => continue,
+        else => return,
+    };
+}
+
+fn connectSockaddr(fd: posix.fd_t, addr: *const posix.sockaddr, addr_len: posix.socklen_t) !void {
+    while (true) switch (posix.errno(posix.system.connect(fd, addr, addr_len))) {
+        .SUCCESS => return,
+        .INTR => continue,
+        .ADDRNOTAVAIL => return error.AddressUnavailable,
+        .AFNOSUPPORT => return error.AddressFamilyUnsupported,
+        .AGAIN, .INPROGRESS => return error.WouldBlock,
+        .ALREADY => return error.ConnectionPending,
+        .CONNREFUSED => return error.ConnectionRefused,
+        .CONNRESET => return error.ConnectionResetByPeer,
+        .HOSTUNREACH => return error.HostUnreachable,
+        .NETUNREACH => return error.NetworkUnreachable,
+        .TIMEDOUT => return error.Timeout,
+        else => |err| return posix.unexpectedErrno(err),
+    };
+}
 
 /// What proxy-level handshake (if any) must be completed after TCP connect.
 pub const ProxyHandshake = enum {
@@ -61,7 +142,7 @@ pub const Upstream = union(Tag) {
     }
 
     pub fn initSocks5(
-        proxy_addr: net.Address,
+        proxy_addr: Address,
         username: ?[]const u8,
         password: ?[]const u8,
     ) Upstream {
@@ -73,7 +154,7 @@ pub const Upstream = union(Tag) {
     }
 
     pub fn initHttpConnect(
-        proxy_addr: net.Address,
+        proxy_addr: Address,
         username: ?[]const u8,
         password: ?[]const u8,
     ) Upstream {
@@ -90,7 +171,7 @@ pub const Upstream = union(Tag) {
     /// For proxy variants, connects to the proxy server; the caller
     /// must check `proxy_handshake` and run the appropriate handshake
     /// before using the socket for DC traffic.
-    pub fn connect(self: *const Upstream, addr: net.Address) !ConnectResult {
+    pub fn connect(self: *const Upstream, addr: Address) !ConnectResult {
         return switch (self.*) {
             .direct => |connector| connector.connect(addr),
             .socks5 => |connector| connector.connect(),
@@ -99,7 +180,7 @@ pub const Upstream = union(Tag) {
     }
 
     /// Get the proxy server address (for logging), or null for direct.
-    pub fn proxyAddr(self: *const Upstream) ?net.Address {
+    pub fn proxyAddr(self: *const Upstream) ?Address {
         return switch (self.*) {
             .direct => null,
             .socks5 => |s| s.proxy_addr,
@@ -128,19 +209,15 @@ pub const Upstream = union(Tag) {
 pub const Direct = struct {
     socket_mark: ?u32 = null,
 
-    pub fn connect(self: Direct, addr: net.Address) !ConnectResult {
-        const fd = try posix.socket(
-            addr.any.family,
-            posix.SOCK.STREAM | posix.SOCK.NONBLOCK | posix.SOCK.CLOEXEC,
-            posix.IPPROTO.TCP,
-        );
-        errdefer posix.close(fd);
+    pub fn connect(self: Direct, addr: Address) !ConnectResult {
+        const fd = try createTcpSocket(socketFamily(addr));
+        errdefer closeFd(fd);
 
         if (self.socket_mark) |mark| {
             try applySocketMark(fd, mark);
         }
 
-        posix.connect(fd, &addr.any, addr.getOsSockLen()) catch |err| switch (err) {
+        connectSocket(fd, addr) catch |err| switch (err) {
             error.WouldBlock, error.ConnectionPending => {
                 return .{ .fd = fd, .pending = true };
             },
@@ -152,7 +229,7 @@ pub const Direct = struct {
 };
 
 pub const Socks5 = struct {
-    proxy_addr: net.Address,
+    proxy_addr: Address,
     username: ?[]const u8 = null,
     password: ?[]const u8 = null,
     socket_mark: ?u32 = null,
@@ -160,18 +237,14 @@ pub const Socks5 = struct {
     /// Connect to the SOCKS5 proxy server (not the target DC).
     /// Returns a result with `.proxy_handshake = .socks5`.
     pub fn connect(self: Socks5) !ConnectResult {
-        const fd = try posix.socket(
-            self.proxy_addr.any.family,
-            posix.SOCK.STREAM | posix.SOCK.NONBLOCK | posix.SOCK.CLOEXEC,
-            posix.IPPROTO.TCP,
-        );
-        errdefer posix.close(fd);
+        const fd = try createTcpSocket(socketFamily(self.proxy_addr));
+        errdefer closeFd(fd);
 
         if (self.socket_mark) |mark| {
             try applySocketMark(fd, mark);
         }
 
-        posix.connect(fd, &self.proxy_addr.any, self.proxy_addr.getOsSockLen()) catch |err| switch (err) {
+        connectSocket(fd, self.proxy_addr) catch |err| switch (err) {
             error.WouldBlock, error.ConnectionPending => {
                 return .{ .fd = fd, .pending = true, .proxy_handshake = .socks5 };
             },
@@ -189,7 +262,7 @@ pub const Socks5 = struct {
 };
 
 pub const HttpConnect = struct {
-    proxy_addr: net.Address,
+    proxy_addr: Address,
     username: ?[]const u8 = null,
     password: ?[]const u8 = null,
     socket_mark: ?u32 = null,
@@ -197,18 +270,14 @@ pub const HttpConnect = struct {
     /// Connect to the HTTP proxy server (not the target DC).
     /// Returns a result with `.proxy_handshake = .http_connect`.
     pub fn connect(self: HttpConnect) !ConnectResult {
-        const fd = try posix.socket(
-            self.proxy_addr.any.family,
-            posix.SOCK.STREAM | posix.SOCK.NONBLOCK | posix.SOCK.CLOEXEC,
-            posix.IPPROTO.TCP,
-        );
-        errdefer posix.close(fd);
+        const fd = try createTcpSocket(socketFamily(self.proxy_addr));
+        errdefer closeFd(fd);
 
         if (self.socket_mark) |mark| {
             try applySocketMark(fd, mark);
         }
 
-        posix.connect(fd, &self.proxy_addr.any, self.proxy_addr.getOsSockLen()) catch |err| switch (err) {
+        connectSocket(fd, self.proxy_addr) catch |err| switch (err) {
             error.WouldBlock, error.ConnectionPending => {
                 return .{ .fd = fd, .pending = true, .proxy_handshake = .http_connect };
             },

--- a/src/proxy/upstream_failover.zig
+++ b/src/proxy/upstream_failover.zig
@@ -1,0 +1,89 @@
+const std = @import("std");
+
+const net_helpers = @import("net_helpers.zig");
+const socket_utils = @import("socket_utils.zig");
+
+const addressEql = net_helpers.addressEql;
+const formatAddress = socket_utils.formatAddress;
+
+const log = std.log.scoped(.proxy);
+
+fn upstreamCandidates(slot: anytype) []const @TypeOf(slot.upstream_candidates_inline[0]) {
+    const count: usize = slot.upstream_candidate_count;
+    if (slot.upstream_candidates_heap) |heap| return heap[0..count];
+    return slot.upstream_candidates_inline[0..count];
+}
+
+pub fn tryNextDcEndpoint(
+    loop: anytype,
+    slot: anytype,
+    err: anyerror,
+    comptime start_connect_upstream_dc: fn (@TypeOf(loop), @TypeOf(slot), @TypeOf(slot.current_upstream_addr.?)) anyerror!void,
+    comptime set_single_upstream_candidate: fn (@TypeOf(loop), @TypeOf(slot), @TypeOf(slot.current_upstream_addr.?)) anyerror!void,
+) bool {
+    const attempt_addr = slot.current_upstream_addr;
+    const candidates = upstreamCandidates(slot);
+    if (candidates.len == 0) return false;
+    const candidate_count = candidates.len;
+
+    const next_u: usize = slot.upstream_candidate_next;
+    if (next_u < candidates.len) {
+        const next_idx = next_u;
+        const next_addr = candidates[next_idx];
+        slot.upstream_candidate_next += 1;
+        start_connect_upstream_dc(loop, slot, next_addr) catch |next_err| {
+            log.warn("[{d}] dc connect candidate {d}/{d} failed immediately: {any}", .{
+                slot.conn_id,
+                next_idx + 1,
+                candidate_count,
+                next_err,
+            });
+            return tryNextDcEndpoint(
+                loop,
+                slot,
+                next_err,
+                start_connect_upstream_dc,
+                set_single_upstream_candidate,
+            );
+        };
+
+        if (attempt_addr) |addr| {
+            var prev_buf: [64]u8 = undefined;
+            const prev_str = formatAddress(addr, &prev_buf);
+            log.warn("[{d}] dc connect failed ({any}), retry candidate {d}/{d} after {s}", .{
+                slot.conn_id,
+                err,
+                next_idx + 1,
+                candidate_count,
+                prev_str,
+            });
+        }
+        return true;
+    }
+
+    if (!slot.direct_fallback_used and slot.direct_fallback_addr != null and slot.use_middle_proxy) {
+        slot.direct_fallback_used = true;
+        slot.use_middle_proxy = false;
+        const fallback = slot.direct_fallback_addr.?;
+        slot.upstream_candidate_next = 1;
+
+        set_single_upstream_candidate(loop, slot, fallback) catch {
+            return false;
+        };
+
+        start_connect_upstream_dc(loop, slot, fallback) catch |fallback_err| {
+            log.warn("[{d}] direct fallback connect failed: {any}", .{ slot.conn_id, fallback_err });
+            return false;
+        };
+
+        var fb_buf: [64]u8 = undefined;
+        const fb_str = formatAddress(fallback, &fb_buf);
+        log.warn("[{d}] middle-proxy exhausted, fallback to direct {s}", .{ slot.conn_id, fb_str });
+        return true;
+    }
+
+    if (slot.is_media_path) {
+        log.warn("[{d}] media path connect failed after all candidates: {any}", .{ slot.conn_id, err });
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- migrate the project to Zig 0.16 APIs and keep build/test green
- continue splitting `src/proxy/proxy.zig` into focused modules and strengthen lifecycle/error handling in core state
- harden release supply-chain flow: publish per-asset `*.sha256`, verify checksums in `mtbuddy install/update` and `bootstrap.sh` before extraction/run
- add optional minisign signature verification (`*.sha256.minisig`) with embedded public key support in `mtbuddy` (`-Dminisign_pubkey=...`)
- remove shell-based Cloudflare DNS update path in `ipv6hop` (no `bash -c`, JSON parsing instead)
- align docs/workflows with Zig 0.16, current Make targets, and safer deploy behavior

## Verification
- `make test`
- `make build`
- `zig build test --summary all`
- `zig build -Dminisign_pubkey=RWT8YwmUuq/3WpUnYJjD6rAfQugYdZKWr61U3O+2kdNvriLSyrvVU/NO -Doptimize=ReleaseFast -Dtarget=x86_64-linux -Dcpu=x86_64_v3+aes --summary all`