### PR TITLE
[codex] add custom mask target

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ tag = ""                  # Optional: promotion tag from @MTProxybot
 [censorship]
 tls_domain = "wb.ru"
 mask = true
+# mask_target = "host.docker.internal" # Optional: custom masking backend host (Docker/remote Nginx)
 mask_port = 8443          # 8443 for local Nginx zero-RTT masking
 fast_mode = true          # Recommended: delegates S2C AES to the DC, saves CPU/RAM
 drs = true                # Dynamic Record Sizing (mimics Chrome/Firefox)
@@ -414,6 +415,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[metrics] port` | `9400` | Metrics port |
 | `[censorship] tls_domain` | `"google.com"` | Domain to impersonate |
 | `[censorship] mask` | `true` | Forward unauthenticated clients to `tls_domain` |
+| `[censorship] mask_target` | unset | Optional backend host for masked clients |
 | `[censorship] mask_port` | `443` | Local masking port (use `8443` for Nginx zero-RTT) |
 | `[censorship] desync` | `true` | Split-TLS: 1-byte Application records |
 | `[censorship] drs` | `false` | Dynamic Record Sizing |

--- a/README.ru.md
+++ b/README.ru.md
@@ -344,6 +344,7 @@ tag = ""                  # Optional: promotion tag from @MTProxybot
 [censorship]
 tls_domain = "wb.ru"
 mask = true
+# mask_target = "host.docker.internal" # Optional: custom masking backend host для Docker/remote Nginx
 mask_port = 8443
 fast_mode = true
 drs = true
@@ -380,6 +381,8 @@ alice = true
 | `[server] handshake_flood_guard_block_sec` | `120` | Длительность временного deny для шумного IP |
 | `[censorship] tls_domain` | `"google.com"` | Домен для TLS-маскировки |
 | `[censorship] mask` | `true` | Forward invalid clients на `tls_domain` |
+| `[censorship] mask_target` | unset | Optional backend host для masked clients |
+| `[censorship] mask_port` | `443` | Local masking port (`8443` для Nginx zero-RTT) |
 | `[censorship] fast_mode` | `false` | Делегировать S2C encryption DC |
 | `[access.users] <name>` | — | 32-hex secret на пользователя |
 | `[access.direct_users] <name>` | — | Bypass MiddleProxy для пользователя |

--- a/config.toml.example
+++ b/config.toml.example
@@ -147,6 +147,11 @@ mask = true
 # Local port override for mask forwarding (e.g. 8443 for zero-RTT local Nginx).
 # When unset, connects to tls_domain:443 directly.
 # mask_port = 8443
+#
+# Optional host override for the masking backend. When unset, mask_port=443
+# targets tls_domain and non-443 mask ports target 127.0.0.1.
+# Useful for Docker deployments that forward probes to host Nginx.
+# mask_target = "host.docker.internal"
 
 # Split ServerHello into 1-byte + 3ms delay + rest (defeats passive DPI signatures).
 # Enabled by default.

--- a/src/config.zig
+++ b/src/config.zig
@@ -6,6 +6,7 @@
 const std = @import("std");
 const net = std.Io.net;
 const default_tls_domain = "google.com";
+const default_local_mask_target = "127.0.0.1";
 
 pub const UpstreamMode = enum {
     /// Automatic egress mode (default).
@@ -178,7 +179,10 @@ pub const Config = struct {
     direct_users: std.StringHashMap(void),
     /// Whether to mask bad clients (forward to tls_domain)
     mask: bool = true,
-    /// Test-only hook to override the mask port
+    /// Optional backend host for masked clients. When unset, mask_port=443 uses
+    /// tls_domain and non-443 mask ports use the local Nginx target.
+    mask_target: ?[]const u8 = null,
+    /// Port used by the masking backend.
     mask_port: u16 = 443,
     /// TCP desync: split ServerHello into 1-byte + rest to evade DPI
     desync: bool = true,
@@ -242,6 +246,23 @@ pub const Config = struct {
         return self.tls_domain.ptr != default_tls_domain.ptr;
     }
 
+    pub fn ownsMaskTarget(self: *const Config) bool {
+        return self.mask_target != null;
+    }
+
+    pub fn effectiveMaskTarget(self: *const Config) []const u8 {
+        if (self.mask_target) |target| return target;
+        if (self.mask_port == 443) return self.tls_domain;
+        return default_local_mask_target;
+    }
+
+    pub fn maskTargetIsLocal(self: *const Config) bool {
+        const target = self.effectiveMaskTarget();
+        return std.mem.eql(u8, target, default_local_mask_target) or
+            std.mem.eql(u8, target, "localhost") or
+            std.mem.eql(u8, target, "::1");
+    }
+
     /// Port to advertise in generated client links.
     pub fn publicLinkPort(self: *const Config) u16 {
         return self.public_port orelse self.port;
@@ -297,7 +318,7 @@ pub const Config = struct {
     /// Port collision exists only when masking points to a local endpoint.
     /// With mask_port=443, masking targets tls_domain:443 (remote), so no local bind clash.
     pub fn hasLocalMaskPortCollision(self: *const Config) bool {
-        return self.mask and self.mask_port != 443 and self.port == self.mask_port;
+        return self.mask and self.maskTargetIsLocal() and self.port == self.mask_port;
     }
 
     /// Emit startup warnings for configuration values known to cause issues.
@@ -517,6 +538,9 @@ pub const Config = struct {
                         cfg.tls_domain = try allocator.dupe(u8, value);
                     } else if (std.mem.eql(u8, key, "mask")) {
                         cfg.mask = std.mem.eql(u8, value, "true");
+                    } else if (std.mem.eql(u8, key, "mask_target")) {
+                        if (cfg.mask_target) |target| allocator.free(target);
+                        cfg.mask_target = if (value.len > 0) try allocator.dupe(u8, value) else null;
                     } else if (std.mem.eql(u8, key, "mask_port")) {
                         cfg.mask_port = std.fmt.parseInt(u16, value, 10) catch 443;
                     } else if (std.mem.eql(u8, key, "desync")) {
@@ -591,6 +615,9 @@ pub const Config = struct {
         // Free tls_domain only when it does not point to the compile-time default.
         if (self.tls_domain.ptr != default_tls_domain.ptr) {
             allocator.free(self.tls_domain);
+        }
+        if (self.mask_target) |target| {
+            allocator.free(target);
         }
         if (self.public_ip) |ip| {
             allocator.free(ip);
@@ -701,6 +728,7 @@ test "parse config - missing fields defaults" {
     try std.testing.expectEqual(@as(u32, 15), cfg.handshake_timeout_sec);
     try std.testing.expectEqual(@as(u32, 15), cfg.graceful_shutdown_timeout_sec);
     try std.testing.expectEqualStrings("google.com", cfg.tls_domain);
+    try std.testing.expect(cfg.mask_target == null);
     try std.testing.expect(!cfg.use_middle_proxy); // Default is false
     try std.testing.expect(cfg.mask); // Default is true
     try std.testing.expect(cfg.desync); // Default is true
@@ -718,6 +746,26 @@ test "parse config - missing fields defaults" {
     try std.testing.expectEqual(@as(u16, 9400), cfg.metrics.port);
     try std.testing.expectEqual(@as(usize, 1), cfg.users.count());
     try std.testing.expectEqual(@as(usize, 0), cfg.direct_users.count());
+}
+
+test "parse config - custom mask target" {
+    const content =
+        \\[censorship]
+        \\tls_domain = "example.com"
+        \\mask = true
+        \\mask_target = "host.docker.internal"
+        \\mask_port = 4443
+        \\
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings("host.docker.internal", cfg.mask_target.?);
+    try std.testing.expectEqualStrings("host.docker.internal", cfg.effectiveMaskTarget());
+    try std.testing.expectEqual(@as(u16, 4443), cfg.mask_port);
 }
 
 test "parse config - metrics section" {
@@ -760,6 +808,20 @@ test "local mask collision check detects local nginx clash" {
     };
     defer cfg.deinit(std.testing.allocator);
     try std.testing.expect(cfg.hasLocalMaskPortCollision());
+}
+
+test "local mask collision check ignores custom non-local target" {
+    const target = try std.testing.allocator.dupe(u8, "host.docker.internal");
+    var cfg = Config{
+        .users = std.StringHashMap([16]u8).init(std.testing.allocator),
+        .direct_users = std.StringHashMap(void).init(std.testing.allocator),
+        .mask = true,
+        .port = 8443,
+        .mask_target = target,
+        .mask_port = 8443,
+    };
+    defer cfg.deinit(std.testing.allocator);
+    try std.testing.expect(!cfg.hasLocalMaskPortCollision());
 }
 
 test "parse config - direct users allowlist" {

--- a/src/ctl/config_cmd.zig
+++ b/src/ctl/config_cmd.zig
@@ -117,6 +117,8 @@ fn doctor(ui: *Tui, allocator: std.mem.Allocator, path: []const u8) !void {
     if (cfg.hasLocalMaskPortCollision()) {
         ui.fail("server.port == censorship.mask_port in local masking mode");
         errors += 1;
+    } else if (cfg.mask and cfg.mask_target != null) {
+        ui.ok("masking uses custom mask_target");
     } else if (cfg.mask and cfg.mask_port == 443) {
         ui.ok("masking uses remote tls_domain:443 (no local bind collision)");
     }
@@ -249,6 +251,9 @@ fn printEffective(ui: *Tui, allocator: std.mem.Allocator, path: []const u8) !voi
     ui.writeRaw("[censorship]\n");
     ui.print("tls_domain = \"{s}\"\n", .{cfg.tls_domain});
     ui.print("mask = {}\n", .{cfg.mask});
+    if (cfg.mask_target) |target| {
+        ui.print("mask_target = \"{s}\"\n", .{target});
+    }
     ui.print("mask_port = {d}\n", .{cfg.mask_port});
     ui.print("desync = {}\n", .{cfg.desync});
     ui.print("drs = {}\n", .{cfg.drs});

--- a/src/ctl/dashboard_assets/server.py
+++ b/src/ctl/dashboard_assets/server.py
@@ -401,6 +401,7 @@ def _load_proxy_runtime_config() -> dict:
         "port": 443,
         "public_port": 0,
         "mask": True,
+        "mask_target": "",
         "mask_port": 443,
         "tls_domain": "google.com",
         "use_middle_proxy": False,
@@ -436,6 +437,7 @@ def _load_proxy_runtime_config() -> dict:
         "port": defaults["port"],
         "public_port": defaults["public_port"],
         "mask": defaults["mask"],
+        "mask_target": defaults["mask_target"],
         "mask_port": defaults["mask_port"],
         "tls_domain": defaults["tls_domain"],
         "use_middle_proxy": defaults["use_middle_proxy"],
@@ -542,6 +544,8 @@ def _load_proxy_runtime_config() -> dict:
                 elif section == "[censorship]":
                     if key == "mask":
                         result["mask"] = _parse_bool(value, defaults["mask"])
+                    elif key == "mask_target":
+                        result["mask_target"] = value
                     elif key == "mask_port":
                         digits = "".join(ch for ch in value if ch.isdigit())
                         if digits:
@@ -576,6 +580,7 @@ def _load_censorship_config() -> dict:
     cfg = _load_proxy_runtime_config()
     return {
         "mask": bool(cfg["mask"]),
+        "mask_target": str(cfg["mask_target"]),
         "mask_port": int(cfg["mask_port"]),
         "tls_domain": str(cfg["tls_domain"]),
     }
@@ -1095,6 +1100,7 @@ def _masking_status() -> dict:
 
     censorship = _load_censorship_config()
     mask_enabled = bool(censorship["mask"])
+    mask_target = str(censorship.get("mask_target") or "").strip()
     mask_port = int(censorship["mask_port"])
     tls_domain = censorship["tls_domain"]
 
@@ -1103,6 +1109,9 @@ def _masking_status() -> dict:
     if not mask_enabled:
         mode = "disabled"
         target_host = "-"
+    elif mask_target:
+        mode = "custom"
+        target_host = mask_target
     elif mask_port == 443:
         mode = "remote"
         target_host = tls_domain
@@ -1111,7 +1120,7 @@ def _masking_status() -> dict:
         target_host = "127.0.0.1"
 
     endpoint_ok = None
-    if mode == "local":
+    if mode in ("local", "custom"):
         endpoint_ok = _probe_mask_endpoint(target_host, mask_port)
 
     nginx_active = _unit_active("nginx.service")
@@ -1122,11 +1131,14 @@ def _masking_status() -> dict:
     healthy = True
     if mode == "local":
         healthy = nginx_active and timer_active and bool(endpoint_ok)
+    elif mode == "custom":
+        healthy = bool(endpoint_ok)
 
     result = {
         "enabled": mask_enabled,
         "mode": mode,
         "mask_port": mask_port,
+        "mask_target": mask_target,
         "tls_domain": tls_domain,
         "target": f"{target_host}:{mask_port}" if mode != "disabled" else "-",
         "using_netns": using_netns_target,

--- a/src/ctl/dashboard_assets/static/app.js
+++ b/src/ctl/dashboard_assets/static/app.js
@@ -1048,6 +1048,8 @@ async function poll() {
     let modeText = masking.mode || '—';
     if (masking.mode === 'remote') {
       modeText = 'remote (' + (masking.tls_domain || '—') + ':443)';
+    } else if (masking.mode === 'custom') {
+      modeText = 'custom';
     } else if (masking.mode === 'local' && masking.using_netns) {
       modeText = 'local (netns)';
     } else if (masking.mode === 'local') {
@@ -1056,7 +1058,7 @@ async function poll() {
     $('maskMode').textContent = modeText;
 
     let endpointText = masking.target || '—';
-    if (masking.mode === 'local') {
+    if (masking.mode === 'local' || masking.mode === 'custom') {
       if (masking.endpoint_ok === true) {
         endpointText += ' (OK)';
       } else if (masking.endpoint_ok === false) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -440,7 +440,8 @@ pub fn main(init: std.process.Init) !void {
         writeStderr("\n  Usage: mtproto-proxy [config.toml]\n\n", .{});
         return;
     };
-    defer cfg.deinit(allocator);
+    var cfg_owned_by_main = true;
+    defer if (cfg_owned_by_main) cfg.deinit(allocator);
 
     // Apply runtime log level from config
     runtime_log.level = cfg.log_level;
@@ -469,6 +470,7 @@ pub fn main(init: std.process.Init) !void {
 
     // Create shared state (DI — no globals)
     var state = try proxy.ProxyState.init(allocator, cfg, config_path);
+    cfg_owned_by_main = false;
     defer state.deinit();
 
     // Run the proxy

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -136,6 +136,14 @@ fn formatFloodGuardTop(entries: []const HandshakeFloodGuard.TopEntry, buf: *[102
     return buf[0..pos];
 }
 
+fn optionalStringEql(a: ?[]const u8, b: ?[]const u8) bool {
+    if (a) |av| {
+        if (b) |bv| return std.mem.eql(u8, av, bv);
+        return false;
+    }
+    return b == null;
+}
+
 const CompatRwLock = struct {
     mutex: std.Io.Mutex = .init,
 
@@ -702,9 +710,11 @@ pub const ProxyState = struct {
 
         var resolved_addr: ?Address = null;
         if (cfg.mask) {
-            const mask_target = if (cfg.mask_port == 443) cfg.tls_domain else "127.0.0.1";
-            if (cfg.mask_port != 443) {
-                log.info("mask_port={d} configured, using local mask target 127.0.0.1", .{cfg.mask_port});
+            const mask_target = cfg.effectiveMaskTarget();
+            if (cfg.mask_target) |configured_target| {
+                log.info("mask_target={s} configured, using mask target {s}:{d}", .{ configured_target, mask_target, cfg.mask_port });
+            } else if (cfg.mask_port != 443) {
+                log.info("mask_port={d} configured, using local mask target {s}", .{ cfg.mask_port, mask_target });
             }
             const list = getAddressList(allocator, mask_target, cfg.mask_port) catch |err| blk: {
                 log.err("Failed to resolve mask target '{s}': {any}", .{ mask_target, err });
@@ -867,6 +877,7 @@ pub const ProxyState = struct {
         self.allocator.free(self.config_path);
         self.allocator.free(self.user_secrets);
         self.allocator.free(self.user_metrics);
+        self.config.deinit(self.allocator);
     }
 
     pub fn findUserMetrics(self: *ProxyState, user_name: []const u8) ?*UserMetrics {
@@ -1937,7 +1948,8 @@ const EventLoop = struct {
             applied += 1;
         }
         const tls_domain_changed = !std.mem.eql(u8, next.tls_domain, self.state.config.tls_domain);
-        if (next.mask != self.state.config.mask or next.mask_port != self.state.config.mask_port or tls_domain_changed) {
+        const mask_target_changed = !optionalStringEql(next.mask_target, self.state.config.mask_target);
+        if (next.mask != self.state.config.mask or next.mask_port != self.state.config.mask_port or tls_domain_changed or mask_target_changed) {
             const resolved_mask_addr = self.resolveMaskAddress(&next);
             if (next.mask) {
                 if (resolved_mask_addr) |addr| {
@@ -1958,6 +1970,23 @@ const EventLoop = struct {
                     self.state.config.tls_domain = owned_tls_domain;
                 } else |_| {
                     log.warn("SIGHUP: failed to apply new tls_domain due to allocation error", .{});
+                }
+            }
+            if (mask_target_changed) {
+                if (next.mask_target) |target| {
+                    if (self.state.allocator.dupe(u8, target)) |owned_mask_target| {
+                        if (self.state.config.ownsMaskTarget()) {
+                            self.state.allocator.free(self.state.config.mask_target.?);
+                        }
+                        self.state.config.mask_target = owned_mask_target;
+                    } else |_| {
+                        log.warn("SIGHUP: failed to apply new mask_target due to allocation error", .{});
+                    }
+                } else {
+                    if (self.state.config.ownsMaskTarget()) {
+                        self.state.allocator.free(self.state.config.mask_target.?);
+                    }
+                    self.state.config.mask_target = null;
                 }
             }
             applied += 1;
@@ -2001,7 +2030,7 @@ const EventLoop = struct {
 
     fn resolveMaskAddress(self: *EventLoop, cfg: *const Config) ?Address {
         if (!cfg.mask) return null;
-        const mask_target = if (cfg.mask_port == 443) cfg.tls_domain else "127.0.0.1";
+        const mask_target = cfg.effectiveMaskTarget();
         const list = getAddressList(self.state.allocator, mask_target, cfg.mask_port) catch |err| {
             log.warn("SIGHUP: mask target resolve failed for '{s}:{d}': {any}", .{ mask_target, cfg.mask_port, err });
             return null;

--- a/test/e2e/run.py
+++ b/test/e2e/run.py
@@ -585,7 +585,8 @@ class FakeHttpConnectServer:
 
 
 class FakeMaskServer:
-    def __init__(self):
+    def __init__(self, host: str = "127.0.0.1"):
+        self.host = host
         self.port = free_port()
         self._sock: Optional[socket.socket] = None
         self._thread: Optional[threading.Thread] = None
@@ -600,7 +601,7 @@ class FakeMaskServer:
     def start(self) -> None:
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self._sock.bind(("127.0.0.1", self.port))
+        self._sock.bind((self.host, self.port))
         self._sock.listen()
         self._sock.settimeout(0.2)
         self._thread = threading.Thread(target=self._loop, daemon=True)
@@ -654,6 +655,7 @@ def base_config(
     port: int,
     secret_hex: str = DEFAULT_SECRET_HEX,
     mask: bool = False,
+    mask_target: Optional[str] = None,
     mask_port: Optional[int] = None,
     use_middle_proxy: bool = False,
     force_media_middle_proxy: bool = False,
@@ -685,6 +687,8 @@ def base_config(
     lines.append("[censorship]")
     lines.append(f'tls_domain = "{DEFAULT_TLS_DOMAIN}"')
     lines.append(f"mask = {'true' if mask else 'false'}")
+    if mask_target is not None:
+        lines.append(f'mask_target = "{mask_target}"')
     if mask_port is not None:
         lines.append(f"mask_port = {mask_port}")
     lines.append("desync = false")
@@ -877,6 +881,34 @@ def scenario_mask_fallback_local_nginx() -> None:
             _ = c.recv(1024)
         received = wait_for_condition(lambda: mask.received_bytes().startswith(payload), timeout_sec=2.0)
         assert received, f"mask target did not receive original bad client bytes: {mask.received_bytes()!r}"
+    finally:
+        proxy.stop()
+        mask.stop()
+
+
+def scenario_mask_fallback_custom_target() -> None:
+    mask = FakeMaskServer(host="127.0.0.2")
+    mask.start()
+    proxy_port = free_port()
+    cfg = base_config(
+        port=proxy_port,
+        mask=True,
+        mask_target=mask.host,
+        mask_port=mask.port,
+        upstream_type="auto",
+    )
+    proxy = start_proxy(cfg, proxy_port)
+    try:
+        payload = b"GET / HTTP/1.1\r\nHost: custom-mask.example\r\n\r\n"
+        with socket.create_connection(("127.0.0.1", proxy_port), timeout=2.0) as c:
+            c.settimeout(2.0)
+            c.sendall(payload)
+            try:
+                _ = c.recv(1024)
+            except (ConnectionResetError, TimeoutError, socket.timeout):
+                pass
+        received = wait_for_condition(lambda: mask.received_bytes().startswith(payload), timeout_sec=2.0)
+        assert received, f"custom mask target did not receive original bad client bytes: {mask.received_bytes()!r}"
     finally:
         proxy.stop()
         mask.stop()
@@ -1095,6 +1127,7 @@ SCENARIOS: dict[str, Callable[[], None]] = {
     "http_connect_failure": scenario_http_connect_failure,
     "middleproxy_fallback_to_direct": scenario_middleproxy_fallback_to_direct,
     "mask_fallback_local_nginx": scenario_mask_fallback_local_nginx,
+    "mask_fallback_custom_target": scenario_mask_fallback_custom_target,
     "invalid_tls_and_mtproto": scenario_invalid_tls_and_mtproto,
     "replay_attack_rejected": scenario_replay_attack_rejected,
     "slowloris_partial_clienthello": scenario_slowloris_partial_clienthello,


### PR DESCRIPTION
## Summary

Adds an optional `[censorship].mask_target` setting so masked clients can be forwarded to a custom backend host instead of always using `127.0.0.1` for non-443 `mask_port` values.

## Why

Issue #294 reports Docker deployments where the real TLS masking site lives on the host network, for example `host.docker.internal:4443`. The proxy currently hardcodes the non-443 masking backend to `127.0.0.1`, which only works when Nginx is in the same network namespace.

## Changes

- Parse and own optional `mask_target` in `Config`.
- Add `effectiveMaskTarget()` and use it for startup and SIGHUP mask address resolution.
- Preserve existing defaults: `mask_port = 443` targets `tls_domain`; non-443 ports target `127.0.0.1` unless `mask_target` is set.
- Update `mtbuddy config`, dashboard masking status, README files, and `config.toml.example`.
- Add unit coverage and a Linux e2e scenario for custom mask targets.

## Validation

- `zig build test --summary all` (`6/6 steps succeeded; 163/163 tests passed`)
- `python3 -m py_compile test/e2e/run.py src/ctl/dashboard_assets/server.py`
- `git diff --check`
- `zig build e2e -- --scenario mask_fallback_custom_target` skipped locally because the e2e harness requires Linux and this run was on Darwin

Fixes #294