### PR TITLE
fix: add release asset download fallbacks

### DIFF
--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -39,6 +39,30 @@ step() { printf "  ${Y}●${N} %s...\n" "$*" >&2; }
 
 [ "$(id -u)" = "0" ] || fail "Run as root: sudo bash bootstrap.sh"
 
+curl_try_download() {
+  local out="$1"
+  shift
+  rm -f "$out"
+  if curl "$@" -o "$out" && [ -s "$out" ]; then
+    return 0
+  fi
+  rm -f "$out"
+  return 1
+}
+
+curl_download() {
+  local url="$1"
+  local out="$2"
+  local common=(-fsSL --connect-timeout 8 --max-time 120 --retry 1 --retry-delay 1 --speed-time 30 --speed-limit 1)
+
+  curl_try_download "$out" "${common[@]}" "$url" && return 0
+  curl_try_download "$out" -4 "${common[@]}" "$url" && return 0
+  curl_try_download "$out" --http1.1 "${common[@]}" "$url" && return 0
+  curl_try_download "$out" -4 --http1.1 "${common[@]}" "$url" && return 0
+
+  return 1
+}
+
 # ── detect arch ───────────────────────────────────────────────────
 cpu_supports_x86_64_v3() {
   local flags
@@ -81,8 +105,10 @@ esac
 
 # ── resolve latest tag ────────────────────────────────────────────
 step "Fetching latest release"
-TAG="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-  | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": "\(.*\)".*/\1/')"
+LATEST_JSON="$TMP/latest-release.json"
+curl_download "https://api.github.com/repos/${REPO}/releases/latest" "$LATEST_JSON" \
+  || fail "Could not fetch latest release metadata"
+TAG="$(grep '"tag_name"' "$LATEST_JSON" | head -1 | sed 's/.*"tag_name": "\(.*\)".*/\1/')"
 [ -n "$TAG" ] || fail "Could not resolve latest release tag"
 ok "Latest release: $TAG"
 
@@ -94,12 +120,12 @@ download_artifact() {
   local url="https://github.com/${REPO}/releases/download/${TAG}/${tar_name}"
   local sha_url="https://github.com/${REPO}/releases/download/${TAG}/${sha_name}"
   step "Downloading $artifact"
-  curl -fsSL "$url" -o "$TMP/${tar_name}" || fail "Download failed: $url"
-  curl -fsSL "$sha_url" -o "$TMP/${sha_name}" || fail "Checksum download failed: $sha_url"
+  curl_download "$url" "$TMP/${tar_name}" || fail "Download failed: $url"
+  curl_download "$sha_url" "$TMP/${sha_name}" || fail "Checksum download failed: $sha_url"
   if [ "$INSECURE_MODE" != "1" ]; then
     local sig_name="${sha_name}.minisig"
     local sig_url="https://github.com/${REPO}/releases/download/${TAG}/${sig_name}"
-    curl -fsSL "$sig_url" -o "$TMP/${sig_name}" || fail "Signature download failed: $sig_url"
+    curl_download "$sig_url" "$TMP/${sig_name}" || fail "Signature download failed: $sig_url"
     if ! command -v minisign >/dev/null 2>&1; then
       fail "minisign is required for signature verification (use --insecure or MTPROTO_INSECURE=1 to bypass)"
     fi

--- a/src/ctl/release.zig
+++ b/src/ctl/release.zig
@@ -290,23 +290,78 @@ fn downloadReleaseFile(
         "https://github.com/{s}/{s}/releases/download/{s}/{s}",
         .{ REPO_OWNER, REPO_NAME, tag, file_name },
     ) catch return false;
-    const dl = sys.exec(allocator, &.{
-        "curl",
+
+    const modes = [_]CurlMode{
+        .{},
+        .{ .force_ipv4 = true },
+        .{ .http1 = true },
+        .{ .force_ipv4 = true, .http1 = true },
+    };
+    for (modes) |mode| {
+        _ = sys.exec(allocator, &.{ "rm", "-f", out_path }) catch {};
+        if (curlDownloadToPath(allocator, url, out_path, mode)) return true;
+    }
+    _ = sys.exec(allocator, &.{ "rm", "-f", out_path }) catch {};
+    return false;
+}
+
+const CurlMode = struct {
+    force_ipv4: bool = false,
+    http1: bool = false,
+};
+
+fn curlDownloadToPath(
+    allocator: std.mem.Allocator,
+    url: []const u8,
+    out_path: []const u8,
+    mode: CurlMode,
+) bool {
+    var argv: [32][]const u8 = undefined;
+    var n: usize = 0;
+
+    argv[n] = "curl";
+    n += 1;
+    if (mode.force_ipv4) {
+        argv[n] = "-4";
+        n += 1;
+    }
+    if (mode.http1) {
+        argv[n] = "--http1.1";
+        n += 1;
+    }
+
+    const common = [_][]const u8{
         "-fsSL",
         "--connect-timeout",
-        "10",
+        "8",
         "--max-time",
         "120",
         "--retry",
-        "2",
+        "1",
         "--retry-delay",
+        "1",
+        "--speed-time",
+        "30",
+        "--speed-limit",
         "1",
         url,
         "-o",
         out_path,
-    }) catch return false;
+    };
+    for (common) |arg| {
+        argv[n] = arg;
+        n += 1;
+    }
+
+    const dl = sys.exec(allocator, argv[0..n]) catch return false;
     defer dl.deinit();
-    return dl.exit_code == 0;
+    return dl.exit_code == 0 and fileIsNonEmpty(allocator, out_path);
+}
+
+fn fileIsNonEmpty(allocator: std.mem.Allocator, path: []const u8) bool {
+    const r = sys.exec(allocator, &.{ "test", "-s", path }) catch return false;
+    defer r.deinit();
+    return r.exit_code == 0;
 }
 
 fn verifyReleaseChecksum(


### PR DESCRIPTION
### Summary
- add retry modes for release asset downloads in mtbuddy: default curl, IPv4, HTTP/1.1, and IPv4+HTTP/1.1
- reject empty downloaded files before checksum/signature verification
- apply the same fallback logic to the bootstrap installer and latest-release metadata fetch

### Why
The VPS could resolve the latest release, but normal `curl -L` calls against GitHub release assets timed out on `.sha256` files. The same URL succeeded immediately with `curl -4`, so updater/bootstrap should tolerate bad CDN/DNS/IPv6 routing without weakening checksum or minisign verification.

### Validation
- `bash -n deploy/bootstrap.sh`
- `zig fmt src/ctl/release.zig`
- `make test`
- `zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux -Dcpu=x86_64_v3+aes`
- copied patched mtbuddy to proxy.sleep3r.ru and verified `mtbuddy update --version v0.22.0` completes; service is active