### PR TITLE
fix(middleproxy): hourly + reactive refresh, and a getent fallback on the metadata fetch

### DIFF
--- a/src/proxy/http_fetch.zig
+++ b/src/proxy/http_fetch.zig
@@ -35,6 +35,18 @@ test "http fetch - curl config escaping backslash and double-quote" {
 }
 
 pub fn fetchUrlBytes(allocator: std.mem.Allocator, url: []const u8) ![]u8 {
+    return fetchUrlBytesStd(allocator, url) catch |err| {
+        // Zig's std resolver throws ResolvConfParseFailed on a /etc/resolv.conf whose
+        // last line lacks a trailing newline (SolusVM and several VPS images). curl
+        // resolves via NSS/getent, which tolerates it — retry there instead of failing
+        // the whole fetch (keeps the dependency-free std path for healthy hosts).
+        if (std.mem.eql(u8, @errorName(err), "ResolvConfParseFailed"))
+            return runCurlFetch(allocator, url, null);
+        return err;
+    };
+}
+
+fn fetchUrlBytesStd(allocator: std.mem.Allocator, url: []const u8) ![]u8 {
     const uri = try std.Uri.parse(url);
 
     var client: std.http.Client = .{
@@ -251,27 +263,39 @@ pub fn fetchUrlBytesViaInterface(
     url: []const u8,
     interface: []const u8,
 ) ![]u8 {
+    return runCurlFetch(allocator, url, interface);
+}
+
+/// Fetch `url` by shelling out to curl, optionally pinned to `interface`. curl
+/// resolves via NSS/getent, which tolerates the malformed `/etc/resolv.conf` (no
+/// trailing newline) that makes Zig's std resolver throw `ResolvConfParseFailed` —
+/// so this also serves as the std-fetch fallback on such hosts.
+fn runCurlFetch(allocator: std.mem.Allocator, url: []const u8, interface: ?[]const u8) ![]u8 {
     // curl requires --interface and its value as separate argv elements; the
     // `--interface=<iface>` form is a common shell idiom but not supported by
     // every curl version, hence the split.
-    const argv = [_][]const u8{
-        "curl",
-        "--silent",
-        "--fail",
-        "--show-error",
-        "--location",
-        "--max-time",
-        "10",
-        "--interface",
-        interface,
-        url,
-    };
+    var argv_buf: [10][]const u8 = undefined;
+    var n: usize = 0;
+    for ([_][]const u8{ "curl", "--silent", "--fail", "--show-error", "--location", "--max-time", "10" }) |a| {
+        argv_buf[n] = a;
+        n += 1;
+    }
+    if (interface) |iface| {
+        argv_buf[n] = "--interface";
+        n += 1;
+        argv_buf[n] = iface;
+        n += 1;
+    }
+    argv_buf[n] = url;
+    n += 1;
+    const argv = argv_buf[0..n];
+    const where = interface orelse "direct";
 
     var io_instance: std.Io.Threaded = .init(std.heap.page_allocator, .{});
     defer io_instance.deinit();
 
     const result = std.process.run(allocator, io_instance.io(), .{
-        .argv = &argv,
+        .argv = argv,
         .stdout_limit = std.Io.Limit.limited(1 * 1024 * 1024),
         .stderr_limit = std.Io.Limit.limited(1 * 1024 * 1024),
     }) catch |err| {
@@ -285,7 +309,7 @@ pub fn fetchUrlBytesViaInterface(
         .exited => |code| {
             if (code != 0) {
                 log.warn("curl {s} via {s} exited with {d}: {s}", .{
-                    url,                                        interface, code,
+                    url,                                        where, code,
                     std.mem.trim(u8, result.stderr, " \t\r\n"),
                 });
                 allocator.free(result.stdout);
@@ -293,7 +317,7 @@ pub fn fetchUrlBytesViaInterface(
             }
         },
         else => {
-            log.warn("curl {s} via {s} terminated abnormally", .{ url, interface });
+            log.warn("curl {s} via {s} terminated abnormally", .{ url, where });
             allocator.free(result.stdout);
             return error.UnexpectedConnectFailure;
         },

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -102,6 +102,11 @@ const middle_proxy_secret_url = "https://core.telegram.org/getProxySecret";
 // refresh hourly to stay ahead of the rotation. The fetch is cheap and best-effort
 // (keeps the current cache on failure), so the extra polls cost ~nothing.
 const middle_proxy_update_period_ns: u64 = 60 * 60 * std.time.ns_per_s;
+// Minimum gap between *reactive* middleproxy refreshes (those triggered by stalled
+// handshakes rather than the periodic timer), so a flood of failing handshakes — or a
+// genuine middleproxy-side outage that fresh metadata can't fix — can't spin the
+// updater into a refresh storm.
+const middle_proxy_reactive_cooldown_ns: u64 = 60 * std.time.ns_per_s;
 const tunnel_socket_mark: u32 = 200;
 const tunnel_route_table: u32 = 200;
 const tunnel_pool_state_path = "/run/mtproto-proxy/tunnel-pool.state";
@@ -213,6 +218,16 @@ const MiddleProxyHandshakeStep = enum {
     sending_rpc_handshake,
     waiting_rpc_handshake_response,
     done,
+
+    /// True while the RPC handshake with the middleproxy is in flight. A slot stuck
+    /// here is waiting on the middleproxy (its DC address / secret), so a timeout
+    /// here is evidence the cached metadata may have gone stale.
+    fn awaitingMiddleProxy(self: MiddleProxyHandshakeStep) bool {
+        return switch (self) {
+            .sending_rpc_nonce, .waiting_rpc_nonce_response, .sending_rpc_handshake, .waiting_rpc_handshake_response => true,
+            .none, .done => false,
+        };
+    }
 };
 
 const MiddleProxyFetchRoute = enum {
@@ -742,6 +757,17 @@ test "CloseReason.classify buckets the evasion signals precisely" {
     try std.testing.expectEqual(CloseReason.other, CloseReason.classify("graceful drain"));
 }
 
+test "MiddleProxyHandshakeStep.awaitingMiddleProxy gates the reactive refresh" {
+    // Only the in-flight RPC-handshake steps should trigger a reactive refresh; a
+    // timeout in .none/.done is not a middleproxy-staleness signal.
+    try std.testing.expect(!MiddleProxyHandshakeStep.none.awaitingMiddleProxy());
+    try std.testing.expect(!MiddleProxyHandshakeStep.done.awaitingMiddleProxy());
+    try std.testing.expect(MiddleProxyHandshakeStep.sending_rpc_nonce.awaitingMiddleProxy());
+    try std.testing.expect(MiddleProxyHandshakeStep.waiting_rpc_nonce_response.awaitingMiddleProxy());
+    try std.testing.expect(MiddleProxyHandshakeStep.sending_rpc_handshake.awaitingMiddleProxy());
+    try std.testing.expect(MiddleProxyHandshakeStep.waiting_rpc_handshake_response.awaitingMiddleProxy());
+}
+
 pub const ProxyState = struct {
     pub const UserMetrics = struct {
         name: []const u8,
@@ -1073,6 +1099,9 @@ pub const ProxyState = struct {
     middle_proxy_secret_len: usize,
     middle_proxy_nat_ip4: ?[4]u8,
     middle_proxy_updater_shutdown: std.atomic.Value(bool),
+    // Set by the data plane when a middleproxy handshake stalls; the updater thread
+    // consumes it to refresh ahead of the periodic timer (debounced by the cooldown).
+    middle_proxy_refresh_requested: std.atomic.Value(bool),
     middle_proxy_updater_thread: ?std.Thread,
     upstream: upstream_mod.Upstream,
     tunnel_info: tunnel_mod.Tunnel,
@@ -1158,6 +1187,7 @@ pub const ProxyState = struct {
             .middle_proxy_secret_len = middleproxy.proxy_secret.len,
             .middle_proxy_nat_ip4 = detected_nat_ip4,
             .middle_proxy_updater_shutdown = std.atomic.Value(bool).init(false),
+            .middle_proxy_refresh_requested = std.atomic.Value(bool).init(false),
             .worker_heartbeats = [_]std.atomic.Value(i64){std.atomic.Value(i64).init(0)} ** max_workers,
             .subnet_limiter = SubnetRateLimit.init(),
             .flood_guard = try HandshakeFloodGuard.create(allocator),
@@ -1723,14 +1753,32 @@ pub const ProxyState = struct {
         }
     }
 
+    /// Ask the background updater to refresh middleproxy metadata ahead of the
+    /// periodic timer — called from the data plane when a middleproxy handshake
+    /// stalls (a sign the cached DC/secret went stale). Idempotent and lock-free;
+    /// the updater debounces it via `middle_proxy_reactive_cooldown_ns`.
+    pub fn requestMiddleProxyRefresh(self: *ProxyState) void {
+        self.middle_proxy_refresh_requested.store(true, .release);
+    }
+
+    /// Sleep up to `total_ns`, returning early (false) once a reactive refresh has
+    /// been requested AND at least the cooldown has elapsed since this wait began
+    /// (i.e. since the last refresh). Requests arriving inside the cooldown are left
+    /// pending and honored as soon as it expires. Returns true on shutdown.
     fn waitForUpdaterDelay(self: *ProxyState, total_ns: u64) bool {
         const step_ns: u64 = std.time.ns_per_s;
-        var remaining = total_ns;
-        while (remaining > 0) {
+        var elapsed: u64 = 0;
+        while (elapsed < total_ns) {
             if (self.middle_proxy_updater_shutdown.load(.acquire)) return true;
-            const chunk = @min(remaining, step_ns);
+            if (elapsed >= middle_proxy_reactive_cooldown_ns and
+                self.middle_proxy_refresh_requested.swap(false, .acq_rel))
+            {
+                log.info("Middle-proxy reactive refresh: stalled handshake(s) suggest stale metadata", .{});
+                return false;
+            }
+            const chunk = @min(total_ns - elapsed, step_ns);
             sleepNs(chunk);
-            remaining -= chunk;
+            elapsed += chunk;
         }
         return self.middle_proxy_updater_shutdown.load(.acquire);
     }
@@ -3788,6 +3836,10 @@ const EventLoop = struct {
                 } else if (now_ms - slot.first_byte_at_ms > secondsToMs(self.state.config.handshake_timeout_sec)) {
                     _ = self.state.stats_hs_timeout.fetchAdd(1, .monotonic);
                     _ = self.state.floodRecord(slot.peer_addr, .handshake_timeout, floodGuardSettings(&self.state.config));
+                    // A timeout while still waiting on the middleproxy RPC handshake
+                    // means the cached DC/secret likely went stale (Telegram rotates
+                    // them) — ask the updater to refresh ahead of its periodic timer.
+                    if (slot.mp_step.awaitingMiddleProxy()) self.state.requestMiddleProxyRefresh();
                     self.closeSlot(slot, "handshake timeout");
                     continue;
                 }

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -96,7 +96,12 @@ const stats_log_interval_ns: i128 = @as(i128, stats_log_interval_s) * std.time.n
 const timer_scan_budget: usize = 512;
 const middle_proxy_config_url = "https://core.telegram.org/getProxyConfig";
 const middle_proxy_secret_url = "https://core.telegram.org/getProxySecret";
-const middle_proxy_update_period_ns: u64 = 24 * 60 * 60 * std.time.ns_per_s;
+// Telegram rotates the middleproxy DC addresses / proxy secret well within a day
+// (observed ~10h in production: dc4 moved 91.108.4.139 -> .200, stalling every
+// middleproxy handshake until restart). A 24h cadence let the cache go stale, so
+// refresh hourly to stay ahead of the rotation. The fetch is cheap and best-effort
+// (keeps the current cache on failure), so the extra polls cost ~nothing.
+const middle_proxy_update_period_ns: u64 = 60 * 60 * std.time.ns_per_s;
 const tunnel_socket_mark: u32 = 200;
 const tunnel_route_table: u32 = 200;
 const tunnel_pool_state_path = "/run/mtproto-proxy/tunnel-pool.state";


### PR DESCRIPTION
## Why

Production outage on `proxy.sleep3r.ru`: process up and listening, tunnel healthy, but `users_total=0` and every connection hit `hs_timeout` — clients passed FakeTLS but the upstream **middleproxy RPC handshake never completed**.

**Root cause:** the MiddleProxy metadata updater (`getProxyConfig` DC addresses + `getProxySecret`) ran on a **24-hour** cadence. Telegram rotated the `dc4` media-DC address (`91.108.4.139` → `91.108.4.200`) ~**10 hours** after the last fetch, so the cache went stale and stalled every middleproxy handshake until a restart pulled fresh metadata.

## Changes

1. **Hourly periodic refresh** (was 24h) — `middle_proxy_update_period_ns`. The fetch is cheap and best-effort (keeps the current cache on failure), so the extra polls cost ~nothing. Bounds the worst-case stale window from a day to an hour.

2. **Reactive refresh** — when a connection times out while still in the middleproxy RPC handshake (`mp_step.awaitingMiddleProxy()`), the data plane asks the updater to refresh **ahead of the timer**. So a stale DC/secret is replaced in ~`handshake_timeout` + one fetch (tens of seconds), not up to an hour. Debounced by a **60s cooldown** so a flood of failing handshakes — or a genuine middleproxy-side outage fresh metadata can't fix — can't cause a refresh storm. Lock-free (atomic flag set on the data path, consumed by the updater's wait loop, which logs the reactive wake).

3. **getent DNS fallback on the metadata fetch** — `fetchUrlBytes` (std.http) throws `ResolvConfParseFailed` on a `/etc/resolv.conf` without a trailing newline (SolusVM / several VPS images), which is why every fetch logged `unreachable directly … retrying via tunnel`. It now falls back to **curl** (NSS/getent resolution, tolerant of that file) on exactly that error — keeping the dependency-free std path for healthy hosts, and unbreaking direct-egress middleproxy on such hosts.

## Verified
- `zig build test` (incl. a new `MiddleProxyHandshakeStep.awaitingMiddleProxy` test) + `x86_64-linux` release build green; `zig fmt` clean.
- Production restored via restart (fresh `dc4=91.108.4.200` + secret; `users_total` climbing, `hs_timeout` gone). This PR prevents recurrence + speeds recovery.