### PR TITLE
[codex] Harden Debian installer commands

### DIFF
--- a/src/ctl/install.zig
+++ b/src/ctl/install.zig
@@ -792,13 +792,16 @@ fn localized(ui: *const Tui, en: []const u8, ru: []const u8) []const u8 {
 }
 
 fn ensureServiceUser(ui: *Tui, allocator: std.mem.Allocator) bool {
+    const groupadd = sys.commandOrPath("groupadd", &.{ "/usr/sbin/groupadd", "/sbin/groupadd" });
+    const useradd = sys.commandOrPath("useradd", &.{ "/usr/sbin/useradd", "/sbin/useradd" });
+
     if (!groupExists(allocator, "mtproto")) {
-        if (!runRequired(ui, allocator, &.{ "groupadd", "--system", "mtproto" }, "Failed to create system group 'mtproto'")) return false;
+        if (!runRequired(ui, allocator, &.{ groupadd, "--system", "mtproto" }, "Failed to create system group 'mtproto'")) return false;
     }
 
     if (!userExists(allocator, "mtproto")) {
         if (!runRequired(ui, allocator, &.{
-            "useradd",
+            useradd,
             "--system",
             "--no-create-home",
             "--home-dir",
@@ -836,9 +839,9 @@ fn groupExists(allocator: std.mem.Allocator, name: []const u8) bool {
 }
 
 fn runRequired(ui: *Tui, allocator: std.mem.Allocator, argv: []const []const u8, failure_msg: []const u8) bool {
-    const result = sys.exec(allocator, argv) catch {
+    const result = sys.exec(allocator, argv) catch |err| {
         ui.fail(failure_msg);
-        ui.info("Failed to spawn command");
+        ui.print("  {s}◆{s} Failed to spawn command: {s}\n", .{ Color.info, Color.reset, @errorName(err) });
         return false;
     };
     defer result.deinit();
@@ -857,10 +860,10 @@ fn runRequiredWhileSpinning(
     failure_msg: []const u8,
     sp: *tui_mod.Spinner,
 ) bool {
-    const result = sys.exec(allocator, argv) catch {
+    const result = sys.exec(allocator, argv) catch |err| {
         sp.stop(false, "");
         ui.fail(failure_msg);
-        ui.info("Failed to spawn command");
+        ui.print("  {s}◆{s} Failed to spawn command: {s}\n", .{ Color.info, Color.reset, @errorName(err) });
         return false;
     };
     defer result.deinit();

--- a/src/ctl/masking.zig
+++ b/src/ctl/masking.zig
@@ -69,11 +69,19 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: MaskingOpts) !void 
         ui.ok("Nginx already installed");
     } else {
         ui.step("Installing Nginx...");
-        _ = sys.exec(allocator, &.{ "mkdir", "-p", "/etc/nginx/sites-available", "/etc/nginx/sites-enabled" }) catch {};
-        sys.writeFile("/etc/nginx/sites-available/default", "# Empty default\n") catch {};
-        sys.execSilent(allocator, &.{ "ln", "-sf", "/etc/nginx/sites-available/default", "/etc/nginx/sites-enabled/default" });
-        _ = sys.execForward(&.{ "apt-get", "update", "-qq" }) catch {};
-        _ = sys.execForward(&.{ "apt-get", "install", "-y", "nginx" }) catch {};
+        if (!runLogged(ui, allocator, &.{ "env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "update", "-qq" }, "apt-get update failed")) return;
+        if (!runLogged(ui, allocator, &.{
+            "env",
+            "DEBIAN_FRONTEND=noninteractive",
+            "apt-get",
+            "-o",
+            "Dpkg::Options::=--force-confdef",
+            "-o",
+            "Dpkg::Options::=--force-confold",
+            "install",
+            "-y",
+            "nginx",
+        }, "Failed to install Nginx")) return;
         ui.ok("Nginx installed");
     }
 
@@ -232,4 +240,36 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: MaskingOpts) !void 
         .{ .label = "Bad clients are now forwarded to local Nginx (<1ms RTT)", .style = .success },
         .{ .label = "Timing side-channel eliminated", .style = .success },
     });
+}
+
+fn runLogged(ui: *Tui, allocator: std.mem.Allocator, argv: []const []const u8, failure_msg: []const u8) bool {
+    const result = sys.exec(allocator, argv) catch |err| {
+        ui.fail(failure_msg);
+        ui.print("  {s}◆{s} Failed to spawn command: {s}\n", .{ Color.info, Color.reset, @errorName(err) });
+        return false;
+    };
+    defer result.deinit();
+
+    if (result.exit_code == 0) return true;
+
+    ui.fail(failure_msg);
+    printCommandOutput(ui, &result);
+    return false;
+}
+
+fn printCommandOutput(ui: *Tui, result: *const sys.ExecResult) void {
+    const stderr = std.mem.trim(u8, result.stderr, &[_]u8{ ' ', '\t', '\r', '\n' });
+    if (stderr.len > 0) {
+        ui.print("  stderr:\n{s}\n", .{tailBytes(stderr, 4096)});
+    }
+
+    const stdout = std.mem.trim(u8, result.stdout, &[_]u8{ ' ', '\t', '\r', '\n' });
+    if (stdout.len > 0) {
+        ui.print("  stdout:\n{s}\n", .{tailBytes(stdout, 4096)});
+    }
+}
+
+fn tailBytes(bytes: []const u8, max_len: usize) []const u8 {
+    if (bytes.len <= max_len) return bytes;
+    return bytes[bytes.len - max_len ..];
 }

--- a/src/ctl/nfqws.zig
+++ b/src/ctl/nfqws.zig
@@ -91,10 +91,24 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: NfqwsOpts) !void {
 
     // ── Install dependencies ──
     ui.step("Installing build dependencies...");
-    if (!runLogged(ui, allocator, &.{ "apt-get", "update", "-qq" }, "apt-get update failed")) return;
+    if (!runLogged(ui, allocator, &.{ "env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "update", "-qq" }, "apt-get update failed")) return;
     if (!runLogged(ui, allocator, &.{
-        "apt-get",                "install",          "-y",         "build-essential", "git",
-        "libnetfilter-queue-dev", "libnfnetlink-dev", "libcap-dev", "iptables",        "libmnl-dev",
+        "env",
+        "DEBIAN_FRONTEND=noninteractive",
+        "apt-get",
+        "-o",
+        "Dpkg::Options::=--force-confdef",
+        "-o",
+        "Dpkg::Options::=--force-confold",
+        "install",
+        "-y",
+        "build-essential",
+        "git",
+        "libnetfilter-queue-dev",
+        "libnfnetlink-dev",
+        "libcap-dev",
+        "iptables",
+        "libmnl-dev",
         "zlib1g-dev",
     }, "Failed to install nfqws build dependencies")) return;
     ui.ok("Dependencies installed");
@@ -126,16 +140,21 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: NfqwsOpts) !void {
     removeNfqwsRules(allocator, "iptables");
     removeNfqwsRules(allocator, "ip6tables");
 
-    _ = sys.exec(allocator, &.{
+    if (!runLogged(ui, allocator, &.{
         "iptables", "-t",          "mangle",    "-A", "OUTPUT",
         "-p",       "tcp",         "--sport",   port, "-j",
         "NFQUEUE",  "--queue-num", NFQUEUE_NUM,
-    }) catch {};
+    }, "Failed to apply IPv4 NFQUEUE rule")) return;
     _ = sys.exec(allocator, &.{
         "ip6tables", "-t",          "mangle",    "-A", "OUTPUT",
         "-p",        "tcp",         "--sport",   port, "-j",
         "NFQUEUE",   "--queue-num", NFQUEUE_NUM,
     }) catch {};
+
+    if (!outputRuleContains(allocator, "iptables", "NFQUEUE")) {
+        ui.fail("IPv4 NFQUEUE rule was not installed");
+        return;
+    }
 
     _ = sys.exec(allocator, &.{ "bash", "-c", "mkdir -p /etc/iptables && iptables-save > /etc/iptables/rules.v4 && ip6tables-save > /etc/iptables/rules.v6" }) catch {};
     ui.ok("NFQUEUE rules applied (queue " ++ NFQUEUE_NUM ++ ")");
@@ -212,10 +231,17 @@ fn removeNfqwsRules(allocator: std.mem.Allocator, ipt: []const u8) void {
     _ = sys.exec(allocator, &.{ "bash", "-c", cmd }) catch {};
 }
 
+fn outputRuleContains(allocator: std.mem.Allocator, ipt: []const u8, needle: []const u8) bool {
+    const result = sys.exec(allocator, &.{ ipt, "-t", "mangle", "-S", "OUTPUT" }) catch return false;
+    defer result.deinit();
+    if (result.exit_code != 0) return false;
+    return std.mem.indexOf(u8, result.stdout, needle) != null;
+}
+
 fn runLogged(ui: *Tui, allocator: std.mem.Allocator, argv: []const []const u8, failure_msg: []const u8) bool {
-    const result = sys.exec(allocator, argv) catch {
+    const result = sys.exec(allocator, argv) catch |err| {
         ui.fail(failure_msg);
-        ui.info("Failed to spawn command");
+        ui.print("  {s}◆{s} Failed to spawn command: {s}\n", .{ Color.info, Color.reset, @errorName(err) });
         return false;
     };
     defer result.deinit();

--- a/src/ctl/sys.zig
+++ b/src/ctl/sys.zig
@@ -182,6 +182,17 @@ pub fn commandExists(name: []const u8) bool {
     return result.exit_code == 0;
 }
 
+/// Resolve a command by PATH first, then by known absolute-path fallbacks.
+pub fn commandOrPath(name: []const u8, candidates: []const []const u8) []const u8 {
+    if (commandExists(name)) return name;
+
+    for (candidates) |candidate| {
+        if (fileExists(candidate)) return candidate;
+    }
+
+    return name;
+}
+
 /// Check if a systemd service is active.
 pub fn isServiceActive(service: []const u8) bool {
     const result = exec(std.heap.page_allocator, &.{ "systemctl", "is-active", "--quiet", service }) catch return false;

--- a/src/ctl/uninstall.zig
+++ b/src/ctl/uninstall.zig
@@ -82,7 +82,8 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
     _ = sys.execForward(&.{ "rm", "-rf", "/opt/zapret" }) catch {};
 
     // 3. Remove user
-    _ = sys.execForward(&.{ "userdel", "mtproto" }) catch {};
+    const userdel = sys.commandOrPath("userdel", &.{ "/usr/sbin/userdel", "/sbin/userdel" });
+    _ = sys.execForward(&.{ userdel, "mtproto" }) catch {};
 
     // 4. Cleanup tunnel routing artifacts (new + legacy)
     _ = sys.execForward(&.{ "ip", "-4", "rule", "del", "fwmark", "200", "table", "200" }) catch {};


### PR DESCRIPTION
## Summary

Harden the mtbuddy Debian install path after reproducing a failure on a clean Debian 12 host.

## What Changed

- Resolve account-management commands through PATH first, then `/usr/sbin` and `/sbin` fallbacks for `groupadd`, `useradd`, and `userdel`.
- Include the underlying spawn error name when required commands cannot be started.
- Run nginx and nfqws package installs with noninteractive apt and `force-confdef`/`force-confold` dpkg options.
- Avoid pre-creating nginx's packaged default conffile before installing nginx.
- Make nfqws fail clearly if the IPv4 NFQUEUE rule is not actually installed.

## Root Cause

The initial install could stop at `Failed to create system group 'mtproto'` when the installer process could not spawn `groupadd`. On minimal Debian systems these account tools live under `/usr/sbin`, and PATH/env differences can make the bare command lookup brittle.

The live Debian 12 retry also exposed two follow-up installer weaknesses: nginx package configuration could hit a conffile prompt, and nfqws reported success paths without confirming the kernel rule was present.

## Impact

Clean Debian 12 installs should complete more reliably, and failures should point at the real command or package-manager problem instead of continuing with misleading success output.

## Validation

- `zig fmt src/ctl/masking.zig src/ctl/nfqws.zig src/ctl/sys.zig src/ctl/install.zig src/ctl/uninstall.zig`
- `git diff --check`
- `zig build -Dtarget=x86_64-linux-musl`
- Validated manually on a clean Debian 12 VPS: `mtproto-proxy`, `nginx`, `nfqws-mtproto`, and `mtproto-mask-health.timer` active; TCP 443 reachable; local masking on `127.0.0.1:8443` returned HTTP 200; IPv4/IPv6 `TCPMSS` and `NFQUEUE #200` rules present.