### PR TITLE
[codex] manage tunnel pool deletion

### DIFF
--- a/src/ctl/dashboard_assets/server.py
+++ b/src/ctl/dashboard_assets/server.py
@@ -407,6 +407,7 @@ def _load_proxy_runtime_config() -> dict:
         "upstream_type": "auto",
         "upstream_tunnel_interface": "awg0",
         "upstream_tunnel_interfaces": [],
+        "upstream_tunnel_interfaces_configured": False,
         "upstream_tunnel_pinned_interface": "",
         "upstream_socks5_host": "",
         "upstream_socks5_port": 0,
@@ -441,6 +442,7 @@ def _load_proxy_runtime_config() -> dict:
         "upstream_type": defaults["upstream_type"],
         "upstream_tunnel_interface": defaults["upstream_tunnel_interface"],
         "upstream_tunnel_interfaces": [],
+        "upstream_tunnel_interfaces_configured": False,
         "upstream_tunnel_pinned_interface": "",
         "upstream_socks5_host": defaults["upstream_socks5_host"],
         "upstream_socks5_port": defaults["upstream_socks5_port"],
@@ -509,6 +511,7 @@ def _load_proxy_runtime_config() -> dict:
                         result["upstream_tunnel_interface"] = value
                     elif key == "interfaces":
                         result["upstream_tunnel_interfaces"] = _parse_toml_string_array(value)
+                        result["upstream_tunnel_interfaces_configured"] = True
                     elif key == "pinned_interface":
                         result["upstream_tunnel_pinned_interface"] = value
 
@@ -562,7 +565,7 @@ def _load_proxy_runtime_config() -> dict:
     except Exception:
         return defaults
 
-    if not result["upstream_tunnel_interfaces"]:
+    if not result["upstream_tunnel_interfaces"] and not result["upstream_tunnel_interfaces_configured"]:
         iface = str(result.get("upstream_tunnel_interface") or "awg0").strip()
         result["upstream_tunnel_interfaces"] = [iface] if iface else ["awg0"]
 
@@ -582,6 +585,9 @@ _routing_cache = {"ts": 0, "data": None}
 ROUTING_CACHE_TTL = 8  # seconds
 TUNNEL_POOL_STATE = Path("/run/mtproto-proxy/tunnel-pool.state")
 TUNNEL_POOL_SCRIPT = Path("/usr/local/bin/setup_tunnel.sh")
+TUNNEL_POOL_SERVICE = Path("/etc/systemd/system/mtproto-tunnel-pool.service")
+TUNNEL_POOL_TIMER = Path("/etc/systemd/system/mtproto-tunnel-pool.timer")
+PROXY_SERVICE_FILE = Path("/etc/systemd/system/mtproto-proxy.service")
 TUNNEL_PROBE_URL = "https://core.telegram.org/getProxyConfig"
 
 
@@ -619,7 +625,7 @@ def _tunnel_tool_hint(interface: str) -> str | None:
 
 def _effective_tunnel_pool(cfg: dict) -> list[str]:
     pool = _dedupe([str(v) for v in cfg.get("upstream_tunnel_interfaces", [])])
-    if pool:
+    if pool or cfg.get("upstream_tunnel_interfaces_configured"):
         return pool
     iface = str(cfg.get("upstream_tunnel_interface", "awg0") or "awg0").strip()
     return [iface] if iface else ["awg0"]
@@ -865,6 +871,22 @@ def _list_system_interfaces() -> list[str]:
     return names
 
 
+def _list_tunnel_config_interfaces() -> list[str]:
+    names: list[str] = []
+    for base in (Path("/etc/amnezia/amneziawg"), Path("/etc/wireguard")):
+        try:
+            entries = sorted(base.glob("*.conf"))
+        except Exception:
+            entries = []
+        for path in entries:
+            iface = path.stem.strip()
+            if not _valid_tunnel_interface_name(iface):
+                continue
+            if iface not in names:
+                names.append(iface)
+    return names
+
+
 def _upstream_target_from_cfg(cfg: dict, policy: dict) -> str:
     upstream_type = str(cfg.get("upstream_type", "auto") or "auto").lower().strip()
 
@@ -900,16 +922,25 @@ def _routing_status() -> dict:
     upstream_type = str(cfg.get("upstream_type", "auto") or "auto").lower().strip()
     pool = _effective_tunnel_pool(cfg)
     pinned_iface = str(cfg.get("upstream_tunnel_pinned_interface", "") or "").strip()
-    selected_iface = pinned_iface or (pool[0] if pool else str(cfg.get("upstream_tunnel_interface", "awg0") or "awg0").strip())
+    fallback_iface = str(cfg.get("upstream_tunnel_interface", "") or "").strip()
+    if not fallback_iface and not cfg.get("upstream_tunnel_interfaces_configured"):
+        fallback_iface = "awg0"
+    selected_iface = pinned_iface or (pool[0] if pool else fallback_iface)
 
-    if not selected_iface:
+    if not selected_iface and not cfg.get("upstream_tunnel_interfaces_configured"):
         selected_iface = "awg0"
 
     system_ifaces = _list_system_interfaces()
+    config_ifaces = _list_tunnel_config_interfaces()
     available_tunnel_ifaces: list[str] = []
-    for iface in system_ifaces:
+    for iface in system_ifaces + config_ifaces:
         low = iface.lower()
-        if not (low.startswith(("awg", "wg", "tun", "tap")) or iface in pool or iface == selected_iface):
+        if not (
+            low.startswith(("awg", "wg", "tun", "tap"))
+            or iface in pool
+            or iface == selected_iface
+            or iface in config_ifaces
+        ):
             continue
         if iface and iface not in available_tunnel_ifaces:
             available_tunnel_ifaces.append(iface)
@@ -924,10 +955,12 @@ def _routing_status() -> dict:
     for iface in interfaces:
         tunnel = _detect_tunnel_interface(iface, _tunnel_tool_hint(iface))
         tunnel["in_pool"] = iface in pool
