### PR TITLE
[codex] add tunnel pool failover and localized docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ sudo mtbuddy setup dashboard
 # VPN tunnel (for servers where Telegram DCs are blocked)
 sudo mtbuddy setup tunnel /path/to/awg0.conf
 sudo mtbuddy setup tunnel 'vpn://...'
+sudo mtbuddy setup tunnel --iface awg1 /path/to/awg1.conf
 
 # IPv6 hopping
 sudo mtbuddy ipv6-hop --check
@@ -268,6 +269,8 @@ sudo mtbuddy setup tunnel 'vpn://...'
 # Add or replace a specific pool member
 sudo mtbuddy setup tunnel --iface awg1 /path/to/awg1.conf
 ```
+
+In the interactive `mtbuddy` menu, tunnel setup first asks for the VPN type (AmneziaWG for now), then shows the current tunnel pool. Choose **Create new tunnel** to append the next free `awgN`, or choose an existing interface to replace that pool member's config.
 
 `mtbuddy` keeps `[general].use_middle_proxy` unchanged and only configures transport (`[upstream].type = "tunnel"`).
 After setup, it installs `mtproto-tunnel-pool.timer`, validates policy routes (`mark 200`) to Telegram DC ranges, and prints operational commands. The pool controller probes Telegram through each tunnel and rewrites table 200 with `ip route replace`; automatic failover does not restart `mtproto-proxy`.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Disguises Telegram traffic as standard TLS 1.3 HTTPS to bypass network censorshi
 [![Zig](https://img.shields.io/badge/zig-0.16.0-f7a41d.svg?logo=zig&logoColor=white)](https://ziglang.org)
 [![Platform](https://img.shields.io/badge/platform-linux-blueviolet.svg?logo=linux&logoColor=white)](#install)
 
+<p align="center">
+  <a href="README.md"><kbd>English</kbd></a>
+  <a href="README.ru.md"><kbd>Русский</kbd></a>
+</p>
+
 </div>
 
 ---
@@ -57,6 +62,8 @@ It also ships more evasion techniques than any of the above:
 | **Anti-replay** | Rejects replayed handshakes + detects ТСПУ Revisor active probes |
 | **Multi-user** | Independent per-user secrets |
 | **MiddleProxy** | ME transport with auto-refreshed Telegram metadata |
+
+MiddleProxy is required for promotion tags and for media on non-Premium accounts. Without it, photos, videos, stories, and other media on non-Premium accounts should be treated as unavailable rather than flaky. Telegram calls are not supported by this proxy: Telegram only routes calls through SOCKS-style paths, and exposing SOCKS traffic cannot be masked by mtproto.zig as normal HTTPS.
 
 ---
 
@@ -229,13 +236,13 @@ The proxy supports multiple ways to route outgoing connections to Telegram DC se
 |---|---|---|
 | `auto` (default) | Direct egress without tunnel policy marks | Most deployments |
 | `direct` | Connect to Telegram DCs directly from the host | DCs reachable from the server |
-| `tunnel` | Direct connect with `SO_MARK=200` policy-routed via VPN interface | DCs blocked by the ISP |
+| `tunnel` | Direct connect with `SO_MARK=200` policy-routed via a VPN tunnel pool | DCs blocked by the ISP |
 | `socks5` | Route through an external SOCKS5 proxy with optional auth | Existing proxy infrastructure |
 | `http` | Route through an HTTP CONNECT proxy with optional auth | Corporate proxy environments |
 
 ### VPN tunnel
 
-If your VPS is in a region where Telegram DCs are blocked at the network level, you can route proxy traffic through a VPN tunnel with explicit socket policy routing. The proxy runs in the host namespace; only sockets marked by the proxy (`SO_MARK=200`) are routed through the tunnel table.
+If your VPS is in a region where Telegram DCs are blocked at the network level, you can route proxy traffic through a VPN tunnel pool with explicit socket policy routing. The proxy runs in the host namespace; only sockets marked by the proxy (`SO_MARK=200`) are routed through table 200. `mtbuddy` keeps that table pointed at the first healthy tunnel in the configured order.
 
 Currently supported VPN types:
 - **AmneziaWG** — DPI-resistant WireGuard fork (recommended for Russia/Iran)
@@ -248,7 +255,7 @@ Client → mtproto-proxy (host namespace)
                      │
         Linux policy routing table 200
                      │
-                 awg0 (tunnel)
+          awg0 / awg1 / ... (pool)
                      │
              Telegram DC servers
 ```
@@ -257,10 +264,13 @@ Client → mtproto-proxy (host namespace)
 sudo mtbuddy setup tunnel /path/to/awg0.conf
 # or paste an Amnezia share link directly
 sudo mtbuddy setup tunnel 'vpn://...'
+
+# Add or replace a specific pool member
+sudo mtbuddy setup tunnel --iface awg1 /path/to/awg1.conf
 ```
 
 `mtbuddy` keeps `[general].use_middle_proxy` unchanged and only configures transport (`[upstream].type = "tunnel"`).
-After setup, it validates policy routes (`mark 200`) to Telegram DC ranges and prints operational commands.
+After setup, it installs `mtproto-tunnel-pool.timer`, validates policy routes (`mark 200`) to Telegram DC ranges, and prints operational commands. The pool controller probes Telegram through each tunnel and rewrites table 200 with `ip route replace`; automatic failover does not restart `mtproto-proxy`.
 
 You can also explicitly configure the tunnel interface in `config.toml`:
 
@@ -270,6 +280,8 @@ type = "tunnel"
 
 [upstream.tunnel]
 interface = "awg0"
+interfaces = ["awg0", "awg1"]
+pinned_interface = ""   # optional; empty means priority auto-failback
 ```
 
 ### SOCKS5 proxy
@@ -351,7 +363,9 @@ alice = true   # bypass MiddleProxy for this user
 |-----|---------|-------------|
 | `[upstream].type` | `auto` | Egress mode: `auto` (direct), `direct`, `tunnel` (VPN via socket policy routing), `socks5`, or `http` |
 | `[upstream] allow_direct_fallback` | `false` | If `true`, allows socks5/http modes to fall back to direct egress when upstream is unavailable |
-| `[upstream.tunnel] interface` | `"awg0"` | Name of the VPN network interface for SO_MARK routing |
+| `[upstream.tunnel] interface` | `"awg0"` | Legacy single tunnel interface / fallback for SO_MARK routing |
+| `[upstream.tunnel] interfaces` | `["awg0"]` | Ordered tunnel pool; first healthy interface wins |
+| `[upstream.tunnel] pinned_interface` | — | Optional manual preference used before the ordered pool when healthy |
 | `[upstream.socks5] host` | — | SOCKS5 proxy address |
 | `[upstream.socks5] port` | — | SOCKS5 proxy port |
 | `[upstream.socks5] username` | — | SOCKS5 username (empty = no auth) |
@@ -399,7 +413,7 @@ alice = true   # bypass MiddleProxy for this user
 
 ## Monitoring dashboard
 
-A lightweight web dashboard (~30 MB RAM) shows live connections, CPU/memory, network throughput, proxy stats, tunnel metrics, user management, and streaming logs.
+A lightweight web dashboard (~30 MB RAM) shows live connections, CPU/memory, network throughput, proxy stats, tunnel pool health/failover state, user management, and streaming logs.
 
 The dashboard is **embedded directly into the `mtbuddy` binary** — no extra files needed.
 
@@ -496,6 +510,8 @@ scp zig-out/bin/mtproto-proxy root@<SERVER>:/opt/mtproto-proxy/
 
 ## Docker
 
+Docker support is provided for testing, packaging experiments, and simple deployments where only the proxy binary is needed. The project is primarily designed for a native Linux host managed by `mtbuddy`: DPI modules, tunnel pool failover, policy routing, Nginx masking, nfqws, and recovery timers are host-level integrations and are not fully represented by the container.
+
 ```bash
 docker pull ghcr.io/sleep3r/mtproto.zig:latest
 
@@ -515,7 +531,7 @@ docker buildx build --platform linux/amd64,linux/arm64 -t your-registry/mtproto-
 
 Published `linux/amd64` images are built with a portable CPU profile (`-Dcpu=x86_64`) to avoid `Illegal instruction` crashes on older VPS CPUs.
 
-> OS-level mitigations (iptables TCPMSS, nfqws, etc.) are not applied inside the container; only the proxy binary runs there.
+> For production censorship-bypass deployments, prefer the native `mtbuddy install` flow. OS-level mitigations (iptables TCPMSS, nfqws, tunnel policy routing, masking/recovery units) are not applied inside the container; only the proxy binary runs there.
 
 ---
 
@@ -541,6 +557,8 @@ For a full model see [THREAT_MODEL.md](THREAT_MODEL.md). Quick operational summa
   - This is a transport-hardening proxy, not an anonymity network.
   - Bypass quality can degrade as DPI strategies evolve.
   - Dashboard/metrics are plaintext by default; do not expose publicly without auth/TLS.
+  - Telegram calls do not work through this proxy. Calls require Telegram's SOCKS-style call path, which is outside the MTProto/TLS-masking model and cannot be disguised cleanly as normal HTTPS here.
+  - Without MiddleProxy (`[general].use_middle_proxy = true`), media on non-Premium accounts will not load. MiddleProxy is required for photos, videos, stories, and promotion tags.
 - **Region-specific caveats**
   - ISP behavior differs by country/region; configs are not universally portable.
   - IPv6 and AAAA handling vary heavily across providers and can impact iOS/Desktop connection latency.

--- a/README.ru.md
+++ b/README.ru.md
@@ -263,6 +263,8 @@ sudo mtbuddy setup tunnel 'vpn://...'
 sudo mtbuddy setup tunnel --iface awg1 /path/to/awg1.conf
 ```
 
