### PR TITLE
[codex] decouple MiddleProxy NAT IP from public_ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ type = "auto"            # auto | direct | tunnel | socks5 | http
 
 [server]
 port = 443
-# public_ip = "proxy.example.com"   # Override auto-detected IP (recommended with tunnel)
+# public_ip = "proxy.example.com"   # Inbound IP/domain used in client links
 # middle_proxy_nat_ip = "203.0.113.10"   # Outbound IPv4 seen by Telegram MiddleProxy
 max_connections = 512
 idle_timeout_sec = 120
@@ -384,8 +384,8 @@ alice = true   # bypass MiddleProxy for this user
 | `[general] ad_tag` | — | Alias for `[server].tag` |
 | `[server] port` | `443` | TCP listen port |
 | `[server] bind_address` | — | Specific IP to bind the listen socket (default: all interfaces) |
-| `[server] public_ip` | auto | Override auto-detected IP/domain. Required with VPN tunnel; set IPv4 explicitly if clients fail on IPv6 links |
-| `[server] middle_proxy_nat_ip` | auto | IPv4 used in MiddleProxy key derivation when DC traffic exits through a VPN/NAT IP different from `public_ip` |
+| `[server] public_ip` | auto | Inbound IP/domain shown in client links. Required with VPN tunnel; set IPv4 explicitly if clients fail on IPv6 links |
+| `[server] middle_proxy_nat_ip` | auto | Outbound IPv4 used in MiddleProxy key derivation; auto-detected independently from `public_ip`, set explicitly when DC traffic exits through a VPN/NAT IP |
 | `[server] backlog` | `4096` | TCP listen queue depth |
 | `[server] max_connections` | `512` | Concurrent connection cap, auto-clamped by RAM and `RLIMIT_NOFILE` |
 | `[server] idle_timeout_sec` | `120` | Connection idle timeout |
@@ -528,7 +528,7 @@ docker run --rm \
   ghcr.io/sleep3r/mtproto.zig:latest
 ```
 
-MiddleProxy media/promo traffic is sensitive to the outbound source IP:port used in its encrypted handshake. For Docker deployments that need MiddleProxy, prefer host networking (`--network host`) or a native `mtbuddy` install. If outbound DC traffic exits through a VPN/NAT IP that differs from `[server].public_ip`, set `[server].middle_proxy_nat_ip` to that egress IPv4; bridge or remote NAT that rewrites source ports can still break MiddleProxy handshakes.
+MiddleProxy media/promo traffic is sensitive to the outbound source IP:port used in its encrypted handshake. For Docker deployments that need MiddleProxy, prefer host networking (`--network host`) or a native `mtbuddy` install. `[server].public_ip` is only the inbound address shown to clients; if outbound DC traffic exits through a VPN/NAT IP, set `[server].middle_proxy_nat_ip` to that egress IPv4. Bridge or remote NAT that rewrites source ports can still break MiddleProxy handshakes.
 
 Build locally:
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -325,7 +325,7 @@ type = "auto"            # auto | direct | tunnel | socks5 | http
 
 [server]
 port = 443
-# public_ip = "proxy.example.com"
+# public_ip = "proxy.example.com"   # входящий IP/domain для клиентских ссылок
 # middle_proxy_nat_ip = "203.0.113.10"   # исходящий IPv4, который видит Telegram MiddleProxy
 max_connections = 512
 idle_timeout_sec = 120
@@ -361,8 +361,8 @@ alice = true
 | `[upstream.tunnel] pinned_interface` | — | Ручной preferred interface, если он жив |
 | `[general] use_middle_proxy` | `false` | ME mode для DC1..5 |
 | `[server] port` | `443` | TCP listen port |
-| `[server] public_ip` | auto | Явный IP/domain для ссылок |
-| `[server] middle_proxy_nat_ip` | auto | IPv4 для MiddleProxy key derivation, если DC-трафик выходит через VPN/NAT IP, отличный от `public_ip` |
+| `[server] public_ip` | auto | Входящий IP/domain для клиентских ссылок |
+| `[server] middle_proxy_nat_ip` | auto | Исходящий IPv4 для MiddleProxy key derivation; auto-detect не использует `public_ip`, задайте явно при VPN/NAT egress |
 | `[server] max_connections` | `512` | Лимит одновременных соединений |
 | `[server] middleproxy_buffer_kb` | `1024` | Буфер MiddleProxy на соединение |
 | `[server] tag` | — | 32-hex promotion tag от [@MTProxybot](https://t.me/MTProxybot) |
@@ -475,7 +475,7 @@ docker run --rm \
   ghcr.io/sleep3r/mtproto.zig:latest
 ```
 
