### PR TITLE
[codex] fix tunnel pool timer recurrence

### DIFF
--- a/src/ctl/main.zig
+++ b/src/ctl/main.zig
@@ -480,3 +480,7 @@ fn printLangFlagError(msg: []const u8) void {
 fn tr(lang: i18n.Lang, en: []const u8, ru: []const u8) []const u8 {
     return if (lang == .ru) ru else en;
 }
+
+test {
+    std.testing.refAllDecls(tunnel);
+}

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -1414,7 +1414,7 @@ fn installTunnelPoolUnits(ui: *Tui, allocator: std.mem.Allocator) void {
         \\
         \\[Timer]
         \\OnBootSec=30s
-        \\OnUnitActiveSec=30s
+        \\OnUnitInactiveSec=30s
         \\RandomizedDelaySec=5s
         \\Persistent=true
         \\
@@ -1946,6 +1946,12 @@ test "tunnel pool - script renders policy route replacement and nonfatal Telegra
     try std.testing.expect(std.mem.indexOf(u8, script, "pinned_interface") != null);
 }
 
+test "tunnel pool timer repeats after oneshot service exits" {
+    const source = @embedFile("tunnel.zig");
+    const needle = "OnUnitInactiveSec" ++ "=30s";
+    try std.testing.expect(std.mem.indexOf(u8, source, needle) != null);
+}
+
 test "tunnel pool - parses interface array" {
     const pool = try parseTunnelInterfaceArray(std.testing.allocator, "[\"awg0\", \"awg1\"]");
     defer freeOwnedStringSlice(std.testing.allocator, pool);
@@ -2037,7 +2043,7 @@ test "tunnel - strips empty AWG assignments" {
     defer tmp.cleanup();
 
     const name = "awg0.conf";
-    try tmp.dir.writeFile(.{
+    try tmp.dir.writeFile(io(), .{
         .sub_path = name,
         .data =
         \\[Interface]
@@ -2057,7 +2063,7 @@ test "tunnel - strips empty AWG assignments" {
 
     try std.testing.expect(try stripAwgEmptyAssignments(std.testing.allocator, path));
 
-    const sanitized = try tmp.dir.readFileAlloc(std.testing.allocator, name, 4096);
+    const sanitized = try tmp.dir.readFileAlloc(io(), name, std.testing.allocator, .limited(4096));
     defer std.testing.allocator.free(sanitized);
 
     try std.testing.expect(std.mem.indexOf(u8, sanitized, "I2") == null);


### PR DESCRIPTION
## What changed

- Change the tunnel pool systemd timer from `OnUnitActiveSec=30s` to `OnUnitInactiveSec=30s` so it repeats after the oneshot health check exits.
- Add a regression test for the tunnel pool timer template.
- Ensure `mtbuddy` test builds reference tunnel command declarations, and update a tunnel test to the current Zig file IO API.

## Why

The tunnel pool service is `Type=oneshot`. On the affected host, `mtproto-tunnel-pool.timer` was enabled but stuck in `active (elapsed)` with no next trigger, so the tunnel policy route was only refreshed when `mtproto-proxy` restarted and ran `setup_tunnel.sh` via `ExecStartPre`.

Using `OnUnitInactiveSec` schedules the next run after the oneshot service completes, keeping policy routing checks active without requiring a proxy restart.

## Validation

- `zig build test --summary all` -> `154/154 tests passed`
- Verified on the affected server that the updated timer is `active (waiting)` and repeatedly triggers `mtproto-tunnel-pool.service`.