+В интерактивном меню `mtbuddy` настройка туннеля сначала спрашивает тип VPN (пока доступен только AmneziaWG), затем показывает текущий пул. Выберите **Создать новый туннель**, чтобы добавить следующий свободный `awgN`, или выберите существующий интерфейс, чтобы заменить конфиг этого участника пула.
+
 `mtbuddy` не трогает `[general].use_middle_proxy`, а настраивает только transport (`[upstream].type = "tunnel"`). После setup он ставит `mtproto-tunnel-pool.timer`, проверяет `mark 200` к Telegram DC и печатает команды для эксплуатации. Контроллер пула пробует Telegram через каждый туннель и делает `ip route replace`; автоматический failover не перезапускает `mtproto-proxy`.
 
 Пример конфига:

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,0 +1,558 @@
+<div align="center">
+
+# mtproto.zig
+
+**Высокопроизводительный Telegram MTProto proxy на Zig**
+
+Маскирует Telegram-трафик под обычный TLS 1.3 HTTPS, чтобы обходить сетевую цензуру.
+
+**177 КБ бинарник · меньше 1 МБ RAM · старт <10 мс · ноль зависимостей**
+
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Zig](https://img.shields.io/badge/zig-0.16.0-f7a41d.svg?logo=zig&logoColor=white)](https://ziglang.org)
+[![Platform](https://img.shields.io/badge/platform-linux-blueviolet.svg?logo=linux&logoColor=white)](#установка)
+
+<p align="center">
+  <a href="README.md"><kbd>English</kbd></a>
+  <a href="README.ru.md"><kbd>Русский</kbd></a>
+</p>
+
+</div>
+
+---
+
+<p align="center">
+<a href="#почему-этот-прокси">Почему этот?</a> · <a href="#установка">Установка</a> · <a href="#обновление">Обновление</a> · <a href="#команды-mtbuddy">Команды</a> · <a href="#маршрутизация-upstream">Маршрутизация</a> · <a href="#конфигурация">Конфиг</a> · <a href="#дашборд-мониторинга">Дашборд</a> · <a href="#локальная-сборка">Сборка</a> · <a href="#docker">Docker</a> · <a href="#доверие-и-безопасность">Безопасность</a> · <a href="#ограничения-и-совместимость">Совместимость</a> · <a href="#troubleshooting--застряло-на-updating">FAQ</a>
+</p>
+
+---
+
+## Почему этот прокси?
+
+Большинство MTProto-прокси крупные, тянут зависимости и потребляют много памяти. Этот проект устроен иначе:
+
+| Proxy | Язык | Бинарник | Baseline RSS | Старт | Зависимости |
+|---|---|---:|---:|---|---|
+| **mtproto.zig** | Zig | **177 КБ** | **0.75 МБ** | **< 10 мс** | **0** |
+| Official MTProxy | C | 524 КБ | 8.0 МБ | < 10 мс | openssl, zlib |
+| Telemt | Rust | 15 МБ | 12.1 МБ | ~ 5-6 с | 423 crates |
+| mtg | Go | 13 МБ | 11.6 МБ | ~ 30 мс | 78 modules |
+| MTProtoProxy | Python | N/A | ~ 30 МБ | ~ 300 мс | python3, cryptography |
+| JSMTProxy | Node.js | N/A | ~ 45 МБ | ~ 400 мс | nodejs, openssl |
+
+## Почему Zig?
+
+Zig даёт производительность и минимальный footprint уровня C, но без привычной боли C-проектов:
+- **Без произвольных аллокаций:** слоты соединений и буферы заранее выделяются на старте. Нет GC, который может уронить кадры под нагрузкой.
+- **Герметичная кросс-компиляция:** можно запустить `zig build` на macOS и получить статически слинкованный Linux-бинарник. Без Docker и несовпадений `glibc`.
+- **Comptime:** маппинг протокола, endian-конверсии и двуязычные строки `mtbuddy` вычисляются при компиляции.
+
+Прокси также включает набор техник обхода DPI:
+
+| Техника | Что делает |
+|---|---|
+| **Fake TLS 1.3** | Соединения выглядят как обычный HTTPS |
+| **DRS** | Имитирует размеры TLS-record у Chrome/Firefox |
+| **Zero-RTT masking** | Локальный Nginx отвечает на активные пробы TLS |
+| **TCPMSS=88** | Дробит ClientHello на маленькие TCP-пакеты |
+| **nfqws TCP desync** | Fake packets + TTL-limited splits против stateful DPI |
+| **Split-TLS** | 1-байтовые Application records против пассивных сигнатур |
+| **VPN tunnel pool** | Маршрутизация через WireGuard/AmneziaWG с `SO_MARK` и failover |
+| **IPv6 hopping** | Авто-ротация IPv6 из /64 при банах через Cloudflare API |
+| **Anti-replay** | Отбрасывает replay handshakes и активные пробы ТСПУ Revisor |
+| **Multi-user** | Отдельные secret для разных пользователей |
+| **MiddleProxy** | ME transport с автообновлением Telegram metadata |
+
+MiddleProxy нужен для промо-тега и медиа на аккаунтах без Premium. Без него фото, видео, истории и другое медиа на non-Premium аккаунтах нужно считать недоступными, а не «иногда лагающими». Звонки Telegram не поддерживаются: Telegram ведёт звонки через SOCKS-пути, а такой трафик нельзя нормально замаскировать в mtproto.zig под обычный HTTPS.
+
+---
+
+## Установка
+
+Установка, обновление и управление делаются через **mtbuddy** — нативный Zig CLI, который поставляется вместе с прокси.
+
+### Одна команда
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sleep3r/mtproto.zig/main/deploy/bootstrap.sh | sudo bash
+
+# Явно разрешить unsigned bootstrap mode (не рекомендуется)
+curl -fsSL https://raw.githubusercontent.com/sleep3r/mtproto.zig/main/deploy/bootstrap.sh | sudo bash -s -- --insecure
+# или: MTPROTO_INSECURE=1
+```
+
+Скрипт скачивает последний `mtbuddy`, проверяет minisign-подпись и SHA-256 checksum из GitHub Release, затем запускает `mtbuddy --help`. После этого установите прокси:
+
+```bash
+# Минимально: secret генерируется автоматически, DPI-модули включены
+sudo mtbuddy install --port 443 --domain wb.ru --yes
+
+# Свой secret и имя пользователя
+sudo mtbuddy install --port 443 --domain wb.ru --secret <32-hex> --user alice --yes
+
+# Без DPI-модулей, только bare proxy
+sudo mtbuddy install --port 443 --domain wb.ru --no-dpi --yes
+
+# Установка из существующего config.toml
+sudo mtbuddy install --config /path/to/config.toml --yes
+
+# Явно разрешить unsigned mode (не рекомендуется)
+sudo mtbuddy install --insecure --port 443 --domain wb.ru --yes
+```
+
+В конце `mtbuddy` напечатает готовую `tg://` ссылку для подключения.
+
+### Интерактивный мастер
+
+```bash
+sudo mtbuddy --interactive
+```
+
+<details>
+<summary>Демо: интерактивная установка</summary>
+<br>
+<p align="center">
+  <img src="https://raw.githubusercontent.com/sleep3r/mtproto.zig/main/assets/buddy.gif" alt="Demo: interactive installer" width="80%">
+</p>
+<br>
+
+</details>
+
+### Что делает установка
+
+1. Скачивает **готовый бинарник прокси** из GitHub Releases.
+2. Генерирует случайный secret или использует `--secret`.
+3. Создаёт systemd service `mtproto-proxy`.
+4. Открывает порт в `ufw`, если он активен.
+5. Применяет iptables-правила TCPMSS=88.
+6. Настраивает Nginx masking и nfqws TCP desync, если не указан `--no-dpi`.
+7. Печатает `tg://` ссылку.
+
+### Параметры установки
+
+| Флаг | По умолчанию | Описание |
+|---|---|---|
+| `--port, -p` | `443` | Порт прокси |
+| `--domain, -d` | `wb.ru` | Домен TLS-маскировки |
+| `--secret, -s` | auto | User secret, 32 hex chars |
+| `--user, -u` | `user` | Имя пользователя в `config.toml` |
+| `--config, -c` | — | Использовать существующий `config.toml` |
+| `--yes, -y` | — | Пропустить подтверждение |
+| `--max-connections <N>` | `512` | Максимум соединений |
+| `--bind, -b` | — | Bind на конкретный IP |
+| `--no-masking` | — | Выключить Nginx masking |
+| `--no-nfqws` | — | Выключить nfqws TCP desync |
+| `--no-tcpmss` | — | Выключить TCPMSS=88 |
+| `--no-dpi` | — | Выключить все DPI-модули |
+| `--middle-proxy` | — | Включить Telegram MiddleProxy relay |
+| `--ipv6-hop` | — | Включить IPv6 auto-hopping |
+| `--version, -v <tag>` | `latest` | Версия релиза |
+| `--insecure` | — | Разрешить unsigned assets (не рекомендуется) |
+
+---
+
+## Обновление
+
+```bash
+# Обновиться до последнего релиза
+sudo mtbuddy update
+
+# Зафиксировать конкретную версию
+sudo mtbuddy update --version v0.11.1
+
+# Явно разрешить unsigned mode (не рекомендуется)
+sudo mtbuddy update --insecure
+```
+
+---
+
+## Команды mtbuddy
+
+```bash
+# Статус прокси и модулей
+sudo mtbuddy status
+
+# Проверка и просмотр конфига
+sudo mtbuddy config validate
+sudo mtbuddy config doctor
+sudo mtbuddy config print-effective
+
+# Напечатать Telegram proxy links из config.toml
+sudo mtbuddy links
+sudo mtbuddy links --server proxy.example.com --config /opt/mtproto-proxy/config.toml
+
+# Сгенерировать новый 32-hex secret
+mtbuddy secret
+
+# Hot-reload config
+sudo mtbuddy reload
+
+# Настроить DPI-модули после установки
+sudo mtbuddy setup masking --domain wb.ru
+sudo mtbuddy setup nfqws
+sudo mtbuddy setup recovery
+
+# Установить web dashboard
+sudo mtbuddy setup dashboard
+
+# VPN tunnel pool
+sudo mtbuddy setup tunnel /path/to/awg0.conf
+sudo mtbuddy setup tunnel 'vpn://...'
+sudo mtbuddy setup tunnel --iface awg1 /path/to/awg1.conf
+
+# IPv6 hopping
+sudo mtbuddy ipv6-hop --check
+sudo mtbuddy ipv6-hop --auto --prefix 2a01:abcd:ef00:: --threshold 5
+
+# Обновить Cloudflare DNS A record
+sudo mtbuddy update-dns 1.2.3.4
+
+# Помощь
+mtbuddy --help
+mtbuddy --lang ru --help
+```
+
+---
+
+## Управление сервисом
+
+```bash
+sudo systemctl status mtproto-proxy
+sudo journalctl -u mtproto-proxy -f
+sudo systemctl reload mtproto-proxy
+sudo systemctl restart mtproto-proxy
+```
+
+---
+
+## Маршрутизация upstream
+
+Прокси поддерживает несколько способов маршрутизации исходящих соединений к Telegram DC.
+
+| `[upstream].type` | Как работает | Когда использовать |
+|---|---|---|
+| `auto` | Direct egress без policy mark | Большинство установок |
+| `direct` | Прямое соединение с Telegram DC | DC доступны с сервера |
+| `tunnel` | `SO_MARK=200` и policy routing через VPN tunnel pool | DC заблокированы провайдером |
+| `socks5` | Внешний SOCKS5 proxy с опциональной auth | Уже есть proxy-инфраструктура |
+| `http` | HTTP CONNECT proxy с Basic auth | Corporate proxy environments |
+
+### VPN tunnel pool
+
+Если Telegram DC заблокированы на уровне сети, можно вести proxy-трафик через пул VPN-туннелей с явным socket policy routing. Прокси работает в host namespace; только сокеты с `SO_MARK=200` идут через table 200. `mtbuddy` держит table 200 на первом живом туннеле из заданного порядка.
+
+Поддерживаемые типы:
+- **AmneziaWG** — DPI-resistant fork WireGuard, основной вариант для Russia/Iran.
+- **WireGuard** — стандартный WireGuard (planned).
+
+```
+Client → mtproto-proxy (host namespace)
+                     │
+                SO_MARK=200
+                     │
+        Linux policy routing table 200
+                     │
+          awg0 / awg1 / ... (pool)
+                     │
+             Telegram DC servers
+```
+
+```bash
+sudo mtbuddy setup tunnel /path/to/awg0.conf
+sudo mtbuddy setup tunnel 'vpn://...'
+sudo mtbuddy setup tunnel --iface awg1 /path/to/awg1.conf
+```
+
+`mtbuddy` не трогает `[general].use_middle_proxy`, а настраивает только transport (`[upstream].type = "tunnel"`). После setup он ставит `mtproto-tunnel-pool.timer`, проверяет `mark 200` к Telegram DC и печатает команды для эксплуатации. Контроллер пула пробует Telegram через каждый туннель и делает `ip route replace`; автоматический failover не перезапускает `mtproto-proxy`.
+
+Пример конфига:
+
+```toml
+[upstream]
+type = "tunnel"
+
+[upstream.tunnel]
+interface = "awg0"       # legacy / fallback
+interfaces = ["awg0", "awg1"]
+pinned_interface = ""    # пусто = priority auto-failback
+```
+
+### SOCKS5 proxy
+
+```toml
+[upstream]
+type = "socks5"
+
+[upstream.socks5]
+host = "127.0.0.1"
+port = 1080
+username = "admin"    # optional
+password = "secret"
+```
+
+### HTTP CONNECT proxy
+
+```toml
+[upstream]
+type = "http"
+
+[upstream.http]
+host = "127.0.0.1"
+port = 8080
+username = "admin"    # optional
+password = "secret"
+```
+
+> **Важно:** через upstream маршрутизируется только трафик к DC. Mask/camouflage-соединения всегда идут напрямую.
+
+---
+
+## Конфигурация
+
+Конфиг находится в `/opt/mtproto-proxy/config.toml`. `mtbuddy` создаёт его при установке; можно редактировать вручную и перезапускать сервис.
+
+```toml
+[general]
+use_middle_proxy = true
+
+[upstream]
+type = "auto"            # auto | direct | tunnel | socks5 | http
+# allow_direct_fallback = false
+
+[server]
+port = 443
+# public_ip = "proxy.example.com"
+max_connections = 512
+idle_timeout_sec = 120
+handshake_timeout_sec = 15
+graceful_shutdown_timeout_sec = 15
+log_level = "info"
+rate_limit_per_subnet = 30
+tag = ""                  # Optional: promotion tag from @MTProxybot
+
+[censorship]
+tls_domain = "wb.ru"
+mask = true
+mask_port = 8443
+fast_mode = true
+drs = true
+
+[access.users]
+alice = "00112233445566778899aabbccddeeff"
+bob   = "ffeeddccbbaa99887766554433221100"
+
+[access.direct_users]
+alice = true
+```
+
+Ключевые параметры:
+
+| Key | Default | Описание |
+|---|---|---|
+| `[upstream].type` | `auto` | `auto`, `direct`, `tunnel`, `socks5`, `http` |
+| `[upstream] allow_direct_fallback` | `false` | Разрешить fallback на direct для socks5/http |
+| `[upstream.tunnel] interface` | `"awg0"` | Legacy single interface / fallback |
+| `[upstream.tunnel] interfaces` | `["awg0"]` | Ordered tunnel pool |
+| `[upstream.tunnel] pinned_interface` | — | Ручной preferred interface, если он жив |
+| `[general] use_middle_proxy` | `false` | ME mode для DC1..5 |
+| `[server] port` | `443` | TCP listen port |
+| `[server] public_ip` | auto | Явный IP/domain для ссылок |
+| `[server] max_connections` | `512` | Лимит одновременных соединений |
+| `[server] middleproxy_buffer_kb` | `1024` | Буфер MiddleProxy на соединение |
+| `[server] tag` | — | 32-hex promotion tag от [@MTProxybot](https://t.me/MTProxybot) |
+| `[censorship] tls_domain` | `"google.com"` | Домен для TLS-маскировки |
+| `[censorship] mask` | `true` | Forward invalid clients на `tls_domain` |
+| `[censorship] fast_mode` | `false` | Делегировать S2C encryption DC |
+| `[access.users] <name>` | — | 32-hex secret на пользователя |
+| `[access.direct_users] <name>` | — | Bypass MiddleProxy для пользователя |
+
+> Secret можно сгенерировать через `mtbuddy secret` или `openssl rand -hex 16`.
+>
+> Ссылки печатаются командой `sudo mtbuddy links`. Runtime-логи намеренно скрывают secrets и proxy links.
+
+---
+
+## Дашборд мониторинга
+
+Лёгкий web dashboard (~30 МБ RAM) показывает live connections, CPU/RAM, network throughput, proxy stats, состояние tunnel pool/failover, пользователей и streaming logs.
+
+```bash
+sudo mtbuddy setup dashboard
+
+# Открыть через SSH tunnel
+ssh -L 61208:localhost:61208 root@<server_ip>
+# → http://localhost:61208
+```
+
+Можно также открыть dashboard напрямую через секцию `[monitor]`, но у него нет встроенной auth. Не публикуйте его без firewall или reverse proxy с auth/TLS.
+
+<details>
+<summary>Демо: dashboard</summary>
+<br>
+<p align="center">
+  <img src="https://raw.githubusercontent.com/sleep3r/mtproto.zig/main/assets/dashboard.gif" alt="Demo: monitoring dashboard" width="80%">
+</p>
+<br>
+
+</details>
+
+---
+
+## Prometheus metrics
+
+`mtproto-proxy` может отдавать Prometheus-compatible endpoint на отдельном порту.
+
+```toml
+[metrics]
+enabled = true
+host = "127.0.0.1"
+port = 9400
+```
+
+Endpoint plaintext HTTP:
+
+```text
+GET /metrics
+```
+
+Docker-пример для метрик:
+
+```bash
+docker run --rm \
+  -p 443:443 \
+  -p 9400:9400 \
+  -v "$PWD/config.toml:/etc/mtproto-proxy/config.toml:ro" \
+  mtproto-zig
+```
+
+---
+
+## Локальная сборка
+
+Нужен [Zig 0.16.0](https://ziglang.org/download/).
+
+```bash
+git clone https://github.com/sleep3r/mtproto.zig.git
+cd mtproto.zig
+
+make build
+make test
+make e2e
+make fmt
+make deploy
+make dashboard
+
+# optional
+zig build bench
+zig build soak
+```
+
+Кросс-компиляция под Linux с macOS:
+
+```bash
+zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux -Dcpu=x86_64_v3+aes
+scp zig-out/bin/mtproto-proxy root@<SERVER>:/opt/mtproto-proxy/
+```
+
+---
+
+## Docker
+
+Docker поддерживается для тестов, упаковочных экспериментов и простых сценариев, где нужен только бинарник прокси. Основной production-путь проекта — нативный Linux host под управлением `mtbuddy`: DPI-модули, tunnel pool failover, policy routing, Nginx masking, nfqws и recovery timers являются host-level интеграциями и не представлены контейнером полностью.
+
+```bash
+docker pull ghcr.io/sleep3r/mtproto.zig:latest
+
+docker run --rm \
+  -p 443:443 \
+  -v "$PWD/config.toml:/etc/mtproto-proxy/config.toml:ro" \
+  ghcr.io/sleep3r/mtproto.zig:latest
+```
+
+Локальная сборка:
+
+```bash
+docker build -t mtproto-zig .
+docker buildx build --platform linux/amd64,linux/arm64 -t your-registry/mtproto-zig:latest --push .
+```
+
+> Для production censorship-bypass deployments лучше использовать `mtbuddy install`. OS-level mitigations (iptables TCPMSS, nfqws, tunnel policy routing, masking/recovery units) внутри контейнера не применяются; в контейнере запускается только proxy binary.
+
+---
+
+## Доверие и безопасность
+
+- [SECURITY.md](SECURITY.md) — vulnerability reporting policy.
+- [THREAT_MODEL.md](THREAT_MODEL.md) — security goals, non-goals, adversary model, residual risks.
+- [CONTRIBUTING.md](CONTRIBUTING.md) — dev workflow и PR expectations.
+- [CHANGELOG.md](CHANGELOG.md) — история релизов.
+- [LICENSE](LICENSE) — MIT license.
+
+---
+
+## Ограничения и совместимость
+
+Полная модель описана в [THREAT_MODEL.md](THREAT_MODEL.md). Кратко:
+
+- **Известные ограничения**
+  - Это transport-hardening proxy, а не анонимная сеть.
+  - Качество обхода может меняться по мере развития DPI.
+  - Dashboard/metrics по умолчанию plaintext; не публикуйте их без auth/TLS.
+  - Звонки Telegram через этот прокси не работают. Звонки требуют SOCKS-style path, который не вписывается в MTProto/TLS masking.
+  - Без MiddleProxy (`[general].use_middle_proxy = true`) медиа на non-Premium аккаунтах не будут грузиться.
+- **Региональные caveats**
+  - Поведение провайдеров отличается по странам и регионам.
+  - IPv6/AAAA сильно зависят от провайдера и могут влиять на iOS/Desktop latency.
+  - Tunnel routing зависит от host policy routing и разрешённых VPN-протоколов.
+- **Telegram clients**
+  - Official Telegram Android/iOS/Desktop: ожидается работа на актуальных версиях.
+  - Third-party clients: best effort.
+- **OS/kernel**
+  - Linux `x86_64`: supported.
+  - Linux `aarch64`: supported.
+  - Docker on Linux: supported with caveats.
+  - macOS/Windows runtime: not supported.
+- **Что может сломаться после изменений Telegram/DC**
+  - MiddleProxy metadata и endpoint behavior.
+  - handshake expectations новых клиентов.
+  - DC/media routing edge cases.
+
+---
+
+## Troubleshooting — застряло на "Updating..."
+
+**1. Есть AAAA record, но IPv6 на сервере не работает.**
+DNS отдаёт AAAA, iOS пробует IPv6 первым, получает timeout и медленно падает на IPv4.
+Решение: убрать AAAA, пока IPv6 routing не настроен полностью.
+
+```bash
+dig +short proxy.example.com AAAA
+ip -6 route
+```
+
+**2. Домашний Wi-Fi блокирует IPv4 сервера.**
+Мобильные сети часто работают, потому что используют IPv6. Домашние роутеры могут блокировать destination IPv4.
+Решение: включить IPv6 Prefix Delegation (IA_PD) на роутере.
+
+**3. VPN режет MTProto traffic.**
+Коммерческие VPN часто DPI'ят и дропают proxy traffic.
+Решение: сменить VPN protocol или использовать self-hosted AmneziaWG.
+
+**4. WireGuard/Docker на том же сервере.**
+Docker bridge может дропать пакеты из VPN subnet.
+Решение: `iptables -I DOCKER-USER -s 172.29.172.0/24 -p tcp --dport 443 -j ACCEPT`
+
+**5. DC203 media resets на non-premium clients.**
+Проверьте логи:
+
+```bash
+journalctl -u mtproto-proxy | grep -E "dc=203|Middle"
+```
+
+Прокси обновляет DC203 metadata с Telegram на старте. Если `core.telegram.org` недоступен, используются bundled fallback addresses.
+
+---
+
+## License
+
+[MIT](LICENSE) © 2026 Aleksandr Kalashnikov

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -57,6 +57,8 @@ Secondary assets:
 - Some mitigations depend on host networking setup (iptables/nftables, kernel routing, NIC offload behavior).
 - Dashboard and metrics endpoints are plain HTTP; exposing them publicly is unsafe unless protected by a reverse proxy and auth.
 - Proxy behavior depends on Telegram DC availability and protocol expectations that can change.
+- Telegram calls are out of scope and do not work through this proxy. Calls use Telegram's SOCKS-style call path, which is outside the MTProto/TLS-masking model and cannot be disguised cleanly as normal HTTPS here.
+- Media for non-Premium accounts requires MiddleProxy (`[general].use_middle_proxy = true`). Without it, photos, videos, stories, and other media on non-Premium accounts should be considered unavailable.
 
 ## Region-Specific Caveats
 
@@ -74,6 +76,8 @@ Secondary assets:
 | Official Telegram iOS | expected to work | IPv6/AAAA issues are a common deployment pitfall |
 | Telegram Desktop | expected to work | verify with your selected masking domain |
 | Third-party Telegram clients | best effort | protocol edge cases may differ |
+
+Compatibility here covers chat and media transport. Telegram calls are unsupported in both direct and MiddleProxy modes.
 
 ### OS / kernel
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,6 +1,11 @@
 [general]
 # Route regular DC traffic via Telegram MiddleProxy transport.
-# Required when using a promotion tag from @MTProxybot.
+# Required when using a promotion tag from @MTProxybot and for media
+# loading on non-Premium accounts. Without MiddleProxy, photos, videos,
+# stories, and other media on non-Premium accounts will not load.
+# Telegram calls are not supported by this MTProto proxy: Telegram only
+# handles calls through SOCKS-style paths, which cannot be masked cleanly
+# as normal HTTPS by this project.
 use_middle_proxy = true
 
 # Telemt-compatible alias for promotion tag (alternative to [server].tag).
@@ -94,10 +99,14 @@ port = 443
 
 # ── VPN tunnel configuration ──
 # Activate with: type = "tunnel"
-# Interface metadata for mtbuddy tooling/status.
 # Runtime proxy routing uses SO_MARK=200 and Linux policy routing.
+# `interfaces` is an ordered tunnel pool: mtbuddy routes through the first
+# healthy interface and automatically falls back to the next one. The legacy
+# `interface` key is kept for compatibility and as the single-tunnel fallback.
 # [upstream.tunnel]
 # interface = "awg0"
+# interfaces = ["awg0", "awg1"]
+# pinned_interface = ""  # optional manual preference; empty = priority auto
 
 # ── SOCKS5 upstream proxy configuration ──
 # Activate with: type = "socks5"
@@ -148,6 +157,9 @@ user2 = "ffeeddccbbaa99887766554433221100"
 [access.direct_users]
 # Optional: users that always bypass MiddleProxy (direct DC path).
 # Useful for admin/service accounts that should always use fast mode.
+# Do not put non-Premium users here if they need media loading; bypassing
+# MiddleProxy means their photos, videos, stories, and other media will not load.
+# Telegram calls remain unsupported in both direct and MiddleProxy modes.
 # Names here must match keys from [access.users].
 # Value must be true/1/yes to enable.
 # user1 = true

--- a/src/config.zig
+++ b/src/config.zig
@@ -65,6 +65,65 @@ fn stripInlineComment(value: []const u8) []const u8 {
     return std.mem.trim(u8, value, &[_]u8{ ' ', '\t' });
 }
 
+fn parseStringArrayValue(allocator: std.mem.Allocator, value: []const u8) ![]const []const u8 {
+    const trimmed = std.mem.trim(u8, value, &[_]u8{ ' ', '\t', '\r', '\n' });
+    if (trimmed.len < 2 or trimmed[0] != '[' or trimmed[trimmed.len - 1] != ']') {
+        return error.InvalidStringArray;
+    }
+
+    var list: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (list.items) |item| allocator.free(item);
+        list.deinit(allocator);
+    }
+
+    var i: usize = 1;
+    while (i + 1 < trimmed.len) {
+        while (i + 1 < trimmed.len and (trimmed[i] == ' ' or trimmed[i] == '\t' or trimmed[i] == ',')) : (i += 1) {}
+        if (i + 1 >= trimmed.len or trimmed[i] == ']') break;
+
+        if (trimmed[i] == '"') {
+            i += 1;
+            const start = i;
+            var escaped = false;
+            while (i < trimmed.len) : (i += 1) {
+                if (escaped) {
+                    escaped = false;
+                    continue;
+                }
+                if (trimmed[i] == '\\') {
+                    escaped = true;
+                    continue;
+                }
+                if (trimmed[i] == '"') break;
+            }
+            if (i >= trimmed.len or trimmed[i] != '"') return error.InvalidStringArray;
+            const item = trimmed[start..i];
+            if (item.len > 0) try list.append(allocator, try allocator.dupe(u8, item));
+            i += 1;
+            continue;
+        }
+
+        const start = i;
+        while (i < trimmed.len and trimmed[i] != ',' and trimmed[i] != ']') : (i += 1) {}
+        const item = std.mem.trim(u8, trimmed[start..i], &[_]u8{ ' ', '\t', '\r', '\n' });
+        if (item.len > 0) try list.append(allocator, try allocator.dupe(u8, item));
+    }
+
+    if (list.items.len == 0) {
+        list.deinit(allocator);
+        return &.{};
+    }
+
+    return try list.toOwnedSlice(allocator);
+}
+
+fn freeStringSlice(allocator: std.mem.Allocator, values: []const []const u8) void {
+    if (values.len == 0) return;
+    for (values) |value| allocator.free(value);
+    allocator.free(values);
+}
+
 pub const Config = struct {
     pub const UserSecret = struct { name: []const u8, secret: [16]u8 };
     pub const Metrics = struct {
@@ -159,6 +218,11 @@ pub const Config = struct {
     /// VPN tunnel interface name (e.g. "awg0", "wg0").
     /// Parsed from [upstream.tunnel].interface.
     upstream_tunnel_interface: ?[]const u8 = null,
+    /// Ordered VPN tunnel pool. Parsed from [upstream.tunnel].interfaces.
+    upstream_tunnel_interfaces: []const []const u8 = &.{},
+    /// Optional manually preferred tunnel from the pool.
+    /// Parsed from [upstream.tunnel].pinned_interface.
+    upstream_tunnel_pinned_interface: ?[]const u8 = null,
     metrics: Metrics = .{},
 
     pub fn middleProxyBufferBytes(self: *const Config) usize {
@@ -171,6 +235,49 @@ pub const Config = struct {
 
     pub fn userBypassesMiddleProxy(self: *const Config, user_name: []const u8) bool {
         return self.direct_users.contains(user_name);
+    }
+
+    pub fn tunnelInterfaceCount(self: *const Config) usize {
+        if (self.upstream_tunnel_interfaces.len > 0) return self.upstream_tunnel_interfaces.len;
+        return 1;
+    }
+
+    pub fn tunnelInterfaceAt(self: *const Config, index: usize) ?[]const u8 {
+        if (self.upstream_tunnel_interfaces.len > 0) {
+            if (index >= self.upstream_tunnel_interfaces.len) return null;
+            return self.upstream_tunnel_interfaces[index];
+        }
+        if (index == 0) return self.upstream_tunnel_interface orelse "awg0";
+        return null;
+    }
+
+    pub fn tunnelCandidateCount(self: *const Config) usize {
+        const base = self.tunnelInterfaceCount();
+        const pinned = self.upstream_tunnel_pinned_interface orelse return base;
+        var found = false;
+        var i: usize = 0;
+        while (self.tunnelInterfaceAt(i)) |iface| : (i += 1) {
+            if (std.mem.eql(u8, iface, pinned)) {
+                found = true;
+                break;
+            }
+        }
+        return if (found) base else base + 1;
+    }
+
+    pub fn tunnelCandidateAt(self: *const Config, index: usize) ?[]const u8 {
+        if (self.upstream_tunnel_pinned_interface) |pinned| {
+            if (index == 0) return pinned;
+            var candidate_idx: usize = 1;
+            var i: usize = 0;
+            while (self.tunnelInterfaceAt(i)) |iface| : (i += 1) {
+                if (std.mem.eql(u8, iface, pinned)) continue;
+                if (candidate_idx == index) return iface;
+                candidate_idx += 1;
+            }
+            return null;
+        }
+        return self.tunnelInterfaceAt(index);
     }
 
     /// Port collision exists only when masking points to a local endpoint.
@@ -424,6 +531,12 @@ pub const Config = struct {
                 } else if (in_upstream_tunnel_section) {
                     if (std.mem.eql(u8, key, "interface")) {
                         cfg.upstream_tunnel_interface = try allocator.dupe(u8, value);
+                    } else if (std.mem.eql(u8, key, "interfaces")) {
+                        freeStringSlice(allocator, cfg.upstream_tunnel_interfaces);
+                        cfg.upstream_tunnel_interfaces = parseStringArrayValue(allocator, value) catch &.{};
+                    } else if (std.mem.eql(u8, key, "pinned_interface")) {
+                        if (cfg.upstream_tunnel_pinned_interface) |iface| allocator.free(iface);
+                        cfg.upstream_tunnel_pinned_interface = if (value.len > 0) try allocator.dupe(u8, value) else null;
                     }
                 }
             }
@@ -467,6 +580,10 @@ pub const Config = struct {
             allocator.free(p);
         }
         if (self.upstream_tunnel_interface) |iface| {
+            allocator.free(iface);
+        }
+        freeStringSlice(allocator, self.upstream_tunnel_interfaces);
+        if (self.upstream_tunnel_pinned_interface) |iface| {
             allocator.free(iface);
         }
         if (self.bind_address) |ba| {
@@ -1188,6 +1305,88 @@ test "parse config - upstream type wireguard backward compat" {
     defer cfg.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(UpstreamMode.tunnel, cfg.upstream_mode);
+}
+
+test "parse config - upstream tunnel legacy interface only" {
+    const content =
+        \\[upstream]
+        \\type = "tunnel"
+        \\[upstream.tunnel]
+        \\interface = "wg0"
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), cfg.tunnelInterfaceCount());
+    try std.testing.expectEqualStrings("wg0", cfg.tunnelInterfaceAt(0).?);
+    try std.testing.expectEqualStrings("wg0", cfg.tunnelCandidateAt(0).?);
+    try std.testing.expect(cfg.tunnelCandidateAt(1) == null);
+}
+
+test "parse config - upstream tunnel interface pool" {
+    const content =
+        \\[upstream]
+        \\type = "tunnel"
+        \\[upstream.tunnel]
+        \\interface = "awg0"
+        \\interfaces = ["awg0", "awg1"]
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), cfg.tunnelInterfaceCount());
+    try std.testing.expectEqualStrings("awg0", cfg.tunnelInterfaceAt(0).?);
+    try std.testing.expectEqualStrings("awg1", cfg.tunnelInterfaceAt(1).?);
+    try std.testing.expectEqualStrings("awg0", cfg.tunnelCandidateAt(0).?);
+    try std.testing.expectEqualStrings("awg1", cfg.tunnelCandidateAt(1).?);
+}
+
+test "parse config - upstream tunnel pinned interface candidate order" {
+    const content =
+        \\[upstream]
+        \\type = "tunnel"
+        \\[upstream.tunnel]
+        \\interfaces = ["awg0", "awg1", "awg2"]
+        \\pinned_interface = "awg1"
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings("awg1", cfg.upstream_tunnel_pinned_interface.?);
+    try std.testing.expectEqual(@as(usize, 3), cfg.tunnelCandidateCount());
+    try std.testing.expectEqualStrings("awg1", cfg.tunnelCandidateAt(0).?);
+    try std.testing.expectEqualStrings("awg0", cfg.tunnelCandidateAt(1).?);
+    try std.testing.expectEqualStrings("awg2", cfg.tunnelCandidateAt(2).?);
+    try std.testing.expect(cfg.tunnelCandidateAt(3) == null);
+}
+
+test "parse config - upstream tunnel pinned interface outside pool" {
+    const content =
+        \\[upstream]
+        \\type = "tunnel"
+        \\[upstream.tunnel]
+        \\interfaces = ["awg0", "awg1"]
+        \\pinned_interface = "awg9"
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), cfg.tunnelCandidateCount());
+    try std.testing.expectEqualStrings("awg9", cfg.tunnelCandidateAt(0).?);
+    try std.testing.expectEqualStrings("awg0", cfg.tunnelCandidateAt(1).?);
+    try std.testing.expectEqualStrings("awg1", cfg.tunnelCandidateAt(2).?);
 }
 
 test "parse config - upstream socks5 with credentials" {

--- a/src/ctl/config_cmd.zig
+++ b/src/ctl/config_cmd.zig
@@ -223,6 +223,17 @@ fn printEffective(ui: *Tui, allocator: std.mem.Allocator, path: []const u8) !voi
     if (cfg.upstream_tunnel_interface) |iface| {
         ui.print("tunnel_interface = \"{s}\"\n", .{iface});
     }
+    if (cfg.upstream_tunnel_interfaces.len > 0) {
+        ui.writeRaw("tunnel_interfaces = [");
+        for (cfg.upstream_tunnel_interfaces, 0..) |iface, idx| {
+            if (idx > 0) ui.writeRaw(", ");
+            ui.print("\"{s}\"", .{iface});
+        }
+        ui.writeRaw("]\n");
+    }
+    if (cfg.upstream_tunnel_pinned_interface) |iface| {
+        ui.print("tunnel_pinned_interface = \"{s}\"\n", .{iface});
+    }
     ui.writeRaw("\n");
 
     ui.writeRaw("[censorship]\n");

--- a/src/ctl/dashboard_assets/server.py
+++ b/src/ctl/dashboard_assets/server.py
@@ -362,6 +362,39 @@ def _parse_bool(value, default: bool) -> bool:
     return default
 
 
+def _parse_toml_string_array(value) -> list[str]:
+    raw = str(value or "").strip()
+    if not raw.startswith("[") or not raw.endswith("]"):
+        return []
+
+    try:
+        parsed = json.loads(raw)
+        if isinstance(parsed, list):
+            return [str(v).strip() for v in parsed if str(v).strip()]
+    except Exception:
+        pass
+
+    raw = raw[1:-1]
+    out: list[str] = []
+    for item in raw.split(","):
+        item = item.strip().strip('"').strip("'").strip()
+        if item:
+            out.append(item)
+    return out
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for value in values:
+        v = str(value or "").strip()
+        if not v or v in seen:
+            continue
+        seen.add(v)
+        out.append(v)
+    return out
+
+
 def _load_proxy_runtime_config() -> dict:
     defaults = {
         "public_ip": "",
@@ -372,6 +405,8 @@ def _load_proxy_runtime_config() -> dict:
         "use_middle_proxy": False,
         "upstream_type": "auto",
         "upstream_tunnel_interface": "awg0",
+        "upstream_tunnel_interfaces": [],
+        "upstream_tunnel_pinned_interface": "",
         "upstream_socks5_host": "",
         "upstream_socks5_port": 0,
         "upstream_socks5_username": "",
@@ -403,6 +438,8 @@ def _load_proxy_runtime_config() -> dict:
         "use_middle_proxy": defaults["use_middle_proxy"],
         "upstream_type": defaults["upstream_type"],
         "upstream_tunnel_interface": defaults["upstream_tunnel_interface"],
+        "upstream_tunnel_interfaces": [],
+        "upstream_tunnel_pinned_interface": "",
         "upstream_socks5_host": defaults["upstream_socks5_host"],
         "upstream_socks5_port": defaults["upstream_socks5_port"],
         "upstream_socks5_username": defaults["upstream_socks5_username"],
@@ -464,6 +501,10 @@ def _load_proxy_runtime_config() -> dict:
                 elif section == "[upstream.tunnel]":
                     if key == "interface" and value:
                         result["upstream_tunnel_interface"] = value
+                    elif key == "interfaces":
+                        result["upstream_tunnel_interfaces"] = _parse_toml_string_array(value)
+                    elif key == "pinned_interface":
+                        result["upstream_tunnel_pinned_interface"] = value
 
                 elif section == "[upstream.socks5]":
                     if key == "host":
@@ -515,6 +556,10 @@ def _load_proxy_runtime_config() -> dict:
     except Exception:
         return defaults
 
+    if not result["upstream_tunnel_interfaces"]:
+        iface = str(result.get("upstream_tunnel_interface") or "awg0").strip()
+        result["upstream_tunnel_interfaces"] = [iface] if iface else ["awg0"]
+
     return result
 
 
@@ -529,6 +574,9 @@ def _load_censorship_config() -> dict:
 
 _routing_cache = {"ts": 0, "data": None}
 ROUTING_CACHE_TTL = 8  # seconds
+TUNNEL_POOL_STATE = Path("/run/mtproto-proxy/tunnel-pool.state")
+TUNNEL_POOL_SCRIPT = Path("/usr/local/bin/setup_tunnel.sh")
+TUNNEL_PROBE_URL = "https://core.telegram.org/getProxyConfig"
 
 
 def _parse_transfer_bytes(value: str | None) -> float:
@@ -555,6 +603,79 @@ def _has_valid_handshake(handshake: str | None) -> bool:
     return hs not in ("", "0", "none", "none (idle)")
 
 
+def _tunnel_tool_hint(interface: str) -> str | None:
+    if interface.startswith("awg"):
+        return "awg"
+    if interface.startswith("wg"):
+        return "wg"
+    return None
+
+
+def _effective_tunnel_pool(cfg: dict) -> list[str]:
+    pool = _dedupe([str(v) for v in cfg.get("upstream_tunnel_interfaces", [])])
+    if pool:
+        return pool
+    iface = str(cfg.get("upstream_tunnel_interface", "awg0") or "awg0").strip()
+    return [iface] if iface else ["awg0"]
+
+
+def _tunnel_candidates(cfg: dict) -> list[str]:
+    pinned = str(cfg.get("upstream_tunnel_pinned_interface", "") or "").strip()
+    return _dedupe(([pinned] if pinned else []) + _effective_tunnel_pool(cfg))
+
+
+def _read_tunnel_pool_state() -> dict:
+    result = {
+        "active": "",
+        "status": "",
+        "reason": "",
+        "pinned": "",
+        "pool": "",
+        "last_switch": "",
+        "checked_at": "",
+    }
+    try:
+        text = TUNNEL_POOL_STATE.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return result
+
+    for line in text.splitlines():
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if key in result:
+            result[key] = value.strip()
+    return result
+
+
+def _probe_tunnel_interface(interface: str) -> dict:
+    if not shutil.which("curl"):
+        return {"ok": None, "reason": "curl unavailable"}
+    try:
+        r = subprocess.run(
+            [
+                "curl",
+                "--interface",
+                interface,
+                "-fsS",
+                "--connect-timeout",
+                "2",
+                "--max-time",
+                "4",
+                TUNNEL_PROBE_URL,
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+    except Exception:
+        return {"ok": False, "reason": "probe failed to run"}
+    if r.returncode == 0:
+        return {"ok": True, "reason": "Telegram probe ok"}
+    return {"ok": False, "reason": "Telegram probe failed"}
+
+
 def _detect_tunnel_interface(interface: str, tool_hint: str | None = None) -> dict:
     result = {
         "interface": interface,
@@ -564,6 +685,9 @@ def _detect_tunnel_interface(interface: str, tool_hint: str | None = None) -> di
         "endpoint": None,
         "handshake": None,
         "handshake_ok": False,
+        "healthy": False,
+        "probe_ok": None,
+        "probe": None,
         "rx": None,
         "tx": None,
         "reason": None,
@@ -642,12 +766,22 @@ def _detect_tunnel_interface(interface: str, tool_hint: str | None = None) -> di
         else:
             result["reason"] = "interface down"
 
+        probe = _probe_tunnel_interface(interface) if result["link_up"] and hs_ok else {"ok": False, "reason": result["reason"] or "handshake missing"}
+        result["probe_ok"] = probe.get("ok")
+        result["probe"] = probe.get("reason")
+        result["healthy"] = bool(result["link_up"] and hs_ok and probe.get("ok") is True)
+        if not result["healthy"] and probe.get("reason"):
+            result["reason"] = str(probe.get("reason"))
+
         return result
 
     if result["link_up"]:
         result["reason"] = "interface up, tool output unavailable"
     else:
         result["reason"] = "interface down"
+    result["probe_ok"] = False
+    result["probe"] = result["reason"]
+    result["healthy"] = False
     return result
 
 
@@ -739,11 +873,11 @@ def _upstream_target_from_cfg(cfg: dict, policy: dict) -> str:
         return f"{host}:{port}" if host and port > 0 else "proxy host/port not set"
 
     if upstream_type == "tunnel":
-        iface = str(cfg.get("upstream_tunnel_interface", "awg0") or "awg0").strip()
         route_dev = policy.get("route_dev")
         if route_dev:
             return f"mark 200 -> table 200 -> dev {route_dev}"
-        return f"mark 200 -> table 200 (iface {iface})"
+        pool = _effective_tunnel_pool(cfg)
+        return f"mark 200 -> table 200 (pool {', '.join(pool)})"
 
     if upstream_type == "direct":
         return "direct host routing"
@@ -758,7 +892,9 @@ def _routing_status() -> dict:
 
     cfg = _load_proxy_runtime_config()
     upstream_type = str(cfg.get("upstream_type", "auto") or "auto").lower().strip()
-    selected_iface = str(cfg.get("upstream_tunnel_interface", "awg0") or "awg0").strip()
+    pool = _effective_tunnel_pool(cfg)
+    pinned_iface = str(cfg.get("upstream_tunnel_pinned_interface", "") or "").strip()
+    selected_iface = pinned_iface or (pool[0] if pool else str(cfg.get("upstream_tunnel_interface", "awg0") or "awg0").strip())
 
     if not selected_iface:
         selected_iface = "awg0"
@@ -767,27 +903,25 @@ def _routing_status() -> dict:
     available_tunnel_ifaces: list[str] = []
     for iface in system_ifaces:
         low = iface.lower()
-        if not (low.startswith(("awg", "wg", "tun", "tap")) or iface == selected_iface):
+        if not (low.startswith(("awg", "wg", "tun", "tap")) or iface in pool or iface == selected_iface):
             continue
         if iface and iface not in available_tunnel_ifaces:
             available_tunnel_ifaces.append(iface)
 
-    interfaces = list(available_tunnel_ifaces)
+    candidates = _tunnel_candidates(cfg)
+    interfaces = _dedupe(candidates + list(available_tunnel_ifaces))
     for iface in ("awg0", "wg0"):
         if iface not in interfaces:
             interfaces.append(iface)
 
     tunnels = []
     for iface in interfaces:
-        hint = None
-        if iface.startswith("awg"):
-            hint = "awg"
-        elif iface.startswith("wg"):
-            hint = "wg"
-
-        tunnel = _detect_tunnel_interface(iface, hint)
+        tunnel = _detect_tunnel_interface(iface, _tunnel_tool_hint(iface))
+        tunnel["in_pool"] = iface in pool
+        tunnel["pinned"] = bool(pinned_iface and iface == pinned_iface)
         if (
             iface == selected_iface
+            or iface in pool
             or tunnel.get("link_up")
             or tunnel.get("active")
             or tunnel.get("endpoint")
@@ -795,6 +929,7 @@ def _routing_status() -> dict:
             tunnels.append(tunnel)
 
     policy = _policy_routing_status()
+    pool_state = _read_tunnel_pool_state()
     target = _upstream_target_from_cfg(cfg, policy)
 
     primary_tunnel = None
@@ -809,6 +944,7 @@ def _routing_status() -> dict:
         primary_tunnel = tunnels[0]
 
     active_tunnels = sum(1 for t in tunnels if t.get("active"))
+    healthy_tunnels = sum(1 for t in tunnels if t.get("healthy"))
 
     if upstream_type == "tunnel":
         healthy = bool(
@@ -816,8 +952,7 @@ def _routing_status() -> dict:
             and policy.get("route_ok")
             and primary_tunnel
             and primary_tunnel.get("link_up")
-            and primary_tunnel.get("active")
-            and primary_tunnel.get("handshake_ok")
+            and primary_tunnel.get("healthy")
         )
     elif upstream_type == "socks5":
         healthy = bool(
@@ -837,10 +972,19 @@ def _routing_status() -> dict:
         "upstream_type": upstream_type,
         "upstream_target": target,
         "selected_tunnel_interface": selected_iface,
+        "active_tunnel_interface": route_dev or pool_state.get("active") or "",
+        "pinned_tunnel_interface": pinned_iface,
+        "tunnel_pool": pool,
+        "tunnel_candidates": candidates,
+        "last_switch": pool_state.get("last_switch") or "",
+        "pool_status": pool_state.get("status") or "",
+        "pool_reason": pool_state.get("reason") or "",
+        "pool_checked_at": pool_state.get("checked_at") or "",
         "available_tunnel_interfaces": available_tunnel_ifaces,
         "policy": policy,
         "tunnels": tunnels,
         "active_tunnels": active_tunnels,
+        "healthy_tunnels": healthy_tunnels,
         "detected_tunnels": len(tunnels),
         "primary_tunnel": primary_tunnel,
         "upstream_socks5": {
@@ -1190,9 +1334,6 @@ def _set_upstream_type(upstream_type: str) -> bool:
         lines, "[upstream]", "type", _toml_string_literal(upstream_type)
     )
 
-    if upstream_type == "tunnel":
-        lines = _set_toml_key(lines, "[upstream.tunnel]", "interface", '"awg0"')
-
     cfg_path.write_text("".join(lines), encoding="utf-8")
     return True
 
@@ -1203,20 +1344,34 @@ def _set_upstream_tunnel_interface(interface: str) -> bool:
         return False
 
     iface = str(interface or "").strip()
-    if not iface:
-        return False
-
-    if not re.fullmatch(r"[A-Za-z0-9_.:-]+", iface):
+    if iface and not re.fullmatch(r"[A-Za-z0-9_.:-]+", iface):
         return False
 
     lines = cfg_path.read_text(encoding="utf-8", errors="replace").splitlines(
         keepends=True
     )
     lines = _set_toml_key(
-        lines, "[upstream.tunnel]", "interface", _toml_string_literal(iface)
+        lines, "[upstream.tunnel]", "pinned_interface", _toml_string_literal(iface)
     )
     cfg_path.write_text("".join(lines), encoding="utf-8")
     return True
+
+
+def _run_tunnel_pool_once() -> bool:
+    if not TUNNEL_POOL_SCRIPT.is_file():
+        return False
+    try:
+        r = subprocess.run(
+            [str(TUNNEL_POOL_SCRIPT)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=12,
+        )
+        _routing_cache["ts"] = 0
+        return r.returncode == 0
+    except Exception:
+        _routing_cache["ts"] = 0
+        return False
 
 
 def _set_upstream_proxy_target(
@@ -1697,22 +1852,20 @@ async def api_routing_upstream(request: Request):
 
 @app.post("/api/routing/tunnel-interface")
 async def api_routing_tunnel_interface(request: Request):
-    """Set [upstream.tunnel].interface. Body: { interface: str }"""
+    """Set [upstream.tunnel].pinned_interface. Body: { interface: str }"""
     try:
         body = await request.json()
     except Exception:
         return JSONResponse({"ok": False, "error": "invalid json"}, status_code=400)
 
-    iface = str(body.get("interface", "")).strip()
-    if not iface:
-        return JSONResponse(
-            {"ok": False, "error": "interface is required"}, status_code=400
-        )
+    clear = bool(body.get("clear", False))
+    iface = "" if clear else str(body.get("interface", "")).strip()
 
-    available = _list_system_interfaces()
-    if available and iface not in available:
+    cfg = _load_proxy_runtime_config()
+    pool = _effective_tunnel_pool(cfg)
+    if iface and iface not in pool:
         return JSONResponse(
-            {"ok": False, "error": "interface is not present on host"},
+            {"ok": False, "error": "interface is not in configured tunnel pool"},
             status_code=400,
         )
 
@@ -1721,8 +1874,16 @@ async def api_routing_tunnel_interface(request: Request):
             {"ok": False, "error": "failed to update config"}, status_code=500
         )
 
-    _restart_proxy()
-    return JSONResponse({"ok": True, "interface": iface, "restarted": True})
+    controller_ok = _run_tunnel_pool_once()
+    return JSONResponse(
+        {
+            "ok": True,
+            "interface": iface,
+            "pinned_interface": iface,
+            "controller_ok": controller_ok,
+            "restarted": False,
+        }
+    )
 
 
 @app.post("/api/routing/proxy-target")

--- a/src/ctl/dashboard_assets/static/app.js
+++ b/src/ctl/dashboard_assets/static/app.js
@@ -652,24 +652,23 @@ function setupRoutingControls() {
       if (!currentRouting) return;
 
       const iface = String(tunnelIfaceSelect.value || '').trim();
-      if (!iface) {
-        setRoutingAction('Select tunnel interface first.', 'error');
-        return;
-      }
-
-      if (iface === String(currentRouting.selected_tunnel_interface || '')) {
-        setRoutingAction('Tunnel interface is already set to ' + iface + '.');
+      const currentPinned = String(currentRouting.pinned_tunnel_interface || '');
+      if (iface === currentPinned) {
+        setRoutingAction(iface ? ('Tunnel interface is already pinned to ' + iface + '.') : 'Tunnel pool is already in priority-auto mode.');
         return;
       }
 
       tunnelIfaceApply.disabled = true;
       tunnelIfaceSelect.disabled = true;
-      setRoutingAction('Switching tunnel interface to ' + iface + '…');
+      setRoutingAction(iface ? ('Pinning tunnel interface to ' + iface + '…') : 'Clearing tunnel pin…');
 
       try {
-        const data = await apiCall('/api/routing/tunnel-interface', { interface: iface });
-        setRoutingAction('Tunnel interface set to ' + data.interface + '. Proxy restarted.', 'ok');
-        showToast('Tunnel interface set to ' + data.interface + '. Proxy restarted.', 'success');
+        const data = await apiCall('/api/routing/tunnel-interface', iface ? { interface: iface } : { clear: true });
+        const msg = data.pinned_interface
+          ? ('Tunnel pinned to ' + data.pinned_interface + '. Controller checked pool.')
+          : 'Tunnel pin cleared. Priority auto-failback restored.';
+        setRoutingAction(msg, data.controller_ok ? 'ok' : '');
+        showToast(msg, 'success');
         await runPoll();
       } catch (e) {
         setRoutingAction('Failed: ' + e.message, 'error');
@@ -766,12 +765,12 @@ function renderRouting(routing) {
   if (tunnelCtl && tunnelSelect) {
     if (upstreamType === 'tunnel') {
       tunnelCtl.style.display = '';
-      const choices = Array.isArray(routing.available_tunnel_interfaces)
-        ? routing.available_tunnel_interfaces
+      const choices = Array.isArray(routing.tunnel_pool)
+        ? routing.tunnel_pool
         : [];
-      const selectedIface = String(routing.selected_tunnel_interface || '');
+      const selectedIface = String(routing.pinned_tunnel_interface || '');
       const seen = new Set();
-      const options = [];
+      const options = [''];
 
       if (selectedIface && choices.includes(selectedIface)) {
         seen.add(selectedIface);
@@ -785,7 +784,7 @@ function renderRouting(routing) {
         options.push(v);
       });
 
-      if (!options.length) {
+      if (options.length <= 1 && !choices.length) {
         tunnelSelect.innerHTML = '<option value="">no interfaces</option>';
         tunnelSelect.value = '';
         tunnelSelect.disabled = true;
@@ -794,11 +793,11 @@ function renderRouting(routing) {
         tunnelSelect.disabled = false;
         if (tunnelApplyBtn) tunnelApplyBtn.disabled = false;
         tunnelSelect.innerHTML = options
-          .map((iface) => '<option value="' + esc(iface) + '">' + esc(iface) + '</option>')
+          .map((iface) => iface
+            ? '<option value="' + esc(iface) + '">' + esc(iface) + '</option>'
+            : '<option value="">priority auto</option>')
           .join('');
-        if (selectedIface) {
-          tunnelSelect.value = selectedIface;
-        }
+        tunnelSelect.value = selectedIface || '';
       }
     } else {
       tunnelCtl.style.display = 'none';
@@ -855,7 +854,8 @@ function renderRouting(routing) {
   const policy = routing.policy || {};
   const policyTxt = (policy.rule_ok ? 'rule ok' : 'rule missing') +
     ' · ' +
-    (policy.route_ok ? ('route ok' + (policy.route_dev ? (' (' + policy.route_dev + ')') : '')) : 'route missing');
+    (policy.route_ok ? ('route ok' + (policy.route_dev ? (' (' + policy.route_dev + ')') : '')) : 'route missing') +
+    (routing.pool_status ? (' · pool ' + routing.pool_status) : '');
   $('routingPolicy').textContent = policyTxt;
 
   const list = $('routingTunnelsList');
@@ -865,25 +865,32 @@ function renderRouting(routing) {
     return;
   }
 
-  const selected = routing.selected_tunnel_interface || '';
+  const selected = routing.active_tunnel_interface || routing.selected_tunnel_interface || '';
+  const pinned = routing.pinned_tunnel_interface || '';
 
   list.innerHTML = tunnels.map((t) => {
     const iface = String(t.interface || '—');
     const isSelected = upstreamType === 'tunnel' && iface === selected;
-    const state = t.active ? 'active' : (t.link_up ? 'up' : 'down');
-    const stateClass = t.active ? 'on' : (t.link_up ? 'mid' : 'off');
+    const isPinned = pinned && iface === pinned;
+    const inPool = Boolean(t.in_pool);
+    const state = t.healthy ? 'healthy' : (t.active ? 'active' : (t.link_up ? 'up' : 'down'));
+    const stateClass = t.healthy ? 'on' : (t.active || t.link_up ? 'mid' : 'off');
 
     const meta = [];
+    if (inPool) meta.push('pool');
+    if (isPinned) meta.push('pinned');
     if (t.tool && t.tool !== '-') meta.push(String(t.tool));
     if (t.endpoint) meta.push(String(t.endpoint));
     if (t.handshake) meta.push('hs: ' + String(t.handshake));
+    if (t.probe) meta.push(String(t.probe));
     if (!meta.length) meta.push(String(t.reason || '—'));
 
     const xfer = '↓ ' + String(t.rx || '—') + ' · ↑ ' + String(t.tx || '—');
 
     return '<div class="routing-row">' +
       '<div class="routing-iface">' + esc(iface) +
-      (isSelected ? '<span class="routing-tag">selected</span>' : '') +
+      (isSelected ? '<span class="routing-tag">active</span>' : '') +
+      (isPinned ? '<span class="routing-tag">pinned</span>' : '') +
       '</div>' +
       '<div class="routing-state ' + stateClass + '">' + esc(state) + '</div>' +
       '<div class="routing-meta" title="' + esc(meta.join(' · ')) + '">' + esc(meta.join(' · ')) + '</div>' +

--- a/src/ctl/dashboard_assets/static/index.html
+++ b/src/ctl/dashboard_assets/static/index.html
@@ -169,9 +169,9 @@
         <button class="ui-btn active" id="routingUpstreamApply" type="button">Apply</button>
       </div>
       <div class="routing-extra-ctl" id="routingTunnelCtl" style="display:none">
-        <label for="routingTunnelIfaceSelect">Tunnel iface</label>
+        <label for="routingTunnelIfaceSelect">Tunnel pin</label>
         <select id="routingTunnelIfaceSelect" class="ui-select"></select>
-        <button class="ui-btn" id="routingTunnelIfaceApply" type="button">Set iface</button>
+        <button class="ui-btn" id="routingTunnelIfaceApply" type="button">Pin</button>
       </div>
       <div class="routing-extra-ctl" id="routingProxyCtl" style="display:none">
         <label id="routingProxyHostLabel" for="routingProxyHost">Proxy host</label>

--- a/src/ctl/i18n.zig
+++ b/src/ctl/i18n.zig
@@ -296,9 +296,9 @@ const en_strings = [_][]const u8{
     // install_middle_proxy_prompt
     "Enable MiddleProxy (Telegram relay)?",
     // install_middle_proxy_help
-    "Routes traffic through Telegram's relay servers.\nUses more RAM (~2 MB per connection) but is required for:\n  • Promo tag / sponsored messages (ad_tag)\n  • Media loading (photos, video, stories) on non-Premium accounts",
+    "Routes traffic through Telegram's relay servers.\nUses more RAM (~2 MB per connection) but is required for:\n  • Promo tag / sponsored messages (ad_tag)\n  • Media loading (photos, video, stories) on non-Premium accounts\n\nTelegram calls are not supported: they require SOCKS-style paths that cannot be masked cleanly as HTTPS.",
     // install_middle_proxy_warn
-    "Without MiddleProxy: promo tags will not work, and non-Premium users may fail to load media.",
+    "Without MiddleProxy: promo tags will not work, and media on non-Premium accounts will not load. Telegram calls are unsupported.",
     // install_checking_deps
     "Installing system dependencies...",
     // install_resolving_tag
@@ -527,9 +527,9 @@ const ru_strings = [_][]const u8{
     // install_middle_proxy_prompt
     "Включить MiddleProxy (релей Telegram)?",
     // install_middle_proxy_help
-    "Маршрутизирует трафик через релей-серверы Telegram.\nПотребляет больше RAM (~2 МБ на подключение), но необходим для:\n  • Промо-тега / спонсорских сообщений (ad_tag)\n  • Загрузки медиа (фото, видео, истории) на аккаунтах без Premium",
+    "Маршрутизирует трафик через релей-серверы Telegram.\nПотребляет больше RAM (~2 МБ на подключение), но необходим для:\n  • Промо-тега / спонсорских сообщений (ad_tag)\n  • Загрузки медиа (фото, видео, истории) на аккаунтах без Premium\n\nЗвонки не поддерживаются: Telegram проводит их только через SOCKS-пути, которые нельзя нормально замаскировать под HTTPS.",
     // install_middle_proxy_warn
-    "Без MiddleProxy: промо-тег не будет работать, а у пользователей без Premium могут не загружаться медиа.",
+    "Без MiddleProxy: промо-тег не будет работать, а медиа на аккаунтах без Premium не будут загружаться. Звонки не поддерживаются.",
     // install_checking_deps
     "Установка системных зависимостей...",
     // install_resolving_tag

--- a/src/ctl/i18n.zig
+++ b/src/ctl/i18n.zig
@@ -81,6 +81,15 @@ pub const S = enum(u16) {
     // ── Tunnel ──
     tunnel_conf_prompt,
     tunnel_conf_help,
+    tunnel_vpn_type_prompt,
+    tunnel_vpn_amneziawg,
+    tunnel_pool_current,
+    tunnel_pool_empty,
+    tunnel_pool_action_prompt,
+    tunnel_pool_action_create,
+    tunnel_pool_action_replace,
+    tunnel_pool_selected_iface,
+    tunnel_pool_replace_warn,
 
     // ── Install ──
     install_header,
@@ -249,6 +258,24 @@ const en_strings = [_][]const u8{
     "VPN config or share link",
     // tunnel_conf_help
     "Path to a .conf file, or an Amnezia vpn:// share link.",
+    // tunnel_vpn_type_prompt
+    "VPN type",
+    // tunnel_vpn_amneziawg
+    "AmneziaWG",
+    // tunnel_pool_current
+    "Configured tunnel pool:",
+    // tunnel_pool_empty
+    "No tunnel pool configured yet.",
+    // tunnel_pool_action_prompt
+    "Tunnel pool action",
+    // tunnel_pool_action_create
+    "Create new tunnel",
+    // tunnel_pool_action_replace
+    "Replace existing tunnel",
+    // tunnel_pool_selected_iface
+    "Selected tunnel interface",
+    // tunnel_pool_replace_warn
+    "The selected tunnel config will be replaced.",
 
     // ── Install ──
     // install_header
@@ -480,6 +507,24 @@ const ru_strings = [_][]const u8{
     "Конфигурация VPN или ссылка",
     // tunnel_conf_help
     "Путь к .conf файлу или ссылка vpn:// из Amnezia.",
+    // tunnel_vpn_type_prompt
+    "Тип VPN",
+    // tunnel_vpn_amneziawg
+    "AmneziaWG",
+    // tunnel_pool_current
+    "Настроенный пул туннелей:",
+    // tunnel_pool_empty
+    "Пул туннелей пока не настроен.",
+    // tunnel_pool_action_prompt
+    "Действие с пулом туннелей",
+    // tunnel_pool_action_create
+    "Создать новый туннель",
+    // tunnel_pool_action_replace
+    "Заменить существующий туннель",
+    // tunnel_pool_selected_iface
+    "Выбранный интерфейс туннеля",
+    // tunnel_pool_replace_warn
+    "Конфиг выбранного туннеля будет заменен.",
 
     // ── Install ──
     // install_header

--- a/src/ctl/main.zig
+++ b/src/ctl/main.zig
@@ -375,7 +375,7 @@ fn printHelp(lang: i18n.Lang) void {
     printCmd(&ui, "update", tr(lang, "Update to latest GitHub release", "Обновить до последнего GitHub релиза"));
     printCmd(&ui, "setup masking", tr(lang, "Setup local Nginx DPI masking", "Настроить локальную DPI-маскировку через Nginx"));
     printCmd(&ui, "setup nfqws", tr(lang, "Setup nfqws TCP desync (Zapret)", "Настроить nfqws TCP desync (Zapret)"));
-    printCmd(&ui, "setup tunnel [--iface awgN] <conf|vpn://>", tr(lang, "Setup VPN tunnel pool member (AmneziaWG, WireGuard, ...)", "Настроить участника пула VPN-туннелей (AmneziaWG, WireGuard, ...)"));
+    printCmd(&ui, "setup tunnel [--iface awgN] <conf|vpn://>", tr(lang, "Setup AmneziaWG tunnel pool member", "Настроить участника пула туннелей AmneziaWG"));
     printCmd(&ui, "setup dashboard", tr(lang, "Install web monitoring dashboard", "Установить веб-дашборд мониторинга"));
     printCmd(&ui, "setup recovery", tr(lang, "Install DPI auto-recovery", "Установить авто-восстановление DPI"));
     printCmd(&ui, "ipv6-hop", tr(lang, "IPv6 address rotation", "Ротация IPv6 адреса"));

--- a/src/ctl/main.zig
+++ b/src/ctl/main.zig
@@ -375,7 +375,7 @@ fn printHelp(lang: i18n.Lang) void {
     printCmd(&ui, "update", tr(lang, "Update to latest GitHub release", "Обновить до последнего GitHub релиза"));
     printCmd(&ui, "setup masking", tr(lang, "Setup local Nginx DPI masking", "Настроить локальную DPI-маскировку через Nginx"));
     printCmd(&ui, "setup nfqws", tr(lang, "Setup nfqws TCP desync (Zapret)", "Настроить nfqws TCP desync (Zapret)"));
-    printCmd(&ui, "setup tunnel <conf|vpn://>", tr(lang, "Setup VPN tunnel (AmneziaWG, WireGuard, ...)", "Настроить VPN-туннель (AmneziaWG, WireGuard, ...)"));
+    printCmd(&ui, "setup tunnel [--iface awgN] <conf|vpn://>", tr(lang, "Setup VPN tunnel pool member (AmneziaWG, WireGuard, ...)", "Настроить участника пула VPN-туннелей (AmneziaWG, WireGuard, ...)"));
     printCmd(&ui, "setup dashboard", tr(lang, "Install web monitoring dashboard", "Установить веб-дашборд мониторинга"));
     printCmd(&ui, "setup recovery", tr(lang, "Install DPI auto-recovery", "Установить авто-восстановление DPI"));
     printCmd(&ui, "ipv6-hop", tr(lang, "IPv6 address rotation", "Ротация IPv6 адреса"));

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -46,6 +46,11 @@ const AwgQuickValidation = enum {
     invalid_config,
 };
 
+const InteractiveTunnelSelection = struct {
+    iface: []const u8,
+    replacing_existing: bool,
+};
+
 /// Run in CLI mode.
 pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) !void {
     var opts = TunnelOpts{};
@@ -79,6 +84,23 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
 pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
     ui.section(i18n.get(ui.lang, .menu_setup_tunnel));
 
+    try chooseInteractiveVpnType(ui);
+
+    const selection = chooseInteractiveTunnelTarget(ui, allocator) catch |err| {
+        switch (err) {
+            error.InvalidInterfaceName => ui.fail("Invalid tunnel interface name. Use names like awg0, awg1, wg0."),
+            error.NoFreeInterface => ui.fail("No free awgN interface name found"),
+            else => ui.fail("Failed to prepare tunnel pool selection"),
+        }
+        return;
+    };
+    defer allocator.free(selection.iface);
+
+    if (selection.replacing_existing) {
+        ui.warn(i18n.get(ui.lang, .tunnel_pool_replace_warn));
+    }
+    ui.stepOk(i18n.get(ui.lang, .tunnel_pool_selected_iface), selection.iface);
+
     var conf_buf: [16 * 1024]u8 = undefined;
     const conf_source = try ui.input(
         i18n.get(ui.lang, .tunnel_conf_prompt),
@@ -92,7 +114,71 @@ pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
         return;
     }
 
-    try execute(ui, allocator, .{ .awg_source = conf_source });
+    try execute(ui, allocator, .{ .awg_source = conf_source, .iface = selection.iface });
+}
+
+fn chooseInteractiveVpnType(ui: *Tui) !void {
+    const items = [_][]const u8{
+        i18n.get(ui.lang, .tunnel_vpn_amneziawg),
+    };
+    _ = try ui.menu(i18n.get(ui.lang, .tunnel_vpn_type_prompt), &items);
+    ui.stepOk(i18n.get(ui.lang, .tunnel_vpn_type_prompt), i18n.get(ui.lang, .tunnel_vpn_amneziawg));
+}
+
+fn chooseInteractiveTunnelTarget(ui: *Tui, allocator: std.mem.Allocator) !InteractiveTunnelSelection {
+    const pool = try loadConfiguredTunnelPool(allocator);
+    defer freeOwnedStringSlice(allocator, pool);
+
+    if (pool.len == 0) {
+        ui.info(i18n.get(ui.lang, .tunnel_pool_empty));
+    } else {
+        ui.info(i18n.get(ui.lang, .tunnel_pool_current));
+        for (pool, 0..) |iface, idx| {
+            ui.print("     {d}. {s}\n", .{ idx + 1, iface });
+        }
+    }
+
+    const next_iface = try selectTunnelInterface(allocator, "");
+    defer allocator.free(next_iface);
+
+    var items: std.ArrayList([]const u8) = .empty;
+    defer {
+        for (items.items) |item| allocator.free(item);
+        items.deinit(allocator);
+    }
+
+    try items.append(
+        allocator,
+        try std.fmt.allocPrint(
+            allocator,
+            "{s} ({s})",
+            .{ i18n.get(ui.lang, .tunnel_pool_action_create), next_iface },
+        ),
+    );
+
+    for (pool) |iface| {
+        try items.append(
+            allocator,
+            try std.fmt.allocPrint(
+                allocator,
+                "{s}: {s}",
+                .{ i18n.get(ui.lang, .tunnel_pool_action_replace), iface },
+            ),
+        );
+    }
+
+    const selected = try ui.menu(i18n.get(ui.lang, .tunnel_pool_action_prompt), items.items);
+    if (selected == 0) {
+        return .{
+            .iface = try allocator.dupe(u8, next_iface),
+            .replacing_existing = false,
+        };
+    }
+
+    return .{
+        .iface = try allocator.dupe(u8, pool[selected - 1]),
+        .replacing_existing = true,
+    };
 }
 
 fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
@@ -825,6 +911,13 @@ fn loadTunnelPoolFromDoc(allocator: std.mem.Allocator, doc: *toml.TomlDoc) ![]co
     }
 
     return &.{};
+}
+
+fn loadConfiguredTunnelPool(allocator: std.mem.Allocator) ![]const []const u8 {
+    var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch return &.{};
+    defer doc.deinit();
+
+    return try loadTunnelPoolFromDoc(allocator, &doc);
 }
 
 fn containsInterface(values: []const []const u8, iface: []const u8) bool {

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -16,8 +16,9 @@ const INSTALL_DIR = "/opt/mtproto-proxy";
 const AWG_CONF_DIR = "/etc/amnezia/amneziawg";
 const AWG_IFACE_CONF_PATH = "/etc/amnezia/awg0.conf";
 const TUNNEL_SCRIPT = "/usr/local/bin/setup_tunnel.sh";
+const TUNNEL_POOL_SERVICE = "/etc/systemd/system/mtproto-tunnel-pool.service";
+const TUNNEL_POOL_TIMER = "/etc/systemd/system/mtproto-tunnel-pool.timer";
 const SERVICE_FILE = "/etc/systemd/system/mtproto-proxy.service";
-const AWG_CONFIG_PATH = AWG_CONF_DIR ++ "/awg0.conf";
 const TUNNEL_MARK: u32 = 200;
 const TUNNEL_TABLE: u32 = 200;
 
@@ -31,6 +32,7 @@ fn readFileAllocCwd(allocator: std.mem.Allocator, path: []const u8, limit: usize
 
 pub const TunnelOpts = struct {
     awg_source: []const u8 = "",
+    iface: []const u8 = "",
 };
 
 const AwgConfigKind = enum {
@@ -55,13 +57,18 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
             continue;
         }
 
+        if (std.mem.eql(u8, arg, "--iface")) {
+            opts.iface = args.next() orelse "";
+            continue;
+        }
+
         if (arg.len > 0 and arg[0] != '-') {
             opts.awg_source = arg;
         }
     }
 
     if (opts.awg_source.len == 0) {
-        ui.fail("Usage: mtbuddy setup tunnel <conf-path-or-vpn-link>");
+        ui.fail("Usage: mtbuddy setup tunnel [--iface awgN] <conf-path-or-vpn-link>");
         return;
     }
 
@@ -118,12 +125,28 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
         ui.ok("AmneziaWG installed");
     }
 
+    const iface = selectTunnelInterface(allocator, opts.iface) catch |err| {
+        switch (err) {
+            error.InvalidInterfaceName => ui.fail("Invalid tunnel interface name. Use names like awg0, awg1, wg0."),
+            error.NoFreeInterface => ui.fail("No free awgN interface name found"),
+            else => ui.fail("Failed to select tunnel interface"),
+        }
+        return;
+    };
+    defer allocator.free(iface);
+
+    var config_path_buf: [256]u8 = undefined;
+    const awg_config_path = awgConfigPath(&config_path_buf, iface) catch {
+        ui.fail("Tunnel interface name is too long");
+        return;
+    };
+
     // ── Copy AWG config ──
     ui.step("Installing AmneziaWG config...");
     _ = sys.exec(allocator, &.{ "mkdir", "-p", "/etc/amnezia" }) catch {};
     _ = sys.exec(allocator, &.{ "mkdir", "-p", AWG_CONF_DIR }) catch {};
 
-    const config_kind = installAwgConfigSource(allocator, awg_source, AWG_CONFIG_PATH) catch |err| {
+    const config_kind = installAwgConfigSource(allocator, awg_source, awg_config_path) catch |err| {
         switch (err) {
             error.ConfigSourceNotFound => ui.fail("Config file not found"),
             error.UnsupportedConfigFormat => ui.fail("Unsupported VPN config format. Use a WireGuard/AmneziaWG .conf file, or an Amnezia vpn:// share link."),
@@ -136,24 +159,26 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
     if (config_kind == .amnezia_vpn_link) {
         ui.warn("Converted Amnezia vpn:// link to AmneziaWG config");
     }
-    _ = sys.execForward(&.{ "ln", "-sfn", AWG_CONFIG_PATH, AWG_IFACE_CONF_PATH }) catch {};
+    if (std.mem.eql(u8, iface, "awg0")) {
+        _ = sys.execForward(&.{ "ln", "-sfn", awg_config_path, AWG_IFACE_CONF_PATH }) catch {};
+    }
 
-    const dns_removed = stripAwgDnsLines(allocator, AWG_CONFIG_PATH) catch false;
+    const dns_removed = stripAwgDnsLines(allocator, awg_config_path) catch false;
     if (dns_removed) {
-        ui.warn("Removed DNS from awg0.conf (host resolver will be used)");
+        ui.warn("Removed DNS from tunnel config (host resolver will be used)");
     }
 
-    const empty_removed = stripAwgEmptyAssignments(allocator, AWG_CONFIG_PATH) catch false;
+    const empty_removed = stripAwgEmptyAssignments(allocator, awg_config_path) catch false;
     if (empty_removed) {
-        ui.warn("Removed empty AmneziaWG parameters from awg0.conf");
+        ui.warn("Removed empty AmneziaWG parameters from tunnel config");
     }
 
-    const table_off_added = ensureAwgTableOff(allocator, AWG_CONFIG_PATH) catch false;
+    const table_off_added = ensureAwgTableOff(allocator, awg_config_path) catch false;
     if (table_off_added) {
-        ui.warn("Added Table = off to [Interface] in awg0.conf");
+        ui.warn("Added Table = off to [Interface] in tunnel config");
     }
 
-    switch (validateAwgQuickConfig(allocator)) {
+    switch (validateAwgQuickConfig(allocator, awg_config_path)) {
         .ok => {},
         .missing_binary => {
             ui.fail("AmneziaWG tools are not available (`awg-quick` was not found). Install amneziawg-tools and retry.");
@@ -165,34 +190,16 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
         },
     }
 
-    ui.ok("Config installed to " ++ AWG_CONFIG_PATH);
+    ui.stepOk("Config installed", awg_config_path);
 
     // ── Create tunnel policy script ──
     ui.step("Creating tunnel policy routing script...");
 
-    var tunnel_script_buf: [2048]u8 = undefined;
-    const tunnel_script = std.fmt.bufPrint(&tunnel_script_buf,
-        \\#!/bin/bash
-        \\set -euo pipefail
-        \\IFACE="awg0"
-        \\MARK={[mark]d}
-        \\TABLE={[table]d}
-        \\
-        \\awg-quick down "$IFACE" 2>/dev/null || true
-        \\awg-quick up "$IFACE"
-        \\
-        \\ip -4 route flush table "$TABLE" 2>/dev/null || true
-        \\ip -4 route add default dev "$IFACE" table "$TABLE"
-        \\ip -4 rule del fwmark "$MARK" table "$TABLE" 2>/dev/null || true
-        \\ip -4 rule add fwmark "$MARK" table "$TABLE" priority 1200
-        \\
-        \\echo "Tunnel routing ready: fwmark=$MARK -> table $TABLE via $IFACE"
-    , .{ .mark = TUNNEL_MARK, .table = TUNNEL_TABLE }) catch "";
-
-    if (tunnel_script.len == 0) {
+    const tunnel_script = renderTunnelPoolScript(allocator) catch {
         ui.fail("Failed to render tunnel setup script");
         return;
-    }
+    };
+    defer allocator.free(tunnel_script);
 
     sys.writeFileMode(TUNNEL_SCRIPT, tunnel_script, 0o755) catch {
         ui.fail("Failed to write tunnel setup script");
@@ -234,10 +241,12 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
     _ = sys.execForward(&.{ "systemctl", "daemon-reload" }) catch {};
     ui.ok("Systemd service patched for tunnel policy routing");
 
+    installTunnelPoolUnits(ui, allocator);
+
     // ── Configure proxy egress mode ──
-    setUpstreamType(allocator, "tunnel");
+    setTunnelPoolConfig(allocator, iface);
     ui.stepOk("Set [upstream].type", "tunnel");
-    ui.stepOk("Set [upstream.tunnel].interface", "awg0");
+    ui.stepOk("Added tunnel pool interface", iface);
     ui.stepOk("Preserved [general].use_middle_proxy", "unchanged");
 
     // ── Inject public IP (preserve existing custom value) ──
@@ -312,13 +321,15 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
     // ── Validate tunnel routing ──
     ui.step("Validating policy routing to Telegram DCs...");
 
-    const awg_status = sys.exec(allocator, &.{ "awg", "show", "awg0" }) catch null;
+    _ = sys.execForward(&.{TUNNEL_SCRIPT}) catch {};
+
+    const awg_status = sys.exec(allocator, &.{ "awg", "show", iface }) catch null;
     if (awg_status) |result| {
         defer result.deinit();
         if (result.exit_code == 0) {
-            ui.stepOk("Tunnel interface active", "awg0");
+            ui.stepOk("Tunnel interface active", iface);
         } else {
-            ui.warn("awg0 is not active (check AWG config and endpoint)");
+            ui.warn("Tunnel interface is not active (check AWG config and endpoint)");
         }
     }
 
@@ -334,8 +345,8 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
 
         if (r) |route_result| {
             defer route_result.deinit();
-            if (route_result.exit_code == 0 and std.mem.indexOf(u8, route_result.stdout, "dev awg0") != null) {
-                ui.stepOk("Policy route via awg0", dc_ip);
+            if (route_result.exit_code == 0 and std.mem.indexOf(u8, route_result.stdout, "dev ") != null) {
+                ui.stepOk("Policy route via tunnel pool", dc_ip);
             } else {
                 var warn_buf: [96]u8 = undefined;
                 const warn_msg = std.fmt.bufPrint(&warn_buf, "Policy route check failed for {s}", .{dc_ip}) catch "Policy route check failed";
@@ -348,12 +359,13 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
     ui.summaryBox("VPN Tunnel Configured", &.{
         .{ .label = "Status:", .value = "systemctl status mtproto-proxy" },
         .{ .label = "Logs:", .value = "journalctl -u mtproto-proxy -f" },
-        .{ .label = "Tunnel:", .value = "awg show awg0" },
+        .{ .label = "Tunnel:", .value = "awg show <iface>" },
+        .{ .label = "Pool:", .value = "systemctl status mtproto-tunnel-pool.timer" },
         .{ .label = "Policy:", .value = "ip -4 rule show | grep fwmark" },
         .{ .label = "Mark:", .value = "SO_MARK=200 -> table 200" },
         .{ .label = "", .style = .blank },
         .{ .label = "Proxy runs in host network namespace", .style = .success },
-        .{ .label = "Tunnel routing is socket-level and explicit", .style = .success },
+        .{ .label = "Tunnel pool failover is socket-level and explicit", .style = .success },
         .{ .label = "SOCKS5/HTTP upstream stay orthogonal", .style = .success },
     });
 }
@@ -733,26 +745,448 @@ fn firstDiagnosticLine(output: []const u8) ?[]const u8 {
     return first_non_empty;
 }
 
-fn validateAwgQuickConfig(allocator: std.mem.Allocator) AwgQuickValidation {
+fn validateAwgQuickConfig(allocator: std.mem.Allocator, path: []const u8) AwgQuickValidation {
     if (!sys.commandExists("awg-quick")) return .missing_binary;
 
-    const result = sys.exec(allocator, &.{ "awg-quick", "strip", AWG_CONFIG_PATH }) catch return .missing_binary;
+    const result = sys.exec(allocator, &.{ "awg-quick", "strip", path }) catch return .missing_binary;
     defer result.deinit();
     return if (result.exit_code == 0) .ok else .invalid_config;
 }
 
-fn setUpstreamType(allocator: std.mem.Allocator, value: []const u8) void {
+fn awgConfigPath(buf: []u8, iface: []const u8) ![]const u8 {
+    return try std.fmt.bufPrint(buf, "{s}/{s}.conf", .{ AWG_CONF_DIR, iface });
+}
+
+fn isValidTunnelInterfaceName(iface: []const u8) bool {
+    if (iface.len == 0 or iface.len > 32) return false;
+    for (iface) |ch| {
+        if (std.ascii.isAlphanumeric(ch) or ch == '_' or ch == '-' or ch == '.') continue;
+        return false;
+    }
+    return true;
+}
+
+fn freeOwnedStringSlice(allocator: std.mem.Allocator, values: []const []const u8) void {
+    if (values.len == 0) return;
+    for (values) |value| allocator.free(value);
+    allocator.free(values);
+}
+
+fn parseTunnelInterfaceArray(allocator: std.mem.Allocator, value: []const u8) ![]const []const u8 {
+    const trimmed = std.mem.trim(u8, value, &[_]u8{ ' ', '\t', '\r', '\n' });
+    if (trimmed.len < 2 or trimmed[0] != '[' or trimmed[trimmed.len - 1] != ']') {
+        return error.InvalidInterfaceArray;
+    }
+
+    var list: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (list.items) |item| allocator.free(item);
+        list.deinit(allocator);
+    }
+
+    var i: usize = 1;
+    while (i + 1 < trimmed.len) {
+        while (i + 1 < trimmed.len and (trimmed[i] == ' ' or trimmed[i] == '\t' or trimmed[i] == ',')) : (i += 1) {}
+        if (i + 1 >= trimmed.len or trimmed[i] == ']') break;
+
+        const quoted = trimmed[i] == '"';
+        const start: usize = if (quoted) blk: {
+            i += 1;
+            break :blk i;
+        } else i;
+        while (i < trimmed.len and ((quoted and trimmed[i] != '"') or (!quoted and trimmed[i] != ',' and trimmed[i] != ']'))) : (i += 1) {}
+        const item = std.mem.trim(u8, trimmed[start..i], &[_]u8{ ' ', '\t', '\r', '\n' });
+        if (quoted and i < trimmed.len and trimmed[i] == '"') i += 1;
+        if (item.len > 0 and isValidTunnelInterfaceName(item)) {
+            try list.append(allocator, try allocator.dupe(u8, item));
+        }
+    }
+
+    if (list.items.len == 0) {
+        list.deinit(allocator);
+        return &.{};
+    }
+    return try list.toOwnedSlice(allocator);
+}
+
+fn loadTunnelPoolFromDoc(allocator: std.mem.Allocator, doc: *toml.TomlDoc) ![]const []const u8 {
+    if (doc.get("upstream.tunnel", "interfaces")) |raw_interfaces| {
+        const parsed = parseTunnelInterfaceArray(allocator, raw_interfaces) catch &.{};
+        if (parsed.len > 0) return parsed;
+    }
+
+    if (doc.get("upstream.tunnel", "interface")) |legacy_iface| {
+        const trimmed = std.mem.trim(u8, legacy_iface, &[_]u8{ ' ', '\t', '\r', '\n' });
+        if (isValidTunnelInterfaceName(trimmed)) {
+            const values = try allocator.alloc([]const u8, 1);
+            values[0] = try allocator.dupe(u8, trimmed);
+            return values;
+        }
+    }
+
+    return &.{};
+}
+
+fn containsInterface(values: []const []const u8, iface: []const u8) bool {
+    for (values) |value| {
+        if (std.mem.eql(u8, value, iface)) return true;
+    }
+    return false;
+}
+
+fn appendInterfaceIfMissing(allocator: std.mem.Allocator, values: []const []const u8, iface: []const u8) ![]const []const u8 {
+    var out: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (out.items) |value| allocator.free(value);
+        out.deinit(allocator);
+    }
+
+    for (values) |value| {
+        try out.append(allocator, try allocator.dupe(u8, value));
+    }
+    if (!containsInterface(values, iface)) {
+        try out.append(allocator, try allocator.dupe(u8, iface));
+    }
+    if (out.items.len == 0) {
+        out.deinit(allocator);
+        return &.{};
+    }
+    return try out.toOwnedSlice(allocator);
+}
+
+fn nextAwgInterfaceNameFromPool(allocator: std.mem.Allocator, used: []const []const u8) ![]const u8 {
+    var i: usize = 0;
+    while (i < 64) : (i += 1) {
+        var buf: [16]u8 = undefined;
+        const candidate = try std.fmt.bufPrint(&buf, "awg{d}", .{i});
+        if (!containsInterface(used, candidate)) return try allocator.dupe(u8, candidate);
+    }
+    return error.NoFreeInterface;
+}
+
+fn selectTunnelInterface(allocator: std.mem.Allocator, requested: []const u8) ![]u8 {
+    const trimmed_requested = std.mem.trim(u8, requested, &[_]u8{ ' ', '\t', '\r', '\n' });
+    if (trimmed_requested.len > 0) {
+        if (!isValidTunnelInterfaceName(trimmed_requested)) return error.InvalidInterfaceName;
+        return try allocator.dupe(u8, trimmed_requested);
+    }
+
+    var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch {
+        return try allocator.dupe(u8, "awg0");
+    };
+    defer doc.deinit();
+
+    const pool = try loadTunnelPoolFromDoc(allocator, &doc);
+    defer freeOwnedStringSlice(allocator, pool);
+
+    var i: usize = 0;
+    while (i < 64) : (i += 1) {
+        var name_buf: [16]u8 = undefined;
+        const candidate = try std.fmt.bufPrint(&name_buf, "awg{d}", .{i});
+        var path_buf: [256]u8 = undefined;
+        const path = awgConfigPath(&path_buf, candidate) catch continue;
+        if (!containsInterface(pool, candidate) and !sys.fileExists(path)) {
+            return try allocator.dupe(u8, candidate);
+        }
+    }
+
+    return error.NoFreeInterface;
+}
+
+fn formatInterfaceArrayLiteral(allocator: std.mem.Allocator, values: []const []const u8) ![]const u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.append(allocator, '[');
+    for (values, 0..) |value, idx| {
+        if (idx > 0) try out.appendSlice(allocator, ", ");
+        try out.append(allocator, '"');
+        try out.appendSlice(allocator, value);
+        try out.append(allocator, '"');
+    }
+    try out.append(allocator, ']');
+    return try out.toOwnedSlice(allocator);
+}
+
+fn setTunnelPoolConfig(allocator: std.mem.Allocator, iface: []const u8) void {
     var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch return;
     defer doc.deinit();
 
-    var quoted_buf: [64]u8 = undefined;
-    const quoted = std.fmt.bufPrint(&quoted_buf, "\"{s}\"", .{value}) catch return;
-    doc.set("upstream", "type", quoted) catch return;
+    doc.set("upstream", "type", "\"tunnel\"") catch return;
 
-    // Default to AmneziaWG interface when setting up tunnel via this script
-    doc.set("upstream.tunnel", "interface", "\"awg0\"") catch return;
+    const existing = loadTunnelPoolFromDoc(allocator, &doc) catch &.{};
+    defer freeOwnedStringSlice(allocator, existing);
+
+    const pool = appendInterfaceIfMissing(allocator, existing, iface) catch return;
+    defer freeOwnedStringSlice(allocator, pool);
+
+    if (pool.len > 0) {
+        var first_buf: [64]u8 = undefined;
+        const first = std.fmt.bufPrint(&first_buf, "\"{s}\"", .{pool[0]}) catch return;
+        doc.set("upstream.tunnel", "interface", first) catch return;
+    }
+
+    const array_literal = formatInterfaceArrayLiteral(allocator, pool) catch return;
+    defer allocator.free(array_literal);
+    doc.set("upstream.tunnel", "interfaces", array_literal) catch return;
 
     doc.save(INSTALL_DIR ++ "/config.toml") catch {};
+}
+
+fn installTunnelPoolUnits(ui: *Tui, allocator: std.mem.Allocator) void {
+    const service =
+        \\[Unit]
+        \\Description=MTProto tunnel pool failover
+        \\Documentation=https://github.com/sleep3r/mtproto.zig
+        \\After=network-online.target
+        \\Wants=network-online.target
+        \\
+        \\[Service]
+        \\Type=oneshot
+        \\ExecStart=/usr/local/bin/setup_tunnel.sh
+        \\AmbientCapabilities=CAP_NET_ADMIN
+    ;
+
+    const timer =
+        \\[Unit]
+        \\Description=Run MTProto tunnel pool failover checks
+        \\
+        \\[Timer]
+        \\OnBootSec=30s
+        \\OnUnitActiveSec=30s
+        \\RandomizedDelaySec=5s
+        \\Persistent=true
+        \\
+        \\[Install]
+        \\WantedBy=timers.target
+    ;
+
+    sys.writeFile(TUNNEL_POOL_SERVICE, service) catch {
+        ui.warn("Failed to write mtproto-tunnel-pool.service");
+        return;
+    };
+    sys.writeFile(TUNNEL_POOL_TIMER, timer) catch {
+        ui.warn("Failed to write mtproto-tunnel-pool.timer");
+        return;
+    };
+
+    _ = sys.execForward(&.{ "systemctl", "daemon-reload" }) catch {};
+    _ = sys.exec(allocator, &.{ "systemctl", "enable", "--now", "mtproto-tunnel-pool.timer" }) catch {};
+    ui.ok("Tunnel pool failover timer installed");
+}
+
+fn renderTunnelPoolScript(allocator: std.mem.Allocator) ![]const u8 {
+    return try allocator.dupe(u8,
+        \\#!/usr/bin/env bash
+        \\set -euo pipefail
+        \\
+        \\CONFIG_FILE="/opt/mtproto-proxy/config.toml"
+        \\CONF_DIR="/etc/amnezia/amneziawg"
+        \\STATE_DIR="/run/mtproto-proxy"
+        \\STATE_FILE="$STATE_DIR/tunnel-pool.state"
+        \\MARK=200
+        \\TABLE=200
+        \\PROBE_URL="https://core.telegram.org/getProxyConfig"
+        \\
+        \\mkdir -p "$STATE_DIR"
+        \\
+        \\log() {
+        \\    logger -t mtproto-tunnel-pool "$*" 2>/dev/null || true
+        \\}
+        \\
+        \\read_tunnel_key() {
+        \\    local want_key="$1"
+        \\    [[ -f "$CONFIG_FILE" ]] || return 1
+        \\    awk -v want_key="$want_key" '
+        \\        BEGIN { in_section=0; value="" }
+        \\        /^[[:space:]]*\[upstream\.tunnel\][[:space:]]*$/ { in_section=1; next }
+        \\        /^[[:space:]]*\[[^]]+\][[:space:]]*$/ { in_section=0; next }
+        \\        in_section {
+        \\            line=$0
+        \\            sub(/[;#].*/, "", line)
+        \\            if (line ~ "^[[:space:]]*" want_key "[[:space:]]*=") {
+        \\                sub(/^[^=]*=/, "", line)
+        \\                gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+        \\                gsub(/^"|"$/, "", line)
+        \\                value=line
+        \\            }
+        \\        }
+        \\        END { if (value != "") print value }
+        \\    ' "$CONFIG_FILE"
+        \\}
+        \\
+        \\trim() {
+        \\    local v="$1"
+        \\    v="${v#"${v%%[![:space:]]*}"}"
+        \\    v="${v%"${v##*[![:space:]]}"}"
+        \\    printf '%s\n' "$v"
+        \\}
+        \\
+        \\parse_interfaces() {
+        \\    local raw="$1"
+        \\    raw="${raw#[}"
+        \\    raw="${raw%]}"
+        \\    raw="${raw//\"/}"
+        \\    local old_ifs="$IFS"
+        \\    IFS=','
+        \\    read -r -a parts <<< "$raw"
+        \\    IFS="$old_ifs"
+        \\    for item in "${parts[@]}"; do
+        \\        item="$(trim "$item")"
+        \\        [[ -n "$item" ]] && printf '%s\n' "$item"
+        \\    done
+        \\}
+        \\
+        \\add_unique() {
+        \\    local item="$1"
+        \\    [[ -n "$item" ]] || return 0
+        \\    local existing
+        \\    for existing in "${candidates[@]}"; do
+        \\        [[ "$existing" == "$item" ]] && return 0
+        \\    done
+        \\    candidates+=("$item")
+        \\}
+        \\
+        \\conf_path_for() {
+        \\    local iface="$1"
+        \\    if [[ -f "$CONF_DIR/${iface}.conf" ]]; then
+        \\        printf '%s/%s.conf\n' "$CONF_DIR" "$iface"
+        \\    elif [[ -f "/etc/wireguard/${iface}.conf" ]]; then
+        \\        printf '/etc/wireguard/%s.conf\n' "$iface"
+        \\    else
+        \\        printf '%s/%s.conf\n' "$CONF_DIR" "$iface"
+        \\    fi
+        \\}
+        \\
+        \\quick_tool_for() {
+        \\    local iface="$1"
+        \\    if [[ "$iface" == wg* ]] && command -v wg-quick >/dev/null 2>&1; then
+        \\        printf 'wg-quick\n'
+        \\        return
+        \\    fi
+        \\    if command -v awg-quick >/dev/null 2>&1; then
+        \\        printf 'awg-quick\n'
+        \\        return
+        \\    fi
+        \\    if command -v wg-quick >/dev/null 2>&1; then
+        \\        printf 'wg-quick\n'
+        \\        return
+        \\    fi
+        \\    return 1
+        \\}
+        \\
+        \\show_tool_for() {
+        \\    local iface="$1"
+        \\    if [[ "$iface" == wg* ]] && command -v wg >/dev/null 2>&1; then
+        \\        printf 'wg\n'
+        \\        return
+        \\    fi
+        \\    if command -v awg >/dev/null 2>&1; then
+        \\        printf 'awg\n'
+        \\        return
+        \\    fi
+        \\    if command -v wg >/dev/null 2>&1; then
+        \\        printf 'wg\n'
+        \\        return
+        \\    fi
+        \\    return 1
+        \\}
+        \\
+        \\ensure_iface_up() {
+        \\    local iface="$1"
+        \\    ip link show dev "$iface" >/dev/null 2>&1 && return 0
+        \\    local quick conf
+        \\    quick="$(quick_tool_for "$iface")" || return 1
+        \\    conf="$(conf_path_for "$iface")"
+        \\    [[ -f "$conf" ]] || return 1
+        \\    "$quick" up "$conf" >/dev/null 2>&1
+        \\}
+        \\
+        \\probe_iface() {
+        \\    local iface="$1"
+        \\    reason=""
+        \\    ensure_iface_up "$iface" || { reason="failed to bring interface up"; return 1; }
+        \\    ip link show dev "$iface" >/dev/null 2>&1 || { reason="interface missing"; return 1; }
+        \\    local show_tool
+        \\    show_tool="$(show_tool_for "$iface")" || { reason="awg/wg show tool missing"; return 1; }
+        \\    "$show_tool" show "$iface" >/dev/null 2>&1 || { reason="tunnel show failed"; return 1; }
+        \\    curl --interface "$iface" -fsS --connect-timeout 3 --max-time 5 "$PROBE_URL" >/dev/null 2>&1 || { reason="Telegram probe failed"; return 1; }
+        \\    reason="healthy"
+        \\    return 0
+        \\}
+        \\
+        \\state_value() {
+        \\    local key="$1"
+        \\    [[ -f "$STATE_FILE" ]] || return 0
+        \\    awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' "$STATE_FILE"
+        \\}
+        \\
+        \\write_state() {
+        \\    local active="$1" status="$2" reason="$3"
+        \\    local prev_active prev_last now last_switch
+        \\    prev_active="$(state_value active || true)"
+        \\    prev_last="$(state_value last_switch || true)"
+        \\    now="$(date -Is)"
+        \\    last_switch="${prev_last:-$now}"
+        \\    [[ "$active" != "$prev_active" ]] && last_switch="$now"
+        \\    {
+        \\        printf 'active=%s\n' "$active"
+        \\        printf 'status=%s\n' "$status"
+        \\        printf 'reason=%s\n' "$reason"
+        \\        printf 'pinned=%s\n' "$pinned"
+        \\        printf 'pool=%s\n' "${pool[*]}"
+        \\        printf 'last_switch=%s\n' "$last_switch"
+        \\        printf 'checked_at=%s\n' "$now"
+        \\    } > "$STATE_FILE"
+        \\}
+        \\
+        \\mapfile -t pool < <(
+        \\    raw_interfaces="$(read_tunnel_key interfaces || true)"
+        \\    if [[ -n "${raw_interfaces:-}" ]]; then
+        \\        parse_interfaces "$raw_interfaces"
+        \\    else
+        \\        legacy="$(read_tunnel_key interface || true)"
+        \\        printf '%s\n' "${legacy:-awg0}"
+        \\    fi
+        \\)
+        \\
+        \\pinned="$(read_tunnel_key pinned_interface || true)"
+        \\candidates=()
+        \\add_unique "$pinned"
+        \\for iface in "${pool[@]}"; do
+        \\    add_unique "$iface"
+        \\done
+        \\
+        \\ip -4 rule del fwmark "$MARK" table "$TABLE" 2>/dev/null || true
+        \\ip -4 rule add fwmark "$MARK" table "$TABLE" priority 1200
+        \\
+        \\selected=""
+        \\selected_reason=""
+        \\for iface in "${candidates[@]}"; do
+        \\    if probe_iface "$iface"; then
+        \\        selected="$iface"
+        \\        selected_reason="$reason"
+        \\        break
+        \\    fi
+        \\    log "tunnel $iface unhealthy: $reason"
+        \\done
+        \\
+        \\if [[ -z "$selected" ]]; then
+        \\    write_state "" "degraded" "no healthy tunnel"
+        \\    echo "No healthy tunnel in pool: ${candidates[*]}" >&2
+        \\    exit 1
+        \\fi
+        \\
+        \\previous="$(ip -4 route show table "$TABLE" default 2>/dev/null | awk '/default/ { for (i=1;i<=NF;i++) if ($i=="dev") { print $(i+1); exit } }')"
+        \\ip -4 route flush table "$TABLE" 2>/dev/null || true
+        \\ip -4 route replace default dev "$selected" table "$TABLE"
+        \\write_state "$selected" "healthy" "$selected_reason"
+        \\
+        \\if [[ "$previous" != "$selected" ]]; then
+        \\    log "selected tunnel $selected (previous: ${previous:-none})"
+        \\fi
+        \\echo "Tunnel routing ready: fwmark=$MARK -> table $TABLE via $selected"
+    );
 }
 
 fn stripAwgDnsLines(allocator: std.mem.Allocator, path: []const u8) !bool {
@@ -946,6 +1380,12 @@ fn cleanupNetnsNginxListen(allocator: std.mem.Allocator) bool {
 /// Returns the `Tunnel.Tag` corresponding to the detected tunnel,
 /// or `.none` if no known tunnel is active.
 pub fn detectActiveTunnel(allocator: std.mem.Allocator) Tunnel.Tag {
+    const route_result = sys.exec(allocator, &.{ "ip", "-4", "route", "show", "table", "200", "default" }) catch null;
+    if (route_result) |r| {
+        defer r.deinit();
+        if (r.exit_code == 0 and std.mem.indexOf(u8, r.stdout, " dev ") != null) return .tunnel;
+    }
+
     const awg_result = sys.exec(allocator, &.{ "awg", "show", "awg0" }) catch null;
     if (awg_result) |r| {
         defer r.deinit();
@@ -963,6 +1403,46 @@ pub fn detectActiveTunnel(allocator: std.mem.Allocator) Tunnel.Tag {
 
 const test_amnezia_vpn_link =
     "vpn://AAABPXicLY9Ra8IwFIX_Srn4WGoSHZSCD6I-lDEX9Gm0IrG5jkKbliSdG6X_fTdWTiA53wn3JCNo4zhkwJOnIA5AEEiTpwhUnfGqNmgdZMUI6vEN2QiNcv5K0b0mC2MJ87mELCqhyI1He1cVXsrSbLW26Fy0iThLgsRyJYhLW_8oj-_4R1FPhtj-eCazkKf8Y3v6upKNo8X5sPs87l-eLuUi2tBGq5CINnTI4dbU1WvUcAutTdM9UOcyFM-9bMkoOBjdd7XxhPFXtX2DSdW12Xq9CjMhpve3fpg_wkXKZtR31gf2xlPBJpimy_QPWglhtw";
+
+test "tunnel pool - next awg interface skips used names" {
+    const used = [_][]const u8{ "awg0", "awg1" };
+    const next = try nextAwgInterfaceNameFromPool(std.testing.allocator, &used);
+    defer std.testing.allocator.free(next);
+    try std.testing.expectEqualStrings("awg2", next);
+}
+
+test "tunnel pool - append interface avoids duplicates" {
+    const existing = [_][]const u8{ "awg0", "awg1" };
+
+    const same = try appendInterfaceIfMissing(std.testing.allocator, &existing, "awg1");
+    defer freeOwnedStringSlice(std.testing.allocator, same);
+    try std.testing.expectEqual(@as(usize, 2), same.len);
+    try std.testing.expectEqualStrings("awg0", same[0]);
+    try std.testing.expectEqualStrings("awg1", same[1]);
+
+    const added = try appendInterfaceIfMissing(std.testing.allocator, &existing, "awg2");
+    defer freeOwnedStringSlice(std.testing.allocator, added);
+    try std.testing.expectEqual(@as(usize, 3), added.len);
+    try std.testing.expectEqualStrings("awg2", added[2]);
+}
+
+test "tunnel pool - script renders route replacement and Telegram probe" {
+    const script = try renderTunnelPoolScript(std.testing.allocator);
+    defer std.testing.allocator.free(script);
+
+    try std.testing.expect(std.mem.indexOf(u8, script, "ip -4 route replace default dev \"$selected\" table \"$TABLE\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "https://core.telegram.org/getProxyConfig") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "pinned_interface") != null);
+}
+
+test "tunnel pool - parses interface array" {
+    const pool = try parseTunnelInterfaceArray(std.testing.allocator, "[\"awg0\", \"awg1\"]");
+    defer freeOwnedStringSlice(std.testing.allocator, pool);
+
+    try std.testing.expectEqual(@as(usize, 2), pool.len);
+    try std.testing.expectEqualStrings("awg0", pool[0]);
+    try std.testing.expectEqualStrings("awg1", pool[1]);
+}
 
 test "tunnel - converts Amnezia vpn link to AWG config" {
     const conf = try convertAmneziaVpnLink(std.testing.allocator, test_amnezia_vpn_link);

--- a/src/ctl/uninstall.zig
+++ b/src/ctl/uninstall.zig
@@ -60,6 +60,8 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
         "nfqws-mtproto",
         "mtproto-mask-health.timer",
         "mtproto-mask-health.service",
+        "mtproto-tunnel-pool.timer",
+        "mtproto-tunnel-pool.service",
     };
     for (services) |svc| {
         _ = sys.execForward(&.{ "systemctl", "stop", svc }) catch {};
@@ -71,6 +73,8 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
     }
 
     _ = sys.execForward(&.{ "rm", "-f", "/etc/systemd/system/mtproto-mask-health.timer" }) catch {};
+    _ = sys.execForward(&.{ "rm", "-f", "/etc/systemd/system/mtproto-tunnel-pool.timer" }) catch {};
+    _ = sys.execForward(&.{ "rm", "-f", "/etc/systemd/system/mtproto-tunnel-pool.service" }) catch {};
     _ = sys.execForward(&.{ "systemctl", "daemon-reload" }) catch {};
 
     // 2. Remove directories

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -81,6 +81,8 @@ const middle_proxy_config_url = "https://core.telegram.org/getProxyConfig";
 const middle_proxy_secret_url = "https://core.telegram.org/getProxySecret";
 const middle_proxy_update_period_ns: u64 = 24 * 60 * 60 * std.time.ns_per_s;
 const tunnel_socket_mark: u32 = 200;
+const tunnel_route_table: u32 = 200;
+const tunnel_pool_state_path = "/run/mtproto-proxy/tunnel-pool.state";
 const min_nofile_soft: usize = 65535;
 const client_hello_inline_size: usize = 512;
 const mp_handshake_frame_buf_size: usize = 2048;
@@ -175,6 +177,79 @@ const getAddressList = net_helpers.getAddressList;
 
 fn detectPublicIpv4(allocator: std.mem.Allocator) ?[4]u8 {
     return network_detect.detectPublicIpv4(allocator, fetchUrlBytes);
+}
+
+fn runSmallCommand(allocator: std.mem.Allocator, argv: []const []const u8) ?[]u8 {
+    var io_instance: std.Io.Threaded = .init(std.heap.page_allocator, .{});
+    defer io_instance.deinit();
+
+    const result = std.process.run(allocator, io_instance.io(), .{
+        .argv = argv,
+        .stdout_limit = std.Io.Limit.limited(512),
+        .stderr_limit = std.Io.Limit.limited(512),
+    }) catch return null;
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    switch (result.term) {
+        .exited => |code| if (code != 0) return null,
+        else => return null,
+    }
+
+    const trimmed = std.mem.trim(u8, result.stdout, &[_]u8{ ' ', '\t', '\r', '\n' });
+    if (trimmed.len == 0) return null;
+    return allocator.dupe(u8, trimmed) catch null;
+}
+
+fn detectActiveTunnelInterface(allocator: std.mem.Allocator) ?[]u8 {
+    var table_buf: [16]u8 = undefined;
+    const table = std.fmt.bufPrint(&table_buf, "{d}", .{tunnel_route_table}) catch "200";
+    const argv = [_][]const u8{
+        "sh",
+        "-c",
+        "ip -4 route show table \"$1\" default 2>/dev/null | awk '/default/ { for (i=1;i<=NF;i++) if ($i==\"dev\") { print $(i+1); exit } }'",
+        "sh",
+        table,
+    };
+    return runSmallCommand(allocator, &argv);
+}
+
+fn readTunnelPoolStateValue(allocator: std.mem.Allocator, key: []const u8) ?[]u8 {
+    const io_instance = std.Io.Threaded.global_single_threaded.io();
+    const content = std.Io.Dir.cwd().readFileAlloc(
+        io_instance,
+        tunnel_pool_state_path,
+        allocator,
+        .limited(4096),
+    ) catch return null;
+    defer allocator.free(content);
+
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line| {
+        const eq = std.mem.indexOfScalar(u8, line, '=') orelse continue;
+        const raw_key = std.mem.trim(u8, line[0..eq], &[_]u8{ ' ', '\t', '\r' });
+        if (!std.mem.eql(u8, raw_key, key)) continue;
+        const value = std.mem.trim(u8, line[eq + 1 ..], &[_]u8{ ' ', '\t', '\r' });
+        if (value.len == 0) return null;
+        return allocator.dupe(u8, value) catch null;
+    }
+
+    return null;
+}
+
+fn tryFetchMiddleProxyViaInterface(
+    allocator: std.mem.Allocator,
+    url: []const u8,
+    iface: []const u8,
+    direct_err: anyerror,
+) ![]u8 {
+    const trimmed = std.mem.trim(u8, iface, &[_]u8{ ' ', '\t', '\r', '\n' });
+    if (trimmed.len == 0) return error.UnexpectedConnectFailure;
+    log.info(
+        "Middle-proxy asset {s} unreachable directly ({s}); retrying via tunnel '{s}'",
+        .{ url, @errorName(direct_err), trimmed },
+    );
+    return fetchUrlBytesViaInterface(allocator, url, trimmed);
 }
 
 const ConnectionSlot = struct {
@@ -946,25 +1021,54 @@ pub const ProxyState = struct {
     }
 
     /// Refresh helper. Tries the default route first; on any network-class
-    /// failure AND when the config selects tunnel upstream, retries via
-    /// `curl --interface <tunnel>`. This is what makes the media MP cache
-    /// warm up correctly on censored hosts where `core.telegram.org` is
-    /// unreachable directly but reachable through the tunnel.
+    /// failure AND when the config selects tunnel upstream, retries via the
+    /// active tunnel route (`table 200`), pool state, then configured tunnel
+    /// candidates. This keeps the media MP cache warm after tunnel failover.
     fn fetchMiddleProxyAsset(self: *ProxyState, allocator: std.mem.Allocator, url: []const u8) ![]u8 {
         if (fetchUrlBytes(allocator, url)) |bytes| {
             return bytes;
         } else |direct_err| {
-            const tunnel_iface = blk: {
-                if (self.config.upstream_mode != .tunnel) break :blk null;
-                break :blk self.config.upstream_tunnel_interface;
-            };
-            const iface = tunnel_iface orelse return direct_err;
-            log.info(
-                "Middle-proxy asset {s} unreachable directly ({s}); retrying via tunnel '{s}'",
-                .{ url, @errorName(direct_err), iface },
-            );
-            return fetchUrlBytesViaInterface(allocator, url, iface);
+            if (self.config.upstream_mode != .tunnel) return direct_err;
+            return self.fetchMiddleProxyAssetViaTunnelPool(allocator, url, direct_err);
         }
+    }
+
+    fn fetchMiddleProxyAssetViaTunnelPool(
+        self: *ProxyState,
+        allocator: std.mem.Allocator,
+        url: []const u8,
+        direct_err: anyerror,
+    ) ![]u8 {
+        var last_err: anyerror = direct_err;
+
+        if (detectActiveTunnelInterface(allocator)) |iface| {
+            defer allocator.free(iface);
+            if (tryFetchMiddleProxyViaInterface(allocator, url, iface, direct_err)) |bytes| {
+                return bytes;
+            } else |err| {
+                last_err = err;
+            }
+        }
+
+        if (readTunnelPoolStateValue(allocator, "active")) |iface| {
+            defer allocator.free(iface);
+            if (tryFetchMiddleProxyViaInterface(allocator, url, iface, direct_err)) |bytes| {
+                return bytes;
+            } else |err| {
+                last_err = err;
+            }
+        }
+
+        var idx: usize = 0;
+        while (self.config.tunnelCandidateAt(idx)) |iface| : (idx += 1) {
+            if (tryFetchMiddleProxyViaInterface(allocator, url, iface, direct_err)) |bytes| {
+                return bytes;
+            } else |err| {
+                last_err = err;
+            }
+        }
+
+        return last_err;
     }
 
     fn middleProxyUpdaterMain(self: *ProxyState) void {


### PR DESCRIPTION
## Summary

- add ordered tunnel pool configuration with optional pinned interface and legacy single-interface compatibility
- install a mtbuddy-managed tunnel pool controller/timer that probes Telegram through tunnel interfaces and rewrites table 200 without restarting the proxy
- update MiddleProxy metadata refresh and dashboard routing UI/API to understand active tunnel state, pool health, failover, and pinning
- document Docker as a secondary/testing-oriented path and add Russian documentation with a language switcher

## Validation

- `python3 -m py_compile src/ctl/dashboard_assets/server.py`
- `node --check src/ctl/dashboard_assets/static/app.js`
- generated tunnel controller script checked with `bash -n`
- `zig build test`
- `zig build -Dtarget=x86_64-linux`
- `git diff --check`

## Notes

`zig build test` exits successfully, but the current Zig runner still prints the existing `failed command: ... --listen=-` line after config warning output.