-MiddleProxy для медиа/промо чувствителен к исходному source IP:port, который попадает в encrypted handshake. Для Docker-деплоя с MiddleProxy лучше использовать host networking (`--network host`) или нативный `mtbuddy install`. Если DC-трафик выходит через VPN/NAT IP, отличный от `[server].public_ip`, задайте `[server].middle_proxy_nat_ip` этим egress IPv4; bridge или удаленный NAT, переписывающий source port, всё равно может ломать MiddleProxy handshake.
+MiddleProxy для медиа/промо чувствителен к исходному source IP:port, который попадает в encrypted handshake. Для Docker-деплоя с MiddleProxy лучше использовать host networking (`--network host`) или нативный `mtbuddy install`. `[server].public_ip` теперь только входящий адрес для клиентов; если DC-трафик выходит через VPN/NAT IP, задайте `[server].middle_proxy_nat_ip` этим egress IPv4. Bridge или удаленный NAT, переписывающий source port, всё равно может ломать MiddleProxy handshake.
 
 Локальная сборка:
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -24,13 +24,15 @@ port = 443
 # Override the auto-detected public IP shown in startup links.
 # Useful when running inside a VPN tunnel (AmneziaWG) where ifconfig.me
 # returns the tunnel exit IP instead of the server's real address.
+# This is the inbound address for clients; it is not used for MiddleProxy NAT.
 # Accepts IP addresses or domain names (e.g. "proxy.example.com").
 # public_ip = "proxy.example.com"
 
 # IPv4 address Telegram MiddleProxy sees for outbound DC connections.
 # Set this when DC traffic exits through a VPN/NAT IP that differs from
-# public_ip. Docker bridge or remote VPN NAT that rewrites source ports can
-# still break MiddleProxy; prefer native/host-network deployments there.
+# public_ip or when auto-detection cannot see the real egress. Docker bridge
+# or remote VPN NAT that rewrites source ports can still break MiddleProxy;
+# prefer native/host-network deployments there.
 # middle_proxy_nat_ip = "203.0.113.10"
 
 # 32 hex-char promotion tag from @MTProxybot (enables sponsored channels).

--- a/src/ctl/config_cmd.zig
+++ b/src/ctl/config_cmd.zig
@@ -200,6 +200,9 @@ fn printEffective(ui: *Tui, allocator: std.mem.Allocator, path: []const u8) !voi
     if (cfg.public_ip) |public_ip| {
         ui.print("public_ip = \"{s}\"\n", .{public_ip});
     }
+    if (cfg.middle_proxy_nat_ip) |middle_proxy_nat_ip| {
+        ui.print("middle_proxy_nat_ip = \"{s}\"\n", .{middle_proxy_nat_ip});
+    }
     ui.print("backlog = {d}\n", .{cfg.backlog});
     ui.print("max_connections = {d}\n", .{cfg.max_connections});
     ui.print("idle_timeout_sec = {d}\n", .{cfg.idle_timeout_sec});

