### PR TITLE
[codex] fix tunnel prestart policy routing

### DIFF
--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -1079,6 +1079,7 @@ fn renderTunnelPoolScript(allocator: std.mem.Allocator) ![]const u8 {
         \\STATE_FILE="$STATE_DIR/tunnel-pool.state"
         \\MARK=200
         \\TABLE=200
+        \\RULE_PRIORITY=1200
         \\PROBE_URL="https://core.telegram.org/getProxyConfig"
         \\
         \\mkdir -p "$STATE_DIR"
@@ -1195,6 +1196,43 @@ fn renderTunnelPoolScript(allocator: std.mem.Allocator) ![]const u8 {
         \\    "$quick" up "$conf" >/dev/null 2>&1
         \\}
         \\
+        \\policy_rule_exists() {
+        \\    local mark_hex
+        \\    mark_hex="$(printf '0x%x' "$MARK")"
+        \\    ip -4 rule show | awk -v mark="$MARK" -v mark_hex="$mark_hex" -v table="$TABLE" '
+        \\        (($0 ~ "fwmark " mark || $0 ~ "fwmark " mark_hex) && ($0 ~ "lookup " table || $0 ~ "table " table)) { found = 1 }
+        \\        END { exit found ? 0 : 1 }
+        \\    '
+        \\}
+        \\
+        \\ensure_policy_rule() {
+        \\    while ip -4 rule del priority "$RULE_PRIORITY" fwmark "$MARK" table "$TABLE" 2>/dev/null; do :; done
+        \\    while ip -4 rule del fwmark "$MARK" table "$TABLE" 2>/dev/null; do :; done
+        \\    ip -4 rule add fwmark "$MARK" table "$TABLE" priority "$RULE_PRIORITY" 2>/dev/null || true
+        \\    policy_rule_exists
+        \\}
+        \\
+        \\route_table_to_iface() {
+        \\    local iface="$1"
+        \\    ip -4 route flush table "$TABLE" 2>/dev/null || true
+        \\    ip -4 route replace default dev "$iface" table "$TABLE"
+        \\}
+        \\
+        \\policy_route_matches_iface() {
+        \\    local iface="$1" target="${2:-149.154.175.50}"
+        \\    ip -4 route get "$target" mark "$MARK" 2>/dev/null |
+        \\        awk -v iface="$iface" '
+        \\            { for (i = 1; i < NF; i++) if ($i == "dev" && $(i + 1) == iface) found = 1 }
+        \\            END { exit found ? 0 : 1 }
+        \\        '
+        \\}
+        \\
+        \\telegram_probe_iface() {
+        \\    local iface="$1"
+        \\    command -v curl >/dev/null 2>&1 || return 2
+        \\    curl --interface "$iface" -fsS --connect-timeout 3 --max-time 5 "$PROBE_URL" >/dev/null 2>&1
+        \\}
+        \\
         \\probe_iface() {
         \\    local iface="$1"
         \\    reason=""
@@ -1203,8 +1241,14 @@ fn renderTunnelPoolScript(allocator: std.mem.Allocator) ![]const u8 {
         \\    local show_tool
         \\    show_tool="$(show_tool_for "$iface")" || { reason="awg/wg show tool missing"; return 1; }
         \\    "$show_tool" show "$iface" >/dev/null 2>&1 || { reason="tunnel show failed"; return 1; }
-        \\    curl --interface "$iface" -fsS --connect-timeout 3 --max-time 5 "$PROBE_URL" >/dev/null 2>&1 || { reason="Telegram probe failed"; return 1; }
-        \\    reason="healthy"
+        \\    route_table_to_iface "$iface" || { reason="failed to install policy route"; return 1; }
+        \\    policy_route_matches_iface "$iface" || { reason="policy route check failed"; return 1; }
+        \\    if telegram_probe_iface "$iface"; then
+        \\        reason="healthy"
+        \\    else
+        \\        reason="policy route ready; Telegram probe failed"
+        \\        log "tunnel $iface selected although Telegram HTTPS probe failed"
+        \\    fi
         \\    return 0
         \\}
         \\
@@ -1250,9 +1294,13 @@ fn renderTunnelPoolScript(allocator: std.mem.Allocator) ![]const u8 {
         \\    add_unique "$iface"
         \\done
         \\
-        \\ip -4 rule del fwmark "$MARK" table "$TABLE" 2>/dev/null || true
-        \\ip -4 rule add fwmark "$MARK" table "$TABLE" priority 1200
+        \\ensure_policy_rule || {
+        \\    write_state "" "degraded" "failed to install policy rule"
+        \\    echo "Failed to install tunnel policy rule: fwmark=$MARK table=$TABLE" >&2
+        \\    exit 1
+        \\}
         \\
+        \\previous="$(ip -4 route show table "$TABLE" default 2>/dev/null | awk '/default/ { for (i=1;i<=NF;i++) if ($i=="dev") { print $(i+1); exit } }' || true)"
         \\selected=""
         \\selected_reason=""
         \\for iface in "${candidates[@]}"; do
@@ -1270,9 +1318,7 @@ fn renderTunnelPoolScript(allocator: std.mem.Allocator) ![]const u8 {
         \\    exit 1
         \\fi
         \\
-        \\previous="$(ip -4 route show table "$TABLE" default 2>/dev/null | awk '/default/ { for (i=1;i<=NF;i++) if ($i=="dev") { print $(i+1); exit } }')"
-        \\ip -4 route flush table "$TABLE" 2>/dev/null || true
-        \\ip -4 route replace default dev "$selected" table "$TABLE"
+        \\route_table_to_iface "$selected"
         \\write_state "$selected" "healthy" "$selected_reason"
         \\
         \\if [[ "$previous" != "$selected" ]]; then
@@ -1519,12 +1565,16 @@ test "tunnel pool - append interface avoids duplicates" {
     try std.testing.expectEqualStrings("awg2", added[2]);
 }
 
-test "tunnel pool - script renders route replacement and Telegram probe" {
+test "tunnel pool - script renders policy route replacement and nonfatal Telegram probe" {
     const script = try renderTunnelPoolScript(std.testing.allocator);
     defer std.testing.allocator.free(script);
 
-    try std.testing.expect(std.mem.indexOf(u8, script, "ip -4 route replace default dev \"$selected\" table \"$TABLE\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "route_table_to_iface \"$selected\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "policy_route_matches_iface \"$iface\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "route show table \"$TABLE\" default 2>/dev/null") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "|| true)") != null);
     try std.testing.expect(std.mem.indexOf(u8, script, "https://core.telegram.org/getProxyConfig") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "selected although Telegram HTTPS probe failed") != null);
     try std.testing.expect(std.mem.indexOf(u8, script, "pinned_interface") != null);
 }
 

--- a/test/installer-e2e/run.sh
+++ b/test/installer-e2e/run.sh
@@ -64,6 +64,7 @@ dump_container_debug() {
   docker exec "$container" journalctl --no-pager -n 300 >"$LOG_DIR/$prefix.journal.log" 2>&1 || true
   docker exec "$container" bash -lc 'systemctl --failed --no-pager || true' >"$LOG_DIR/$prefix.systemd-failed.log" 2>&1 || true
   docker exec "$container" bash -lc 'iptables -t mangle -S || true; ip6tables -t mangle -S || true' >"$LOG_DIR/$prefix.iptables.log" 2>&1 || true
+  docker exec "$container" bash -lc 'ip -4 rule show || true; ip -4 route show table 200 || true; cat /run/mtproto-proxy/tunnel-pool.state 2>/dev/null || true; systemctl status mtproto-proxy mtproto-tunnel-pool.service mtproto-tunnel-pool.timer --no-pager || true' >"$LOG_DIR/$prefix.tunnel.log" 2>&1 || true
   docker exec "$container" bash -lc 'ss -lntp || true' >"$LOG_DIR/$prefix.ss.log" 2>&1 || true
 }
 
@@ -110,6 +111,16 @@ run_in_container() {
     "$container" "$@"
 }
 
+run_script_in_container() {
+  local container="$1"
+  docker exec -i \
+    -e DEBIAN_FRONTEND=noninteractive \
+    -e LANG=C.UTF-8 \
+    -e LC_ALL=C.UTF-8 \
+    -e PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    "$container" bash -s
+}
+
 verify_install_once() {
   local container="$1"
 
@@ -138,6 +149,136 @@ verify_install_once() {
     ss -lnt "( sport = :443 or sport = :8443 )" | grep "127.0.0.1:8443" >/dev/null
     curl -kfsS --resolve "wb.ru:8443:127.0.0.1" https://wb.ru:8443/ >/dev/null
   '
+}
+
+install_fake_tunnel_tools() {
+  local container="$1"
+
+  run_script_in_container "$container" <<'CONTAINER_SCRIPT'
+set -Eeuo pipefail
+
+real_curl="$(command -v curl)"
+if [[ "$real_curl" == "/usr/local/bin/curl" ]]; then
+  real_curl="/usr/bin/curl"
+fi
+test -x "$real_curl"
+
+cat >/usr/local/bin/awg-quick <<'AWG_QUICK'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+cmd="${1:-}"
+case "$cmd" in
+  strip)
+    cat "${2:?missing config}"
+    ;;
+  up)
+    conf="${2:?missing config}"
+    iface="$(basename "$conf" .conf)"
+    ip link show dev "$iface" >/dev/null 2>&1 || ip link add "$iface" type dummy 2>/dev/null || ip link add "$iface" type veth peer name "${iface}-peer"
+    ip link set dev "$iface" up
+    ip link set dev "${iface}-peer" up 2>/dev/null || true
+    ;;
+  down)
+    conf="${2:?missing config}"
+    iface="$(basename "$conf" .conf)"
+    ip link del dev "$iface" 2>/dev/null || true
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+AWG_QUICK
+chmod 0755 /usr/local/bin/awg-quick
+
+cat >/usr/local/bin/awg <<'AWG'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [[ "${1:-}" == "show" ]]; then
+  iface="${2:-awg0}"
+  ip link show dev "$iface" >/dev/null 2>&1 || exit 1
+  cat <<EOF
+interface: $iface
+  public key: fake-public-key
+  private key: (hidden)
+  listening port: 51820
+
+peer: fake-peer-key
+  endpoint: 203.0.113.1:51820
+  allowed ips: 0.0.0.0/0
+  latest handshake: 1 second ago
+  transfer: 1 KiB received, 1 KiB sent
+EOF
+  exit 0
+fi
+
+exit 0
+AWG
+chmod 0755 /usr/local/bin/awg
+
+cat >/usr/local/bin/curl <<CURL
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+next_is_iface=0
+for arg in "\$@"; do
+  if [[ "\$next_is_iface" == "1" ]]; then
+    if [[ "\$arg" == "awg0" ]]; then
+      echo "blocked fake tunnel probe: \$*" >>/run/mtproto-fake-curl.log
+      exit 7
+    fi
+    next_is_iface=0
+    continue
+  fi
+
+  if [[ "\$arg" == "--interface" ]]; then
+    next_is_iface=1
+  fi
+done
+
+exec "$real_curl" "\$@"
+CURL
+chmod 0755 /usr/local/bin/curl
+CONTAINER_SCRIPT
+}
+
+verify_tunnel_probe_failure_is_nonfatal() {
+  local container="$1"
+
+  run_script_in_container "$container" <<'CONTAINER_SCRIPT'
+set -Eeuo pipefail
+
+cat >/tmp/awg0.conf <<'AWG_CONF'
+[Interface]
+PrivateKey = fake-private-key
+Address = 10.123.0.2/32
+DNS = 1.1.1.1
+
+[Peer]
+PublicKey = fake-peer-key
+Endpoint = 203.0.113.1:51820
+AllowedIPs = 0.0.0.0/0
+AWG_CONF
+
+mtbuddy setup tunnel --iface awg0 /tmp/awg0.conf
+
+systemctl is-active --quiet mtproto-proxy
+systemctl is-active --quiet mtproto-tunnel-pool.timer
+systemctl is-enabled --quiet mtproto-tunnel-pool.timer
+
+grep -F "ExecStartPre=/usr/local/bin/setup_tunnel.sh" /etc/systemd/system/mtproto-proxy.service >/dev/null
+test -x /usr/local/bin/setup_tunnel.sh
+
+/usr/local/bin/setup_tunnel.sh
+grep -F "active=awg0" /run/mtproto-proxy/tunnel-pool.state >/dev/null
+grep -F "status=healthy" /run/mtproto-proxy/tunnel-pool.state >/dev/null
+grep -F "reason=policy route ready; Telegram probe failed" /run/mtproto-proxy/tunnel-pool.state >/dev/null
+grep -F "blocked fake tunnel probe:" /run/mtproto-fake-curl.log >/dev/null
+
+ip -4 rule show | grep -E "fwmark (0xc8|200).*(lookup|table) 200" >/dev/null
+ip -4 route get 149.154.175.50 mark 200 | grep -F " dev awg0" >/dev/null
+CONTAINER_SCRIPT
 }
 
 verify_install() {
@@ -225,6 +366,11 @@ run_case() {
   echo "::group::Re-run nfqws setup ($base_image)"
   run_in_container "$container" mtbuddy setup nfqws 2>&1 | tee "$LOG_DIR/$safe.nfqws-rerun.log"
   verify_install "$container" 2>&1 | tee "$LOG_DIR/$safe.verify-after-nfqws-rerun.log"
+  echo "::endgroup::"
+
+  echo "::group::Setup tunnel with failing Telegram probe ($base_image)"
+  install_fake_tunnel_tools "$container"
+  verify_tunnel_probe_failure_is_nonfatal "$container" 2>&1 | tee "$LOG_DIR/$safe.tunnel-probe-failure.log"
   echo "::endgroup::"
 
   dump_container_debug "$container" "$safe"


### PR DESCRIPTION
## What changed

- Made the generated tunnel policy routing script tolerate a failed Telegram HTTPS probe after policy routing is installed.
- Made `fwmark 200 -> table 200` rule setup idempotent before `ExecStartPre` runs.
- Prevented first-run failure when route table 200 does not exist yet.
- Extended installer e2e with a fake AmneziaWG tunnel and a deliberately failing `curl --interface awg0` probe.

## Why

`mtproto-proxy.service` could fail during `ExecStartPre=/usr/local/bin/setup_tunnel.sh` even when the tunnel interface and policy route were usable. The script treated the Telegram `curl --interface` probe as fatal, and `set -euo pipefail` also made first-run route-table inspection fail when table 200 had not been created yet.

## Impact

Tunnel setup now starts the proxy as long as the interface is up, `awg/wg show` works, and `SO_MARK=200` traffic routes through the selected tunnel. The Telegram probe remains diagnostic and records the degraded reason in tunnel state.

## Validation

- `bash -n test/installer-e2e/run.sh`
- `zig build test`
- `MTPROTO_INSTALLER_E2E_IMAGES='debian:12' test/installer-e2e/run.sh`