+        tunnel["config_present"] = iface in config_ifaces
         tunnel["pinned"] = bool(pinned_iface and iface == pinned_iface)
         if (
             iface == selected_iface
             or iface in pool
+            or iface in config_ifaces
             or tunnel.get("link_up")
             or tunnel.get("active")
             or tunnel.get("endpoint")
@@ -1362,6 +1395,256 @@ def _set_upstream_tunnel_interface(interface: str) -> bool:
     )
     cfg_path.write_text("".join(lines), encoding="utf-8")
     return True
+
+
+def _valid_tunnel_interface_name(interface: str) -> bool:
+    return bool(re.fullmatch(r"[A-Za-z0-9_.-]{1,32}", str(interface or "").strip()))
+
+
+def _toml_string_array_literal(values: list[str]) -> str:
+    return json.dumps([str(v) for v in values], ensure_ascii=False)
+
+
+def _tunnel_config_paths(interface: str) -> list[Path]:
+    iface = str(interface or "").strip()
+    paths = [
+        Path("/etc/amnezia/amneziawg") / f"{iface}.conf",
+        Path("/etc/wireguard") / f"{iface}.conf",
+    ]
+    if iface == "awg0":
+        paths.append(Path("/etc/amnezia/awg0.conf"))
+    return paths
+
+
+def _tunnel_config_exists(interface: str) -> bool:
+    return any(path.exists() for path in _tunnel_config_paths(interface))
+
+
+def _remove_tunnel_from_config(interface: str) -> dict | None:
+    cfg_path = _find_config_path()
+    if cfg_path is None:
+        return None
+
+    iface = str(interface or "").strip()
+    if not _valid_tunnel_interface_name(iface):
+        return None
+
+    cfg = _load_proxy_runtime_config()
+    pool = _effective_tunnel_pool(cfg)
+    in_pool = iface in pool
+    if not in_pool and not _tunnel_config_exists(iface):
+        return None
+
+    remaining = [value for value in pool if value != iface]
+    removed_last = bool(in_pool and not remaining)
+
+    if in_pool:
+        lines = cfg_path.read_text(encoding="utf-8", errors="replace").splitlines(
+            keepends=True
+        )
+        if remaining:
+            lines = _set_toml_key(
+                lines,
+                "[upstream.tunnel]",
+                "interface",
+                _toml_string_literal(remaining[0]),
+            )
+        else:
+            lines = _set_toml_key(
+                lines, "[upstream]", "type", _toml_string_literal("auto")
+            )
+            lines = _set_toml_key(
+                lines, "[upstream.tunnel]", "interface", _toml_string_literal("")
+            )
+
+        lines = _set_toml_key(
+            lines,
+            "[upstream.tunnel]",
+            "interfaces",
+            _toml_string_array_literal(remaining),
+        )
+
+        pinned = str(cfg.get("upstream_tunnel_pinned_interface", "") or "").strip()
+        if pinned == iface or removed_last:
+            lines = _set_toml_key(
+                lines,
+                "[upstream.tunnel]",
+                "pinned_interface",
+                _toml_string_literal(""),
+            )
+
+        cfg_path.write_text("".join(lines), encoding="utf-8")
+
+    return {
+        "removed_from_pool": in_pool,
+        "removed_last": removed_last,
+        "remaining_pool": remaining,
+    }
+
+
+def _clear_tunnel_config() -> bool:
+    cfg_path = _find_config_path()
+    if cfg_path is None:
+        return False
+
+    lines = cfg_path.read_text(encoding="utf-8", errors="replace").splitlines(
+        keepends=True
+    )
+    lines = _set_toml_key(lines, "[upstream]", "type", _toml_string_literal("auto"))
+    lines = _set_toml_key(
+        lines, "[upstream.tunnel]", "interface", _toml_string_literal("")
+    )
+    lines = _set_toml_key(lines, "[upstream.tunnel]", "interfaces", "[]")
+    lines = _set_toml_key(
+        lines, "[upstream.tunnel]", "pinned_interface", _toml_string_literal("")
+    )
+    cfg_path.write_text("".join(lines), encoding="utf-8")
+    return True
+
+
+def _quick_tool_for_interface(interface: str) -> str | None:
+    iface = str(interface or "")
+    if iface.startswith("wg") and shutil.which("wg-quick"):
+        return "wg-quick"
+    if shutil.which("awg-quick"):
+        return "awg-quick"
+    if shutil.which("wg-quick"):
+        return "wg-quick"
+    return None
+
+
+def _run_silent(args: list[str], timeout: int = 10) -> int | None:
+    try:
+        r = subprocess.run(
+            args,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=timeout,
+        )
+        return r.returncode
+    except Exception:
+        return None
+
+
+def _stop_tunnel_interface(interface: str) -> None:
+    tool = _quick_tool_for_interface(interface)
+    if tool:
+        for path in _tunnel_config_paths(interface):
+            if path.exists():
+                _run_silent([tool, "down", str(path)])
+        _run_silent([tool, "down", interface])
+    _run_silent(["ip", "link", "delete", "dev", interface])
+
+
+def _delete_tunnel_config_files(interface: str) -> None:
+    for path in _tunnel_config_paths(interface):
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        except Exception:
+            pass
+
+
+def _write_default_proxy_service() -> bool:
+    content = """[Unit]
+Description=MTProto Proxy (Zig)
+Documentation=https://github.com/sleep3r/mtproto.zig
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=mtproto
+Group=mtproto
+WorkingDirectory=/opt/mtproto-proxy
+ExecStart=/opt/mtproto-proxy/mtproto-proxy /opt/mtproto-proxy/config.toml
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=SIGTERM
+TimeoutStopSec=25
+Restart=always
+RestartSec=3
+
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+ReadOnlyPaths=/opt/mtproto-proxy
+
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+
+LimitNOFILE=131582
+TasksMax=65535
+
+[Install]
+WantedBy=multi-user.target
+"""
+    try:
+        PROXY_SERVICE_FILE.write_text(content, encoding="utf-8")
+        return True
+    except Exception:
+        return False
+
+
+def _disable_tunnel_pool_runtime() -> None:
+    _run_silent(["systemctl", "disable", "--now", "mtproto-tunnel-pool.timer"])
+    _run_silent(["systemctl", "stop", "mtproto-tunnel-pool.service"])
+    _run_silent(
+        [
+            "sh",
+            "-c",
+            "while ip -4 rule del priority 1200 fwmark 200 table 200 2>/dev/null; do :; done; "
+            "while ip -4 rule del fwmark 200 table 200 2>/dev/null; do :; done; "
+            "ip -4 route flush table 200 2>/dev/null || true",
+        ]
+    )
+    for path in (TUNNEL_POOL_SCRIPT, TUNNEL_POOL_STATE, TUNNEL_POOL_SERVICE, TUNNEL_POOL_TIMER):
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        except Exception:
+            pass
+    _write_default_proxy_service()
+    _run_silent(["systemctl", "daemon-reload"])
+
+
+def _delete_tunnel_interface(interface: str) -> dict | None:
+    iface = str(interface or "").strip()
+    if not _valid_tunnel_interface_name(iface):
+        return None
+
+    known_before = _list_tunnel_config_interfaces()
+    result = _remove_tunnel_from_config(iface)
+    if result is None:
+        return None
+
+    stale_last = (
+        not result["removed_from_pool"]
+        and not result["remaining_pool"]
+        and set(known_before).issubset({iface})
+    )
+    if stale_last:
+        _clear_tunnel_config()
+        result["removed_last"] = True
+
+    _stop_tunnel_interface(iface)
+    _delete_tunnel_config_files(iface)
+
+    if result["removed_last"]:
+        _disable_tunnel_pool_runtime()
+    elif result["removed_from_pool"]:
+        result["controller_ok"] = _run_tunnel_pool_once()
+    else:
+        result["controller_ok"] = None
+
+    _restart_proxy()
+    _awg_cache["ts"] = 0
+    _routing_cache["ts"] = 0
+    result["interface"] = iface
+    result["restarted"] = True
+    return result
 
 
 def _run_tunnel_pool_once() -> bool:
@@ -1891,6 +2174,30 @@ async def api_routing_tunnel_interface(request: Request):
             "restarted": False,
         }
     )
+
+
+@app.post("/api/routing/tunnel-delete")
+async def api_routing_tunnel_delete(request: Request):
+    """Hard-delete a tunnel interface. Body: { interface: str }"""
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"ok": False, "error": "invalid json"}, status_code=400)
+
+    iface = str(body.get("interface", "")).strip()
+    if not _valid_tunnel_interface_name(iface):
+        return JSONResponse(
+            {"ok": False, "error": "invalid tunnel interface"}, status_code=400
+        )
+
+    result = _delete_tunnel_interface(iface)
+    if result is None:
+        return JSONResponse(
+            {"ok": False, "error": "tunnel interface is not configured"},
+            status_code=404,
+        )
+
+    return JSONResponse({"ok": True, **result})
 
 
 @app.post("/api/routing/proxy-target")

--- a/src/ctl/dashboard_assets/static/app.js
+++ b/src/ctl/dashboard_assets/static/app.js
@@ -307,6 +307,7 @@ async function copyText(text) {
 // ── User Management ──
 
 let pendingDeleteUser = null;
+let pendingDeleteTunnel = null;
 let pendingToggleUser = null;
 
 function showToast(msg, type) {
@@ -429,6 +430,59 @@ function showDeleteModal(name) {
   pendingDeleteUser = name;
   $('deleteUserName').textContent = name;
   $('deleteModal').style.display = '';
+  $('deleteConfirm').focus();
+}
+
+function setupTunnelDeleteModal() {
+  const modal = $('deleteTunnelModal');
+  const confirmBtn = $('deleteTunnelConfirm');
+  const cancelBtn = $('deleteTunnelCancel');
+  if (!modal || !confirmBtn || !cancelBtn) return;
+
+  const close = () => {
+    modal.style.display = 'none';
+    pendingDeleteTunnel = null;
+  };
+
+  cancelBtn.addEventListener('click', close);
+
+  modal.addEventListener('click', (e) => {
+    if (e.target === modal) close();
+  });
+
+  modal.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') close();
+  });
+
+  confirmBtn.addEventListener('click', async () => {
+    if (!pendingDeleteTunnel) return;
+    const iface = pendingDeleteTunnel;
+    confirmBtn.disabled = true;
+    setRoutingAction('Deleting tunnel ' + iface + '…');
+    try {
+      const data = await apiCall('/api/routing/tunnel-delete', { interface: iface });
+      const left = Array.isArray(data.remaining_pool) ? data.remaining_pool.length : 0;
+      const msg = data.removed_last
+        ? ('Tunnel ' + iface + ' deleted. No tunnels left; upstream switched to auto.')
+        : ('Tunnel ' + iface + ' deleted. ' + left + ' tunnel(s) remain.');
+      showToast(msg, 'success');
+      setRoutingAction(msg, 'ok');
+      await runPoll();
+    } catch (e) {
+      setRoutingAction('Delete failed: ' + e.message, 'error');
+      showToast('Delete failed: ' + e.message, 'error');
+    } finally {
+      confirmBtn.disabled = false;
+      close();
+    }
+  });
+}
+
+function showTunnelDeleteModal(iface) {
+  pendingDeleteTunnel = iface;
+  $('deleteTunnelName').textContent = iface;
+  $('deleteTunnelModal').style.display = '';
+  $('deleteTunnelConfirm').focus();
 }
 
 async function toggleDirect(name, newDirect) {
@@ -878,6 +932,7 @@ function renderRouting(routing) {
 
     const meta = [];
     if (inPool) meta.push('pool');
+    if (t.config_present && !inPool) meta.push('config');
     if (isPinned) meta.push('pinned');
     if (t.tool && t.tool !== '-') meta.push(String(t.tool));
     if (t.endpoint) meta.push(String(t.endpoint));
@@ -886,6 +941,7 @@ function renderRouting(routing) {
     if (!meta.length) meta.push(String(t.reason || '—'));
 
     const xfer = '↓ ' + String(t.rx || '—') + ' · ↑ ' + String(t.tx || '—');
+    const canDelete = inPool || t.config_present || t.link_up || iface.startsWith('awg') || iface.startsWith('wg');
 
     return '<div class="routing-row">' +
       '<div class="routing-iface">' + esc(iface) +
@@ -895,8 +951,20 @@ function renderRouting(routing) {
       '<div class="routing-state ' + stateClass + '">' + esc(state) + '</div>' +
       '<div class="routing-meta" title="' + esc(meta.join(' · ')) + '">' + esc(meta.join(' · ')) + '</div>' +
       '<div class="routing-xfer">' + esc(xfer) + '</div>' +
+      '<div class="routing-actions">' +
+      (canDelete
+        ? '<button class="ui-btn danger routing-delete" type="button" data-iface="' + esc(iface) + '" aria-label="Delete tunnel ' + esc(iface) + '">Delete</button>'
+        : '') +
+      '</div>' +
       '</div>';
   }).join('');
+
+  list.querySelectorAll('.routing-delete').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const iface = String(btn.dataset.iface || '').trim();
+      if (iface) showTunnelDeleteModal(iface);
+    });
+  });
 }
 
 // ── Polling ──