--- a/src/proxy/middle_proxy_nat.zig
+++ b/src/proxy/middle_proxy_nat.zig
@@ -1,0 +1,102 @@
+const std = @import("std");
+
+const Config = @import("../config.zig").Config;
+const network_detect = @import("network_detect.zig");
+
+const log = std.log.scoped(.proxy);
+
+pub fn detectIpv4(
+    allocator: std.mem.Allocator,
+    cfg: *const Config,
+    comptime detect_awg: fn (std.mem.Allocator) ?[4]u8,
+    comptime detect_public: fn (std.mem.Allocator) ?[4]u8,
+) ?[4]u8 {
+    if (cfg.middle_proxy_nat_ip) |configured_nat_ip| {
+        if (network_detect.parseIpv4Literal(configured_nat_ip)) |parsed_ip| {
+            var ip_buf: [16]u8 = undefined;
+            log.info("Using server.middle_proxy_nat_ip for middle-proxy NAT translation: {s}", .{network_detect.formatIpv4Bytes(parsed_ip, &ip_buf)});
+            return parsed_ip;
+        }
+        log.info("server.middle_proxy_nat_ip='{s}' is not an IPv4 literal; falling back to AWG/public detection", .{configured_nat_ip});
+    }
+
+    if (detect_awg(allocator)) |awg_ip| {
+        var awg_ip_buf: [16]u8 = undefined;
+        log.info("Using AWG endpoint IPv4 for middle-proxy NAT translation: {s}", .{network_detect.formatIpv4Bytes(awg_ip, &awg_ip_buf)});
+        return awg_ip;
+    }
+
+    if (detect_public(allocator)) |ip| {
+        var ip_buf: [16]u8 = undefined;
+        log.info("Detected public IPv4 for middle-proxy NAT translation: {s}", .{network_detect.formatIpv4Bytes(ip, &ip_buf)});
+        return ip;
+    }
+
+    return null;
+}
+
+fn emptyConfig() Config {
+    return .{
+        .users = std.StringHashMap([16]u8).init(std.testing.allocator),
+        .direct_users = std.StringHashMap(void).init(std.testing.allocator),
+    };
+}
+
+test "middle-proxy NAT detection does not derive from public_ip" {
+    const Callbacks = struct {
+        fn noAwg(_: std.mem.Allocator) ?[4]u8 {
+            return null;
+        }
+
+        fn publicEgress(_: std.mem.Allocator) ?[4]u8 {
+            return .{ 203, 0, 113, 9 };
+        }
+    };
+
+    var cfg = emptyConfig();
+    defer cfg.users.deinit();
+    defer cfg.direct_users.deinit();
+    cfg.public_ip = "198.51.100.10";
+
+    const got = detectIpv4(std.testing.allocator, &cfg, Callbacks.noAwg, Callbacks.publicEgress).?;
+    try std.testing.expectEqual([4]u8{ 203, 0, 113, 9 }, got);
+}
+
+test "middle-proxy NAT detection prefers explicit override" {
+    const Callbacks = struct {
+        fn awgEgress(_: std.mem.Allocator) ?[4]u8 {
+            return .{ 203, 0, 113, 9 };
+        }
+
+        fn publicEgress(_: std.mem.Allocator) ?[4]u8 {
+            return .{ 198, 51, 100, 20 };
+        }
+    };
+
+    var cfg = emptyConfig();
+    defer cfg.users.deinit();
+    defer cfg.direct_users.deinit();
+    cfg.middle_proxy_nat_ip = "192.0.2.7";
+
+    const got = detectIpv4(std.testing.allocator, &cfg, Callbacks.awgEgress, Callbacks.publicEgress).?;
+    try std.testing.expectEqual([4]u8{ 192, 0, 2, 7 }, got);
+}
+
+test "middle-proxy NAT detection prefers AWG endpoint before public egress probe" {
+    const Callbacks = struct {
+        fn awgEgress(_: std.mem.Allocator) ?[4]u8 {
+            return .{ 203, 0, 113, 9 };
+        }
+
+        fn publicEgress(_: std.mem.Allocator) ?[4]u8 {
+            return .{ 198, 51, 100, 20 };
+        }
+    };
+
+    var cfg = emptyConfig();
+    defer cfg.users.deinit();
+    defer cfg.direct_users.deinit();
+
+    const got = detectIpv4(std.testing.allocator, &cfg, Callbacks.awgEgress, Callbacks.publicEgress).?;
+    try std.testing.expectEqual([4]u8{ 203, 0, 113, 9 }, got);
+}

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -38,6 +38,7 @@ const middle_proxy_frames = @import("middle_proxy_frames.zig");
 const middle_proxy_handshake = @import("middle_proxy_handshake.zig");
 const proxy_upstream_handshake = @import("proxy_upstream_handshake.zig");
 const middle_proxy_fallback = @import("middle_proxy_fallback.zig");
