### PR TITLE
feat: add handshake flood guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,10 @@ handshake_timeout_sec = 15
 graceful_shutdown_timeout_sec = 15
 log_level = "info"        # debug | info | warn | err
 rate_limit_per_subnet = 30
+handshake_flood_guard_enabled = true
+handshake_flood_guard_threshold = 20
+handshake_flood_guard_window_sec = 30
+handshake_flood_guard_block_sec = 120
 tag = ""                  # Optional: promotion tag from @MTProxybot
 
 [censorship]
@@ -398,6 +402,10 @@ alice = true   # bypass MiddleProxy for this user
 | `[server] tag` | — | 32 hex-char promotion tag from [@MTProxybot](https://t.me/MTProxybot) |
 | `[server] log_level` | `"info"` | `debug` / `info` / `warn` / `err` |
 | `[server] rate_limit_per_subnet` | `30` | Max new conns/sec per /24 (IPv4) or /48 (IPv6). Set `0` to disable |
+| `[server] handshake_flood_guard_enabled` | `true` | Temporarily deny exact source IPs that repeatedly fail the MTProto handshake |
+| `[server] handshake_flood_guard_threshold` | `20` | Bad handshake/rate/budget events per source IP before temporary deny |
+| `[server] handshake_flood_guard_window_sec` | `30` | Rolling window for `handshake_flood_guard_threshold` |
+| `[server] handshake_flood_guard_block_sec` | `120` | Temporary deny duration for noisy source IPs |
 | `[server] unsafe_override_limits` | `false` | Disable auto-clamping of `max_connections` |
 | `[monitor] host` | `"127.0.0.1"` | Dashboard bind address |
 | `[monitor] port` | `61208` | Dashboard port |

--- a/README.ru.md
+++ b/README.ru.md
@@ -335,6 +335,10 @@ handshake_timeout_sec = 15
 graceful_shutdown_timeout_sec = 15
 log_level = "info"
 rate_limit_per_subnet = 30
+handshake_flood_guard_enabled = true
+handshake_flood_guard_threshold = 20
+handshake_flood_guard_window_sec = 30
+handshake_flood_guard_block_sec = 120
 tag = ""                  # Optional: promotion tag from @MTProxybot
 
 [censorship]
@@ -369,6 +373,11 @@ alice = true
 | `[server] max_connections` | `512` | Лимит одновременных соединений |
 | `[server] middleproxy_buffer_kb` | `1024` | Буфер MiddleProxy на соединение |
 | `[server] tag` | — | 32-hex promotion tag от [@MTProxybot](https://t.me/MTProxybot) |
+| `[server] rate_limit_per_subnet` | `30` | Лимит новых соединений в секунду на /24 (IPv4) или /48 (IPv6), `0` отключает |
+| `[server] handshake_flood_guard_enabled` | `true` | Временно отклонять IP, которые часто не проходят MTProto handshake |
+| `[server] handshake_flood_guard_threshold` | `20` | Число плохих handshake/rate/budget событий с одного IP до временного deny |
+| `[server] handshake_flood_guard_window_sec` | `30` | Окно подсчёта для `handshake_flood_guard_threshold` |
+| `[server] handshake_flood_guard_block_sec` | `120` | Длительность временного deny для шумного IP |
 | `[censorship] tls_domain` | `"google.com"` | Домен для TLS-маскировки |
 | `[censorship] mask` | `true` | Forward invalid clients на `tls_domain` |
 | `[censorship] fast_mode` | `false` | Делегировать S2C encryption DC |

--- a/src/config.zig
+++ b/src/config.zig
@@ -198,6 +198,12 @@ pub const Config = struct {
     /// Limits scanner/flood/DPI-probe impact. Generous for legitimate Telegram clients
     /// which open 3-6 connections at startup and hold them.
     rate_limit_per_subnet: u8 = 30,
+    /// Exact-IP handshake flood guard. Temporarily denies clients that repeatedly
+    /// hit handshake timeouts, subnet rate limits, or the handshake budget.
+    handshake_flood_guard_enabled: bool = true,
+    handshake_flood_guard_threshold: u16 = 20,
+    handshake_flood_guard_window_sec: u16 = 30,
+    handshake_flood_guard_block_sec: u16 = 120,
     /// When true, disables auto-clamping of max_connections to the RAM-safe estimate.
     /// Use only if you know your host has enough memory for the configured limits.
     unsafe_override_limits: bool = false,
@@ -492,6 +498,17 @@ pub const Config = struct {
                         }
                     } else if (std.mem.eql(u8, key, "rate_limit_per_subnet")) {
                         cfg.rate_limit_per_subnet = std.fmt.parseInt(u8, value, 10) catch cfg.rate_limit_per_subnet;
+                    } else if (std.mem.eql(u8, key, "handshake_flood_guard_enabled")) {
+                        cfg.handshake_flood_guard_enabled = std.mem.eql(u8, value, "true");
+                    } else if (std.mem.eql(u8, key, "handshake_flood_guard_threshold")) {
+                        const parsed = std.fmt.parseInt(u16, value, 10) catch cfg.handshake_flood_guard_threshold;
+                        cfg.handshake_flood_guard_threshold = @max(@as(u16, 1), parsed);
+                    } else if (std.mem.eql(u8, key, "handshake_flood_guard_window_sec")) {
+                        const parsed = std.fmt.parseInt(u16, value, 10) catch cfg.handshake_flood_guard_window_sec;
+                        cfg.handshake_flood_guard_window_sec = @max(@as(u16, 1), parsed);
+                    } else if (std.mem.eql(u8, key, "handshake_flood_guard_block_sec")) {
+                        const parsed = std.fmt.parseInt(u16, value, 10) catch cfg.handshake_flood_guard_block_sec;
+                        cfg.handshake_flood_guard_block_sec = @max(@as(u16, 1), parsed);
                     } else if (std.mem.eql(u8, key, "unsafe_override_limits")) {
                         cfg.unsafe_override_limits = std.mem.eql(u8, value, "true");
                     }
@@ -691,6 +708,10 @@ test "parse config - missing fields defaults" {
     try std.testing.expectEqual(@as(u32, 1024), cfg.middleproxy_buffer_kb);
     try std.testing.expectEqual(@as(usize, 1024 * 1024), cfg.middleProxyBufferBytes());
     try std.testing.expectEqual(@as(u8, 30), cfg.rate_limit_per_subnet);
+    try std.testing.expect(cfg.handshake_flood_guard_enabled);
+    try std.testing.expectEqual(@as(u16, 20), cfg.handshake_flood_guard_threshold);
+    try std.testing.expectEqual(@as(u16, 30), cfg.handshake_flood_guard_window_sec);
+    try std.testing.expectEqual(@as(u16, 120), cfg.handshake_flood_guard_block_sec);
     try std.testing.expect(!cfg.unsafe_override_limits);
     try std.testing.expect(!cfg.metrics.enabled);
     try std.testing.expect(cfg.metrics.host == null);
@@ -1062,6 +1083,41 @@ test "parse config - rate_limit_per_subnet disabled" {
     defer cfg.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(u8, 0), cfg.rate_limit_per_subnet);
+}
+
+test "parse config - handshake flood guard defaults enabled" {
+    const content =
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expect(cfg.handshake_flood_guard_enabled);
+    try std.testing.expectEqual(@as(u16, 20), cfg.handshake_flood_guard_threshold);
+    try std.testing.expectEqual(@as(u16, 30), cfg.handshake_flood_guard_window_sec);
+    try std.testing.expectEqual(@as(u16, 120), cfg.handshake_flood_guard_block_sec);
+}
+
+test "parse config - handshake flood guard custom values" {
+    const content =
+        \\[server]
+        \\handshake_flood_guard_enabled = false
+        \\handshake_flood_guard_threshold = 9
+        \\handshake_flood_guard_window_sec = 17
+        \\handshake_flood_guard_block_sec = 45
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expect(!cfg.handshake_flood_guard_enabled);
+    try std.testing.expectEqual(@as(u16, 9), cfg.handshake_flood_guard_threshold);
+    try std.testing.expectEqual(@as(u16, 17), cfg.handshake_flood_guard_window_sec);
+    try std.testing.expectEqual(@as(u16, 45), cfg.handshake_flood_guard_block_sec);
 }
 
 test "parse config - unsafe_override_limits true" {

--- a/src/ctl/config_cmd.zig
+++ b/src/ctl/config_cmd.zig
@@ -214,6 +214,10 @@ fn printEffective(ui: *Tui, allocator: std.mem.Allocator, path: []const u8) !voi
     ui.print("middleproxy_buffer_kb = {d}\n", .{cfg.middleproxy_buffer_kb});
     ui.print("log_level = \"{s}\"\n", .{@tagName(cfg.log_level)});
     ui.print("rate_limit_per_subnet = {d}\n", .{cfg.rate_limit_per_subnet});
+    ui.print("handshake_flood_guard_enabled = {}\n", .{cfg.handshake_flood_guard_enabled});
+    ui.print("handshake_flood_guard_threshold = {d}\n", .{cfg.handshake_flood_guard_threshold});
+    ui.print("handshake_flood_guard_window_sec = {d}\n", .{cfg.handshake_flood_guard_window_sec});
+    ui.print("handshake_flood_guard_block_sec = {d}\n", .{cfg.handshake_flood_guard_block_sec});
     ui.print("unsafe_override_limits = {}\n", .{cfg.unsafe_override_limits});
     ui.writeRaw("\n");
 

--- a/src/ctl/install.zig
+++ b/src/ctl/install.zig
@@ -448,6 +448,10 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
         try doc.addKv("max_connections", "512");
         try doc.addKv("idle_timeout_sec", "120");
         try doc.addKv("handshake_timeout_sec", "15");
+        try doc.addKv("handshake_flood_guard_enabled", "true");
+        try doc.addKv("handshake_flood_guard_threshold", "20");
+        try doc.addKv("handshake_flood_guard_window_sec", "30");
+        try doc.addKv("handshake_flood_guard_block_sec", "120");
 
         try doc.addSection("upstream");
         try doc.addKvStr("type", "direct");

--- a/src/monitoring.zig
+++ b/src/monitoring.zig
@@ -202,6 +202,7 @@ fn writeMetrics(writer: anytype, state: *proxy.ProxyState, process: ProcessMetri
     try writeCounter(writer, "mtproto_drops_capacity_total", "connections dropped because max_connections was reached", snapshot.drops_capacity_total);
     try writeCounter(writer, "mtproto_drops_saturation_total", "accept attempts dropped due to saturation hysteresis", snapshot.drops_saturation_total);
     try writeCounter(writer, "mtproto_drops_rate_limit_total", "connections dropped by subnet rate limiter", snapshot.drops_rate_limit_total);
+    try writeCounter(writer, "mtproto_drops_flood_guard_total", "connections dropped by exact-IP handshake flood guard", snapshot.drops_flood_guard_total);
     try writeCounter(writer, "mtproto_drops_handshake_budget_total", "connections dropped because handshake budget was exhausted", snapshot.drops_handshake_budget_total);
     try writeCounter(writer, "mtproto_handshake_timeouts_total", "connections dropped due to handshake timeout", snapshot.handshake_timeouts_total);
     try writeCounter(writer, "mtproto_middleproxy_fallback_total", "times middleproxy fell back to direct path", snapshot.middleproxy_fallback_total);

--- a/src/proxy/handshake_flood_guard.zig
+++ b/src/proxy/handshake_flood_guard.zig
@@ -1,0 +1,396 @@
+const std = @import("std");
+const posix = std.posix;
+const crypto = @import("../crypto/crypto.zig");
+
+const Address = std.Io.net.IpAddress;
+
+fn nowSeconds() i64 {
+    var ts: posix.timespec = undefined;
+    const rc = posix.system.clock_gettime(.MONOTONIC, &ts);
+    if (posix.errno(rc) != .SUCCESS) return 0;
+    return @intCast(ts.sec);
+}
+
+/// Tracks short-lived handshake failures by exact client IP.
+///
+/// This complements the coarser /24 subnet rate limiter: a noisy client can
+/// be temporarily denied without punishing the whole provider subnet.
+pub const HandshakeFloodGuard = struct {
+    pub const BUCKETS = 8192;
+    pub const MAX_PROBES = 8;
+    pub const stale_after_s: i64 = 300;
+
+    pub const Settings = struct {
+        enabled: bool = true,
+        threshold: u16 = 20,
+        window_sec: u16 = 30,
+        block_sec: u16 = 120,
+    };
+
+    pub const Event = enum {
+        rate_limit,
+        handshake_budget,
+        handshake_timeout,
+    };
+
+    pub const ClientKey = struct {
+        const Family = enum(u8) { ip4, ip6 };
+
+        family: Family = .ip4,
+        bytes: [16]u8 = [_]u8{0} ** 16,
+
+        fn eql(self: ClientKey, other: ClientKey) bool {
+            return self.family == other.family and std.mem.eql(u8, &self.bytes, &other.bytes);
+        }
+    };
+
+    pub const Entry = struct {
+        used: bool = false,
+        key: ClientKey = .{},
+        total: u16 = 0,
+        rate_limit: u16 = 0,
+        handshake_budget: u16 = 0,
+        handshake_timeout: u16 = 0,
+        window_start_s: i64 = 0,
+        last_event_s: i64 = 0,
+        blocked_until_s: i64 = 0,
+    };
+
+    pub const TopEntry = struct {
+        key: ClientKey,
+        total: u16,
+        rate_limit: u16,
+        handshake_budget: u16,
+        handshake_timeout: u16,
+        blocked_until_s: i64,
+
+        fn desc(_: void, a: TopEntry, b: TopEntry) bool {
+            if (a.total == b.total) return a.blocked_until_s > b.blocked_until_s;
+            return a.total > b.total;
+        }
+    };
+
+    hash_seed: u64 = 0,
+    entries: [BUCKETS]Entry = [_]Entry{.{}} ** BUCKETS,
+
+    pub fn init() HandshakeFloodGuard {
+        return .{ .hash_seed = crypto.randomInt(u64) };
+    }
+
+    pub fn create(allocator: std.mem.Allocator) !*HandshakeFloodGuard {
+        const guard = try allocator.create(HandshakeFloodGuard);
+        guard.hash_seed = crypto.randomInt(u64);
+        @memset(guard.entries[0..], .{});
+        return guard;
+    }
+
+    pub fn destroy(self: *HandshakeFloodGuard, allocator: std.mem.Allocator) void {
+        allocator.destroy(self);
+    }
+
+    pub fn settings(
+        enabled: bool,
+        threshold: u16,
+        window_sec: u16,
+        block_sec: u16,
+    ) Settings {
+        return .{
+            .enabled = enabled,
+            .threshold = @max(@as(u16, 1), threshold),
+            .window_sec = @max(@as(u16, 1), window_sec),
+            .block_sec = @max(@as(u16, 1), block_sec),
+        };
+    }
+
+    pub fn isBlocked(self: *HandshakeFloodGuard, addr: Address, cfg: Settings) bool {
+        return self.isBlockedAt(addr, cfg, nowSeconds());
+    }
+
+    pub fn isBlockedAt(self: *HandshakeFloodGuard, addr: Address, cfg: Settings, now_s: i64) bool {
+        if (!cfg.enabled) return false;
+        const key = keyFromAddress(addr);
+        const entry = self.findEntry(key) orelse return false;
+        return entry.blocked_until_s > now_s;
+    }
+
+    /// Records a bad handshake-related event.
+    /// Returns true when the client is blocked after this event.
+    pub fn record(self: *HandshakeFloodGuard, addr: Address, event: Event, cfg: Settings) bool {
+        return self.recordAt(addr, event, cfg, nowSeconds());
+    }
+
+    pub fn recordAt(
+        self: *HandshakeFloodGuard,
+        addr: Address,
+        event: Event,
+        cfg: Settings,
+        now_s: i64,
+    ) bool {
+        if (!cfg.enabled) return false;
+
+        const key = keyFromAddress(addr);
+        const entry = self.getOrPutEntry(key, now_s);
+
+        if (now_s - entry.window_start_s >= cfg.window_sec) {
+            entry.total = 0;
+            entry.rate_limit = 0;
+            entry.handshake_budget = 0;
+            entry.handshake_timeout = 0;
+            entry.window_start_s = now_s;
+        }
+
+        increment(&entry.total);
+        switch (event) {
+            .rate_limit => increment(&entry.rate_limit),
+            .handshake_budget => increment(&entry.handshake_budget),
+            .handshake_timeout => increment(&entry.handshake_timeout),
+        }
+        entry.last_event_s = now_s;
+
+        if (entry.total >= cfg.threshold) {
+            entry.blocked_until_s = @max(entry.blocked_until_s, now_s + cfg.block_sec);
+            return true;
+        }
+        return entry.blocked_until_s > now_s;
+    }
+
+    pub fn top(self: *HandshakeFloodGuard, cfg: Settings, out: []TopEntry) usize {
+        return self.topAt(cfg, nowSeconds(), out);
+    }
+
+    pub fn topAt(self: *HandshakeFloodGuard, cfg: Settings, now_s: i64, out: []TopEntry) usize {
+        if (!cfg.enabled or out.len == 0) return 0;
+
+        var len: usize = 0;
+        for (&self.entries) |*entry| {
+            if (!entry.used or entry.total == 0) continue;
+            const active_window = now_s - entry.window_start_s < cfg.window_sec;
+            const blocked = entry.blocked_until_s > now_s;
+            if (!active_window and !blocked) continue;
+
+            const item = TopEntry{
+                .key = entry.key,
+                .total = entry.total,
+                .rate_limit = entry.rate_limit,
+                .handshake_budget = entry.handshake_budget,
+                .handshake_timeout = entry.handshake_timeout,
+                .blocked_until_s = entry.blocked_until_s,
+            };
+
+            if (len < out.len) {
+                out[len] = item;
+                len += 1;
+                continue;
+            }
+
+            var min_idx: usize = 0;
+            for (out[1..], 1..) |existing, idx| {
+                if (existing.total < out[min_idx].total) min_idx = idx;
+            }
+            if (item.total > out[min_idx].total) out[min_idx] = item;
+        }
+
+        std.mem.sort(TopEntry, out[0..len], {}, TopEntry.desc);
+        return len;
+    }
+
+    pub fn keyFromAddress(addr: Address) ClientKey {
+        return switch (addr) {
+            .ip4 => |ip4_addr| blk: {
+                var key = ClientKey{ .family = .ip4 };
+                @memcpy(key.bytes[0..4], &ip4_addr.bytes);
+                break :blk key;
+            },
+            .ip6 => |ip6_addr| blk: {
+                const b = &ip6_addr.bytes;
+                const is_ipv4_mapped = std.mem.eql(u8, b[0..10], &[_]u8{0} ** 10) and
+                    b[10] == 0xff and b[11] == 0xff;
+                if (is_ipv4_mapped) {
+                    var key = ClientKey{ .family = .ip4 };
+                    @memcpy(key.bytes[0..4], b[12..16]);
+                    break :blk key;
+                }
+
+                var key = ClientKey{ .family = .ip6 };
+                @memcpy(&key.bytes, b);
+                break :blk key;
+            },
+        };
+    }
+
+    pub fn formatKey(key: ClientKey, buf: []u8) []const u8 {
+        return switch (key.family) {
+            .ip4 => std.fmt.bufPrint(buf, "{d}.{d}.{d}.{d}", .{
+                key.bytes[0],
+                key.bytes[1],
+                key.bytes[2],
+                key.bytes[3],
+            }) catch "",
+            .ip6 => blk: {
+                const groups = [_]u16{
+                    std.mem.readInt(u16, key.bytes[0..2], .big),
+                    std.mem.readInt(u16, key.bytes[2..4], .big),
+                    std.mem.readInt(u16, key.bytes[4..6], .big),
+                    std.mem.readInt(u16, key.bytes[6..8], .big),
+                    std.mem.readInt(u16, key.bytes[8..10], .big),
+                    std.mem.readInt(u16, key.bytes[10..12], .big),
+                    std.mem.readInt(u16, key.bytes[12..14], .big),
+                    std.mem.readInt(u16, key.bytes[14..16], .big),
+                };
+                break :blk std.fmt.bufPrint(
+                    buf,
+                    "{x:0>4}:{x:0>4}:{x:0>4}:{x:0>4}:{x:0>4}:{x:0>4}:{x:0>4}:{x:0>4}",
+                    .{ groups[0], groups[1], groups[2], groups[3], groups[4], groups[5], groups[6], groups[7] },
+                ) catch "";
+            },
+        };
+    }
+
+    fn findEntry(self: *HandshakeFloodGuard, key: ClientKey) ?*Entry {
+        const start = self.indexFor(key);
+        var probe: usize = 0;
+        while (probe < MAX_PROBES) : (probe += 1) {
+            const idx = (start + probe) & (BUCKETS - 1);
+            const entry = &self.entries[idx];
+            if (!entry.used) return null;
+            if (entry.key.eql(key)) return entry;
+        }
+        return null;
+    }
+
+    fn getOrPutEntry(self: *HandshakeFloodGuard, key: ClientKey, now_s: i64) *Entry {
+        const start = self.indexFor(key);
+        var first_stale_idx: ?usize = null;
+        var oldest_idx: usize = start;
+        var oldest_ts: i64 = std.math.maxInt(i64);
+
+        var probe: usize = 0;
+        while (probe < MAX_PROBES) : (probe += 1) {
+            const idx = (start + probe) & (BUCKETS - 1);
+            const entry = &self.entries[idx];
+
+            if (!entry.used) {
+                entry.* = freshEntry(key, now_s);
+                return entry;
+            }
+            if (entry.key.eql(key)) return entry;
+
+            if (now_s - entry.last_event_s > stale_after_s and first_stale_idx == null) {
+                first_stale_idx = idx;
+            }
+            if (entry.last_event_s < oldest_ts) {
+                oldest_ts = entry.last_event_s;
+                oldest_idx = idx;
+            }
+        }
+
+        const victim_idx = first_stale_idx orelse oldest_idx;
+        self.entries[victim_idx] = freshEntry(key, now_s);
+        return &self.entries[victim_idx];
+    }
+
+    fn indexFor(self: *const HandshakeFloodGuard, key: ClientKey) usize {
+        var hasher = std.hash.Wyhash.init(self.hash_seed);
+        const family_byte: u8 = @intFromEnum(key.family);
+        hasher.update(&[_]u8{family_byte});
+        hasher.update(&key.bytes);
+        return @as(usize, @intCast(hasher.final() & (BUCKETS - 1)));
+    }
+
+    fn freshEntry(key: ClientKey, now_s: i64) Entry {
+        return .{
+            .used = true,
+            .key = key,
+            .window_start_s = now_s,
+            .last_event_s = now_s,
+        };
+    }
+
+    fn increment(value: *u16) void {
+        if (value.* < std.math.maxInt(u16)) value.* += 1;
+    }
+};
+
+fn ip4(bytes: [4]u8, port: u16) Address {
+    return .{ .ip4 = .{ .bytes = bytes, .port = port } };
+}
+
+fn ip6(bytes: [16]u8, port: u16, flow: u32, scope_id: u32) Address {
+    return .{ .ip6 = .{
+        .bytes = bytes,
+        .port = port,
+        .flow = flow,
+        .interface = .{ .index = scope_id },
+    } };
+}
+
+test "handshake flood guard blocks exact IP after threshold" {
+    var guard = HandshakeFloodGuard{};
+    const cfg = HandshakeFloodGuard.settings(true, 3, 30, 120);
+    const addr = ip4(.{ 203, 0, 113, 10 }, 443);
+
+    try std.testing.expect(!guard.recordAt(addr, .handshake_timeout, cfg, 100));
+    try std.testing.expect(!guard.recordAt(addr, .handshake_timeout, cfg, 101));
+    try std.testing.expect(guard.recordAt(addr, .handshake_timeout, cfg, 102));
+    try std.testing.expect(guard.isBlockedAt(addr, cfg, 103));
+    try std.testing.expect(!guard.isBlockedAt(addr, cfg, 223));
+}
+
+test "handshake flood guard window expiry resets score" {
+    var guard = HandshakeFloodGuard{};
+    const cfg = HandshakeFloodGuard.settings(true, 3, 10, 120);
+    const addr = ip4(.{ 198, 51, 100, 42 }, 443);
+
+    try std.testing.expect(!guard.recordAt(addr, .rate_limit, cfg, 100));
+    try std.testing.expect(!guard.recordAt(addr, .rate_limit, cfg, 101));
+    try std.testing.expect(!guard.recordAt(addr, .rate_limit, cfg, 112));
+    try std.testing.expect(!guard.isBlockedAt(addr, cfg, 113));
+}
+
+test "handshake flood guard tracks top offenders and event mix" {
+    var guard = HandshakeFloodGuard{};
+    const cfg = HandshakeFloodGuard.settings(true, 4, 30, 120);
+    const noisy = ip4(.{ 203, 0, 113, 77 }, 443);
+    const quieter = ip4(.{ 203, 0, 113, 88 }, 443);
+
+    _ = guard.recordAt(noisy, .rate_limit, cfg, 10);
+    _ = guard.recordAt(noisy, .handshake_budget, cfg, 11);
+    _ = guard.recordAt(noisy, .handshake_timeout, cfg, 12);
+    _ = guard.recordAt(noisy, .handshake_timeout, cfg, 13);
+    _ = guard.recordAt(quieter, .handshake_timeout, cfg, 14);
+
+    var top_entries: [2]HandshakeFloodGuard.TopEntry = undefined;
+    const len = guard.topAt(cfg, 15, top_entries[0..]);
+    try std.testing.expectEqual(@as(usize, 2), len);
+    try std.testing.expectEqual(@as(u16, 4), top_entries[0].total);
+    try std.testing.expectEqual(@as(u16, 1), top_entries[0].rate_limit);
+    try std.testing.expectEqual(@as(u16, 1), top_entries[0].handshake_budget);
+    try std.testing.expectEqual(@as(u16, 2), top_entries[0].handshake_timeout);
+
+    var buf: [64]u8 = undefined;
+    try std.testing.expectEqualStrings("203.0.113.77", HandshakeFloodGuard.formatKey(top_entries[0].key, &buf));
+}
+
+test "handshake flood guard disabled records nothing" {
+    var guard = HandshakeFloodGuard{};
+    const cfg = HandshakeFloodGuard.settings(false, 1, 30, 120);
+    const addr = ip4(.{ 192, 0, 2, 9 }, 443);
+
+    try std.testing.expect(!guard.recordAt(addr, .handshake_timeout, cfg, 100));
+    try std.testing.expect(!guard.isBlockedAt(addr, cfg, 100));
+
+    var top_entries: [1]HandshakeFloodGuard.TopEntry = undefined;
+    try std.testing.expectEqual(@as(usize, 0), guard.topAt(cfg, 100, top_entries[0..]));
+}
+
+test "handshake flood guard normalizes IPv4-mapped IPv6 addresses" {
+    var guard = HandshakeFloodGuard{};
+    const cfg = HandshakeFloodGuard.settings(true, 2, 30, 120);
+    const native = ip4(.{ 192, 0, 2, 44 }, 443);
+    const mapped_bytes = [_]u8{0} ** 10 ++ [_]u8{ 0xff, 0xff } ++ [_]u8{ 192, 0, 2, 44 };
+    const mapped = ip6(mapped_bytes, 443, 0, 0);
+
+    try std.testing.expect(!guard.recordAt(native, .handshake_timeout, cfg, 100));
+    try std.testing.expect(guard.recordAt(mapped, .handshake_timeout, cfg, 101));
+    try std.testing.expect(guard.isBlockedAt(native, cfg, 102));
+}

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -21,6 +21,7 @@ const tunnel_mod = @import("../tunnel.zig");
 const socks5 = @import("socks5.zig");
 const http_connect = @import("http_connect.zig");
 const SubnetRateLimit = @import("subnet_rate_limit.zig").SubnetRateLimit;
+const HandshakeFloodGuard = @import("handshake_flood_guard.zig").HandshakeFloodGuard;
 const DynamicRecordSizer = @import("drs.zig").DynamicRecordSizer;
 const ReplayCache = @import("replay_cache.zig").ReplayCache;
 const MessageQueue = @import("message_queue.zig").MessageQueue;
@@ -46,6 +47,7 @@ const runtime_log = @import("../runtime_log.zig");
 test {
     // Keep extracted proxy submodule tests in the default `zig build test` run.
     _ = @import("subnet_rate_limit.zig");
+    _ = @import("handshake_flood_guard.zig");
     _ = @import("drs.zig");
     _ = @import("replay_cache.zig");
     _ = @import("message_queue.zig");
@@ -93,6 +95,46 @@ const max_pipelined_handshake_bytes: usize = 128 * 1024;
 const graceful_shutdown_check_ms: i32 = 100;
 
 const upstream_candidates_inline_cap: usize = 4;
+
+fn floodGuardSettings(cfg: *const Config) HandshakeFloodGuard.Settings {
+    return HandshakeFloodGuard.settings(
+        cfg.handshake_flood_guard_enabled,
+        cfg.handshake_flood_guard_threshold,
+        cfg.handshake_flood_guard_window_sec,
+        cfg.handshake_flood_guard_block_sec,
+    );
+}
+
+fn formatFloodGuardTop(entries: []const HandshakeFloodGuard.TopEntry, buf: *[1024]u8) []const u8 {
+    const now_s = @divTrunc(nowMs(), std.time.ms_per_s);
+    var pos: usize = 0;
+
+    for (entries) |entry| {
+        var ip_buf: [64]u8 = undefined;
+        const ip = HandshakeFloodGuard.formatKey(entry.key, &ip_buf);
+        const blocked_for = if (entry.blocked_until_s > now_s) entry.blocked_until_s - now_s else 0;
+
+        if (pos > 0 and pos < buf.len) {
+            buf[pos] = ',';
+            pos += 1;
+        }
+        const written = std.fmt.bufPrint(
+            buf[pos..],
+            "{s}=total:{d}/rate:{d}/budget:{d}/timeout:{d}/blocked:{d}s",
+            .{
+                ip,
+                entry.total,
+                entry.rate_limit,
+                entry.handshake_budget,
+                entry.handshake_timeout,
+                blocked_for,
+            },
+        ) catch break;
+        pos += written.len;
+    }
+
+    return buf[0..pos];
+}
 
 const CompatRwLock = struct {
     mutex: std.Io.Mutex = .init,
@@ -572,6 +614,7 @@ pub const ProxyState = struct {
         drops_capacity_total: u64,
         drops_saturation_total: u64,
         drops_rate_limit_total: u64,
+        drops_flood_guard_total: u64,
         drops_handshake_budget_total: u64,
         handshake_timeouts_total: u64,
         middleproxy_fallback_total: u64,
@@ -608,6 +651,7 @@ pub const ProxyState = struct {
     stats_dropped_cap: std.atomic.Value(u64),
     stats_dropped_saturation: std.atomic.Value(u64),
     stats_dropped_rate_limit: std.atomic.Value(u64),
+    stats_dropped_flood_guard: std.atomic.Value(u64),
     stats_dropped_hs_budget: std.atomic.Value(u64),
     stats_hs_timeout: std.atomic.Value(u64),
     stats_mp_fallback: std.atomic.Value(u64),
@@ -712,6 +756,7 @@ pub const ProxyState = struct {
             .stats_dropped_cap = std.atomic.Value(u64).init(0),
             .stats_dropped_saturation = std.atomic.Value(u64).init(0),
             .stats_dropped_rate_limit = std.atomic.Value(u64).init(0),
+            .stats_dropped_flood_guard = std.atomic.Value(u64).init(0),
             .stats_dropped_hs_budget = std.atomic.Value(u64).init(0),
             .stats_hs_timeout = std.atomic.Value(u64).init(0),
             .stats_mp_fallback = std.atomic.Value(u64).init(0),
@@ -848,6 +893,7 @@ pub const ProxyState = struct {
             .drops_capacity_total = self.stats_dropped_cap.load(.monotonic),
             .drops_saturation_total = self.stats_dropped_saturation.load(.monotonic),
             .drops_rate_limit_total = self.stats_dropped_rate_limit.load(.monotonic),
+            .drops_flood_guard_total = self.stats_dropped_flood_guard.load(.monotonic),
             .drops_handshake_budget_total = self.stats_dropped_hs_budget.load(.monotonic),
             .handshake_timeouts_total = self.stats_hs_timeout.load(.monotonic),
             .middleproxy_fallback_total = self.stats_mp_fallback.load(.monotonic),
@@ -1267,10 +1313,12 @@ const EventLoop = struct {
     accepted_since_log: u64,
     closed_since_log: u64,
     subnet_limiter: SubnetRateLimit,
+    flood_guard: *HandshakeFloodGuard,
     // Snapshot of degradation counters for delta logging
     prev_dropped_cap: u64,
     prev_dropped_saturation: u64,
     prev_dropped_rate_limit: u64,
+    prev_dropped_flood_guard: u64,
     prev_dropped_hs_budget: u64,
     prev_hs_timeout: u64,
     prev_mp_fallback: u64,
@@ -1282,6 +1330,9 @@ const EventLoop = struct {
     fn init(state: *ProxyState, listen_fd: posix.fd_t, signal_fd: posix.fd_t) !EventLoop {
         const epoll_fd = try epollCreate();
         errdefer closeFd(epoll_fd);
+
+        const flood_guard = try HandshakeFloodGuard.create(state.allocator);
+        errdefer flood_guard.destroy(state.allocator);
 
         var loop = EventLoop{
             .state = state,
@@ -1299,9 +1350,11 @@ const EventLoop = struct {
             .accepted_since_log = 0,
             .closed_since_log = 0,
             .subnet_limiter = SubnetRateLimit.init(),
+            .flood_guard = flood_guard,
             .prev_dropped_cap = 0,
             .prev_dropped_saturation = 0,
             .prev_dropped_rate_limit = 0,
+            .prev_dropped_flood_guard = 0,
             .prev_dropped_hs_budget = 0,
             .prev_hs_timeout = 0,
             .prev_mp_fallback = 0,
@@ -1331,6 +1384,7 @@ const EventLoop = struct {
         self.desync_wait_slots.deinit(self.state.allocator);
 
         self.pool.deinit();
+        self.flood_guard.destroy(self.state.allocator);
         closeFd(self.epoll_fd);
     }
 
@@ -1482,12 +1536,20 @@ const EventLoop = struct {
             const client_addr = accepted.?.addr;
             accepted_this_round += 1;
 
+            const flood_cfg = floodGuardSettings(&self.state.config);
+            if (self.flood_guard.isBlocked(client_addr, flood_cfg)) {
+                _ = self.state.stats_dropped_flood_guard.fetchAdd(1, .monotonic);
+                closeFd(cfd);
+                continue;
+            }
+
             // Ensure desync byte-splitting is not coalesced by Nagle during early handshake.
             setTcpNoDelay(cfd);
 
             // Per-/24 subnet rate limit (before we allocate any slot)
             if (!self.subnet_limiter.check(client_addr, self.state.config.rate_limit_per_subnet)) {
                 _ = self.state.stats_dropped_rate_limit.fetchAdd(1, .monotonic);
+                _ = self.flood_guard.record(client_addr, .rate_limit, flood_cfg);
                 closeFd(cfd);
                 continue;
             }
@@ -1508,6 +1570,7 @@ const EventLoop = struct {
                 _ = self.state.handshakes_inflight.fetchSub(1, .monotonic);
                 _ = self.state.active_connections.fetchSub(1, .monotonic);
                 _ = self.state.stats_dropped_hs_budget.fetchAdd(1, .monotonic);
+                _ = self.flood_guard.record(client_addr, .handshake_budget, flood_cfg);
                 closeFd(cfd);
                 continue;
             }
@@ -1553,6 +1616,7 @@ const EventLoop = struct {
         const cur_cap = self.state.stats_dropped_cap.load(.monotonic);
         const cur_sat = self.state.stats_dropped_saturation.load(.monotonic);
         const cur_rate = self.state.stats_dropped_rate_limit.load(.monotonic);
+        const cur_flood = self.state.stats_dropped_flood_guard.load(.monotonic);
         const cur_hs = self.state.stats_dropped_hs_budget.load(.monotonic);
         const cur_hst = self.state.stats_hs_timeout.load(.monotonic);
         const cur_mpf = self.state.stats_mp_fallback.load(.monotonic);
@@ -1560,6 +1624,7 @@ const EventLoop = struct {
         const d_cap = cur_cap - self.prev_dropped_cap;
         const d_sat = cur_sat - self.prev_dropped_saturation;
         const d_rate = cur_rate - self.prev_dropped_rate_limit;
+        const d_flood = cur_flood - self.prev_dropped_flood_guard;
         const d_hs = cur_hs - self.prev_dropped_hs_budget;
         const d_hst = cur_hst - self.prev_hs_timeout;
         const d_mpf = cur_mpf - self.prev_mp_fallback;
@@ -1567,11 +1632,12 @@ const EventLoop = struct {
         self.prev_dropped_cap = cur_cap;
         self.prev_dropped_saturation = cur_sat;
         self.prev_dropped_rate_limit = cur_rate;
+        self.prev_dropped_flood_guard = cur_flood;
         self.prev_dropped_hs_budget = cur_hs;
         self.prev_hs_timeout = cur_hst;
         self.prev_mp_fallback = cur_mpf;
 
-        const has_drops = d_cap + d_sat + d_rate + d_hs + d_hst + d_mpf > 0;
+        const has_drops = d_cap + d_sat + d_rate + d_flood + d_hs + d_hst + d_mpf > 0;
 
         // Build per-user active connection counts for dashboard parsing
         var user_buf: [1024]u8 = undefined;
@@ -1607,9 +1673,20 @@ const EventLoop = struct {
         });
 
         if (has_drops) {
-            log.info("  drops: cap+={d} sat+={d} rate+={d} hs_budget+={d} hs_timeout+={d} mp_fallback+={d}", .{
-                d_cap, d_sat, d_rate, d_hs, d_hst, d_mpf,
+            log.info("  drops: cap+={d} sat+={d} rate+={d} flood_guard+={d} hs_budget+={d} hs_timeout+={d} mp_fallback+={d}", .{
+                d_cap, d_sat, d_rate, d_flood, d_hs, d_hst, d_mpf,
             });
+        }
+
+        var top_entries: [5]HandshakeFloodGuard.TopEntry = undefined;
+        const flood_cfg = floodGuardSettings(&self.state.config);
+        const top_len = self.flood_guard.top(flood_cfg, top_entries[0..]);
+        if (top_len > 0 and (d_flood + d_rate + d_hs + d_hst > 0 or hs > 0)) {
+            var top_buf: [1024]u8 = undefined;
+            const top = formatFloodGuardTop(top_entries[0..top_len], &top_buf);
+            if (top.len > 0) {
+                log.info("  flood_guard: blocked+={d} top{{{s}}}", .{ d_flood, top });
+            }
         }
 
         self.accepted_since_log = 0;
@@ -1769,7 +1846,7 @@ const EventLoop = struct {
     fn dumpSignalStats(self: *EventLoop) void {
         const snapshot = self.state.getMetricsSnapshot();
         log.info(
-            "SIGUSR1 stats: active={d}/{d} hs={d} total={d} closed={d} c2s={d} s2c={d} paused={}/{} drops(cap/sat/rate/hs)={d}/{d}/{d}/{d}",
+            "SIGUSR1 stats: active={d}/{d} hs={d} total={d} closed={d} c2s={d} s2c={d} paused={}/{} drops(cap/sat/rate/flood/hs)={d}/{d}/{d}/{d}/{d}",
             .{
                 snapshot.connections_active,
                 snapshot.connections_max,
@@ -1783,6 +1860,7 @@ const EventLoop = struct {
                 snapshot.drops_capacity_total,
                 snapshot.drops_saturation_total,
                 snapshot.drops_rate_limit_total,
+                snapshot.drops_flood_guard_total,
                 snapshot.drops_handshake_budget_total,
             },
         );
@@ -1835,6 +1913,22 @@ const EventLoop = struct {
         }
         if (next.rate_limit_per_subnet != self.state.config.rate_limit_per_subnet) {
             self.state.config.rate_limit_per_subnet = next.rate_limit_per_subnet;
+            applied += 1;
+        }
+        if (next.handshake_flood_guard_enabled != self.state.config.handshake_flood_guard_enabled) {
+            self.state.config.handshake_flood_guard_enabled = next.handshake_flood_guard_enabled;
+            applied += 1;
+        }
+        if (next.handshake_flood_guard_threshold != self.state.config.handshake_flood_guard_threshold) {
+            self.state.config.handshake_flood_guard_threshold = next.handshake_flood_guard_threshold;
+            applied += 1;
+        }
+        if (next.handshake_flood_guard_window_sec != self.state.config.handshake_flood_guard_window_sec) {
+            self.state.config.handshake_flood_guard_window_sec = next.handshake_flood_guard_window_sec;
+            applied += 1;
+        }
+        if (next.handshake_flood_guard_block_sec != self.state.config.handshake_flood_guard_block_sec) {
+            self.state.config.handshake_flood_guard_block_sec = next.handshake_flood_guard_block_sec;
             applied += 1;
         }
         if (next.log_level != self.state.config.log_level) {
@@ -2808,6 +2902,7 @@ const EventLoop = struct {
                     }
                 } else if (now_ms - slot.first_byte_at_ms > secondsToMs(self.state.config.handshake_timeout_sec)) {
                     _ = self.state.stats_hs_timeout.fetchAdd(1, .monotonic);
+                    _ = self.flood_guard.record(slot.peer_addr, .handshake_timeout, floodGuardSettings(&self.state.config));
                     self.closeSlot(slot, "handshake timeout");
                     continue;
                 }


### PR DESCRIPTION
## Summary

Adds an in-process exact-IP handshake flood guard for the proxy accept path.

## Why

The latest outage was not a tunnel failure: the proxy was reachable upstream, but noisy sources kept piling up handshakes until `hs_inflight`, `hs_budget`, and handshake timeouts dominated. Restarting cleared state temporarily, but did not add any automatic protection against the next wave.

## What changed

- Track bad handshake-related events per exact source IP: subnet rate-limit drops, handshake-budget drops, and handshake timeouts.
- Temporarily deny a source IP once it crosses the configured threshold, before slot allocation.
- Log top noisy sources in periodic stats and expose `mtproto_drops_flood_guard_total` for monitoring.
- Add hot-reloadable config knobs under `[server]`:
  - `handshake_flood_guard_enabled`
  - `handshake_flood_guard_threshold`
  - `handshake_flood_guard_window_sec`
  - `handshake_flood_guard_block_sec`
- Update README, README.ru.md, generated install config, and `mtbuddy config print-effective` output.

## Validation

- `zig fmt --check src/proxy/handshake_flood_guard.zig src/proxy/proxy.zig src/config.zig src/monitoring.zig src/ctl/install.zig src/ctl/config_cmd.zig`
- `git diff --check`
- `zig build test --summary all` (161/161 tests passed)
- `zig build -Dtarget=x86_64-linux-gnu --summary all` (8/8 steps succeeded)

Note: native macOS `zig build --summary all` still fails in pre-existing Linux-only `std.os.linux.timespec` calls for `mtproto-bench`/`mtbuddy`; `mtproto-proxy` compiled successfully in that run, and the Linux cross-build passed all install steps.