### PR TITLE
fix: harden nfqws install diagnostics

### DIFF
--- a/src/ctl/install.zig
+++ b/src/ctl/install.zig
@@ -426,27 +426,23 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
         ui.ok(ui.str(.install_config_exists));
     }
 
-    // ── Create system user ──
-    if (!blk: {
-        const r = sys.exec(allocator, &.{ "id", "-u", "mtproto" }) catch break :blk false;
-        defer r.deinit();
-        break :blk r.exit_code == 0;
-    }) {
-        _ = sys.exec(allocator, &.{
-            "useradd", "--system", "--no-create-home", "--shell", "/usr/sbin/nologin", "mtproto",
-        }) catch {};
-        ui.ok(ui.str(.install_user_created));
-    }
-
-    _ = sys.exec(allocator, &.{ "chown", "-R", "mtproto:mtproto", INSTALL_DIR }) catch {};
+    // ── Create system user/group ──
+    if (!ensureServiceUser(ui, allocator)) return;
+    if (!runRequired(ui, allocator, &.{ "chown", "-R", "mtproto:mtproto", INSTALL_DIR }, "Failed to chown install directory")) return;
 
     // ── Systemd service ──
     {
         var sp = ui.spinner(ui.str(.install_service_installed));
         sp.start();
-        _ = sys.exec(allocator, &.{ "systemctl", "daemon-reload" }) catch {};
-        _ = sys.exec(allocator, &.{ "systemctl", "enable", SERVICE_NAME }) catch {};
-        _ = sys.exec(allocator, &.{ "systemctl", "restart", SERVICE_NAME }) catch {};
+        if (!runRequiredWhileSpinning(ui, allocator, &.{ "systemctl", "daemon-reload" }, "systemctl daemon-reload failed", &sp)) return;
+        if (!runRequiredWhileSpinning(ui, allocator, &.{ "systemctl", "enable", SERVICE_NAME }, "Failed to enable mtproto-proxy service", &sp)) return;
+        if (!runRequiredWhileSpinning(ui, allocator, &.{ "systemctl", "restart", SERVICE_NAME }, "Failed to start mtproto-proxy service", &sp)) return;
+        if (!sys.isServiceActive(SERVICE_NAME)) {
+            sp.stop(false, "");
+            ui.fail("mtproto-proxy service is not active after restart");
+            printServiceStatus(ui, allocator);
+            return;
+        }
         sp.stop(true, "");
     }
 
@@ -498,8 +494,13 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
     }
 
     // ── Final restart ──
-    _ = sys.exec(allocator, &.{ "chown", "-R", "mtproto:mtproto", INSTALL_DIR }) catch {};
-    _ = sys.exec(allocator, &.{ "systemctl", "restart", SERVICE_NAME }) catch {};
+    if (!runRequired(ui, allocator, &.{ "chown", "-R", "mtproto:mtproto", INSTALL_DIR }, "Failed to chown install directory")) return;
+    if (!runRequired(ui, allocator, &.{ "systemctl", "restart", SERVICE_NAME }, "Failed to restart mtproto-proxy after setup")) return;
+    if (!sys.isServiceActive(SERVICE_NAME)) {
+        ui.fail("mtproto-proxy service is not active after setup");
+        printServiceStatus(ui, allocator);
+        return;
+    }
 
     ui.rule();
 
@@ -779,4 +780,109 @@ fn printSummary(
     }
 
     ui.print("  {s}╰─{s}\n", .{ tui_mod.Color.gray, tui_mod.Color.reset });