+const middle_proxy_nat = @import("middle_proxy_nat.zig");
 const dc_nonce = @import("dc_nonce.zig");
 const upstream_failover = @import("upstream_failover.zig");
 const runtime_log = @import("../runtime_log.zig");
@@ -62,6 +63,7 @@ test {
     _ = @import("middle_proxy_handshake.zig");
     _ = @import("proxy_upstream_handshake.zig");
     _ = @import("middle_proxy_fallback.zig");
+    _ = @import("middle_proxy_nat.zig");
     _ = @import("dc_nonce.zig");
     _ = @import("upstream_failover.zig");
 }
@@ -151,11 +153,9 @@ const setTcpNoDelay = socket_utils.setTcpNoDelay;
 const configureRelaySocket = socket_utils.configureRelaySocket;
 const formatAddress = socket_utils.formatAddress;
 
-const parseIpv4Literal = network_detect.parseIpv4Literal;
 const parseListenAddress = network_detect.parseListenAddress;
 const isRunningInNonInitNetns = network_detect.isRunningInNonInitNetns;
 const detectAwgEndpointIpv4 = network_detect.detectAwgEndpointIpv4;
-const formatIpv4Bytes = network_detect.formatIpv4Bytes;
 const ipv4NetworkToHostBytes = network_detect.ipv4NetworkToHostBytes;
 const fetchUrlBytes = http_fetch.fetchUrlBytes;
 const fetchUrlBytesViaInterface = http_fetch.fetchUrlBytesViaInterface;