@@ -1105,6 +1173,7 @@ updatePollControls();
 updateFreshness();
 setupAddUserForm();
 setupDeleteModal();
+setupTunnelDeleteModal();
 setupRoutingControls();
 runPoll();
 restartPollingLoop();

--- a/src/ctl/dashboard_assets/static/index.html
+++ b/src/ctl/dashboard_assets/static/index.html
@@ -260,8 +260,8 @@
 
   <!-- Delete confirmation modal -->
   <div class="modal-overlay" id="deleteModal" style="display:none">
-    <div class="modal">
-      <div class="modal-title">⚠ Delete User</div>
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="deleteModalTitle">
+      <div class="modal-title" id="deleteModalTitle">Delete User</div>
       <div class="modal-body">
         Are you sure you want to delete <b id="deleteUserName"></b>?
         <br><span class="form-hint">The proxy will be restarted to apply changes.</span>
@@ -272,8 +272,22 @@
       </div>
     </div>
   </div>
+
+  <div class="modal-overlay" id="deleteTunnelModal" style="display:none">
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="deleteTunnelTitle">
+      <div class="modal-title" id="deleteTunnelTitle">Delete Tunnel</div>
+      <div class="modal-body">
+        Delete <b id="deleteTunnelName"></b> from the tunnel pool?
+        <br><span class="form-hint">The interface will be stopped, config files removed, and proxy routing refreshed.</span>
+      </div>
+      <div class="modal-actions">
+        <button class="ui-btn danger" id="deleteTunnelConfirm" type="button">Delete</button>
+        <button class="ui-btn" id="deleteTunnelCancel" type="button">Cancel</button>
+      </div>
+    </div>
+  </div>
 </div>
 
-<script src="/app.js?v=20260422"></script>
+<script src="/app.js?v=20260524"></script>
 </body>
 </html>

