### PR TITLE
fix(config): handshake flood guard off by default (NAT/VPN-safe)

### DIFF
--- a/README.fa.md
+++ b/README.fa.md
@@ -372,7 +372,7 @@ handshake_timeout_sec = 15
 graceful_shutdown_timeout_sec = 15
 log_level = "info"        # debug | info | warn | err
 rate_limit_per_subnet = 0   # 0 = disabled (default; avoids carrier-NAT false positives). Set e.g. 30 for non-NAT hosts
-handshake_flood_guard_enabled = true
+handshake_flood_guard_enabled = false
 handshake_flood_guard_threshold = 20
 handshake_flood_guard_window_sec = 30
 handshake_flood_guard_block_sec = 120
@@ -429,7 +429,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[server] tag` | — | برچسب تبلیغاتیِ 32 کاراکتر hex از [@MTProxybot](https://t.me/MTProxybot) |
 | `[server] log_level` | `"info"` | `debug` / `info` / `warn` / `err` |
 | `[server] rate_limit_per_subnet` | `0` | حداکثر اتصال‌های جدید در ثانیه به ازای هر /24 (IPv4) یا /48 (IPv6). `0` = غیرفعال (پیش‌فرض، سازگار با NAT)؛ برای هاست‌های بدون NAT مثلاً `30` تنظیم کنید |
-| `[server] handshake_flood_guard_enabled` | `true` | مسدودسازیِ موقت IPهای مبدأِ دقیقی که مکرراً در هندشیک MTProto ناموفق‌اند |
+| `[server] handshake_flood_guard_enabled` | `false` | مسدودسازیِ موقت IPهای مبدأِ دقیقی که مکرراً در هندشیک MTProto ناموفق‌اند (پیش‌فرض خاموش — امن برای NAT/VPN) |
 | `[server] handshake_flood_guard_threshold` | `20` | تعداد رویدادهای هندشیک/نرخ/بودجه‌ی نامعتبر به ازای هر IP مبدأ پیش از مسدودسازی موقت |
 | `[server] handshake_flood_guard_window_sec` | `30` | پنجره‌ی متحرک برای `handshake_flood_guard_threshold` |
 | `[server] handshake_flood_guard_block_sec` | `120` | مدت‌زمان مسدودسازی موقت برای IPهای مبدأِ پر سر و صدا |
@@ -457,7 +457,7 @@ alice = true   # bypass MiddleProxy for this user
 >
 > **ترابری `dd` («امن»/بالشتک‌دار) به‌صورت پیش‌فرض رد می‌شود** (`[censorship].fake_tls_only = true`) — این فقط MTProto مبهم‌سازی‌شده با **بدون استتار TLS** است که مستقیماً توسط DPI به‌عنوان MTProto قابل‌اثرانگشت‌گیری است. به‌صورت پیش‌فرض پراکسی فقط FakeTLS (`ee`) را می‌پذیرد و `mtbuddy links` فقط لینک‌های `ee` را چاپ می‌کند. برای ارائه‌ی لینک‌های `dd` (سناریوهای سازگاری / DPI ضعیف‌تر)، مقدار `fake_tls_only = false` را تنظیم کنید. به [THREAT_MODEL.md](THREAT_MODEL.md) مراجعه کنید.
 >
-> محدودیت نرخ اتصال جدید به ازای هر زیرشبکه **به‌صورت پیش‌فرض خاموش است** (`rate_limit_per_subnet = 0`) تا شبکه‌های بزرگ carrier-NAT یا دفاتر اشتراکی (با کلاینت‌های مشروع زیاد پشت یک IP/زیرشبکه) به‌اشتباه شناسایی نشوند. نگهبان سیلِ هندشیک روشن می‌ماند اما با خاموش بودن محدودیت زیرشبکه، فقط روی هندشیک‌های رهاشده/ناتمام عمل می‌کند — چیزی که دارندگان واقعیِ secret عملاً هرگز تولید نمی‌کنند. اگر همچنان می‌بینید `flood_guard+` کاربران واقعی را به‌صورت انفجاری مسدود می‌کند، مقدار `handshake_flood_guard_threshold` / پنجره / مدت مسدودسازی را افزایش دهید، یا `handshake_flood_guard_enabled = false` را تنظیم کنید. `rate_limit_per_subnet` را فقط روی هاست‌های تک‌مستأجر / بدون NAT فعال کنید.
+> هر دو نگهبانِ سوءاستفاده **به‌صورت پیش‌فرض خاموش‌اند** تا شبکه‌های بزرگ carrier-NAT، خروجی VPN یا دفاتر اشتراکی (با کلاینت‌های مشروع زیاد پشت یک IP/زیرشبکه) به‌اشتباه شناسایی و یکجا مسدود نشوند: محدودیت نرخ اتصال جدید به ازای هر زیرشبکه (`rate_limit_per_subnet = 0`) و نگهبان سیلِ هندشیکِ مبتنی بر IP دقیق (`handshake_flood_guard_enabled = false`). دسترسی پیشاپیش با secret هر کاربر، بودجهٔ سراسریِ هندشیک‌های در جریان و `max_connections` کنترل می‌شود. روی یک هاست تک‌مستأجر / بدون NAT که زیر سوءاستفادهٔ واقعی است، آن‌ها را روشن کنید: `rate_limit_per_subnet` را تنظیم کنید (مثلاً `30`) و `handshake_flood_guard_enabled = true` را قرار دهید (مقادیر `handshake_flood_guard_threshold` / پنجره / مدت مسدودسازی را تنظیم کنید).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ handshake_timeout_sec = 15
 graceful_shutdown_timeout_sec = 15
 log_level = "info"        # debug | info | warn | err
 rate_limit_per_subnet = 0   # 0 = disabled (default; avoids carrier-NAT false positives). Set e.g. 30 for non-NAT hosts
-handshake_flood_guard_enabled = true
+handshake_flood_guard_enabled = false
 handshake_flood_guard_threshold = 20
 handshake_flood_guard_window_sec = 30
 handshake_flood_guard_block_sec = 120
@@ -429,7 +429,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[server] tag` | — | 32 hex-char promotion tag from [@MTProxybot](https://t.me/MTProxybot) |
 | `[server] log_level` | `"info"` | `debug` / `info` / `warn` / `err` |
 | `[server] rate_limit_per_subnet` | `0` | Max new conns/sec per /24 (IPv4) or /48 (IPv6). `0` = disabled (default, NAT-friendly); set e.g. `30` for non-NAT hosts |
-| `[server] handshake_flood_guard_enabled` | `true` | Temporarily deny exact source IPs that repeatedly fail the MTProto handshake |
+| `[server] handshake_flood_guard_enabled` | `false` | Temporarily deny exact source IPs that repeatedly fail the MTProto handshake (off by default — NAT/VPN-safe) |
 | `[server] handshake_flood_guard_threshold` | `20` | Bad handshake/rate/budget events per source IP before temporary deny |
 | `[server] handshake_flood_guard_window_sec` | `30` | Rolling window for `handshake_flood_guard_threshold` |
 | `[server] handshake_flood_guard_block_sec` | `120` | Temporary deny duration for noisy source IPs |
@@ -457,7 +457,7 @@ alice = true   # bypass MiddleProxy for this user
 >
 > **The `dd` ("secure"/padded) transport is rejected by default** (`[censorship].fake_tls_only = true`) — it is plain obfuscated MTProto with **no TLS disguise**, directly fingerprintable as MTProto by DPI. By default the proxy accepts only FakeTLS (`ee`), and `mtbuddy links` prints only `ee` links. To hand out `dd` links (lower-DPI / compatibility scenarios), set `fake_tls_only = false`. See [THREAT_MODEL.md](THREAT_MODEL.md).
 >
-> The per-subnet new-connection rate limit is **off by default** (`rate_limit_per_subnet = 0`) so large carrier-NAT or shared-office networks (many legitimate clients behind one IP/subnet) aren't false-positived. The handshake flood guard stays on but, with the subnet limit off, it only acts on abandoned/incomplete handshakes — which legitimate secret-holders virtually never produce. If you still see `flood_guard+` blocking real users in bursts, raise `handshake_flood_guard_threshold` / window / block, or set `handshake_flood_guard_enabled = false`. Enable `rate_limit_per_subnet` only on single-tenant / non-NAT hosts.
+> Both abuse guards are **off by default** so large carrier-NAT, VPN-egress, or shared-office networks (many legitimate clients behind one source IP/subnet) aren't false-positived and blocked together: the per-subnet new-connection rate limit (`rate_limit_per_subnet = 0`) and the exact-IP handshake flood guard (`handshake_flood_guard_enabled = false`). Access is already gated by the per-user secret, the global handshake-inflight budget, and `max_connections`. On a single-tenant / non-NAT host under real abuse, turn them on: set `rate_limit_per_subnet` (e.g. `30`) and `handshake_flood_guard_enabled = true` (tune `handshake_flood_guard_threshold` / window / block).
 
 ---
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -356,7 +356,7 @@ handshake_timeout_sec = 15
 graceful_shutdown_timeout_sec = 15
 log_level = "info"
 rate_limit_per_subnet = 0   # 0 = выключено (по умолчанию; не ложно-срабатывает на carrier-NAT). Для не-NAT хостов задайте напр. 30
-handshake_flood_guard_enabled = true
+handshake_flood_guard_enabled = false
 handshake_flood_guard_threshold = 20
 handshake_flood_guard_window_sec = 30
 handshake_flood_guard_block_sec = 120
@@ -397,7 +397,7 @@ alice = true
 | `[server] middleproxy_buffer_kb` | `1024` | Буфер MiddleProxy на соединение |
 | `[server] tag` | — | 32-hex promotion tag от [@MTProxybot](https://t.me/MTProxybot) |
 | `[server] rate_limit_per_subnet` | `0` | Лимит новых соединений/сек на /24 (IPv4) или /48 (IPv6). `0` = выключено (по умолчанию, NAT-friendly); для не-NAT хостов задайте напр. `30` |
-| `[server] handshake_flood_guard_enabled` | `true` | Временно отклонять IP, которые часто не проходят MTProto handshake |
+| `[server] handshake_flood_guard_enabled` | `false` | Временно отклонять IP, которые часто не проходят MTProto handshake (по умолчанию выключен — безопасно для NAT/VPN) |
 | `[server] handshake_flood_guard_threshold` | `20` | Число плохих handshake/rate/budget событий с одного IP до временного deny |
 | `[server] handshake_flood_guard_window_sec` | `30` | Окно подсчёта для `handshake_flood_guard_threshold` |
 | `[server] handshake_flood_guard_block_sec` | `120` | Длительность временного deny для шумного IP |
@@ -415,7 +415,7 @@ alice = true
 >
 > **Транспорт `dd` («secure»/padded) по умолчанию отключён** (`[censorship].fake_tls_only = true`) — это обычный обфусцированный MTProto **без TLS-маскировки**, который DPI фингерпринтит напрямую как MTProto. По умолчанию прокси принимает только FakeTLS (`ee`), и `mtbuddy links` печатает только `ee`-ссылки. Чтобы раздавать `dd`-ссылки (сценарии с низким DPI / совместимость), задайте `fake_tls_only = false`. См. [THREAT_MODEL.md](THREAT_MODEL.md).
 >
-> Per-subnet rate limit **по умолчанию выключен** (`rate_limit_per_subnet = 0`), чтобы carrier-NAT/офисные сети (много легитимных клиентов за одним IP/подсетью) не получали ложных блокировок. Handshake flood guard остаётся включённым, но с выключенным subnet-лимитом он реагирует только на брошенные/незавершённые handshake — которые легитимные владельцы secret практически не создают. Если `flood_guard+` всё же блокирует реальных пользователей при burst, поднимите `handshake_flood_guard_threshold` / window / block или задайте `handshake_flood_guard_enabled = false`. `rate_limit_per_subnet` включайте только на single-tenant / не-NAT хостах.
+> Оба стража **по умолчанию выключены**, чтобы carrier-NAT, VPN-egress и офисные сети (много легитимных клиентов за одним IP/подсетью) не получали ложных блокировок скопом: per-subnet rate limit (`rate_limit_per_subnet = 0`) и exact-IP handshake flood guard (`handshake_flood_guard_enabled = false`). Доступ и так закрыт per-user secret, глобальным handshake-inflight бюджетом и `max_connections`. На single-tenant / не-NAT хосте под реальным абьюзом включите: задайте `rate_limit_per_subnet` (например `30`) и `handshake_flood_guard_enabled = true` (настройте `handshake_flood_guard_threshold` / window / block).
 
 ---
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -372,7 +372,7 @@ handshake_timeout_sec = 15
 graceful_shutdown_timeout_sec = 15
 log_level = "info"        # debug | info | warn | err
 rate_limit_per_subnet = 0   # 0 = disabled (default; avoids carrier-NAT false positives). Set e.g. 30 for non-NAT hosts
-handshake_flood_guard_enabled = true
+handshake_flood_guard_enabled = false
 handshake_flood_guard_threshold = 20
 handshake_flood_guard_window_sec = 30
 handshake_flood_guard_block_sec = 120
@@ -429,7 +429,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[server] tag` | — | Thẻ quảng bá 32 ký tự hex từ [@MTProxybot](https://t.me/MTProxybot) |
 | `[server] log_level` | `"info"` | `debug` / `info` / `warn` / `err` |
 | `[server] rate_limit_per_subnet` | `0` | Số kết nối mới tối đa/giây cho mỗi /24 (IPv4) hoặc /48 (IPv6). `0` = tắt (mặc định, thân thiện NAT); ví dụ đặt `30` cho các máy không NAT |
-| `[server] handshake_flood_guard_enabled` | `true` | Tạm thời từ chối các IP nguồn cụ thể liên tục thất bại trong bắt tay MTProto |
+| `[server] handshake_flood_guard_enabled` | `false` | Tạm thời từ chối các IP nguồn cụ thể liên tục thất bại trong bắt tay MTProto (mặc định tắt — an toàn cho NAT/VPN) |
 | `[server] handshake_flood_guard_threshold` | `20` | Số sự kiện bắt tay lỗi/vượt tốc độ/vượt ngân sách trên mỗi IP nguồn trước khi tạm từ chối |
 | `[server] handshake_flood_guard_window_sec` | `30` | Cửa sổ trượt cho `handshake_flood_guard_threshold` |
 | `[server] handshake_flood_guard_block_sec` | `120` | Thời lượng tạm từ chối đối với các IP nguồn gây nhiễu |
@@ -457,7 +457,7 @@ alice = true   # bypass MiddleProxy for this user
 >
 > **Lớp truyền tải `dd` ("secure"/padded) bị từ chối theo mặc định** (`[censorship].fake_tls_only = true`) — đó là MTProto được làm rối thông thường, **không có ngụy trang TLS**, có thể bị DPI nhận diện trực tiếp là MTProto. Theo mặc định proxy chỉ chấp nhận FakeTLS (`ee`), và `mtbuddy links` chỉ in các liên kết `ee`. Để phát các liên kết `dd` (cho các tình huống ít DPI / tương thích), hãy đặt `fake_tls_only = false`. Xem [THREAT_MODEL.md](THREAT_MODEL.md).
 >
-> Giới hạn tốc độ kết nối mới theo mỗi subnet **mặc định bị tắt** (`rate_limit_per_subnet = 0`) để các mạng carrier-NAT lớn hoặc mạng văn phòng dùng chung (nhiều client hợp lệ sau một IP/subnet) không bị nhận diện nhầm. Bộ chống lụt bắt tay vẫn bật, nhưng khi giới hạn subnet tắt, nó chỉ tác động lên các bắt tay bị bỏ dở/chưa hoàn tất — điều mà những người nắm secret hợp lệ gần như không bao giờ tạo ra. Nếu bạn vẫn thấy `flood_guard+` chặn người dùng thật theo từng đợt, hãy tăng `handshake_flood_guard_threshold` / cửa sổ / thời gian chặn, hoặc đặt `handshake_flood_guard_enabled = false`. Chỉ bật `rate_limit_per_subnet` trên các máy đơn người thuê / không NAT.
+> Cả hai bộ chống lạm dụng đều **mặc định bị tắt** để các mạng carrier-NAT lớn, mạng VPN-egress hoặc mạng văn phòng dùng chung (nhiều client hợp lệ sau một IP/subnet nguồn) không bị nhận diện nhầm và chặn cùng nhau: giới hạn tốc độ kết nối mới theo mỗi subnet (`rate_limit_per_subnet = 0`) và bộ chống lụt bắt tay theo IP chính xác (`handshake_flood_guard_enabled = false`). Quyền truy cập đã được kiểm soát bởi secret theo từng người dùng, ngân sách bắt tay đang chờ toàn cục và `max_connections`. Trên một máy đơn người thuê / không NAT khi thực sự bị lạm dụng, hãy bật chúng lên: đặt `rate_limit_per_subnet` (ví dụ `30`) và `handshake_flood_guard_enabled = true` (tinh chỉnh `handshake_flood_guard_threshold` / cửa sổ / thời gian chặn).
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -372,7 +372,7 @@ handshake_timeout_sec = 15
 graceful_shutdown_timeout_sec = 15
 log_level = "info"        # debug | info | warn | err
 rate_limit_per_subnet = 0   # 0 = disabled (default; avoids carrier-NAT false positives). Set e.g. 30 for non-NAT hosts
-handshake_flood_guard_enabled = true
+handshake_flood_guard_enabled = false
 handshake_flood_guard_threshold = 20
 handshake_flood_guard_window_sec = 30
 handshake_flood_guard_block_sec = 120
@@ -429,7 +429,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[server] tag` | — | 来自 [@MTProxybot](https://t.me/MTProxybot) 的 32 个十六进制字符推广标签 |
 | `[server] log_level` | `"info"` | `debug` / `info` / `warn` / `err` |
 | `[server] rate_limit_per_subnet` | `0` | 每个 /24（IPv4）或 /48（IPv6）每秒最大新建连接数。`0` = 禁用（默认，对 NAT 友好）；非 NAT 主机可设为如 `30` |
-| `[server] handshake_flood_guard_enabled` | `true` | 临时拒绝那些反复 MTProto 握手失败的具体源 IP |
+| `[server] handshake_flood_guard_enabled` | `false` | 临时拒绝那些反复 MTProto 握手失败的具体源 IP（默认关闭 —— 对 NAT/VPN 安全） |
 | `[server] handshake_flood_guard_threshold` | `20` | 每个源 IP 触发临时拒绝前所允许的错误握手/限速/预算事件数 |
 | `[server] handshake_flood_guard_window_sec` | `30` | `handshake_flood_guard_threshold` 的滚动时间窗口 |
 | `[server] handshake_flood_guard_block_sec` | `120` | 对喧闹源 IP 的临时拒绝时长 |
@@ -457,7 +457,7 @@ alice = true   # bypass MiddleProxy for this user
 >
 > **`dd`（“安全”/填充）传输默认被拒绝**（`[censorship].fake_tls_only = true`）—— 它是纯粹混淆的 MTProto，**没有任何 TLS 伪装**，可被 DPI 直接识别为 MTProto 特征。默认情况下代理只接受 FakeTLS（`ee`），且 `mtbuddy links` 只打印 `ee` 链接。若要发放 `dd` 链接（低 DPI / 兼容性场景），请设置 `fake_tls_only = false`。参见 [THREAT_MODEL.md](THREAT_MODEL.md)。
 >
-> 每子网的新建连接速率限制**默认关闭**（`rate_limit_per_subnet = 0`），以免大型运营商 NAT 或共享办公网络（许多合法客户端共用一个 IP/子网）被误判。握手洪水防护保持开启，但在子网限制关闭的情况下，它只对被放弃/未完成的握手起作用 —— 而合法的密钥持有者几乎从不产生这类握手。如果你仍看到 `flood_guard+` 在突发流量中拦截真实用户，请调高 `handshake_flood_guard_threshold` / 窗口 / 拦截时长，或设置 `handshake_flood_guard_enabled = false`。只在单租户 / 非 NAT 主机上启用 `rate_limit_per_subnet`。
+> 两个滥用防护默认均关闭，以免大型运营商 NAT、VPN 出口或共享办公网络（许多合法客户端共用一个源 IP/子网）被误判并一起拦截：每子网的新建连接速率限制（`rate_limit_per_subnet = 0`）与精确 IP 的握手洪水防护（`handshake_flood_guard_enabled = false`）。访问本就已由每用户密钥、全局握手在途预算以及 `max_connections` 把关。在遭受真实滥用的单租户 / 非 NAT 主机上，请将它们开启：设置 `rate_limit_per_subnet`（如 `30`）并设 `handshake_flood_guard_enabled = true`（调整 `handshake_flood_guard_threshold` / 窗口 / 拦截时长）。
 
 ---
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -93,9 +93,10 @@ port = 443
 # unsafe_override_limits = false
 
 # Handshake flood guard: temporarily blocks source IPs that generate too many
-# failed/abandoned handshakes. Raise the threshold / window for carrier-NAT or
-# shared-office networks where many legitimate clients share one IP.
-# handshake_flood_guard_enabled = true
+# failed/abandoned handshakes. OFF by default — it false-positives on carrier-NAT,
+# VPN-egress and shared-office networks where many legitimate clients share one IP.
+# Turn on (and tune threshold/window) only on single-tenant / non-NAT hosts under abuse.
+# handshake_flood_guard_enabled = false
 # handshake_flood_guard_threshold = 20     # failed handshakes per window before block
 # handshake_flood_guard_window_sec = 30
 # handshake_flood_guard_block_sec = 120

--- a/src/config.zig
+++ b/src/config.zig
@@ -234,9 +234,14 @@ pub const Config = struct {
     /// secret, the global handshake-inflight budget, and max_connections. Set a
     /// value (e.g. 30) to re-enable for single-tenant / non-NAT deployments.
     rate_limit_per_subnet: u8 = 0,
-    /// Exact-IP handshake flood guard. Temporarily denies clients that repeatedly
-    /// hit handshake timeouts, subnet rate limits, or the handshake budget.
-    handshake_flood_guard_enabled: bool = true,
+    /// Exact-IP handshake flood guard: temporarily denies clients that repeatedly hit
+    /// handshake timeouts, subnet rate limits, or the handshake budget. Off by default
+    /// — like rate_limit_per_subnet it false-positives on carrier-NAT / VPN-egress /
+    /// shared IPs, where many legitimate clients share one source IP and get blocked
+    /// together. Access is already gated by the per-user secret, the handshake-inflight
+    /// budget, and max_connections. Set true (and tune threshold/window/block) on a
+    /// single-tenant / non-NAT host under real abuse.
+    handshake_flood_guard_enabled: bool = false,
     handshake_flood_guard_threshold: u16 = 20,
     handshake_flood_guard_window_sec: u16 = 30,
     handshake_flood_guard_block_sec: u16 = 120,
@@ -798,7 +803,7 @@ test "parse config - missing fields defaults" {
     try std.testing.expectEqual(@as(u32, 1024), cfg.middleproxy_buffer_kb);
     try std.testing.expectEqual(@as(usize, 1024 * 1024), cfg.middleProxyBufferBytes());
     try std.testing.expectEqual(@as(u8, 0), cfg.rate_limit_per_subnet); // Default 0 (disabled)
-    try std.testing.expect(cfg.handshake_flood_guard_enabled);
+    try std.testing.expect(!cfg.handshake_flood_guard_enabled);
     try std.testing.expectEqual(@as(u16, 20), cfg.handshake_flood_guard_threshold);
     try std.testing.expectEqual(@as(u16, 30), cfg.handshake_flood_guard_window_sec);
     try std.testing.expectEqual(@as(u16, 120), cfg.handshake_flood_guard_block_sec);
@@ -1209,7 +1214,7 @@ test "parse config - rate_limit_per_subnet disabled" {
     try std.testing.expectEqual(@as(u8, 0), cfg.rate_limit_per_subnet);
 }
 
-test "parse config - handshake flood guard defaults enabled" {
+test "parse config - handshake flood guard defaults disabled" {
     const content =
         \\[access.users]
         \\alice = "00112233445566778899aabbccddeeff"
@@ -1218,7 +1223,7 @@ test "parse config - handshake flood guard defaults enabled" {
     var cfg = try Config.parse(std.testing.allocator, content);
     defer cfg.deinit(std.testing.allocator);
 
-    try std.testing.expect(cfg.handshake_flood_guard_enabled);
+    try std.testing.expect(!cfg.handshake_flood_guard_enabled);
     try std.testing.expectEqual(@as(u16, 20), cfg.handshake_flood_guard_threshold);
     try std.testing.expectEqual(@as(u16, 30), cfg.handshake_flood_guard_window_sec);
     try std.testing.expectEqual(@as(u16, 120), cfg.handshake_flood_guard_block_sec);

--- a/src/ctl/install.zig
+++ b/src/ctl/install.zig
@@ -560,7 +560,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
         try doc.addKv("max_connections", max_conn_val);
         try doc.addKv("idle_timeout_sec", "120");
         try doc.addKv("handshake_timeout_sec", "15");
-        try doc.addKv("handshake_flood_guard_enabled", "true");
+        try doc.addKv("handshake_flood_guard_enabled", "false");
         try doc.addKv("handshake_flood_guard_threshold", "20");
         try doc.addKv("handshake_flood_guard_window_sec", "30");
         try doc.addKv("handshake_flood_guard_block_sec", "120");


### PR DESCRIPTION
## Why
The exact-IP handshake flood guard defaulted to **enabled**, but it false-positives on **carrier-NAT, VPN-egress, and shared-office** networks: many legitimate clients share one source IP, so a burst of abandoned/incomplete handshakes from that IP crosses the threshold and the guard blocks the IP — **taking every real user behind it down with it**.

Seen in production on `proxy.sleep3r.ru`: a VPN egress IP that real users (and the operator) connect through was repeatedly blocked for ~56s at a time, so the proxy *worked* but "worked badly" for those users. Disabling the guard immediately recovered them (`users_total` jumped 1 → 13).

## Change
Flip `handshake_flood_guard_enabled` default to **false**, matching `rate_limit_per_subnet` (already off by default for the same NAT reason). Access is already gated by the per-user secret + the global handshake-inflight budget + `max_connections`, so the guard is redundant for a typical multi-NAT deployment while its false-positive cost is real.

The guard **code stays** — operators on single-tenant / non-NAT hosts under real abuse can set `handshake_flood_guard_enabled = true` and tune threshold/window/block.

Touched: the default + doc comment (config.zig), the installer-generated config (install.zig), config.toml.example, the README config tables + snippets + the abuse-guard note (EN/RU), and the two default-parse tests.

## Verified
`zig build test` + `x86_64-linux` build green; `zig fmt` clean.