@@ -177,104 +177,6 @@ const getAddressList = net_helpers.getAddressList;
 
 fn detectPublicIpv4(allocator: std.mem.Allocator) ?[4]u8 {
     return network_detect.detectPublicIpv4(allocator, fetchUrlBytes);
-}
-
-fn detectMiddleProxyNatIpv4(
-    allocator: std.mem.Allocator,
-    cfg: *const Config,
-    comptime detect_awg: fn (std.mem.Allocator) ?[4]u8,
-    comptime detect_public: fn (std.mem.Allocator) ?[4]u8,
-) ?[4]u8 {
-    if (cfg.middle_proxy_nat_ip) |configured_nat_ip| {
-        if (parseIpv4Literal(configured_nat_ip)) |parsed_ip| {
-            var ip_buf: [16]u8 = undefined;
-            log.info("Using server.middle_proxy_nat_ip for middle-proxy NAT translation: {s}", .{formatIpv4Bytes(parsed_ip, &ip_buf)});
-            return parsed_ip;
-        }
-        log.info("server.middle_proxy_nat_ip='{s}' is not an IPv4 literal; falling back to AWG/public detection", .{configured_nat_ip});
-    }
-
-    if (detect_awg(allocator)) |awg_ip| {
-        var awg_ip_buf: [16]u8 = undefined;
-        log.info("Using AWG endpoint IPv4 for middle-proxy NAT translation: {s}", .{formatIpv4Bytes(awg_ip, &awg_ip_buf)});
-        return awg_ip;
-    }
-
-    if (detect_public(allocator)) |ip| {
-        var ip_buf: [16]u8 = undefined;
-        log.info("Detected public IPv4 for middle-proxy NAT translation: {s}", .{formatIpv4Bytes(ip, &ip_buf)});
-        return ip;
-    }
-
-    return null;
-}
-
-test "middle-proxy NAT detection does not derive from public_ip" {
-    const Callbacks = struct {
-        fn noAwg(_: std.mem.Allocator) ?[4]u8 {
-            return null;
-        }
-
-        fn publicEgress(_: std.mem.Allocator) ?[4]u8 {
-            return .{ 203, 0, 113, 9 };
-        }
-    };
-
-    var cfg = Config{
-        .public_ip = "198.51.100.10",
-        .users = std.StringHashMap([16]u8).init(std.testing.allocator),
-        .direct_users = std.StringHashMap(void).init(std.testing.allocator),
-    };
-    defer cfg.users.deinit();
-    defer cfg.direct_users.deinit();
-
-    const got = detectMiddleProxyNatIpv4(std.testing.allocator, &cfg, Callbacks.noAwg, Callbacks.publicEgress).?;
-    try std.testing.expectEqual([4]u8{ 203, 0, 113, 9 }, got);
-}
-
-test "middle-proxy NAT detection prefers explicit override" {
-    const Callbacks = struct {
-        fn awgEgress(_: std.mem.Allocator) ?[4]u8 {
-            return .{ 203, 0, 113, 9 };
-        }
-
-        fn publicEgress(_: std.mem.Allocator) ?[4]u8 {
-            return .{ 198, 51, 100, 20 };
-        }
-    };
-
-    var cfg = Config{
-        .middle_proxy_nat_ip = "192.0.2.7",
-        .users = std.StringHashMap([16]u8).init(std.testing.allocator),
-        .direct_users = std.StringHashMap(void).init(std.testing.allocator),
-    };
-    defer cfg.users.deinit();
-    defer cfg.direct_users.deinit();
-
-    const got = detectMiddleProxyNatIpv4(std.testing.allocator, &cfg, Callbacks.awgEgress, Callbacks.publicEgress).?;
-    try std.testing.expectEqual([4]u8{ 192, 0, 2, 7 }, got);
-}
-
-test "middle-proxy NAT detection prefers AWG endpoint before public egress probe" {
-    const Callbacks = struct {
-        fn awgEgress(_: std.mem.Allocator) ?[4]u8 {
-            return .{ 203, 0, 113, 9 };
-        }
-
-        fn publicEgress(_: std.mem.Allocator) ?[4]u8 {
-            return .{ 198, 51, 100, 20 };
-        }
-    };
-
-    var cfg = Config{
-        .users = std.StringHashMap([16]u8).init(std.testing.allocator),
-        .direct_users = std.StringHashMap(void).init(std.testing.allocator),
-    };
-    defer cfg.users.deinit();
-    defer cfg.direct_users.deinit();
-
-    const got = detectMiddleProxyNatIpv4(std.testing.allocator, &cfg, Callbacks.awgEgress, Callbacks.publicEgress).?;
-    try std.testing.expectEqual([4]u8{ 203, 0, 113, 9 }, got);
 }
 
 fn runSmallCommand(allocator: std.mem.Allocator, argv: []const []const u8) ?[]u8 {
@@ -777,7 +679,7 @@ pub const ProxyState = struct {
         @memcpy(default_middle_proxy_secret[0..middleproxy.proxy_secret.len], middleproxy.proxy_secret[0..]);
 
         const detected_nat_ip4 = if (cfg.datacenter_override == null)
-            detectMiddleProxyNatIpv4(allocator, &cfg, detectAwgEndpointIpv4, detectPublicIpv4)
+            middle_proxy_nat.detectIpv4(allocator, &cfg, detectAwgEndpointIpv4, detectPublicIpv4)
         else
             null;
 

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -179,6 +179,104 @@ fn detectPublicIpv4(allocator: std.mem.Allocator) ?[4]u8 {
     return network_detect.detectPublicIpv4(allocator, fetchUrlBytes);
 }
 
+fn detectMiddleProxyNatIpv4(
+    allocator: std.mem.Allocator,
+    cfg: *const Config,
+    comptime detect_awg: fn (std.mem.Allocator) ?[4]u8,
+    comptime detect_public: fn (std.mem.Allocator) ?[4]u8,
+) ?[4]u8 {
+    if (cfg.middle_proxy_nat_ip) |configured_nat_ip| {
+        if (parseIpv4Literal(configured_nat_ip)) |parsed_ip| {
+            var ip_buf: [16]u8 = undefined;
+            log.info("Using server.middle_proxy_nat_ip for middle-proxy NAT translation: {s}", .{formatIpv4Bytes(parsed_ip, &ip_buf)});
+            return parsed_ip;
+        }
+        log.info("server.middle_proxy_nat_ip='{s}' is not an IPv4 literal; falling back to AWG/public detection", .{configured_nat_ip});
+    }
+
+    if (detect_awg(allocator)) |awg_ip| {
+        var awg_ip_buf: [16]u8 = undefined;
+        log.info("Using AWG endpoint IPv4 for middle-proxy NAT translation: {s}", .{formatIpv4Bytes(awg_ip, &awg_ip_buf)});
+        return awg_ip;
+    }
+
+    if (detect_public(allocator)) |ip| {
+        var ip_buf: [16]u8 = undefined;
+        log.info("Detected public IPv4 for middle-proxy NAT translation: {s}", .{formatIpv4Bytes(ip, &ip_buf)});
+        return ip;
+    }
+
+    return null;
+}
+
+test "middle-proxy NAT detection does not derive from public_ip" {
+    const Callbacks = struct {
+        fn noAwg(_: std.mem.Allocator) ?[4]u8 {
+            return null;
+        }
+
+        fn publicEgress(_: std.mem.Allocator) ?[4]u8 {
+            return .{ 203, 0, 113, 9 };
+        }
+    };
+
+    var cfg = Config{
+        .public_ip = "198.51.100.10",
+        .users = std.StringHashMap([16]u8).init(std.testing.allocator),
+        .direct_users = std.StringHashMap(void).init(std.testing.allocator),
+    };
+    defer cfg.users.deinit();
+    defer cfg.direct_users.deinit();
+
+    const got = detectMiddleProxyNatIpv4(std.testing.allocator, &cfg, Callbacks.noAwg, Callbacks.publicEgress).?;
+    try std.testing.expectEqual([4]u8{ 203, 0, 113, 9 }, got);
+}
+
+test "middle-proxy NAT detection prefers explicit override" {
+    const Callbacks = struct {
+        fn awgEgress(_: std.mem.Allocator) ?[4]u8 {
+            return .{ 203, 0, 113, 9 };
+        }
+
+        fn publicEgress(_: std.mem.Allocator) ?[4]u8 {
+            return .{ 198, 51, 100, 20 };
+        }
+    };
+
+    var cfg = Config{
+        .middle_proxy_nat_ip = "192.0.2.7",
+        .users = std.StringHashMap([16]u8).init(std.testing.allocator),
+        .direct_users = std.StringHashMap(void).init(std.testing.allocator),
+    };
+    defer cfg.users.deinit();
+    defer cfg.direct_users.deinit();
+
+    const got = detectMiddleProxyNatIpv4(std.testing.allocator, &cfg, Callbacks.awgEgress, Callbacks.publicEgress).?;
+    try std.testing.expectEqual([4]u8{ 192, 0, 2, 7 }, got);
+}
+
+test "middle-proxy NAT detection prefers AWG endpoint before public egress probe" {
+    const Callbacks = struct {
+        fn awgEgress(_: std.mem.Allocator) ?[4]u8 {
+            return .{ 203, 0, 113, 9 };
+        }
+
+        fn publicEgress(_: std.mem.Allocator) ?[4]u8 {
+            return .{ 198, 51, 100, 20 };
+        }
+    };
+
+    var cfg = Config{
+        .users = std.StringHashMap([16]u8).init(std.testing.allocator),
+        .direct_users = std.StringHashMap(void).init(std.testing.allocator),
+    };
+    defer cfg.users.deinit();
+    defer cfg.direct_users.deinit();
+
+    const got = detectMiddleProxyNatIpv4(std.testing.allocator, &cfg, Callbacks.awgEgress, Callbacks.publicEgress).?;
+    try std.testing.expectEqual([4]u8{ 203, 0, 113, 9 }, got);
+}
+
 fn runSmallCommand(allocator: std.mem.Allocator, argv: []const []const u8) ?[]u8 {
     var io_instance: std.Io.Threaded = .init(std.heap.page_allocator, .{});
     defer io_instance.deinit();
@@ -678,46 +776,10 @@ pub const ProxyState = struct {
         var default_middle_proxy_secret = [_]u8{0} ** 256;
         @memcpy(default_middle_proxy_secret[0..middleproxy.proxy_secret.len], middleproxy.proxy_secret[0..]);
 
-        var detected_nat_ip4: ?[4]u8 = null;
-        if (cfg.datacenter_override == null) {
-            if (cfg.middle_proxy_nat_ip) |configured_nat_ip| {
-                if (parseIpv4Literal(configured_nat_ip)) |parsed_ip| {
-                    detected_nat_ip4 = parsed_ip;
-                    var ip_buf: [16]u8 = undefined;
-                    log.info("Using server.middle_proxy_nat_ip for middle-proxy NAT translation: {s}", .{formatIpv4Bytes(parsed_ip, &ip_buf)});
-                } else {
-                    log.info("server.middle_proxy_nat_ip='{s}' is not an IPv4 literal; falling back to AWG/public detection", .{configured_nat_ip});
-                }
-            }
-
-            if (detected_nat_ip4 == null) {
-                if (detectAwgEndpointIpv4(allocator)) |awg_ip| {
-                    detected_nat_ip4 = awg_ip;
-                    var awg_ip_buf: [16]u8 = undefined;
-                    log.info("Using AWG endpoint IPv4 for middle-proxy NAT translation: {s}", .{formatIpv4Bytes(awg_ip, &awg_ip_buf)});
-                }
-            }
-
-            if (detected_nat_ip4 == null) {
-                if (cfg.public_ip) |configured_public_ip| {
-                    if (parseIpv4Literal(configured_public_ip)) |parsed_ip| {
-                        detected_nat_ip4 = parsed_ip;
-                        var ip_buf: [16]u8 = undefined;
-                        log.info("Using server.public_ip for middle-proxy NAT translation: {s}", .{formatIpv4Bytes(parsed_ip, &ip_buf)});
-                    } else {
-                        log.info("server.public_ip='{s}' is not an IPv4 literal; auto-detecting middle-proxy NAT IP", .{configured_public_ip});
-                    }
-                }
-            }
-
-            if (detected_nat_ip4 == null) {
-                detected_nat_ip4 = detectPublicIpv4(allocator);
-                if (detected_nat_ip4) |ip| {
-                    var ip_buf: [16]u8 = undefined;
-                    log.info("Detected public IPv4 for middle-proxy NAT translation: {s}", .{formatIpv4Bytes(ip, &ip_buf)});
-                }
-            }
-        }
+        const detected_nat_ip4 = if (cfg.datacenter_override == null)
+            detectMiddleProxyNatIpv4(allocator, &cfg, detectAwgEndpointIpv4, detectPublicIpv4)
+        else
+            null;
 
         const user_secrets = try secrets.toOwnedSlice(allocator);
         errdefer allocator.free(user_secrets);


### PR DESCRIPTION
## What changed
- Stopped using `[server].public_ip` as a fallback source for MiddleProxy NAT translation.
- Extracted MiddleProxy NAT IPv4 selection into a tested helper.
- Preserved the intended priority order: explicit `[server].middle_proxy_nat_ip`, AWG endpoint detection, then independent public egress detection.
- Added regression coverage proving `public_ip` is not used as the NAT IP source.
- Printed `middle_proxy_nat_ip` in `mtbuddy config` effective output when configured.
- Updated README/config wording to separate inbound client links from outbound MiddleProxy egress.

## Root cause
`public_ip` is an inbound address used in generated client links. In tunnel/NAT setups, the outbound source IP seen by Telegram MiddleProxy can be different. Reusing `public_ip` for MiddleProxy key derivation made operators choose between a working client link and a working media path.

## Impact
Operators can now keep `public_ip` pointed at the server clients connect to, while MiddleProxy NAT uses the actual outbound egress IP via `middle_proxy_nat_ip` or auto-detection.

## Validation
- `zig fmt src/proxy/proxy.zig src/ctl/config_cmd.zig --check`
- `git diff --check`
- `zig build test --summary all`
- Result: `137/137 tests passed`