### PR TITLE
[codex] add public port override for proxy links

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ sudo mtbuddy --interactive
 | Flag | Default | Description |
 |---|---|---|
 | `--port, -p` | `443` | Proxy listen port |
+| `--public-port` | — | Port advertised in generated Telegram links |
 | `--domain, -d` | `wb.ru` | TLS masking domain |
 | `--secret, -s` | auto | User secret (32 hex chars) |
 | `--user, -u` | `user` | Username in `config.toml` |
@@ -338,6 +339,7 @@ type = "auto"            # auto | direct | tunnel | socks5 | http
 [server]
 port = 443
 # public_ip = "proxy.example.com"   # Inbound IP/domain used in client links
+# public_port = 443                 # Link port when behind HAProxy/Nginx
 # middle_proxy_nat_ip = "203.0.113.10"   # Outbound IPv4 seen by Telegram MiddleProxy
 max_connections = 512
 idle_timeout_sec = 120
@@ -385,6 +387,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[server] port` | `443` | TCP listen port |
 | `[server] bind_address` | — | Specific IP to bind the listen socket (default: all interfaces) |
 | `[server] public_ip` | auto | Inbound IP/domain shown in client links. Required with VPN tunnel; set IPv4 explicitly if clients fail on IPv6 links |
+| `[server] public_port` | `[server].port` | Port shown in client links; useful when HAProxy/Nginx exposes a different public port |
 | `[server] middle_proxy_nat_ip` | auto | Outbound IPv4 used in MiddleProxy key derivation; auto-detected independently from `public_ip`, set explicitly when DC traffic exits through a VPN/NAT IP |
 | `[server] backlog` | `4096` | TCP listen queue depth |
 | `[server] max_connections` | `512` | Concurrent connection cap, auto-clamped by RAM and `RLIMIT_NOFILE` |

--- a/README.ru.md
+++ b/README.ru.md
@@ -135,6 +135,7 @@ sudo mtbuddy --interactive
 | Флаг | По умолчанию | Описание |
 |---|---|---|
 | `--port, -p` | `443` | Порт прокси |
+| `--public-port` | — | Порт, который будет указан в Telegram-ссылках |
 | `--domain, -d` | `wb.ru` | Домен TLS-маскировки |
 | `--secret, -s` | auto | User secret, 32 hex chars |
 | `--user, -u` | `user` | Имя пользователя в `config.toml` |
@@ -326,6 +327,7 @@ type = "auto"            # auto | direct | tunnel | socks5 | http
 [server]
 port = 443
 # public_ip = "proxy.example.com"   # входящий IP/domain для клиентских ссылок
+# public_port = 443                 # порт в ссылках при HAProxy/Nginx
 # middle_proxy_nat_ip = "203.0.113.10"   # исходящий IPv4, который видит Telegram MiddleProxy
 max_connections = 512
 idle_timeout_sec = 120
@@ -362,6 +364,7 @@ alice = true
 | `[general] use_middle_proxy` | `false` | ME mode для DC1..5 |
 | `[server] port` | `443` | TCP listen port |
 | `[server] public_ip` | auto | Входящий IP/domain для клиентских ссылок |
+| `[server] public_port` | `[server].port` | Порт для клиентских ссылок, если публичный порт отличается от listen-port |
 | `[server] middle_proxy_nat_ip` | auto | Исходящий IPv4 для MiddleProxy key derivation; auto-detect не использует `public_ip`, задайте явно при VPN/NAT egress |
 | `[server] max_connections` | `512` | Лимит одновременных соединений |
 | `[server] middleproxy_buffer_kb` | `1024` | Буфер MiddleProxy на соединение |

--- a/config.toml.example
+++ b/config.toml.example
@@ -28,6 +28,10 @@ port = 443
 # Accepts IP addresses or domain names (e.g. "proxy.example.com").
 # public_ip = "proxy.example.com"
 
+# Override the port shown in generated Telegram client links.
+# Useful behind HAProxy/Nginx: listen on a backend port, advertise 443.
+# public_port = 443
+
 # IPv4 address Telegram MiddleProxy sees for outbound DC connections.
 # Set this when DC traffic exits through a VPN/NAT IP that differs from
 # public_ip or when auto-detection cannot see the real egress. Docker bridge

--- a/src/config.zig
+++ b/src/config.zig
@@ -150,6 +150,9 @@ pub const Config = struct {
     bind_address: ?[]const u8 = null,
     /// Explicit public IP address. If set, bypasses detection via external services.
     public_ip: ?[]const u8 = null,
+    /// Explicit public port shown in generated Telegram client links.
+    /// Useful when the proxy listens on an internal HAProxy/backend port.
+    public_port: ?u16 = null,
     /// Explicit IPv4 to use in Telegram MiddleProxy AES key derivation.
     /// Useful when `public_ip` is a domain name or when tunnel egress differs
     /// from generic "what is my IP" services.
@@ -231,6 +234,11 @@ pub const Config = struct {
 
     pub fn ownsTlsDomain(self: *const Config) bool {
         return self.tls_domain.ptr != default_tls_domain.ptr;
+    }
+
+    /// Port to advertise in generated client links.
+    pub fn publicLinkPort(self: *const Config) u16 {
+        return self.public_port orelse self.port;
     }
 
     pub fn userBypassesMiddleProxy(self: *const Config, user_name: []const u8) bool {
@@ -462,6 +470,9 @@ pub const Config = struct {
                         }
                     } else if (std.mem.eql(u8, key, "public_ip")) {
                         cfg.public_ip = try allocator.dupe(u8, value);
+                    } else if (std.mem.eql(u8, key, "public_port")) {
+                        const parsed = std.fmt.parseInt(u16, value, 10) catch 0;
+                        if (parsed > 0) cfg.public_port = parsed;
                     } else if (std.mem.eql(u8, key, "middle_proxy_nat_ip")) {
                         cfg.middle_proxy_nat_ip = try allocator.dupe(u8, value);
                     } else if (std.mem.eql(u8, key, "fast_mode")) {
@@ -617,6 +628,7 @@ test "parse config - valid complete" {
         \\
         \\[server]
         \\port = 8443
+        \\public_port = 443
         \\backlog = 8192
         \\max_connections = 6000
         \\idle_timeout_sec = 180
@@ -637,6 +649,8 @@ test "parse config - valid complete" {
     defer cfg.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(u16, 8443), cfg.port);
+    try std.testing.expectEqual(@as(u16, 443), cfg.public_port.?);
+    try std.testing.expectEqual(@as(u16, 443), cfg.publicLinkPort());
     try std.testing.expectEqual(@as(u32, 8192), cfg.backlog);
     try std.testing.expectEqual(@as(u32, 6000), cfg.max_connections);
     try std.testing.expectEqual(@as(u32, 180), cfg.idle_timeout_sec);
@@ -662,6 +676,8 @@ test "parse config - missing fields defaults" {
     defer cfg.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(u16, 443), cfg.port);
+    try std.testing.expect(cfg.public_port == null);
+    try std.testing.expectEqual(@as(u16, 443), cfg.publicLinkPort());
     try std.testing.expectEqual(@as(u32, 4096), cfg.backlog); // Default is 4096
     try std.testing.expectEqual(@as(u32, 512), cfg.max_connections);
     try std.testing.expectEqual(@as(u32, 120), cfg.idle_timeout_sec);

--- a/src/ctl/config_cmd.zig
+++ b/src/ctl/config_cmd.zig
@@ -200,6 +200,9 @@ fn printEffective(ui: *Tui, allocator: std.mem.Allocator, path: []const u8) !voi
     if (cfg.public_ip) |public_ip| {
         ui.print("public_ip = \"{s}\"\n", .{public_ip});
     }
+    if (cfg.public_port) |public_port| {
+        ui.print("public_port = {d}\n", .{public_port});
+    }
     if (cfg.middle_proxy_nat_ip) |middle_proxy_nat_ip| {
         ui.print("middle_proxy_nat_ip = \"{s}\"\n", .{middle_proxy_nat_ip});
     }

--- a/src/ctl/dashboard_assets/server.py
+++ b/src/ctl/dashboard_assets/server.py
@@ -399,6 +399,7 @@ def _load_proxy_runtime_config() -> dict:
     defaults = {
         "public_ip": "",
         "port": 443,
+        "public_port": 0,
         "mask": True,
         "mask_port": 443,
         "tls_domain": "google.com",
@@ -432,6 +433,7 @@ def _load_proxy_runtime_config() -> dict:
     result = {
         "public_ip": defaults["public_ip"],
         "port": defaults["port"],
+        "public_port": defaults["public_port"],
         "mask": defaults["mask"],
         "mask_port": defaults["mask_port"],
         "tls_domain": defaults["tls_domain"],
@@ -487,6 +489,10 @@ def _load_proxy_runtime_config() -> dict:
                         digits = "".join(ch for ch in value if ch.isdigit())
                         if digits:
                             result["port"] = int(digits)
+                    elif key == "public_port":
+                        digits = "".join(ch for ch in value if ch.isdigit())
+                        if digits:
+                            result["public_port"] = int(digits)
 
                 elif section == "[general]":
                     if key == "use_middle_proxy":
@@ -1147,7 +1153,7 @@ def _users_status() -> dict:
     server = str(cfg.get("public_ip") or "").strip()
     if not server:
         server = _detect_public_ip()
-    port = int(cfg.get("port", 443))
+    port = int(cfg.get("public_port", 0) or cfg.get("port", 443))
     tls_domain = str(cfg.get("tls_domain", "google.com"))
     domain_hex = tls_domain.encode("utf-8", errors="ignore").hex()
 
@@ -1207,6 +1213,7 @@ def _users_status() -> dict:
         "links_ready": bool(server),
         "server": server,
         "port": port,
+        "listen_port": int(cfg.get("port", 443)),
         "tls_domain": tls_domain,
         "items": items,
     }

--- a/src/ctl/install.zig
+++ b/src/ctl/install.zig
@@ -25,6 +25,8 @@ const SERVICE_NAME = release.SERVICE_NAME;
 
 pub const InstallOpts = struct {
     port: u16 = 443,
+    /// Public port to place into generated Telegram client links.
+    public_port: ?u16 = null,
     /// Bind to a specific IP address instead of all interfaces.
     bind_address: ?[]const u8 = null,
     tls_domain: []const u8 = "wb.ru",
@@ -52,6 +54,7 @@ pub const InstallOpts = struct {
     config_path: ?[]const u8 = null,
     /// Internal flags to track if user explicitly provided a value.
     port_provided: bool = false,
+    public_port_provided: bool = false,
     domain_provided: bool = false,
 };
 
@@ -65,6 +68,16 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
             if (args.next()) |val| {
                 opts.port = std.fmt.parseInt(u16, val, 10) catch 443;
                 opts.port_provided = true;
+            }
+        } else if (std.mem.eql(u8, arg, "--public-port")) {
+            if (args.next()) |val| {
+                const parsed = std.fmt.parseInt(u16, val, 10) catch 0;
+                if (parsed > 0) {
+                    opts.public_port = parsed;
+                    opts.public_port_provided = true;
+                } else {
+                    ui.warn("--public-port must be a valid TCP port, ignoring");
+                }
             }
         } else if (std.mem.eql(u8, arg, "--domain") or std.mem.eql(u8, arg, "-d")) {
             if (args.next()) |val| {
@@ -129,6 +142,12 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
                 opts.port = std.fmt.parseInt(u16, p_str, 10) catch 443;
             }
         }
+        if (!opts.public_port_provided) {
+            if (doc.get("server", "public_port")) |p_str| {
+                const parsed = std.fmt.parseInt(u16, p_str, 10) catch 0;
+                if (parsed > 0) opts.public_port = parsed;
+            }
+        }
         if (!opts.domain_provided) {
             if (doc.get("censorship", "tls_domain")) |d_str| {
                 opts.tls_domain = d_str;
@@ -141,6 +160,9 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
         ui.writeRaw("\n");
         ui.print("  {s}⚡ mtbuddy install{s}\n\n", .{ Color.header, Color.reset });
         ui.print("  {s}Port:{s}     {d}\n", .{ Color.dim, Color.reset, opts.port });
+        if (opts.public_port) |public_port| {
+            ui.print("  {s}Public:{s}   {d}\n", .{ Color.dim, Color.reset, public_port });
+        }
         ui.print("  {s}Domain:{s}   {s}\n", .{ Color.dim, Color.reset, opts.tls_domain });
         ui.print("  {s}TCPMSS:{s}   {s}\n", .{ Color.dim, Color.reset, if (opts.enable_tcpmss) "enabled" else "disabled" });
         ui.print("  {s}Masking:{s}  {s}\n", .{ Color.dim, Color.reset, if (opts.enable_masking) "enabled" else "disabled" });
@@ -415,6 +437,11 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
         var port_val_buf: [8]u8 = undefined;
         const port_val = std.fmt.bufPrint(&port_val_buf, "{d}", .{opts.port}) catch "443";
         try doc.addKv("port", port_val);
+        if (opts.public_port) |public_port| {
+            var public_port_val_buf: [8]u8 = undefined;
+            const public_port_val = std.fmt.bufPrint(&public_port_val_buf, "{d}", .{public_port}) catch "443";
+            try doc.addKv("public_port", public_port_val);
+        }
         if (opts.bind_address) |ba| {
             try doc.addKvStr("bind_address", ba);
         }
@@ -542,6 +569,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
     var summary_server: []const u8 = public_ip;
     var summary_server_buf: [256]u8 = undefined;
     var summary_port: u16 = opts.port;
+    var summary_public_port: u16 = opts.public_port orelse opts.port;
     var summary_tls_domain: []const u8 = opts.tls_domain;
     var summary_tls_domain_buf: [256]u8 = undefined;
     var secret_from_cfg: []const u8 = "unknown";
@@ -549,7 +577,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
 
     {
         var cfg_doc = toml.TomlDoc.load(allocator, config_path_buf) catch {
-            printSummary(ui, allocator, public_ip, opts.port, secret_from_cfg, opts.tls_domain, summary_opts, config_path_buf);
+            printSummary(ui, allocator, public_ip, opts.port, opts.public_port orelse opts.port, secret_from_cfg, opts.tls_domain, summary_opts, config_path_buf);
             return;
         };
         defer cfg_doc.deinit();
@@ -565,6 +593,12 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
 
         if (cfg_doc.get("server", "port")) |configured_port| {
             summary_port = std.fmt.parseInt(u16, configured_port, 10) catch summary_port;
+            summary_public_port = summary_port;
+        }
+
+        if (cfg_doc.get("server", "public_port")) |configured_public_port| {
+            const parsed = std.fmt.parseInt(u16, configured_public_port, 10) catch 0;
+            if (parsed > 0) summary_public_port = parsed;
         }
 
         if (cfg_doc.get("censorship", "tls_domain")) |configured_domain| {
@@ -589,6 +623,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
         allocator,
         summary_server,
         summary_port,
+        summary_public_port,
         secret_from_cfg,
         summary_tls_domain,
         summary_opts,
@@ -744,6 +779,7 @@ fn printSummary(
     allocator: std.mem.Allocator,
     public_ip: []const u8,
     port: u16,
+    public_port: u16,
     secret: []const u8,
     tls_domain: []const u8,
     opts: InstallOpts,
@@ -751,6 +787,8 @@ fn printSummary(
 ) void {
     var port_buf: [8]u8 = undefined;
     const port_str = std.fmt.bufPrint(&port_buf, "{d}", .{port}) catch "443";
+    var public_port_buf: [8]u8 = undefined;
+    const public_port_str = std.fmt.bufPrint(&public_port_buf, "{d}", .{public_port}) catch "443";
 
     ui.summaryBox(ui.str(.install_success_header), &.{
         .{ .label = ui.str(.install_status_cmd), .value = "systemctl status mtproto-proxy" },
@@ -758,6 +796,11 @@ fn printSummary(
         .{ .label = ui.str(.install_config_path), .value = INSTALL_DIR ++ "/config.toml" },
         .{ .label = "Server:", .value = public_ip },
         .{ .label = "Port:", .value = port_str },
+        .{
+            .label = if (public_port != port) "Public Port:" else "",
+            .value = public_port_str,
+            .style = if (public_port != port) .label_value else .blank,
+        },
         .{ .label = "", .style = .blank },
         .{ .label = ui.str(.install_dpi_active), .style = .highlight },
         .{
@@ -790,7 +833,7 @@ fn printSummary(
     ui.writeRaw("\n");
     ui.print("  {s}╭─ {s}{s}\n", .{ tui_mod.Color.gray, tui_mod.Color.bold, ui.str(.install_connection_link) });
 
-    if (!printLinksFromConfig(ui, allocator, public_ip, port, tls_domain, config_path)) {
+    if (!printLinksFromConfig(ui, allocator, public_ip, public_port, tls_domain, config_path)) {
         var ee_buf: [512]u8 = undefined;
         const ee_secret = buildEeSecret(secret, tls_domain, &ee_buf);
 
@@ -800,7 +843,7 @@ fn printSummary(
         var link_buf: [512]u8 = undefined;
         const link = std.fmt.bufPrint(&link_buf, "tg://proxy?server={s}&port={d}&secret={s}", .{
             safe_public_ip,
-            port,
+            public_port,
             ee_secret,
         }) catch "error building link";
 

--- a/src/ctl/links.zig
+++ b/src/ctl/links.zig
@@ -87,7 +87,7 @@ fn printLinks(ui: *Tui, allocator: std.mem.Allocator, opts: LinkOpts) !void {
         ui.hint("Pass --server <ip-or-domain>, or set [server].public_ip in config.toml");
         return error.PublicAddressUnavailable;
     };
-    const port = opts.port orelse cfg.port;
+    const port = opts.port orelse cfg.publicLinkPort();
     const domain = opts.domain orelse cfg.tls_domain;
 
     ui.section("MTProto links");
@@ -136,6 +136,7 @@ fn printLinksHelp(ui: *Tui) void {
     ui.writeRaw("\n");
     ui.writeRaw("  mtbuddy links [--config <path>] [--server <host>] [--port <port>] [--domain <tls-domain>]\n\n");
     ui.writeRaw("  Prints tg:// and t.me proxy links from [access.users].\n");
+    ui.writeRaw("  Link port defaults to [server].public_port, then [server].port.\n");
     ui.writeRaw("  Sensitive output: links contain user secrets.\n\n");
     ui.writeRaw("  mtbuddy secret\n");
     ui.writeRaw("  Prints a fresh 32-hex MTProto secret.\n\n");

--- a/src/ctl/main.zig
+++ b/src/ctl/main.zig
@@ -390,6 +390,7 @@ fn printHelp(lang: i18n.Lang) void {
     // ── Install options ──
     ui.print("  {s}{s}:{s}\n\n", .{ Color.accent, tr(lang, "Install options", "Опции установки"), Color.reset });
     printOpt(&ui, "--port,   -p <port>", tr(lang, "Proxy port (default: 443)", "Порт прокси (по умолчанию: 443)"));
+    printOpt(&ui, "--public-port <port>", tr(lang, "Port advertised in Telegram links", "Порт для Telegram-ссылок"));
     printOpt(&ui, "--domain, -d <domain>", tr(lang, "TLS masking domain (default: wb.ru)", "TLS-домен маскировки (по умолчанию: wb.ru)"));
     printOpt(&ui, "--secret, -s <hex32>", tr(lang, "User secret (32 hex chars, auto-generated if omitted)", "Секрет пользователя (32 hex, если не задан — генерируется)"));
     printOpt(&ui, "--user,   -u <name>", tr(lang, "Username in config.toml (default: user)", "Имя пользователя в config.toml (по умолчанию: user)"));

--- a/src/main.zig
+++ b/src/main.zig
@@ -352,6 +352,11 @@ fn printBanner(allocator: std.mem.Allocator, cfg: config.Config, capacity_estima
         if (has_ip) green else yellow,
         server_ip,
     });
+    if (cfg.public_port) |public_port| {
+        if (public_port != cfg.port) {
+            writeStdout("      Public Port  " ++ B ++ green ++ "{d}" ++ R ++ "\n", .{public_port});
+        }
+    }
     writeStdout("      TLS Domain   " ++ B ++ yellow ++ "{s}" ++ R ++ "\n", .{cfg.tls_domain});
     writeRaw("      Masking      " ++ B);
     if (cfg.mask) {


### PR DESCRIPTION
## Summary

Adds a persistent `[server].public_port` setting for generated Telegram proxy links. This lets deployments listen on an internal/backend port while advertising a different public port, such as HAProxy exposing `443` and forwarding to `8444`.

## What Changed

- Parses optional `[server].public_port` in runtime config.
- Uses `public_port` for `mtbuddy links`, install summary links, and dashboard links, with fallback to `[server].port`.
- Adds `mtbuddy install --public-port <port>` so new installs can write the setting directly.
- Shows the configured public port in config diagnostics/startup output when it differs from the listen port.
- Documents the option in README files and `config.toml.example`.

## Impact

Existing configs keep the same behavior. Operators behind HAProxy/Nginx can now set:

```toml
[server]
port = 8444
public_port = 443
```

and generated links will use `port=443`.

Closes #260.

## Validation

- `zig build test`
- `zig build -Dtarget=x86_64-linux-musl`
- `python3 -m py_compile src/ctl/dashboard_assets/server.py`