### PR TITLE
[codex] Harden installer e2e dependencies

### DIFF
--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -46,8 +46,8 @@ install_minisign_if_needed() {
   step "Installing minisign for signature verification"
   if command -v apt-get >/dev/null 2>&1; then
     export DEBIAN_FRONTEND="${DEBIAN_FRONTEND:-noninteractive}"
-    apt-get update -qq || fail "apt-get update failed while installing minisign"
-    apt-get install -y --no-install-recommends minisign \
+    apt-get -o DPkg::Lock::Timeout=600 update -qq || fail "apt-get update failed while installing minisign"
+    apt-get -o DPkg::Lock::Timeout=600 install -y --no-install-recommends minisign \
       || fail "apt-get could not install minisign"
   elif command -v dnf >/dev/null 2>&1; then
     dnf install -y minisign || fail "dnf could not install minisign"
@@ -200,9 +200,16 @@ fi
 install -m 0755 "$BUDDY_BIN" "$INSTALL_TO"
 ok "mtbuddy installed → $INSTALL_TO"
 
+if ! command -v mtbuddy >/dev/null 2>&1 && [ -d /usr/bin ]; then
+  if [ ! -e /usr/bin/mtbuddy ] || [ -L /usr/bin/mtbuddy ]; then
+    ln -sf "$INSTALL_TO" /usr/bin/mtbuddy \
+      && ok "mtbuddy linked → /usr/bin/mtbuddy"
+  fi
+fi
+
 # ── run with forwarded args ───────────────────────────────────────
 if [ "${#FORWARD_ARGS[@]}" -gt 0 ]; then
-  exec mtbuddy "${FORWARD_ARGS[@]}"
+  exec "$INSTALL_TO" "${FORWARD_ARGS[@]}"
 else
-  mtbuddy --help
+  "$INSTALL_TO" --help
 fi

--- a/src/ctl/install.zig
+++ b/src/ctl/install.zig
@@ -313,23 +313,41 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
     {
         var sp = ui.spinner(ui.str(.install_checking_deps));
         sp.start();
-        _ = sys.exec(allocator, &.{ "apt-get", "update", "-qq" }) catch {};
+        if (!sys.commandExists("apt-get")) {
+            sp.stop(false, "");
+            ui.fail("apt-get is required to install system dependencies");
+            return;
+        }
+        if (!runRequiredWhileSpinning(ui, allocator, &.{ "env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "-o", "DPkg::Lock::Timeout=600", "update", "-qq" }, "apt-get update failed", &sp)) return;
         const base_packages: []const []const u8 = if (signature_available and !insecure_mode)
             &.{
-                "apt-get",  "install", "-y",
-                "iptables", "xxd",     "curl",
-                "openssl",  "tar",     "minisign",
+                "env",                     "DEBIAN_FRONTEND=noninteractive",
+                "apt-get",                 "-o",
+                "DPkg::Lock::Timeout=600", "install",
+                "-y",                      "--no-install-recommends",
+                "iptables",                "xxd",
+                "curl",                    "openssl",
+                "tar",                     "passwd",
+                "minisign",
             }
         else
             &.{
-                "apt-get",  "install", "-y",
-                "iptables", "xxd",     "curl",
-                "openssl",  "tar",
+                "env",                     "DEBIAN_FRONTEND=noninteractive",
+                "apt-get",                 "-o",
+                "DPkg::Lock::Timeout=600", "install",
+                "-y",                      "--no-install-recommends",
+                "iptables",                "xxd",
+                "curl",                    "openssl",
+                "tar",                     "passwd",
             };
-        _ = sys.exec(allocator, base_packages) catch {};
+        if (!runRequiredWhileSpinning(ui, allocator, base_packages, "Failed to install system dependencies", &sp)) return;
         if (signature_available and !insecure_mode and !sys.commandExists("minisign")) {
             sp.stop(false, "");
             ui.fail("minisign is required for release signature verification");
+            return;
+        }
+        if (!requiredAccountToolsAvailable(ui)) {
+            sp.stop(false, "");
             return;
         }
         sp.stop(true, "");
@@ -479,11 +497,17 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
         ui.ok(ui.str(.install_tcpmss_ok));
     }
 
+    var summary_opts = opts;
+
     // ── Masking (via Zig module) ──
     if (opts.enable_masking) {
         masking.execute(ui, allocator, .{ .tls_domain = opts.tls_domain }) catch {
             ui.warn("Masking setup failed");
         };
+        summary_opts.enable_masking = sys.fileExists("/etc/nginx/sites-enabled/mtproto-masking") and sys.isServiceActive("nginx");
+        if (!summary_opts.enable_masking) {
+            ui.warn("Masking setup did not complete; final summary will show it disabled.");
+        }
     }
 
     // ── nfqws (via Zig module) ──
@@ -491,6 +515,10 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
         nfqws.execute(ui, allocator, .{}) catch {
             ui.warn("nfqws setup failed");
         };
+        summary_opts.enable_nfqws = sys.fileExists("/opt/zapret/nfq/nfqws") and sys.isServiceActive("nfqws-mtproto");
+        if (!summary_opts.enable_nfqws) {
+            ui.warn("nfqws setup did not complete; final summary will show it disabled.");
+        }
     }
 
     // ── Final restart ──
@@ -521,7 +549,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
 
     {
         var cfg_doc = toml.TomlDoc.load(allocator, config_path_buf) catch {
-            printSummary(ui, allocator, public_ip, opts.port, secret_from_cfg, opts.tls_domain, opts, config_path_buf);
+            printSummary(ui, allocator, public_ip, opts.port, secret_from_cfg, opts.tls_domain, summary_opts, config_path_buf);
             return;
         };
         defer cfg_doc.deinit();
@@ -563,7 +591,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
         summary_port,
         secret_from_cfg,
         summary_tls_domain,
-        opts,
+        summary_opts,
         config_path_buf,
     );
 }
@@ -792,8 +820,22 @@ fn localized(ui: *const Tui, en: []const u8, ru: []const u8) []const u8 {
 }
 
 fn ensureServiceUser(ui: *Tui, allocator: std.mem.Allocator) bool {
-    const groupadd = sys.commandOrPath("groupadd", &.{ "/usr/sbin/groupadd", "/sbin/groupadd" });
-    const useradd = sys.commandOrPath("useradd", &.{ "/usr/sbin/useradd", "/sbin/useradd" });
+    const groupadd_candidates = &[_][]const u8{ "/usr/sbin/groupadd", "/sbin/groupadd" };
+    const useradd_candidates = &[_][]const u8{ "/usr/sbin/useradd", "/sbin/useradd" };
+
+    if (!commandAvailable("groupadd", groupadd_candidates)) {
+        ui.fail("Missing required system command 'groupadd'");
+        ui.info("Install Debian package 'passwd' and run the installer again.");
+        return false;
+    }
+    if (!commandAvailable("useradd", useradd_candidates)) {
+        ui.fail("Missing required system command 'useradd'");
+        ui.info("Install Debian package 'passwd' and run the installer again.");
+        return false;
+    }
+
+    const groupadd = sys.commandOrPath("groupadd", groupadd_candidates);
+    const useradd = sys.commandOrPath("useradd", useradd_candidates);
 
     if (!groupExists(allocator, "mtproto")) {
         if (!runRequired(ui, allocator, &.{ groupadd, "--system", "mtproto" }, "Failed to create system group 'mtproto'")) return false;
@@ -824,6 +866,28 @@ fn ensureServiceUser(ui: *Tui, allocator: std.mem.Allocator) bool {
         return false;
     }
     return true;
+}
+
+fn requiredAccountToolsAvailable(ui: *Tui) bool {
+    if (!commandAvailable("groupadd", &.{ "/usr/sbin/groupadd", "/sbin/groupadd" })) {
+        ui.fail("Missing required system command 'groupadd' after dependency install");
+        ui.info("Debian package 'passwd' should provide it.");
+        return false;
+    }
+    if (!commandAvailable("useradd", &.{ "/usr/sbin/useradd", "/sbin/useradd" })) {
+        ui.fail("Missing required system command 'useradd' after dependency install");
+        ui.info("Debian package 'passwd' should provide it.");
+        return false;
+    }
+    return true;
+}
+
+fn commandAvailable(name: []const u8, candidates: []const []const u8) bool {
+    if (sys.commandExists(name)) return true;
+    for (candidates) |candidate| {
+        if (sys.fileExists(candidate)) return true;
+    }
+    return false;
 }
 
 fn userExists(allocator: std.mem.Allocator, name: []const u8) bool {

--- a/src/ctl/masking.zig
+++ b/src/ctl/masking.zig
@@ -69,11 +69,13 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: MaskingOpts) !void 
         ui.ok("Nginx already installed");
     } else {
         ui.step("Installing Nginx...");
-        if (!runLogged(ui, allocator, &.{ "env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "update", "-qq" }, "apt-get update failed")) return;
+        if (!runLogged(ui, allocator, &.{ "env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "-o", "DPkg::Lock::Timeout=600", "update", "-qq" }, "apt-get update failed")) return;
         if (!runLogged(ui, allocator, &.{
             "env",
             "DEBIAN_FRONTEND=noninteractive",
             "apt-get",
+            "-o",
+            "DPkg::Lock::Timeout=600",
             "-o",
             "Dpkg::Options::=--force-confdef",
             "-o",

--- a/src/ctl/nfqws.zig
+++ b/src/ctl/nfqws.zig
@@ -74,6 +74,8 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: NfqwsOpts) !void {
 
     // ── Uninstall ──
     if (opts.remove) {
+        const ipt = iptablesCommands();
+
         ui.step("Removing nfqws-mtproto...");
         _ = sys.execForward(&.{ "systemctl", "stop", SERVICE_NAME }) catch {};
         _ = sys.execForward(&.{ "systemctl", "disable", SERVICE_NAME }) catch {};
@@ -81,9 +83,16 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: NfqwsOpts) !void {
         _ = sys.execForward(&.{ "systemctl", "daemon-reload" }) catch {};
 
         // Remove iptables rules
-        removeNfqwsRules(allocator, "iptables");
-        removeNfqwsRules(allocator, "ip6tables");
-        _ = sys.exec(allocator, &.{ "bash", "-c", "iptables-save > /etc/iptables/rules.v4 2>/dev/null; ip6tables-save > /etc/iptables/rules.v6 2>/dev/null" }) catch {};
+        removeNfqwsRules(allocator, ipt.iptables);
+        removeNfqwsRules(allocator, ipt.ip6tables);
+        var save_cmd_buf: [512]u8 = undefined;
+        const save_cmd = std.fmt.bufPrint(&save_cmd_buf, "{s} > /etc/iptables/rules.v4 2>/dev/null; {s} > /etc/iptables/rules.v6 2>/dev/null", .{
+            ipt.iptables_save,
+            ipt.ip6tables_save,
+        }) catch "";
+        if (save_cmd.len > 0) {
+            _ = sys.exec(allocator, &.{ "bash", "-c", save_cmd }) catch {};
+        }
 
         ui.ok("nfqws-mtproto removed");
         return;
@@ -91,11 +100,13 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: NfqwsOpts) !void {
 
     // ── Install dependencies ──
     ui.step("Installing build dependencies...");
-    if (!runLogged(ui, allocator, &.{ "env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "update", "-qq" }, "apt-get update failed")) return;
+    if (!runLogged(ui, allocator, &.{ "env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "-o", "DPkg::Lock::Timeout=600", "update", "-qq" }, "apt-get update failed")) return;
     if (!runLogged(ui, allocator, &.{
         "env",
         "DEBIAN_FRONTEND=noninteractive",
         "apt-get",
+        "-o",
+        "DPkg::Lock::Timeout=600",
         "-o",
         "Dpkg::Options::=--force-confdef",
         "-o",
@@ -103,6 +114,12 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: NfqwsOpts) !void {
         "install",
         "-y",
         "build-essential",
+        "gcc",
+        "g++",
+        "cpp",
+        "make",
+        "binutils",
+        "libc6-dev",
         "git",
         "libnetfilter-queue-dev",
         "libnfnetlink-dev",
@@ -113,10 +130,14 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: NfqwsOpts) !void {
     }, "Failed to install nfqws build dependencies")) return;
     ui.ok("Dependencies installed");
 
+    const ipt = iptablesCommands();
+
     // ── Clone and build zapret ──
     if (sys.fileExists(ZAPRET_DIR ++ "/nfq/nfqws")) {
         ui.ok("nfqws already built");
     } else {
+        const cc = chooseWorkingCCompiler(ui, allocator) orelse return;
+
         ui.step("Cloning and building zapret...");
         _ = sys.exec(allocator, &.{ "rm", "-rf", ZAPRET_DIR }) catch {};
         if (!runLogged(ui, allocator, &.{
@@ -124,8 +145,14 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: NfqwsOpts) !void {
         }, "Failed to clone zapret")) return;
 
         _ = sys.exec(allocator, &.{ "bash", "-c", "cd " ++ ZAPRET_DIR ++ "/nfq && make clean" }) catch {};
+        var make_cmd_buf: [128]u8 = undefined;
+        const make_cmd = std.fmt.bufPrint(
+            &make_cmd_buf,
+            "cd " ++ ZAPRET_DIR ++ "/nfq && PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make CC={s}",
+            .{cc},
+        ) catch "cd " ++ ZAPRET_DIR ++ "/nfq && make";
         if (!runLogged(ui, allocator, &.{
-            "bash", "-c", "cd " ++ ZAPRET_DIR ++ "/nfq && make",
+            "bash", "-c", make_cmd,
         }, "nfqws build failed")) return;
 
         if (!sys.fileExists(ZAPRET_DIR ++ "/nfq/nfqws")) {
@@ -137,31 +164,38 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: NfqwsOpts) !void {
 
     // ── Configure iptables NFQUEUE ──
     ui.step("Setting up NFQUEUE rules...");
-    removeNfqwsRules(allocator, "iptables");
-    removeNfqwsRules(allocator, "ip6tables");
+    removeNfqwsRules(allocator, ipt.iptables);
+    removeNfqwsRules(allocator, ipt.ip6tables);
 
     if (!runLogged(ui, allocator, &.{
-        "iptables", "-t",          "mangle",    "-A", "OUTPUT",
-        "-p",       "tcp",         "--sport",   port, "-j",
-        "NFQUEUE",  "--queue-num", NFQUEUE_NUM,
+        ipt.iptables, "-t",          "mangle",    "-A", "OUTPUT",
+        "-p",         "tcp",         "--sport",   port, "-j",
+        "NFQUEUE",    "--queue-num", NFQUEUE_NUM,
     }, "Failed to apply IPv4 NFQUEUE rule")) return;
     _ = sys.exec(allocator, &.{
-        "ip6tables", "-t",          "mangle",    "-A", "OUTPUT",
-        "-p",        "tcp",         "--sport",   port, "-j",
-        "NFQUEUE",   "--queue-num", NFQUEUE_NUM,
+        ipt.ip6tables, "-t",          "mangle",    "-A", "OUTPUT",
+        "-p",          "tcp",         "--sport",   port, "-j",
+        "NFQUEUE",     "--queue-num", NFQUEUE_NUM,
     }) catch {};
 
-    if (!outputRuleContains(allocator, "iptables", "NFQUEUE")) {
+    if (!outputRuleContains(allocator, ipt.iptables, "NFQUEUE")) {
         ui.fail("IPv4 NFQUEUE rule was not installed");
         return;
     }
 
-    _ = sys.exec(allocator, &.{ "bash", "-c", "mkdir -p /etc/iptables && iptables-save > /etc/iptables/rules.v4 && ip6tables-save > /etc/iptables/rules.v6" }) catch {};
+    var save_cmd_buf: [512]u8 = undefined;
+    const save_cmd = std.fmt.bufPrint(&save_cmd_buf, "mkdir -p /etc/iptables && {s} > /etc/iptables/rules.v4 && {s} > /etc/iptables/rules.v6", .{
+        ipt.iptables_save,
+        ipt.ip6tables_save,
+    }) catch "";
+    if (save_cmd.len > 0) {
+        _ = sys.exec(allocator, &.{ "bash", "-c", save_cmd }) catch {};
+    }
     ui.ok("NFQUEUE rules applied (queue " ++ NFQUEUE_NUM ++ ")");
 
     // ── Create systemd service ──
     ui.step("Creating systemd service...");
-    var svc_buf: [2048]u8 = undefined;
+    var svc_buf: [3072]u8 = undefined;
     const svc_content = std.fmt.bufPrint(&svc_buf,
         \\[Unit]
         \\Description=nfqws TCP desync for MTProto proxy
@@ -170,6 +204,10 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: NfqwsOpts) !void {
         \\
         \\[Service]
         \\Type=simple
+        \\ExecStartPre=-{[iptables]s} -t mangle -D OUTPUT -p tcp --sport {[port]s} -j NFQUEUE --queue-num {[queue]s}
+        \\ExecStartPre=-{[ip6tables]s} -t mangle -D OUTPUT -p tcp --sport {[port]s} -j NFQUEUE --queue-num {[queue]s}
+        \\ExecStartPre={[iptables]s} -t mangle -A OUTPUT -p tcp --sport {[port]s} -j NFQUEUE --queue-num {[queue]s}
+        \\ExecStartPre=-{[ip6tables]s} -t mangle -A OUTPUT -p tcp --sport {[port]s} -j NFQUEUE --queue-num {[queue]s}
         \\ExecStart={[zapret_dir]s}/nfq/nfqws \
         \\    --qnum={[queue]s} \
         \\    --dpi-desync=fake,split2 \
@@ -187,7 +225,14 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: NfqwsOpts) !void {
         \\
         \\[Install]
         \\WantedBy=multi-user.target
-    , .{ .zapret_dir = ZAPRET_DIR, .queue = NFQUEUE_NUM, .ttl = opts.ttl }) catch "";
+    , .{
+        .iptables = ipt.iptables,
+        .ip6tables = ipt.ip6tables,
+        .port = port,
+        .zapret_dir = ZAPRET_DIR,
+        .queue = NFQUEUE_NUM,
+        .ttl = opts.ttl,
+    }) catch "";
 
     if (svc_content.len > 0) {
         sys.writeFile("/etc/systemd/system/" ++ SERVICE_NAME ++ ".service", svc_content) catch {
@@ -218,6 +263,103 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: NfqwsOpts) !void {
         .{ .label = "Split at byte 1 → DPI can't reassemble", .style = .success },
         .{ .label = "MD5sig fooling → fake never reaches client", .style = .success },
     });
+}
+
+const IptablesCommands = struct {
+    iptables: []const u8,
+    ip6tables: []const u8,
+    iptables_save: []const u8,
+    ip6tables_save: []const u8,
+};
+
+fn iptablesCommands() IptablesCommands {
+    return .{
+        .iptables = sys.commandOrPath("iptables", &.{ "/usr/sbin/iptables", "/sbin/iptables" }),
+        .ip6tables = sys.commandOrPath("ip6tables", &.{ "/usr/sbin/ip6tables", "/sbin/ip6tables" }),
+        .iptables_save = sys.commandOrPath("iptables-save", &.{ "/usr/sbin/iptables-save", "/sbin/iptables-save" }),
+        .ip6tables_save = sys.commandOrPath("ip6tables-save", &.{ "/usr/sbin/ip6tables-save", "/sbin/ip6tables-save" }),
+    };
+}
+
+fn chooseWorkingCCompiler(ui: *Tui, allocator: std.mem.Allocator) ?[]const u8 {
+    if (sys.fileExists("/usr/bin/gcc")) return "/usr/bin/gcc";
+    if (sys.commandExists("gcc")) return "gcc";
+
+    ui.warn("GCC not found after dependency install; reinstalling GCC toolchain...");
+    if (!repairGccToolchain(ui, allocator)) return null;
+
+    if (sys.fileExists("/usr/bin/gcc")) return "/usr/bin/gcc";
+    if (sys.commandExists("gcc")) return "gcc";
+
+    ui.fail("GCC is required to build nfqws but was not found");
+    ui.info("On Debian install it with: apt-get install gcc build-essential");
+    return null;
+}
+
+fn repairGccToolchain(ui: *Tui, allocator: std.mem.Allocator) bool {
+    _ = sys.exec(allocator, &.{ "env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "-o", "DPkg::Lock::Timeout=600", "update", "-qq" }) catch {};
+
+    if (!runLogged(ui, allocator, &.{
+        "env",
+        "DEBIAN_FRONTEND=noninteractive",
+        "apt-get",
+        "-o",
+        "DPkg::Lock::Timeout=600",
+        "-o",
+        "Dpkg::Options::=--force-confdef",
+        "-o",
+        "Dpkg::Options::=--force-confold",
+        "install",
+        "--reinstall",
+        "-y",
+        "build-essential",
+        "gcc",
+        "g++",
+        "cpp",
+        "make",
+        "binutils",
+        "libc6-dev",
+    }, "Failed to reinstall GCC toolchain")) return false;
+
+    reinstallVersionedGccPackages(ui, allocator);
+    return true;
+}
+
+fn reinstallVersionedGccPackages(ui: *Tui, allocator: std.mem.Allocator) void {
+    const result = sys.exec(allocator, &.{ "gcc", "-dumpversion" }) catch return;
+    defer result.deinit();
+    if (result.exit_code != 0) return;
+
+    const version = std.mem.trim(u8, result.stdout, &[_]u8{ ' ', '\t', '\r', '\n' });
+    var dot_pos = std.mem.indexOfScalar(u8, version, '.') orelse version.len;
+    if (dot_pos == 0) return;
+    dot_pos = @min(dot_pos, 8);
+    const major = version[0..dot_pos];
+    for (major) |c| {
+        if (!std.ascii.isDigit(c)) return;
+    }
+
+    var gcc_pkg_buf: [32]u8 = undefined;
+    var cpp_pkg_buf: [32]u8 = undefined;
+    const gcc_pkg = std.fmt.bufPrint(&gcc_pkg_buf, "gcc-{s}", .{major}) catch return;
+    const cpp_pkg = std.fmt.bufPrint(&cpp_pkg_buf, "cpp-{s}", .{major}) catch return;
+
+    const reinstall = sys.exec(allocator, &.{
+        "env",
+        "DEBIAN_FRONTEND=noninteractive",
+        "apt-get",
+        "-o",
+        "DPkg::Lock::Timeout=600",
+        "install",
+        "--reinstall",
+        "-y",
+        gcc_pkg,
+        cpp_pkg,
+    }) catch return;
+    defer reinstall.deinit();
+    if (reinstall.exit_code != 0) {
+        ui.warn("Versioned GCC package reinstall was skipped");
+    }
 }
 
 fn removeNfqwsRules(allocator: std.mem.Allocator, ipt: []const u8) void {

--- a/src/ctl/sys.zig
+++ b/src/ctl/sys.zig
@@ -56,6 +56,7 @@ pub fn exec(allocator: std.mem.Allocator, argv: []const []const u8) !ExecResult 
 
     const result = try std.process.run(allocator, io_instance.io(), .{
         .argv = argv,
+        .expand_arg0 = .expand,
         .stdout_limit = std.Io.Limit.limited(1024 * 1024),
         .stderr_limit = std.Io.Limit.limited(1024 * 1024),
     });
@@ -83,6 +84,7 @@ pub fn execForward(argv: []const []const u8) !u8 {
     const io_ctx = io_instance.io();
     var child = try std.process.spawn(io_ctx, .{
         .argv = argv,
+        .expand_arg0 = .expand,
         .stdout = .inherit,
         .stderr = .inherit,
     });
@@ -177,18 +179,28 @@ fn containsWord(haystack: []const u8, word: []const u8) bool {
 
 /// Check if a command exists on PATH.
 pub fn commandExists(name: []const u8) bool {
-    const result = exec(std.heap.page_allocator, &.{ "which", name }) catch return false;
+    if (std.mem.indexOfScalar(u8, name, '/') != null) return fileExists(name);
+
+    const shell = if (fileExists("/bin/sh")) "/bin/sh" else "sh";
+    const result = exec(std.heap.page_allocator, &.{
+        shell,
+        "-c",
+        "command -v \"$1\" >/dev/null 2>&1",
+        "sh",
+        name,
+    }) catch return false;
     defer result.deinit();
     return result.exit_code == 0;
 }
 
-/// Resolve a command by PATH first, then by known absolute-path fallbacks.
+/// Resolve a command by known absolute-path fallbacks first, then PATH.
+/// This avoids minimal root environments losing /usr/sbin tools at spawn time.
 pub fn commandOrPath(name: []const u8, candidates: []const []const u8) []const u8 {
-    if (commandExists(name)) return name;
-
     for (candidates) |candidate| {
         if (fileExists(candidate)) return candidate;
     }
+
+    if (commandExists(name)) return name;
 
     return name;
 }

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -728,14 +728,14 @@ fn ensureAmneziaWgInstalled(ui: *Tui, allocator: std.mem.Allocator) bool {
     if (!runCommandChecked(
         ui,
         allocator,
-        &.{ "apt-get", "-o", "APT::Update::Error-Mode=any", "update", "-qq" },
+        &.{ "apt-get", "-o", "DPkg::Lock::Timeout=600", "-o", "APT::Update::Error-Mode=any", "update", "-qq" },
         "Failed to refresh apt package index",
     )) return false;
 
     if (!runCommandChecked(
         ui,
         allocator,
-        &.{ "apt-get", "install", "-y", "software-properties-common" },
+        &.{ "apt-get", "-o", "DPkg::Lock::Timeout=600", "install", "-y", "software-properties-common" },
         "Failed to install software-properties-common",
     )) return false;
 
@@ -749,14 +749,14 @@ fn ensureAmneziaWgInstalled(ui: *Tui, allocator: std.mem.Allocator) bool {
     if (!runCommandChecked(
         ui,
         allocator,
-        &.{ "apt-get", "-o", "APT::Update::Error-Mode=any", "update", "-qq" },
+        &.{ "apt-get", "-o", "DPkg::Lock::Timeout=600", "-o", "APT::Update::Error-Mode=any", "update", "-qq" },
         "Failed to refresh apt index after adding Amnezia PPA",
     )) return false;
 
     if (!runCommandChecked(
         ui,
         allocator,
-        &.{ "apt-get", "install", "-y", "amneziawg-tools" },
+        &.{ "apt-get", "-o", "DPkg::Lock::Timeout=600", "install", "-y", "amneziawg-tools" },
         "Failed to install amneziawg-tools",
     )) return false;
 

--- a/src/ctl/uninstall.zig
+++ b/src/ctl/uninstall.zig
@@ -106,6 +106,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
     _ = sys.execForward(&.{ "bash", "-c", "while iptables -t mangle -D OUTPUT -p tcp --tcp-flags SYN,ACK SYN,ACK -j TCPMSS --set-mss 88 2>/dev/null; do true; done" }) catch {};
 
     // Note: Self-removal: The mtbuddy binary is running right now. Removing it while running usually works on Linux.
+    _ = sys.execForward(&.{ "bash", "-c", "[ \"$(readlink -f /usr/bin/mtbuddy 2>/dev/null)\" = /usr/local/bin/mtbuddy ] && rm -f /usr/bin/mtbuddy || true" }) catch {};
     _ = sys.execForward(&.{ "rm", "-f", "/usr/local/bin/mtbuddy" }) catch {};
 
     sp.stop(true, "");

--- a/src/ctl/update.zig
+++ b/src/ctl/update.zig
@@ -95,8 +95,8 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: UpdateOpts) !void {
     // ── Ensure signature verifier dependency ──
     if (signature_available and !insecure_mode and !sys.commandExists("minisign")) {
         ui.step("Installing minisign for release signature verification...");
-        _ = sys.exec(allocator, &.{ "apt-get", "update", "-qq" }) catch {};
-        _ = sys.exec(allocator, &.{ "apt-get", "install", "-y", "minisign" }) catch {};
+        _ = sys.exec(allocator, &.{ "apt-get", "-o", "DPkg::Lock::Timeout=600", "update", "-qq" }) catch {};
+        _ = sys.exec(allocator, &.{ "apt-get", "-o", "DPkg::Lock::Timeout=600", "install", "-y", "minisign" }) catch {};
         if (!sys.commandExists("minisign")) {
             ui.fail("minisign is required for release signature verification");
             return;


### PR DESCRIPTION
## Summary

This hardens the mtbuddy installer flow based on fresh Debian 12 and Ubuntu 24.04 e2e runs.

- install required account/toolchain packages explicitly, including `passwd`, GCC toolchain components, and iptables helpers
- resolve `/usr/sbin` commands with absolute fallbacks so minimal root PATHs do not break `groupadd`, `useradd`, or iptables
- make apt usage wait for dpkg locks across install, masking, nfqws, tunnel, update, and bootstrap paths
- build zapret/nfqws with an explicit working compiler and make the systemd NFQUEUE setup idempotent
- make the final install summary reflect actual masking/nfqws service state instead of showing false green checks
- link `/usr/bin/mtbuddy` from bootstrap when PATH lookup would otherwise miss `/usr/local/bin`

## Root Cause

Clean Debian/Ubuntu hosts can have minimal PATHs, missing `passwd`/toolchain components before dependency install, transient apt locks, and no shell expansion for command lookup. Those combined into `FileNotFound` failures for system user creation and iptables, plus `cc1` failures during nfqws builds.

## Validation

- `zig fmt src/ctl/install.zig src/ctl/sys.zig src/ctl/nfqws.zig src/ctl/masking.zig src/ctl/tunnel.zig src/ctl/uninstall.zig src/ctl/update.zig`
- `zig build test`
- `zig build -Dtarget=x86_64-linux-musl -Doptimize=ReleaseFast`
- `bash -n deploy/bootstrap.sh`
- fresh Debian 12 e2e install, repeated `mtbuddy setup nfqws`, service/listener/NFQUEUE checks
- fresh Ubuntu 24.04 e2e install, repeated `mtbuddy setup nfqws`, service/listener/NFQUEUE checks
