### PR TITLE
[codex] fix DC203 middle-proxy fallback reconnect + docs/runbook hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ type = "auto"            # auto | direct | tunnel | socks5 | http
 [server]
 port = 443
 # public_ip = "proxy.example.com"   # Override auto-detected IP (recommended with tunnel)
+# middle_proxy_nat_ip = "203.0.113.10"   # Outbound IPv4 seen by Telegram MiddleProxy
 max_connections = 512
 idle_timeout_sec = 120
 handshake_timeout_sec = 15
@@ -384,6 +385,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[server] port` | `443` | TCP listen port |
 | `[server] bind_address` | — | Specific IP to bind the listen socket (default: all interfaces) |
 | `[server] public_ip` | auto | Override auto-detected IP/domain. Required with VPN tunnel; set IPv4 explicitly if clients fail on IPv6 links |
+| `[server] middle_proxy_nat_ip` | auto | IPv4 used in MiddleProxy key derivation when DC traffic exits through a VPN/NAT IP different from `public_ip` |
 | `[server] backlog` | `4096` | TCP listen queue depth |
 | `[server] max_connections` | `512` | Concurrent connection cap, auto-clamped by RAM and `RLIMIT_NOFILE` |
 | `[server] idle_timeout_sec` | `120` | Connection idle timeout |
@@ -525,6 +527,8 @@ docker run --rm \
   -v "$PWD/config.toml:/etc/mtproto-proxy/config.toml:ro" \
   ghcr.io/sleep3r/mtproto.zig:latest
 ```
+
+MiddleProxy media/promo traffic is sensitive to the outbound source IP:port used in its encrypted handshake. For Docker deployments that need MiddleProxy, prefer host networking (`--network host`) or a native `mtbuddy` install. If outbound DC traffic exits through a VPN/NAT IP that differs from `[server].public_ip`, set `[server].middle_proxy_nat_ip` to that egress IPv4; bridge or remote NAT that rewrites source ports can still break MiddleProxy handshakes.
 
 Build locally:
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -326,6 +326,7 @@ type = "auto"            # auto | direct | tunnel | socks5 | http
 [server]
 port = 443
 # public_ip = "proxy.example.com"
+# middle_proxy_nat_ip = "203.0.113.10"   # исходящий IPv4, который видит Telegram MiddleProxy
 max_connections = 512
 idle_timeout_sec = 120
 handshake_timeout_sec = 15
@@ -361,6 +362,7 @@ alice = true
 | `[general] use_middle_proxy` | `false` | ME mode для DC1..5 |
 | `[server] port` | `443` | TCP listen port |
 | `[server] public_ip` | auto | Явный IP/domain для ссылок |
