### PR TITLE
fix(cli): honor --help on subcommands; create mtproto user on update (#310)

### DIFF
--- a/src/ctl/install.zig
+++ b/src/ctl/install.zig
@@ -72,7 +72,7 @@ fn shouldWarnIgnoredSecret(config_exists: bool, secret_provided: bool, config_pa
     return config_exists and secret_provided and !config_path_provided;
 }
 
-fn printInstallHelp(ui: *Tui) void {
+pub fn printInstallHelp(ui: *Tui) void {
     ui.writeRaw("\n");
     ui.writeRaw("  mtbuddy install [options]\n\n");
     ui.writeRaw("  Options:\n");
@@ -1140,7 +1140,7 @@ fn resolvePublicServer(ui: *Tui, allocator: std.mem.Allocator, config_path: []co
     return ip;
 }
 
-fn ensureServiceUser(ui: *Tui, allocator: std.mem.Allocator) bool {
+pub fn ensureServiceUser(ui: *Tui, allocator: std.mem.Allocator) bool {
     const groupadd_candidates = &[_][]const u8{ "/usr/sbin/groupadd", "/sbin/groupadd" };
     const useradd_candidates = &[_][]const u8{ "/usr/sbin/useradd", "/sbin/useradd" };
 

--- a/src/ctl/main.zig
+++ b/src/ctl/main.zig
@@ -104,6 +104,22 @@ pub fn main(init: std.process.Init) !void {
 
     // ── CLI dispatch ──
     if (command) |cmd| {
+        // CLI convention: `-h`/`--help` after a subcommand shows help, never runs the
+        // action. The per-subcommand parsers silently ignore unknown flags, so without
+        // this guard `mtbuddy update --help` would DOWNLOAD + INSTALL instead of
+        // printing help (issue #310). Scan a copy so the real iterator stays intact.
+        var help_scan = remaining_args;
+        while (help_scan.next()) |a| {
+            if (std.mem.eql(u8, a, "--help") or std.mem.eql(u8, a, "-h")) {
+                if (std.mem.eql(u8, cmd, "install")) {
+                    install.printInstallHelp(&ui);
+                } else {
+                    printHelp(ui.lang);
+                }
+                return;
+            }
+        }
+
         if (std.mem.eql(u8, cmd, "install")) {
             return install.run(&ui, allocator, &remaining_args);
         } else if (std.mem.eql(u8, cmd, "uninstall")) {

--- a/src/ctl/update.zig
+++ b/src/ctl/update.zig
@@ -10,6 +10,7 @@ const sys = @import("sys.zig");
 const release = @import("release.zig");
 const dashboard = @import("dashboard.zig");
 const recovery = @import("recovery.zig");
+const install = @import("install.zig");
 
 const Tui = tui_mod.Tui;
 const Color = tui_mod.Color;
@@ -156,6 +157,14 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: UpdateOpts) !void {
             "Артефакт mtbuddy недоступен; обновляем только бинарник прокси",
         ));
     }
+
+    // The service runs as User=mtproto. Older installs (pre-1.0 ran as root) never
+    // created that account, so an `update` that rewrites the unit would otherwise
+    // leave systemd failing the service with status=217/USER (issue #310). Ensure the
+    // user exists up front — before we stop the running service — and abort cleanly if
+    // we can't, so a missing account never takes the proxy down. Idempotent: a no-op
+    // when the user already exists.
+    if (!install.ensureServiceUser(ui, allocator)) return;
 
     // ── Backup current binary ──
     ui.step(ui.str(.update_backing_up));


### PR DESCRIPTION
Fixes #310 — two operator-facing CLI bugs, the first of which caused a production outage.

## 1. `<subcommand> --help` ran the subcommand instead of showing help
Per-subcommand parsers silently ignore unknown flags, so `--help`/`-h` after a subcommand was dropped and the action ran. Worst case: `sudo mtbuddy update --help` **downloaded + installed** the latest release.

The dispatcher now scans a subcommand's args for `-h`/`--help` up front and prints help — `install`'s detailed help for `install`, the general help for everything else — **without executing**. (`install` already honored its own `--help`; this generalizes the convention to `update`/`status`/`config`/`links`/`setup`/…)

## 2. `update` rewrites the unit to `User=mtproto` but never created that user
Only `install` created the `mtproto` account. A host first installed **before 1.0** (proxy ran as root) hit `status=217/USER` after a plain `update`, and the rollback restored only the binary — not the unit — leaving the proxy down. `update` now ensures the `mtproto` user/group exist (reusing `install.ensureServiceUser`, idempotent) **before stopping the service**, and aborts cleanly if it can't.

## Verified
- `zig build test` + `x86_64-linux` build green; `zig fmt` clean.
- On a real Linux host (throwaway binary, installed mtbuddy untouched): `update --help` / `status --help` / `update -h` print help and do **not** execute; `install --help` shows install help; bare `update` still resolves + updates.

Out of scope (noted for a follow-up): generically warning on *all* unknown flags per subcommand — the `--help` case here is the one with a dangerous side effect.