+}
+
+fn ensureServiceUser(ui: *Tui, allocator: std.mem.Allocator) bool {
+    if (!groupExists(allocator, "mtproto")) {
+        if (!runRequired(ui, allocator, &.{ "groupadd", "--system", "mtproto" }, "Failed to create system group 'mtproto'")) return false;
+    }
+
+    if (!userExists(allocator, "mtproto")) {
+        if (!runRequired(ui, allocator, &.{
+            "useradd",
+            "--system",
+            "--no-create-home",
+            "--home-dir",
+            INSTALL_DIR,
+            "--shell",
+            "/usr/sbin/nologin",
+            "--gid",
+            "mtproto",
+            "mtproto",
+        }, "Failed to create system user 'mtproto'")) return false;
+        ui.ok(ui.str(.install_user_created));
+    }
+
+    if (!groupExists(allocator, "mtproto")) {
+        ui.fail("System group 'mtproto' is missing");
+        return false;
+    }
+    if (!userExists(allocator, "mtproto")) {
+        ui.fail("System user 'mtproto' is missing");
+        return false;
+    }
+    return true;
+}
+
+fn userExists(allocator: std.mem.Allocator, name: []const u8) bool {
+    const result = sys.exec(allocator, &.{ "id", "-u", name }) catch return false;
+    defer result.deinit();
+    return result.exit_code == 0;
+}
+
+fn groupExists(allocator: std.mem.Allocator, name: []const u8) bool {
+    const result = sys.exec(allocator, &.{ "getent", "group", name }) catch return false;
+    defer result.deinit();
+    return result.exit_code == 0;
+}
+
+fn runRequired(ui: *Tui, allocator: std.mem.Allocator, argv: []const []const u8, failure_msg: []const u8) bool {
+    const result = sys.exec(allocator, argv) catch {
+        ui.fail(failure_msg);
+        ui.info("Failed to spawn command");
+        return false;
+    };
+    defer result.deinit();
+
+    if (result.exit_code == 0) return true;
+
+    ui.fail(failure_msg);
+    printCommandOutput(ui, &result);
+    return false;
+}
+
+fn runRequiredWhileSpinning(
+    ui: *Tui,
+    allocator: std.mem.Allocator,
+    argv: []const []const u8,
+    failure_msg: []const u8,
+    sp: *tui_mod.Spinner,
+) bool {
+    const result = sys.exec(allocator, argv) catch {
+        sp.stop(false, "");
+        ui.fail(failure_msg);
+        ui.info("Failed to spawn command");
+        return false;
+    };
+    defer result.deinit();
+
+    if (result.exit_code == 0) return true;
+
+    sp.stop(false, "");
+    ui.fail(failure_msg);
+    printCommandOutput(ui, &result);
+    return false;
+}
+
+fn printServiceStatus(ui: *Tui, allocator: std.mem.Allocator) void {
+    const status = sys.exec(allocator, &.{ "systemctl", "status", SERVICE_NAME, "--no-pager", "-l" }) catch return;
+    defer status.deinit();
+    printCommandOutput(ui, &status);
+}
+
+fn printCommandOutput(ui: *Tui, result: *const sys.ExecResult) void {
+    const stderr = std.mem.trim(u8, result.stderr, &[_]u8{ ' ', '\t', '\r', '\n' });
+    if (stderr.len > 0) {
+        ui.print("  stderr:\n{s}\n", .{tailBytes(stderr, 4096)});
+    }
+
+    const stdout = std.mem.trim(u8, result.stdout, &[_]u8{ ' ', '\t', '\r', '\n' });
+    if (stdout.len > 0) {
+        ui.print("  stdout:\n{s}\n", .{tailBytes(stdout, 4096)});
+    }
+}
+
+fn tailBytes(bytes: []const u8, max_len: usize) []const u8 {
+    if (bytes.len <= max_len) return bytes;
+    return bytes[bytes.len - max_len ..];
 }

