### PR TITLE
[codex] highlight README language switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ Disguises Telegram traffic as standard TLS 1.3 HTTPS to bypass network censorshi
 [![Platform](https://img.shields.io/badge/platform-linux-blueviolet.svg?logo=linux&logoColor=white)](#install)
 
 <p align="center">
-  <a href="README.md"><kbd>English</kbd></a>
-  <a href="README.ru.md"><kbd>Русский</kbd></a>
+  <strong>🌐 Language</strong><br>
+  <kbd><strong>🇬🇧 English</strong></kbd>
+  ·
+  <a href="README.ru.md"><kbd>🇷🇺 Русский</kbd></a>
 </p>
 
 </div>

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,8 +13,10 @@
 [![Platform](https://img.shields.io/badge/platform-linux-blueviolet.svg?logo=linux&logoColor=white)](#установка)
 
 <p align="center">
-  <a href="README.md"><kbd>English</kbd></a>
-  <a href="README.ru.md"><kbd>Русский</kbd></a>
+  <strong>🌐 Язык</strong><br>
+  <a href="README.md"><kbd>🇬🇧 English</kbd></a>
+  ·
+  <kbd><strong>🇷🇺 Русский</strong></kbd>
 </p>
 
 </div>


### PR DESCRIPTION
## Summary

- Makes the language switcher near the top of both README files more visible.
- Adds a clear language label, country flags, and bold styling for the currently selected language.

## Impact

Readers can spot the English/Russian README switcher faster, especially when landing near the badges at the top of the page.

## Validation

- Ran `git diff --check` before committing.
- Ran `git diff --check origin/main...HEAD` after committing.

This is documentation-only, so no build or runtime tests were run.