+| `[server] middle_proxy_nat_ip` | auto | IPv4 для MiddleProxy key derivation, если DC-трафик выходит через VPN/NAT IP, отличный от `public_ip` |
 | `[server] max_connections` | `512` | Лимит одновременных соединений |
 | `[server] middleproxy_buffer_kb` | `1024` | Буфер MiddleProxy на соединение |
 | `[server] tag` | — | 32-hex promotion tag от [@MTProxybot](https://t.me/MTProxybot) |
@@ -472,6 +474,8 @@ docker run --rm \
   -v "$PWD/config.toml:/etc/mtproto-proxy/config.toml:ro" \
   ghcr.io/sleep3r/mtproto.zig:latest
 ```
+
+MiddleProxy для медиа/промо чувствителен к исходному source IP:port, который попадает в encrypted handshake. Для Docker-деплоя с MiddleProxy лучше использовать host networking (`--network host`) или нативный `mtbuddy install`. Если DC-трафик выходит через VPN/NAT IP, отличный от `[server].public_ip`, задайте `[server].middle_proxy_nat_ip` этим egress IPv4; bridge или удаленный NAT, переписывающий source port, всё равно может ломать MiddleProxy handshake.
 
 Локальная сборка:
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -27,6 +27,12 @@ port = 443
 # Accepts IP addresses or domain names (e.g. "proxy.example.com").
 # public_ip = "proxy.example.com"
 
+# IPv4 address Telegram MiddleProxy sees for outbound DC connections.
+# Set this when DC traffic exits through a VPN/NAT IP that differs from
+# public_ip. Docker bridge or remote VPN NAT that rewrites source ports can
+# still break MiddleProxy; prefer native/host-network deployments there.
+# middle_proxy_nat_ip = "203.0.113.10"
+
 # 32 hex-char promotion tag from @MTProxybot (enables sponsored channels).
 # tag = "1234567890abcdef1234567890abcdef"
 

--- a/src/proxy/middle_proxy_fallback.zig
+++ b/src/proxy/middle_proxy_fallback.zig
@@ -1,10 +1,8 @@
 const std = @import("std");
 
 const constants = @import("../protocol/constants.zig");
-const net_helpers = @import("net_helpers.zig");
 const socket_utils = @import("socket_utils.zig");
 
-const addressEql = net_helpers.addressEql;
 const formatAddress = socket_utils.formatAddress;
 
 const log = std.log.scoped(.proxy);
@@ -12,7 +10,6 @@ const log = std.log.scoped(.proxy);
 pub fn fallbackToDirect(
     loop: anytype,
     slot: anytype,
-    comptime send_dc_nonce: fn (@TypeOf(loop), @TypeOf(slot)) void,
     comptime cleanup_failed_upstream_connect: fn (@TypeOf(loop), @TypeOf(slot)) void,
     comptime set_single_upstream_candidate: fn (@TypeOf(loop), @TypeOf(slot), @TypeOf(slot.direct_fallback_addr.?)) anyerror!void,
     comptime start_direct_connect: fn (@TypeOf(loop), @TypeOf(slot), @TypeOf(slot.direct_fallback_addr.?)) anyerror!void,
@@ -40,16 +37,10 @@ pub fn fallbackToDirect(
     slot.tg_encryptor = null;
     slot.tg_decryptor = null;
 
-    // If current connected endpoint is already the direct fallback, continue inline.
     const fallback = slot.direct_fallback_addr.?;
-    if (slot.current_upstream_addr) |cur| {
-        if (addressEql(cur, fallback)) {
-            send_dc_nonce(loop, slot);
-            return true;
-        }
-    }
-
-    // Otherwise reconnect to direct fallback endpoint.
+    // The current socket has already been used for a rejected MiddleProxy
+    // handshake. Reconnect even when the direct fallback has the same endpoint
+    // (DC203), otherwise we may write a direct nonce to a half-closed socket.
     cleanup_failed_upstream_connect(loop, slot);
     slot.upstream_candidate_next = 1;
 
@@ -66,4 +57,89 @@ pub fn fallbackToDirect(
     const fb_str = formatAddress(fallback, &fb_buf);
     log.warn("[{d}] middle-proxy handshake failed, reconnecting direct to {s}", .{ slot.conn_id, fb_str });
     return true;
+}
+
+test "fallback reconnects when direct endpoint matches current middle-proxy endpoint" {
+    const Address = std.Io.net.IpAddress;
+    const FakeStep = enum { none, middle_proxy_handshake };
+    const FakeCipher = struct {
+        wiped: bool = false,
+
+        fn wipe(self: *@This()) void {
+            self.wiped = true;
+        }
+    };
+    const FakeConfig = struct {
+        fast_mode: bool = true,
+    };
+    const FakeState = struct {
+        stats_mp_fallback: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+        config: FakeConfig = .{},
+        allocator: std.mem.Allocator = std.testing.allocator,
+    };
+    const FakeLoop = struct {
+        state: FakeState = .{},
+        cleanup_calls: usize = 0,
+        set_candidate_calls: usize = 0,
+        start_connect_calls: usize = 0,
+        started_addr: ?Address = null,
+    };
+    const FakeSlot = struct {
+        direct_fallback_addr: ?Address = null,
+        direct_fallback_used: bool = false,
+        obf_params: ?void = {},
+        use_middle_proxy: bool = true,
+        mp_step: FakeStep = .middle_proxy_handshake,
+        mp_enc: ?FakeCipher = null,
+        mp_dec: ?FakeCipher = null,
+        dc_abs: u16 = 203,
+        use_fast_mode: bool = false,
+        dc_initial_tail: ?[]u8 = null,
+        tg_encryptor: ?FakeCipher = null,
+        tg_decryptor: ?FakeCipher = null,
+        upstream_candidate_next: u8 = 0,
+        current_upstream_addr: ?Address = null,
+        conn_id: u64 = 42,
+    };
+    const Callbacks = struct {
+        fn cleanup(loop: *FakeLoop, slot: *FakeSlot) void {
+            _ = slot;
+            loop.cleanup_calls += 1;
+        }
+
+        fn setCandidate(loop: *FakeLoop, slot: *FakeSlot, addr: Address) !void {
+            _ = slot;
+            _ = addr;
+            loop.set_candidate_calls += 1;
+        }
+
+        fn startConnect(loop: *FakeLoop, slot: *FakeSlot, addr: Address) !void {
+            _ = slot;
+            loop.start_connect_calls += 1;
+            loop.started_addr = addr;
+        }
+    };
+
+    const fallback = Address{ .ip4 = .{ .bytes = .{ 91, 105, 192, 110 }, .port = 443 } };
+    var loop = FakeLoop{};
+    var slot = FakeSlot{
+        .direct_fallback_addr = fallback,
+        .current_upstream_addr = fallback,
+    };
+
+    try std.testing.expect(fallbackToDirect(
+        &loop,
+        &slot,
+        Callbacks.cleanup,
+        Callbacks.setCandidate,
+        Callbacks.startConnect,
+    ));
+    try std.testing.expectEqual(@as(usize, 1), loop.cleanup_calls);
+    try std.testing.expectEqual(@as(usize, 1), loop.set_candidate_calls);
+    try std.testing.expectEqual(@as(usize, 1), loop.start_connect_calls);
+    try std.testing.expectEqual(true, slot.direct_fallback_used);
+    try std.testing.expectEqual(false, slot.use_middle_proxy);
+    try std.testing.expectEqual(FakeStep.none, slot.mp_step);
+    try std.testing.expectEqual(@as(u64, 1), loop.state.stats_mp_fallback.load(.monotonic));
+    try std.testing.expect(Address.eql(&fallback, &loop.started_addr.?));
 }

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -2786,7 +2786,6 @@ const EventLoop = struct {
         return middle_proxy_fallback.fallbackToDirect(
             self,
             slot,
-            mpFallbackSendDcNonce,
             mpFallbackCleanupFailedUpstreamConnect,
             mpFallbackSetSingleUpstreamCandidate,
             mpFallbackStartDirectConnect,
@@ -3225,10 +3224,6 @@ fn relayQueueClient(loop: *EventLoop, slot: *ConnectionSlot, data: []const u8) !
 
 fn startConnectUpstreamDc(loop: *EventLoop, slot: *ConnectionSlot, addr: Address) !void {
     return loop.startConnectUpstream(slot, addr, .dc);
-}
-
-fn mpFallbackSendDcNonce(loop: *EventLoop, slot: *ConnectionSlot) void {
-    return loop.sendDcNonce(slot);
 }
 
 fn mpFallbackCleanupFailedUpstreamConnect(loop: *EventLoop, slot: *ConnectionSlot) void {


### PR DESCRIPTION
## What changed
- Fixed middle-proxy fallback behavior when the direct fallback endpoint equals the current middle-proxy endpoint (notably `dc_idx=203`).
- Removed the inline "send direct nonce on current socket" shortcut in that path.
- Fallback now always tears down the failed upstream socket and starts a fresh direct reconnect.
- Added a regression test covering this exact same-endpoint fallback case.
- Documented `server.middle_proxy_nat_ip` in config/docs and clarified Docker MiddleProxy caveats.

## Root cause
For DC203, MiddleProxy endpoint and direct fallback can both resolve to `...:443`.
After a failed MP handshake, the old path could detect "same endpoint" and send direct nonce on the already-rejected/half-closed socket instead of reconnecting. That could immediately end with `epoll hup/err` and zero relay bytes.

## Why this helps
Direct fallback now consistently uses a new socket, including same-address cases, which removes this failure mode for DC203.

## Validation
- `zig build test --summary all`
- Result: `134/134 tests passed`

## Notes
This fixes a concrete fallback bug. If operators still see widespread `mp handshake ... EndOfStream`, remaining issues are likely network/NAT related and should be diagnosed separately (bridge vs host networking, egress IP/port behavior).