### PR TITLE
fix: bound release download timeouts

### DIFF
--- a/src/ctl/release.zig
+++ b/src/ctl/release.zig
@@ -290,7 +290,21 @@ fn downloadReleaseFile(
         "https://github.com/{s}/{s}/releases/download/{s}/{s}",
         .{ REPO_OWNER, REPO_NAME, tag, file_name },
     ) catch return false;
-    const dl = sys.exec(allocator, &.{ "curl", "-fsSL", url, "-o", out_path }) catch return false;
+    const dl = sys.exec(allocator, &.{
+        "curl",
+        "-fsSL",
+        "--connect-timeout",
+        "10",
+        "--max-time",
+        "120",
+        "--retry",
+        "2",
+        "--retry-delay",
+        "1",
+        url,
+        "-o",
+        out_path,
+    }) catch return false;
     defer dl.deinit();
     return dl.exit_code == 0;
 }

--- a/src/ctl/update.zig
+++ b/src/ctl/update.zig
@@ -131,6 +131,11 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: UpdateOpts) !void {
 
     // ── Download mtbuddy (optional) ──
     var buddy_buf: [256]u8 = undefined;
+    ui.step(localized(
+        ui,
+        "Downloading mtbuddy updater...",
+        "Скачивание обновления mtbuddy...",
+    ));
     const buddy_path = release.downloadBuddyArtifact(
         allocator,
         tag.slice(),
@@ -139,6 +144,18 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: UpdateOpts) !void {
         !insecure_mode,
         &buddy_buf,
     );
+    if (buddy_path) |_| {
+        ui.stepOk(
+            localized(ui, "mtbuddy updater downloaded", "Обновление mtbuddy скачано"),
+            "mtbuddy",
+        );
+    } else {
+        ui.warn(localized(
+            ui,
+            "mtbuddy artifact unavailable; updating proxy binary only",
+            "Артефакт mtbuddy недоступен; обновляем только бинарник прокси",
+        ));
+    }
 
     // ── Backup current binary ──
     ui.step(ui.str(.update_backing_up));
@@ -235,4 +252,11 @@ fn isTunnelServiceUnit() bool {
     }) catch return false;
     defer result.deinit();
     return result.exit_code == 0;
+}
+
+fn localized(ui: *const Tui, en: []const u8, ru: []const u8) []const u8 {
+    return switch (ui.lang) {
+        .en => en,
+        .ru => ru,
+    };
 }


### PR DESCRIPTION
## Summary
- add connect and total timeouts to GitHub release asset downloads
- make the optional mtbuddy updater download visible in update output
- warn and continue with proxy-only update if the mtbuddy artifact cannot be fetched

## Verification
- make test
- zig build -Dtarget=x86_64-linux -Doptimize=ReleaseFast
- confirmed proxy.sleep3r.ru recovered to mtbuddy v0.21.1 and mtproto-proxy v0.21.1