--- a/src/ctl/dashboard_assets/static/style.css
+++ b/src/ctl/dashboard_assets/static/style.css
@@ -782,7 +782,7 @@ body::after {
 
 .routing-row {
   display: grid;
-  grid-template-columns: minmax(80px, 110px) 80px 1fr auto;
+  grid-template-columns: minmax(80px, 110px) 80px 1fr auto auto;
   gap: 10px;
   align-items: center;
   padding: 10px 24px;
@@ -844,6 +844,15 @@ body::after {
   color: var(--text-muted);
   font-family: 'JetBrains Mono', monospace;
   white-space: nowrap;
+}
+
+.routing-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.routing-actions .ui-btn {
+  min-width: 64px;
 }
 
 .routing-empty {
@@ -994,6 +1003,9 @@ body::after {
     grid-template-columns: 1fr;
     gap: 6px;
     padding: 10px 14px;
+  }
+  .routing-actions {
+    justify-content: flex-start;
   }
   .routing-meta { white-space: normal; }
   .routing-controls {

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -8,9 +8,11 @@ const tui_mod = @import("tui.zig");
 const i18n = @import("i18n.zig");
 const sys = @import("sys.zig");
 const toml = @import("toml.zig");
+const release = @import("release.zig");
 const Tunnel = @import("tunnel").Tunnel;
 
 const Tui = tui_mod.Tui;
+const Color = tui_mod.Color;
 
 const INSTALL_DIR = "/opt/mtproto-proxy";
 const AWG_CONF_DIR = "/etc/amnezia/amneziawg";
@@ -18,6 +20,7 @@ const AWG_IFACE_CONF_PATH = "/etc/amnezia/awg0.conf";
 const TUNNEL_SCRIPT = "/usr/local/bin/setup_tunnel.sh";
 const TUNNEL_POOL_SERVICE = "/etc/systemd/system/mtproto-tunnel-pool.service";
 const TUNNEL_POOL_TIMER = "/etc/systemd/system/mtproto-tunnel-pool.timer";
+const TUNNEL_POOL_STATE = "/run/mtproto-proxy/tunnel-pool.state";
 const SERVICE_FILE = "/etc/systemd/system/mtproto-proxy.service";
 const TUNNEL_MARK: u32 = 200;
 const TUNNEL_TABLE: u32 = 200;
@@ -48,7 +51,13 @@ const AwgQuickValidation = enum {
 
 const InteractiveTunnelSelection = struct {
     iface: []const u8,
-    replacing_existing: bool,
+    action: InteractiveTunnelAction,
+};
+
+const InteractiveTunnelAction = enum {
+    create,
+    replace,
+    delete,
 };
 
 /// Run in CLI mode.
@@ -84,8 +93,6 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
 pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
     ui.section(i18n.get(ui.lang, .menu_setup_tunnel));
 
-    try chooseInteractiveVpnType(ui);
-
     const selection = chooseInteractiveTunnelTarget(ui, allocator) catch |err| {
         switch (err) {
             error.InvalidInterfaceName => ui.fail("Invalid tunnel interface name. Use names like awg0, awg1, wg0."),
@@ -96,7 +103,14 @@ pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
     };
     defer allocator.free(selection.iface);
 
-    if (selection.replacing_existing) {
+    if (selection.action == .delete) {
+        try deleteTunnelInteractive(ui, allocator, selection.iface);
+        return;
+    }
+
+    try chooseInteractiveVpnType(ui);
+
+    if (selection.action == .replace) {
         ui.warn(i18n.get(ui.lang, .tunnel_pool_replace_warn));
     }
     ui.stepOk(i18n.get(ui.lang, .tunnel_pool_selected_iface), selection.iface);
@@ -117,6 +131,10 @@ pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
     try execute(ui, allocator, .{ .awg_source = conf_source, .iface = selection.iface });
 }
 
+fn tr(lang: i18n.Lang, en: []const u8, ru: []const u8) []const u8 {
+    return if (lang == .ru) ru else en;
+}
+
 fn chooseInteractiveVpnType(ui: *Tui) !void {
     const items = [_][]const u8{
         i18n.get(ui.lang, .tunnel_vpn_amneziawg),
@@ -128,14 +146,14 @@ fn chooseInteractiveVpnType(ui: *Tui) !void {
 fn chooseInteractiveTunnelTarget(ui: *Tui, allocator: std.mem.Allocator) !InteractiveTunnelSelection {
     const pool = try loadConfiguredTunnelPool(allocator);
     defer freeOwnedStringSlice(allocator, pool);
+    const known = try loadKnownTunnelInterfaces(allocator);
+    defer freeOwnedStringSlice(allocator, known);
 
-    if (pool.len == 0) {
+    if (known.len == 0) {
         ui.info(i18n.get(ui.lang, .tunnel_pool_empty));
     } else {
         ui.info(i18n.get(ui.lang, .tunnel_pool_current));
-        for (pool, 0..) |iface, idx| {
-            ui.print("     {d}. {s}\n", .{ idx + 1, iface });
-        }
+        printTunnelPoolRuntimeStatus(ui, allocator, known, pool);
     }
 
     const next_iface = try selectTunnelInterface(allocator, "");
@@ -156,7 +174,7 @@ fn chooseInteractiveTunnelTarget(ui: *Tui, allocator: std.mem.Allocator) !Intera
         ),
     );
 
-    for (pool) |iface| {
+    for (known) |iface| {
         try items.append(
             allocator,
             try std.fmt.allocPrint(
@@ -167,18 +185,254 @@ fn chooseInteractiveTunnelTarget(ui: *Tui, allocator: std.mem.Allocator) !Intera
         );
     }
 
+    for (known) |iface| {
+        try items.append(
+            allocator,
+            try std.fmt.allocPrint(
+                allocator,
+                "{s}: {s}",
+                .{ tr(ui.lang, "Delete tunnel", "Удалить туннель"), iface },
+            ),
+        );
+    }
+
     const selected = try ui.menu(i18n.get(ui.lang, .tunnel_pool_action_prompt), items.items);
     if (selected == 0) {
         return .{
             .iface = try allocator.dupe(u8, next_iface),
-            .replacing_existing = false,
+            .action = .create,
+        };
+    }
+
+    if (selected <= known.len) {
+        return .{
+            .iface = try allocator.dupe(u8, known[selected - 1]),
+            .action = .replace,
         };
     }
 
     return .{
-        .iface = try allocator.dupe(u8, pool[selected - 1]),
-        .replacing_existing = true,
+        .iface = try allocator.dupe(u8, known[selected - known.len - 1]),
+        .action = .delete,
     };
+}
+
+fn tunnelShowTool(iface: []const u8) ?[]const u8 {
+    if (std.mem.startsWith(u8, iface, "wg") and sys.commandExists("wg")) return "wg";
+    if (sys.commandExists("awg")) return "awg";
+    if (sys.commandExists("wg")) return "wg";
+    return null;
+}
+
+fn quickToolForInterface(iface: []const u8) ?[]const u8 {
+    if (std.mem.startsWith(u8, iface, "wg") and sys.commandExists("wg-quick")) return "wg-quick";
+    if (sys.commandExists("awg-quick")) return "awg-quick";
+    if (sys.commandExists("wg-quick")) return "wg-quick";
+    return null;
+}
+
+fn hasValidHandshakeFromShow(out: []const u8) bool {
+    var lines = std.mem.splitScalar(u8, out, '\n');
+    while (lines.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r' });
+        if (!std.mem.startsWith(u8, trimmed, "latest handshake:")) continue;
+        const value = std.mem.trim(u8, trimmed["latest handshake:".len..], &[_]u8{ ' ', '\t', '\r' });
+        if (value.len == 0) return false;
+        if (std.ascii.eqlIgnoreCase(value, "0")) return false;
+        if (std.ascii.eqlIgnoreCase(value, "none")) return false;
+        if (std.ascii.eqlIgnoreCase(value, "none (idle)")) return false;
+        return true;
+    }
+    return false;
+}
+
+fn hasEndpointFromShow(out: []const u8) bool {
+    var lines = std.mem.splitScalar(u8, out, '\n');
+    while (lines.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r' });
+        if (std.mem.startsWith(u8, trimmed, "endpoint:")) return true;
+    }
+    return false;
+}
+
+fn tunnelRuntimeStatus(allocator: std.mem.Allocator, iface: []const u8) []const u8 {
+    const link = sys.exec(allocator, &.{ "ip", "link", "show", "dev", iface }) catch return "unknown";
+    defer link.deinit();
+    if (link.exit_code != 0) return "down";
+
+    const tool = tunnelShowTool(iface) orelse return "up, no tool";
+    const show = sys.exec(allocator, &.{ tool, "show", iface }) catch return "up, show failed";
+    defer show.deinit();
+    if (show.exit_code != 0) return "up, show failed";
+    if (hasValidHandshakeFromShow(show.stdout)) return "active";
+    if (hasEndpointFromShow(show.stdout)) return "up, no handshake";
+    return "up, no endpoint";
+}
+
+fn printTunnelPoolRuntimeStatus(ui: *Tui, allocator: std.mem.Allocator, interfaces: []const []const u8, pool: []const []const u8) void {
+    for (interfaces, 0..) |iface, idx| {
+        const status = tunnelRuntimeStatus(allocator, iface);
+        const source = if (containsInterface(pool, iface)) "pool" else "config";
+        const status_color = if (std.mem.eql(u8, status, "active"))
+            Color.ok
+        else if (std.mem.startsWith(u8, status, "up"))
+            Color.bright_yellow
+        else
+            Color.err;
+        ui.print("     {d}. {s}  {s}{s}{s}  {s}{s}{s}\n", .{ idx + 1, iface, status_color, status, Color.reset, Color.dim, source, Color.reset });
+    }
+}
+
+const TunnelDeleteResult = struct {
+    removed_last: bool,
+    remaining_count: usize,
+};
+
+fn deleteTunnelInteractive(ui: *Tui, allocator: std.mem.Allocator, iface: []const u8) !void {
+    if (!sys.isRoot()) {
+        ui.fail(i18n.get(ui.lang, .error_not_root));
+        return;
+    }
+
+    var prompt_buf: [256]u8 = undefined;
+    const prompt = std.fmt.bufPrint(
+        &prompt_buf,
+        "{s} {s}? {s}",
+        .{
+            tr(ui.lang, "Delete tunnel", "Удалить туннель"),
+            iface,
+            tr(ui.lang, "Config file and pool entry will be removed.", "Конфиг и запись в пуле будут удалены."),
+        },
+    ) catch "Delete tunnel?";
+
+    if (!try ui.confirm(prompt, false)) {
+        ui.info(i18n.get(ui.lang, .aborting));
+        return;
+    }
+
+    ui.step(tr(ui.lang, "Deleting tunnel", "Удаление туннеля"));
+    const result = deleteTunnelPoolMember(allocator, iface) catch |err| {
+        switch (err) {
+            error.InvalidInterfaceName => ui.fail("Invalid tunnel interface name"),
+            error.TunnelNotInPool => ui.fail("Tunnel interface is not in configured pool"),
+            error.ConfigSourceNotFound => ui.fail("Config file not found"),
+            else => ui.fail("Failed to delete tunnel"),
+        }
+        return;
+    };
+
+    ui.stepOk(tr(ui.lang, "Tunnel deleted", "Туннель удален"), iface);
+    if (result.removed_last) {
+        ui.warn(tr(
+            ui.lang,
+            "No tunnels left; upstream switched to auto and tunnel policy routing was disabled.",
+            "Туннелей не осталось; upstream переключен в auto, policy routing выключен.",
+        ));
+    } else {
+        var msg_buf: [128]u8 = undefined;
+        const msg = std.fmt.bufPrint(
+            &msg_buf,
+            "{d} {s}",
+            .{ result.remaining_count, tr(ui.lang, "tunnel(s) remain; pool controller refreshed.", "туннелей осталось; контроллер пула обновлен.") },
+        ) catch "Tunnel pool refreshed.";
+        ui.ok(msg);
+    }
+}
+
+fn deleteTunnelPoolMember(allocator: std.mem.Allocator, iface: []const u8) !TunnelDeleteResult {
+    if (!isValidTunnelInterfaceName(iface)) return error.InvalidInterfaceName;
+
+    const known_before = try loadKnownTunnelInterfaces(allocator);
+    defer freeOwnedStringSlice(allocator, known_before);
+
+    var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch return error.ConfigSourceNotFound;
+    defer doc.deinit();
+
+    const config_result = try removeTunnelFromDoc(allocator, &doc, iface);
+    defer freeOwnedStringSlice(allocator, config_result.remaining_pool);
+    if (!config_result.removed and !tunnelConfigExists(iface)) return error.TunnelNotInPool;
+
+    const stale_last = !config_result.removed and config_result.remaining_pool.len == 0 and known_before.len <= 1;
+    if (stale_last) {
+        try clearTunnelConfigInDoc(&doc);
+    }
+
+    const removed_last = config_result.removed_last or stale_last;
+    const remaining_count = config_result.remaining_pool.len;
+    if (config_result.removed or stale_last) {
+        try doc.save(INSTALL_DIR ++ "/config.toml");
+    }
+
+    stopTunnelInterface(allocator, iface);
+    deleteTunnelConfigFiles(allocator, iface);
+
+    if (removed_last) {
+        disableTunnelPoolRuntime(allocator);
+        release.writeServiceFile();
+        _ = sys.exec(allocator, &.{ "systemctl", "daemon-reload" }) catch null;
+    } else {
+        refreshTunnelPoolRuntime(allocator);
+    }
+
+    _ = sys.exec(allocator, &.{ "systemctl", "restart", "mtproto-proxy" }) catch null;
+
+    return .{
+        .removed_last = removed_last,
+        .remaining_count = remaining_count,
+    };
+}
+
+fn stopTunnelInterface(allocator: std.mem.Allocator, iface: []const u8) void {
+    const quick = quickToolForInterface(iface);
+
+    var awg_buf: [256]u8 = undefined;
+    const awg_path = awgConfigPath(&awg_buf, iface) catch "";
+    var wg_buf: [256]u8 = undefined;
+    const wg_path = std.fmt.bufPrint(&wg_buf, "/etc/wireguard/{s}.conf", .{iface}) catch "";
+
+    if (quick) |tool| {
+        if (awg_path.len > 0 and sys.fileExists(awg_path)) sys.execSilent(allocator, &.{ tool, "down", awg_path });
+        if (wg_path.len > 0 and sys.fileExists(wg_path)) sys.execSilent(allocator, &.{ tool, "down", wg_path });
+        sys.execSilent(allocator, &.{ tool, "down", iface });
+    }
+    sys.execSilent(allocator, &.{ "ip", "link", "delete", "dev", iface });
+}
+
+fn tunnelConfigExists(iface: []const u8) bool {
+    var awg_buf: [256]u8 = undefined;
+    const awg_path = awgConfigPath(&awg_buf, iface) catch "";
+    var wg_buf: [256]u8 = undefined;
+    const wg_path = std.fmt.bufPrint(&wg_buf, "/etc/wireguard/{s}.conf", .{iface}) catch "";
+
+    if (awg_path.len > 0 and sys.fileExists(awg_path)) return true;
+    if (wg_path.len > 0 and sys.fileExists(wg_path)) return true;
+    if (std.mem.eql(u8, iface, "awg0") and sys.fileExists(AWG_IFACE_CONF_PATH)) return true;
+    return false;
+}
+
+fn deleteTunnelConfigFiles(allocator: std.mem.Allocator, iface: []const u8) void {
+    var awg_buf: [256]u8 = undefined;
+    const awg_path = awgConfigPath(&awg_buf, iface) catch "";
+    var wg_buf: [256]u8 = undefined;
+    const wg_path = std.fmt.bufPrint(&wg_buf, "/etc/wireguard/{s}.conf", .{iface}) catch "";
+
+    if (awg_path.len > 0) sys.execSilent(allocator, &.{ "rm", "-f", awg_path });
+    if (wg_path.len > 0) sys.execSilent(allocator, &.{ "rm", "-f", wg_path });
+    if (std.mem.eql(u8, iface, "awg0")) {
+        sys.execSilent(allocator, &.{ "rm", "-f", AWG_IFACE_CONF_PATH });
+    }
+}
+
+fn disableTunnelPoolRuntime(allocator: std.mem.Allocator) void {
+    sys.execSilent(allocator, &.{ "systemctl", "disable", "--now", "mtproto-tunnel-pool.timer" });
+    sys.execSilent(allocator, &.{ "systemctl", "stop", "mtproto-tunnel-pool.service" });
+    sys.execSilent(allocator, &.{ "sh", "-c", "while ip -4 rule del priority 1200 fwmark 200 table 200 2>/dev/null; do :; done; while ip -4 rule del fwmark 200 table 200 2>/dev/null; do :; done; ip -4 route flush table 200 2>/dev/null || true" });
+    sys.execSilent(allocator, &.{ "rm", "-f", TUNNEL_SCRIPT, TUNNEL_POOL_STATE, TUNNEL_POOL_SERVICE, TUNNEL_POOL_TIMER });
+}
+
+fn refreshTunnelPoolRuntime(allocator: std.mem.Allocator) void {
+    if (!sys.fileExists(TUNNEL_SCRIPT)) return;
+    sys.execSilent(allocator, &.{TUNNEL_SCRIPT});
 }
 
 fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
@@ -920,6 +1174,55 @@ fn loadConfiguredTunnelPool(allocator: std.mem.Allocator) ![]const []const u8 {
     return try loadTunnelPoolFromDoc(allocator, &doc);
 }
 
+fn loadKnownTunnelInterfaces(allocator: std.mem.Allocator) ![]const []const u8 {
+    var list: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (list.items) |item| allocator.free(item);
+        list.deinit(allocator);
+    }
+
+    const pool = try loadConfiguredTunnelPool(allocator);
+    defer freeOwnedStringSlice(allocator, pool);
+    for (pool) |iface| {
+        if (!containsInterface(list.items, iface)) {
+            try list.append(allocator, try allocator.dupe(u8, iface));
+        }
+    }
+
+    const found = sys.exec(allocator, &.{
+        "find",
+        "/etc/amnezia/amneziawg",
+        "/etc/wireguard",
+        "-maxdepth",
+        "1",
+        "-type",
+        "f",
+        "-name",
+        "*.conf",
+        "-printf",
+        "%f\n",
+    }) catch null;
+    if (found) |result| {
+        defer result.deinit();
+        var lines = std.mem.splitScalar(u8, result.stdout, '\n');
+        while (lines.next()) |line| {
+            const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r', '\n' });
+            if (!std.mem.endsWith(u8, trimmed, ".conf")) continue;
+            const iface = trimmed[0 .. trimmed.len - ".conf".len];
+            if (!isValidTunnelInterfaceName(iface)) continue;
+            if (!containsInterface(list.items, iface)) {
+                try list.append(allocator, try allocator.dupe(u8, iface));
+            }
+        }
+    }
+
+    if (list.items.len == 0) {
+        list.deinit(allocator);
+        return &.{};
+    }
+    return try list.toOwnedSlice(allocator);
+}
+
 fn containsInterface(values: []const []const u8, iface: []const u8) bool {
     for (values) |value| {
         if (std.mem.eql(u8, value, iface)) return true;
@@ -945,6 +1248,71 @@ fn appendInterfaceIfMissing(allocator: std.mem.Allocator, values: []const []cons
         return &.{};
     }
     return try out.toOwnedSlice(allocator);
+}
+
+const TunnelRemovalConfigResult = struct {
+    removed: bool,
+    removed_last: bool,
+    remaining_pool: []const []const u8,
+};
+
+fn removeInterfaceFromPool(allocator: std.mem.Allocator, values: []const []const u8, iface: []const u8) !TunnelRemovalConfigResult {
+    var out: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (out.items) |value| allocator.free(value);
+        out.deinit(allocator);
+    }
+
+    var removed = false;
+    for (values) |value| {
+        if (std.mem.eql(u8, value, iface)) {
+            removed = true;
+            continue;
+        }
+        try out.append(allocator, try allocator.dupe(u8, value));
+    }
+
+    return .{
+        .removed = removed,
+        .removed_last = removed and out.items.len == 0,
+        .remaining_pool = try out.toOwnedSlice(allocator),
+    };
+}
+
+fn removeTunnelFromDoc(allocator: std.mem.Allocator, doc: *toml.TomlDoc, iface: []const u8) !TunnelRemovalConfigResult {
+    const existing = try loadTunnelPoolFromDoc(allocator, doc);
+    defer freeOwnedStringSlice(allocator, existing);
+
+    const result = try removeInterfaceFromPool(allocator, existing, iface);
+    errdefer freeOwnedStringSlice(allocator, result.remaining_pool);
+
+    if (!result.removed) return result;
+
+    if (result.remaining_pool.len > 0) {
+        var first_buf: [64]u8 = undefined;
+        const first = try std.fmt.bufPrint(&first_buf, "\"{s}\"", .{result.remaining_pool[0]});
+        try doc.set("upstream.tunnel", "interface", first);
+    } else {
+        try clearTunnelConfigInDoc(doc);
+    }
+
+    const array_literal = try formatInterfaceArrayLiteral(allocator, result.remaining_pool);
+    defer allocator.free(array_literal);
+    try doc.set("upstream.tunnel", "interfaces", array_literal);
+
+    const pinned = doc.get("upstream.tunnel", "pinned_interface") orelse "";
+    if (std.mem.eql(u8, pinned, iface) or result.remaining_pool.len == 0) {
+        try doc.set("upstream.tunnel", "pinned_interface", "\"\"");
+    }
+
+    return result;
+}
+
+fn clearTunnelConfigInDoc(doc: *toml.TomlDoc) !void {
+    try doc.set("upstream", "type", "\"auto\"");
+    try doc.set("upstream.tunnel", "interface", "\"\"");
+    try doc.set("upstream.tunnel", "interfaces", "[]");
+    try doc.set("upstream.tunnel", "pinned_interface", "\"\"");
 }
 
 fn nextAwgInterfaceNameFromPool(allocator: std.mem.Allocator, used: []const []const u8) ![]const u8 {
@@ -1585,6 +1953,54 @@ test "tunnel pool - parses interface array" {
     try std.testing.expectEqual(@as(usize, 2), pool.len);
     try std.testing.expectEqualStrings("awg0", pool[0]);
     try std.testing.expectEqualStrings("awg1", pool[1]);
+}
+
+test "tunnel pool - remove interface from doc clears matching pin" {
+    var doc = toml.TomlDoc.initEmpty(std.testing.allocator);
+    defer doc.deinit();
+
+    try doc.addSection("upstream");
+    try doc.addKvStr("type", "tunnel");
+    try doc.addSection("upstream.tunnel");
+    try doc.addKvStr("interface", "awg0");
+    try doc.addKv("interfaces", "[\"awg0\", \"awg1\", \"awg2\"]");
+    try doc.addKvStr("pinned_interface", "awg1");
+
+    const result = try removeTunnelFromDoc(std.testing.allocator, &doc, "awg1");
+    defer freeOwnedStringSlice(std.testing.allocator, result.remaining_pool);
+
+    try std.testing.expect(result.removed);
+    try std.testing.expect(!result.removed_last);
+    try std.testing.expectEqual(@as(usize, 2), result.remaining_pool.len);
+    try std.testing.expectEqualStrings("awg0", result.remaining_pool[0]);
+    try std.testing.expectEqualStrings("awg2", result.remaining_pool[1]);
+    try std.testing.expectEqualStrings("tunnel", doc.get("upstream", "type").?);
+    try std.testing.expectEqualStrings("awg0", doc.get("upstream.tunnel", "interface").?);
+    try std.testing.expectEqualStrings("[\"awg0\", \"awg2\"]", doc.get("upstream.tunnel", "interfaces").?);
+    try std.testing.expectEqualStrings("", doc.get("upstream.tunnel", "pinned_interface").?);
+}
+
+test "tunnel pool - remove last interface disables tunnel upstream" {
+    var doc = toml.TomlDoc.initEmpty(std.testing.allocator);
+    defer doc.deinit();
+
+    try doc.addSection("upstream");
+    try doc.addKvStr("type", "tunnel");
+    try doc.addSection("upstream.tunnel");
+    try doc.addKvStr("interface", "awg0");
+    try doc.addKv("interfaces", "[\"awg0\"]");
+    try doc.addKvStr("pinned_interface", "awg0");
+
+    const result = try removeTunnelFromDoc(std.testing.allocator, &doc, "awg0");
+    defer freeOwnedStringSlice(std.testing.allocator, result.remaining_pool);
+
+    try std.testing.expect(result.removed);
+    try std.testing.expect(result.removed_last);
+    try std.testing.expectEqual(@as(usize, 0), result.remaining_pool.len);
+    try std.testing.expectEqualStrings("auto", doc.get("upstream", "type").?);
+    try std.testing.expectEqualStrings("", doc.get("upstream.tunnel", "interface").?);
+    try std.testing.expectEqualStrings("[]", doc.get("upstream.tunnel", "interfaces").?);
+    try std.testing.expectEqualStrings("", doc.get("upstream.tunnel", "pinned_interface").?);
 }
 
 test "tunnel - converts Amnezia vpn link to AWG config" {


### PR DESCRIPTION
## Summary

- Add hard-delete tunnel pool management to the TUI setup flow, including stale config-file discovery and runtime status labels.
- Add dashboard tunnel discovery/delete API and row-level delete controls with confirmation.
- Clean up last-tunnel removal by switching upstream back to `auto`, removing table-200 policy routing/state, disabling pool units, and restoring the default proxy service unit.

## Why

Tunnel entries could look deleted while stale config files, pool state, and policy routing still made `awg0`/`awg1` appear configured. This makes the state explicit and gives operators a safe delete path from both UI surfaces.

## Validation

- `zig build test`
- `python3 -m py_compile src/ctl/dashboard_assets/server.py`
- `node --check src/ctl/dashboard_assets/static/app.js`
- `git diff --check`

Note: the Codex in-app browser backend was unavailable in this session, so visual dashboard verification was limited to static syntax/checks.