--- a/src/ctl/nfqws.zig
+++ b/src/ctl/nfqws.zig
@@ -91,11 +91,12 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: NfqwsOpts) !void {
 
     // ── Install dependencies ──
     ui.step("Installing build dependencies...");
-    _ = sys.execForward(&.{ "apt-get", "update", "-qq" }) catch {};
-    _ = sys.execForward(&.{
-        "apt-get",                "install",    "-y",       "build-essential", "git",
-        "libnetfilter-queue-dev", "libcap-dev", "iptables", "libmnl-dev",      "zlib1g-dev",
-    }) catch {};
+    if (!runLogged(ui, allocator, &.{ "apt-get", "update", "-qq" }, "apt-get update failed")) return;
+    if (!runLogged(ui, allocator, &.{
+        "apt-get",                "install",          "-y",         "build-essential", "git",
+        "libnetfilter-queue-dev", "libnfnetlink-dev", "libcap-dev", "iptables",        "libmnl-dev",
+        "zlib1g-dev",
+    }, "Failed to install nfqws build dependencies")) return;
     ui.ok("Dependencies installed");
 
     // ── Clone and build zapret ──
@@ -104,16 +105,17 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: NfqwsOpts) !void {
     } else {
         ui.step("Cloning and building zapret...");
         _ = sys.exec(allocator, &.{ "rm", "-rf", ZAPRET_DIR }) catch {};
-        const build_result = sys.execForward(&.{
-            "bash", "-c",
-            "git clone --depth 1 https://github.com/bol-van/zapret.git " ++ ZAPRET_DIR ++
-                " && cd " ++ ZAPRET_DIR ++ "/nfq && make clean >/dev/null 2>&1 || true && make >/dev/null 2>&1",
-        }) catch {
-            ui.fail("nfqws build failed");
-            return;
-        };
-        if (build_result != 0 or !sys.fileExists(ZAPRET_DIR ++ "/nfq/nfqws")) {
-            ui.fail("nfqws build failed");
+        if (!runLogged(ui, allocator, &.{
+            "git", "clone", "--depth", "1", "https://github.com/bol-van/zapret.git", ZAPRET_DIR,
+        }, "Failed to clone zapret")) return;
+
+        _ = sys.exec(allocator, &.{ "bash", "-c", "cd " ++ ZAPRET_DIR ++ "/nfq && make clean" }) catch {};
+        if (!runLogged(ui, allocator, &.{
+            "bash", "-c", "cd " ++ ZAPRET_DIR ++ "/nfq && make",
+        }, "nfqws build failed")) return;
+
+        if (!sys.fileExists(ZAPRET_DIR ++ "/nfq/nfqws")) {
+            ui.fail("nfqws build finished but /opt/zapret/nfq/nfqws was not created");
             return;
         }
         ui.ok("nfqws built successfully");
@@ -208,4 +210,36 @@ fn removeNfqwsRules(allocator: std.mem.Allocator, ipt: []const u8) void {
         .{ ipt, NFQUEUE_NUM, ipt },
     ) catch return;
     _ = sys.exec(allocator, &.{ "bash", "-c", cmd }) catch {};
+}
+
+fn runLogged(ui: *Tui, allocator: std.mem.Allocator, argv: []const []const u8, failure_msg: []const u8) bool {
+    const result = sys.exec(allocator, argv) catch {
+        ui.fail(failure_msg);
+        ui.info("Failed to spawn command");
+        return false;
+    };
+    defer result.deinit();
+
+    if (result.exit_code == 0) return true;
+
+    ui.fail(failure_msg);
+    printCommandOutput(ui, &result);
+    return false;
+}
+
+fn printCommandOutput(ui: *Tui, result: *const sys.ExecResult) void {
+    const stderr = std.mem.trim(u8, result.stderr, &[_]u8{ ' ', '\t', '\r', '\n' });
+    if (stderr.len > 0) {
+        ui.print("  stderr:\n{s}\n", .{tailBytes(stderr, 4096)});
+    }
+
+    const stdout = std.mem.trim(u8, result.stdout, &[_]u8{ ' ', '\t', '\r', '\n' });
+    if (stdout.len > 0) {
+        ui.print("  stdout:\n{s}\n", .{tailBytes(stdout, 4096)});
+    }
+}
+
+fn tailBytes(bytes: []const u8, max_len: usize) []const u8 {
+    if (bytes.len <= max_len) return bytes;
+    return bytes[bytes.len - max_len ..];
 }


### PR DESCRIPTION
## Summary
- install the explicit `libnfnetlink-dev` dependency required by `zapret/nfq` (`-lnfnetlink`)
- stop hiding zapret clone/build stderr so `nfqws` failures show actionable output
- create the `mtproto` system group explicitly and create the service user with `--gid mtproto`
- fail install when `chown` / `systemctl enable` / `systemctl restart` fails instead of printing a false success

Fixes #236

## Verification
- `make test`
- `zig build -Dtarget=x86_64-linux -Doptimize=ReleaseFast`
- Debian 12 container: apt install deps + build `zapret/nfq` => `nfqws-ok`
