### PR TITLE
feat: evasion + robustness + UX bundle (+ Ubuntu 20.04 installer fix)

### DIFF
--- a/README.fa.md
+++ b/README.fa.md
@@ -423,6 +423,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[server] max_connections` | `512` | سقف اتصال‌های هم‌زمان که به‌صورت خودکار بر اساس RAM و `RLIMIT_NOFILE` محدود می‌شود |
 | `[server] workers` | `1` | نخ‌های کارگرِ epoll با SO_REUSEPORT. `1` = تک‌نخی؛ `0` = یکی به ازای هر CPU؛ `N` بار رله/رمزنگاری را روی هسته‌ها پخش می‌کند. وقتی `>1` باشد، بارگذاری مجدد پیکربندی با SIGHUP نیازمند ری‌استارت است |
 | `[server] idle_timeout_sec` | `120` | مهلت بی‌کاریِ اتصال |
+| `[server] idle_timeout_jitter_pct` | `15` | لرزش ±٪ به ازای هر اتصال روی مهلت بی‌کاری تا یک مقدار ثابت به اثر انگشت تبدیل نشود (`0` غیرفعال می‌کند) |
 | `[server] handshake_timeout_sec` | `15` | مهلت تکمیل هندشیک |
 | `[server] graceful_shutdown_timeout_sec` | `15` | مهلت تخلیه‌ی SIGTERM پیش از بستن اجباری |
 | `[server] middleproxy_buffer_kb` | `1024` | بافر ME برای هر اتصال (KiB). کمتر از 1024 ممکن است در ترافیک رسانه‌ای باعث سرریز شود |
@@ -441,6 +442,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[metrics] port` | `9400` | پورت متریک‌ها |
 | `[censorship] tls_domain` | `"google.com"` | دامنه‌ای که جعل هویت می‌شود |
 | `[censorship] mask` | `true` | هدایت کلاینت‌های احراز هویت‌نشده به `tls_domain` |
+| `[censorship] unknown_sni_action` | `"mask"` | ClientHello با SNI ناشناخته: `mask` (هدایت)، `reject` (هشدار مرگبار TLS مانند سروری که رد می‌کند)، یا `drop` |
 | `[censorship] mask_target` | تنظیم‌نشده | هاست بک‌اند اختیاری برای کلاینت‌های استتارشده |
 | `[censorship] mask_port` | `443` | پورت استتار محلی (برای Nginx با zero-RTT از `8443` استفاده کنید) |
 | `[censorship] desync` | `true` | Split-TLS: رکوردهای Application یک‌بایتی |
@@ -448,6 +450,8 @@ alice = true   # bypass MiddleProxy for this user
 | `[censorship] fast_mode` | `false` | واگذاری رمزنگاریِ S2C به DC (توصیه‌شده) |
 | `[access.users] <name>` | — | secret‏ 32 کاراکتر hex برای هر کاربر |
 | `[access.direct_users] <name>` | — | دور زدن ME برای این کاربر |
+| `[access.user_max_conns] <name>` | — | سقف اتصال‌های هم‌زمان به ازای هر کاربر (برای تغییر، ری‌استارت لازم است) |
+| `[access.user_expirations] <name>` | — | تاریخ انقضای هر کاربر `"YYYY-MM-DD"` (برای تغییر، ری‌استارت لازم است) |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[server] max_connections` | `512` | Concurrent connection cap, auto-clamped by RAM and `RLIMIT_NOFILE` |
 | `[server] workers` | `1` | SO_REUSEPORT epoll worker threads. `1` = single-threaded; `0` = one per CPU; `N` spreads relay/crypto load across cores. SIGHUP config reload requires a restart when `>1` |
 | `[server] idle_timeout_sec` | `120` | Connection idle timeout |
+| `[server] idle_timeout_jitter_pct` | `15` | Per-connection ±% jitter on the idle timeout so a constant value isn't a fingerprint (`0` disables) |
 | `[server] handshake_timeout_sec` | `15` | Handshake completion timeout |
 | `[server] graceful_shutdown_timeout_sec` | `15` | SIGTERM drain timeout before force-close |
 | `[server] middleproxy_buffer_kb` | `1024` | ME per-connection buffer (KiB). Below 1024 may cause overflow on media traffic |
@@ -441,6 +442,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[metrics] port` | `9400` | Metrics port |
 | `[censorship] tls_domain` | `"google.com"` | Domain to impersonate |
 | `[censorship] mask` | `true` | Forward unauthenticated clients to `tls_domain` |
+| `[censorship] unknown_sni_action` | `"mask"` | Unknown-SNI ClientHello: `mask` (forward), `reject` (fatal TLS alert like a rejecting server), or `drop` |
 | `[censorship] mask_target` | unset | Optional backend host for masked clients |
 | `[censorship] mask_port` | `443` | Local masking port (use `8443` for Nginx zero-RTT) |
 | `[censorship] desync` | `true` | Split-TLS: 1-byte Application records |
@@ -448,6 +450,8 @@ alice = true   # bypass MiddleProxy for this user
 | `[censorship] fast_mode` | `false` | Delegate S2C encryption to DC (recommended) |
 | `[access.users] <name>` | — | 32 hex-char secret per user |
 | `[access.direct_users] <name>` | — | Bypass ME for this user |
+| `[access.user_max_conns] <name>` | — | Per-user concurrent-connection cap (restart to change) |
+| `[access.user_expirations] <name>` | — | Per-user expiry date `"YYYY-MM-DD"` (restart to change) |
 
 </details>
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -401,13 +401,17 @@ alice = true
 | `[server] handshake_flood_guard_threshold` | `20` | Число плохих handshake/rate/budget событий с одного IP до временного deny |
 | `[server] handshake_flood_guard_window_sec` | `30` | Окно подсчёта для `handshake_flood_guard_threshold` |
 | `[server] handshake_flood_guard_block_sec` | `120` | Длительность временного deny для шумного IP |
+| `[server] idle_timeout_jitter_pct` | `15` | Джиттер ±% на idle-таймаут соединения, чтобы константа не была сигнатурой (`0` — выключить) |
 | `[censorship] tls_domain` | `"google.com"` | Домен для TLS-маскировки |
 | `[censorship] mask` | `true` | Forward invalid clients на `tls_domain` |
+| `[censorship] unknown_sni_action` | `"mask"` | ClientHello с чужим SNI: `mask` (forward), `reject` (фатальный TLS-alert, как отклоняющий сервер) или `drop` |
 | `[censorship] mask_target` | unset | Optional backend host для masked clients |
 | `[censorship] mask_port` | `443` | Local masking port (`8443` для Nginx zero-RTT) |
 | `[censorship] fast_mode` | `false` | Делегировать S2C encryption DC |
 | `[access.users] <name>` | — | 32-hex secret на пользователя |
 | `[access.direct_users] <name>` | — | Bypass MiddleProxy для пользователя |
+| `[access.user_max_conns] <name>` | — | Лимит одновременных соединений на пользователя (меняется рестартом) |
+| `[access.user_expirations] <name>` | — | Дата истечения доступа `"YYYY-MM-DD"` для пользователя (меняется рестартом) |
 
 > Secret можно сгенерировать через `mtbuddy secret` или `openssl rand -hex 16`.
 >

--- a/README.vi.md
+++ b/README.vi.md
@@ -423,6 +423,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[server] max_connections` | `512` | Giới hạn kết nối đồng thời, tự động giới hạn theo RAM và `RLIMIT_NOFILE` |
 | `[server] workers` | `1` | Số luồng worker epoll SO_REUSEPORT. `1` = đơn luồng; `0` = một luồng mỗi CPU; `N` phân tán tải chuyển tiếp/mã hóa qua các nhân. Việc nạp lại cấu hình bằng SIGHUP cần khởi động lại khi `>1` |
 | `[server] idle_timeout_sec` | `120` | Thời gian chờ kết nối nhàn rỗi |
+| `[server] idle_timeout_jitter_pct` | `15` | Jitter ±% trên mỗi kết nối cho thời gian chờ nhàn rỗi để một giá trị cố định không trở thành dấu vân tay (`0` để tắt) |
 | `[server] handshake_timeout_sec` | `15` | Thời gian chờ hoàn tất bắt tay |
 | `[server] graceful_shutdown_timeout_sec` | `15` | Thời gian chờ rút cạn khi SIGTERM trước khi buộc đóng |
 | `[server] middleproxy_buffer_kb` | `1024` | Bộ đệm ME cho mỗi kết nối (KiB). Dưới 1024 có thể gây tràn với lưu lượng media |
@@ -441,6 +442,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[metrics] port` | `9400` | Cổng metrics |
 | `[censorship] tls_domain` | `"google.com"` | Tên miền để giả mạo |
 | `[censorship] mask` | `true` | Chuyển tiếp các client chưa xác thực tới `tls_domain` |
+| `[censorship] unknown_sni_action` | `"mask"` | ClientHello với SNI không xác định: `mask` (chuyển tiếp), `reject` (cảnh báo TLS nghiêm trọng như một máy chủ từ chối), hoặc `drop` |
 | `[censorship] mask_target` | unset | Máy backend tùy chọn cho các client bị che giấu |
 | `[censorship] mask_port` | `443` | Cổng che giấu cục bộ (dùng `8443` cho Nginx zero-RTT) |
 | `[censorship] desync` | `true` | Split-TLS: các bản ghi Application 1 byte |
@@ -448,6 +450,8 @@ alice = true   # bypass MiddleProxy for this user
 | `[censorship] fast_mode` | `false` | Ủy thác mã hóa S2C cho DC (khuyến nghị) |
 | `[access.users] <name>` | — | Secret 32 ký tự hex cho mỗi người dùng |
 | `[access.direct_users] <name>` | — | Bỏ qua ME cho người dùng này |
+| `[access.user_max_conns] <name>` | — | Giới hạn số kết nối đồng thời cho mỗi người dùng (cần khởi động lại để thay đổi) |
+| `[access.user_expirations] <name>` | — | Ngày hết hạn cho mỗi người dùng `"YYYY-MM-DD"` (cần khởi động lại để thay đổi) |
 
 </details>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -423,6 +423,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[server] max_connections` | `512` | 并发连接上限，会根据 RAM 和 `RLIMIT_NOFILE` 自动钳制 |
 | `[server] workers` | `1` | SO_REUSEPORT epoll 工作线程数。`1` = 单线程；`0` = 每个 CPU 一个；`N` 将中继/加密负载分散到多个核心。当 `>1` 时，SIGHUP 配置重载需要重启 |
 | `[server] idle_timeout_sec` | `120` | 连接空闲超时 |
+| `[server] idle_timeout_jitter_pct` | `15` | 对空闲超时施加每连接 ±% 的抖动，避免固定值成为指纹（`0` 表示禁用） |
 | `[server] handshake_timeout_sec` | `15` | 握手完成超时 |
 | `[server] graceful_shutdown_timeout_sec` | `15` | 强制关闭前 SIGTERM 排空超时 |
 | `[server] middleproxy_buffer_kb` | `1024` | ME 每连接缓冲区（KiB）。低于 1024 在媒体流量下可能导致溢出 |
@@ -441,6 +442,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[metrics] port` | `9400` | 指标端口 |
 | `[censorship] tls_domain` | `"google.com"` | 要冒充的域名 |
 | `[censorship] mask` | `true` | 将未认证的客户端转发到 `tls_domain` |
+| `[censorship] unknown_sni_action` | `"mask"` | 对未知 SNI 的 ClientHello 的处理方式：`mask`（转发）、`reject`（像拒绝连接的服务器那样返回致命 TLS 警报）或 `drop` |
 | `[censorship] mask_target` | unset | 被伪装客户端的可选后端主机 |
 | `[censorship] mask_port` | `443` | 本地伪装端口（Nginx zero-RTT 时使用 `8443`） |
 | `[censorship] desync` | `true` | Split-TLS：1 字节的 Application 记录 |
@@ -448,6 +450,8 @@ alice = true   # bypass MiddleProxy for this user
 | `[censorship] fast_mode` | `false` | 将 S2C 加密委托给 DC（推荐） |
 | `[access.users] <name>` | — | 每个用户的 32 个十六进制字符密钥 |
 | `[access.direct_users] <name>` | — | 为该用户绕过 ME |
+| `[access.user_max_conns] <name>` | — | 每个用户的并发连接上限（更改需重启） |
+| `[access.user_expirations] <name>` | — | 每个用户的到期日期 `"YYYY-MM-DD"`（更改需重启） |
 
 </details>
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -186,7 +186,7 @@ mask = true
 
 # What to do with a TLS ClientHello whose SNI doesn't match tls_domain:
 #   "mask"   — forward to the masking backend (default; active-probe defense)
-#   "reject" — emit a real `unrecognized_name` TLS alert like stock nginx, then close
+#   "reject" — send a fatal TLS alert (handshake_failure) like a rejecting server, then close
 #   "drop"   — close silently with no response
 # (Connections that DO present the right SNI but fail validation/replay always mask.)
 # unknown_sni_action = "mask"

--- a/config.toml.example
+++ b/config.toml.example
@@ -65,6 +65,10 @@ port = 443
 # Keep high (300) to accommodate mobile pre-warmed connection pools.
 # idle_timeout_sec = 300
 
+# Per-connection random jitter (± percent) applied to the idle timeout, so a
+# constant timeout isn't itself a behavioral fingerprint. 0 disables. Default 15.
+# idle_timeout_jitter_pct = 15
+
 # Seconds to complete TLS+MTProto handshake after first byte arrives.
 # handshake_timeout_sec = 60
 
@@ -180,6 +184,13 @@ tls_domain = "rutube.ru"
 # Forward unauthenticated / invalid connections to tls_domain (active probing defense).
 mask = true
 
+# What to do with a TLS ClientHello whose SNI doesn't match tls_domain:
+#   "mask"   — forward to the masking backend (default; active-probe defense)
+#   "reject" — emit a real `unrecognized_name` TLS alert like stock nginx, then close
+#   "drop"   — close silently with no response
+# (Connections that DO present the right SNI but fail validation/replay always mask.)
+# unknown_sni_action = "mask"
+
 # Reject the non-TLS "direct obfuscated" (dd / secure) transport. ENABLED by
 # default (true): only FakeTLS (ee) clients are accepted and any non-TLS first
 # bytes are masked immediately. This is the secure default for a TLS-camouflage
@@ -224,3 +235,14 @@ user2 = "ffeeddccbbaa99887766554433221100"
 # Names here must match keys from [access.users].
 # Value must be true/1/yes to enable.
 # user1 = true
+
+[access.user_max_conns]
+# Optional per-user concurrent-connection caps (name = N, names match [access.users]).
+# Absent / 0 = no cap. Read at startup; changing them requires a restart.
+# Handy for sharing one proxy with family/friends without one device hogging it.
+# user1 = 3
+
+[access.user_expirations]
+# Optional per-user expiry (name = "YYYY-MM-DD", UTC midnight). Absent = never expires.
+# After the date the user's new connections are refused. Read at startup; restart to change.
+# user1 = "2026-12-31"

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -9,6 +9,8 @@
 # After bootstrap, mtbuddy lives at /usr/local/bin/mtbuddy and can be called directly.
 
 set -euo pipefail
+PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH:-}"
+export PATH
 
 REPO="sleep3r/mtproto.zig"
 INSTALL_TO="/usr/local/bin/mtbuddy"
@@ -16,6 +18,8 @@ TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 PINNED_MINISIGN_PUBKEY="RWT8YwmUuq/3WpUnYJjD6rAfQugYdZKWr61U3O+2kdNvriLSyrvVU/NO"
 MINISIGN_PUBKEY="${MTPROTO_MINISIGN_PUBKEY:-$PINNED_MINISIGN_PUBKEY}"
+MINISIGN_BOOTSTRAP_VERSION="0.12"
+MINISIGN_BOOTSTRAP_SHA256="9a599b48ba6eb7b1e80f12f36b94ceca7c00b7a5173c95c3efc88d9822957e73"
 INSECURE_MODE="${MTPROTO_INSECURE:-0}"
 
 FORWARD_ARGS=()
@@ -46,9 +50,13 @@ install_minisign_if_needed() {
   step "Installing minisign for signature verification"
   if command -v apt-get >/dev/null 2>&1; then
     export DEBIAN_FRONTEND="${DEBIAN_FRONTEND:-noninteractive}"
-    apt-get -o DPkg::Lock::Timeout=600 update -qq || fail "apt-get update failed while installing minisign"
-    apt-get -o DPkg::Lock::Timeout=600 install -y --no-install-recommends minisign \
-      || fail "apt-get could not install minisign"
+    if apt-get -o DPkg::Lock::Timeout=600 update -qq \
+      && apt-get -o DPkg::Lock::Timeout=600 install -y --no-install-recommends minisign; then
+      :
+    else
+      step "apt could not install minisign, using pinned upstream binary"
+      install_minisign_from_upstream
+    fi
   elif command -v dnf >/dev/null 2>&1; then
     dnf install -y minisign || fail "dnf could not install minisign"
   elif command -v yum >/dev/null 2>&1; then
@@ -65,8 +73,6 @@ install_minisign_if_needed() {
     || fail "minisign is required for signature verification (use --insecure or MTPROTO_INSECURE=1 to bypass)"
   ok "minisign installed"
 }
-
-install_minisign_if_needed
 
 curl_try_download() {
   local out="$1"
@@ -91,6 +97,40 @@ curl_download() {
 
   return 1
 }
+
+verify_sha256_literal() {
+  local file="$1"
+  local expected="$2"
+  local actual
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$file" | awk '{print $1}')"
+  elif command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "$file" | awk '{print $1}')"
+  else
+    fail "Neither sha256sum nor shasum is available for checksum verification"
+  fi
+
+  [ "$actual" = "$expected" ] || fail "Checksum verification failed: $(basename "$file")"
+}
+
+install_minisign_from_upstream() {
+  local minisign_arch
+  case "$(uname -m)" in
+    x86_64) minisign_arch="x86_64" ;;
+    aarch64) minisign_arch="aarch64" ;;
+    *) fail "No pinned minisign bootstrap binary for architecture: $(uname -m)" ;;
+  esac
+
+  local archive="minisign-${MINISIGN_BOOTSTRAP_VERSION}-linux.tar.gz"
+  local url="https://github.com/jedisct1/minisign/releases/download/${MINISIGN_BOOTSTRAP_VERSION}/${archive}"
+  curl_download "$url" "$TMP/$archive" || fail "Download failed: $url"
+  verify_sha256_literal "$TMP/$archive" "$MINISIGN_BOOTSTRAP_SHA256"
+  tar xzf "$TMP/$archive" -C "$TMP" "minisign-linux/${minisign_arch}/minisign"
+  install -m 0755 "$TMP/minisign-linux/${minisign_arch}/minisign" /usr/local/bin/minisign
+}
+
+install_minisign_if_needed
 
 # ── detect arch ───────────────────────────────────────────────────
 cpu_supports_x86_64_v3() {

--- a/src/config.zig
+++ b/src/config.zig
@@ -40,14 +40,24 @@ fn parseUnknownSniAction(value: []const u8) ?UnknownSniAction {
     return null;
 }
 
-/// Parse "YYYY-MM-DD" into Unix seconds at 00:00 UTC of that day (Hinnant's
-/// days_from_civil). Returns null on malformed input.
+/// Parse "YYYY-MM-DD" into the Unix-seconds instant the user EXPIRES — i.e. 00:00 UTC
+/// of the day AFTER the named date, so the user stays valid through the whole named
+/// UTC date (end-of-day inclusive). Returns null on any malformed / impossible date.
+/// (Hinnant's days_from_civil.)
 fn parseExpiryToUnix(value: []const u8) ?i64 {
     if (value.len != 10 or value[4] != '-' or value[7] != '-') return null;
+    // Digits only — std.fmt.parseInt would otherwise accept '+'/'-' signs.
+    for ([_][]const u8{ value[0..4], value[5..7], value[8..10] }) |field| {
+        for (field) |c| if (c < '0' or c > '9') return null;
+    }
     const y = std.fmt.parseInt(i64, value[0..4], 10) catch return null;
     const m = std.fmt.parseInt(i64, value[5..7], 10) catch return null;
     const d = std.fmt.parseInt(i64, value[8..10], 10) catch return null;
-    if (m < 1 or m > 12 or d < 1 or d > 31) return null;
+    if (y < 1970 or y > 9999 or m < 1 or m > 12) return null;
+    // Reject impossible days (e.g. Feb 31) instead of silently rolling them forward.
+    const leap = (@mod(y, 4) == 0 and @mod(y, 100) != 0) or @mod(y, 400) == 0;
+    const month_days = [_]i64{ 31, if (leap) 29 else 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+    if (d < 1 or d > month_days[@intCast(m - 1)]) return null;
     const ym = y - @as(i64, @intFromBool(m <= 2));
     const era = @divFloor(if (ym >= 0) ym else ym - 399, 400);
     const yoe = ym - era * 400;
@@ -55,7 +65,7 @@ fn parseExpiryToUnix(value: []const u8) ?i64 {
     const doy = @divTrunc(153 * mp + 2, 5) + d - 1;
     const doe = yoe * 365 + @divTrunc(yoe, 4) - @divTrunc(yoe, 100) + doy;
     const days = era * 146097 + doe - 719468;
-    return days * 86400;
+    return (days + 1) * 86400; // +1 day → expiry at 00:00 UTC the following day
 }
 
 fn parseUpstreamMode(value: []const u8) ?UpstreamMode {
@@ -237,10 +247,12 @@ pub const Config = struct {
     /// Section: [access.direct_users] (alias: [access.admins])
     direct_users: std.StringHashMap(void),
     /// Optional per-user concurrent-connection caps. Section [access.user_max_conns]
-    /// (name = N). null/absent = no cap. Hot-reloadable with the access-user reload.
+    /// (name = N). null/absent = no cap. Read at startup; changing it needs a restart
+    /// (a SIGHUP reload does not pick it up).
     user_max_conns: ?std.StringHashMap(u32) = null,
-    /// Optional per-user expiry (Unix seconds). Section [access.user_expirations]
-    /// (name = "YYYY-MM-DD"). null/absent = never expires. Hot-reloadable.
+    /// Optional per-user expiry. Section [access.user_expirations] (name = "YYYY-MM-DD",
+    /// end-of-day inclusive). null/absent = never expires. Read at startup; changing it
+    /// needs a restart.
     user_expirations: ?std.StringHashMap(i64) = null,
     /// Whether to mask bad clients (forward to tls_domain)
     mask: bool = true,
@@ -1356,10 +1368,15 @@ test "parse config - defaults for new knobs" {
 }
 
 test "parseExpiryToUnix" {
-    try std.testing.expectEqual(@as(i64, 1609459200), parseExpiryToUnix("2021-01-01").?); // 2021-01-01 00:00 UTC
-    try std.testing.expectEqual(@as(i64, 1640908800), parseExpiryToUnix("2021-12-31").?); // 2021-12-31 00:00 UTC
+    // End-of-day inclusive: expiry is 00:00 UTC of the FOLLOWING day.
+    try std.testing.expectEqual(@as(i64, 1609545600), parseExpiryToUnix("2021-01-01").?); // → 2021-01-02 00:00 UTC
+    try std.testing.expectEqual(@as(i64, 1640995200), parseExpiryToUnix("2021-12-31").?); // → 2022-01-01 00:00 UTC
+    try std.testing.expectEqual(@as(i64, 1583020800), parseExpiryToUnix("2020-02-29").?); // leap day valid
     try std.testing.expect(parseExpiryToUnix("not-a-date") == null);
-    try std.testing.expect(parseExpiryToUnix("2021-13-01") == null);
+    try std.testing.expect(parseExpiryToUnix("2021-13-01") == null); // bad month
+    try std.testing.expect(parseExpiryToUnix("2021-02-29") == null); // 2021 not a leap year
+    try std.testing.expect(parseExpiryToUnix("2021-04-31") == null); // April has 30 days
+    try std.testing.expect(parseExpiryToUnix("2021--1-01") == null); // signed field rejected
     try std.testing.expect(parseExpiryToUnix("2021-1-1") == null); // wrong length
 }
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -23,6 +23,41 @@ pub const UpstreamMode = enum {
     http,
 };
 
+/// Action for a TLS ClientHello whose SNI doesn't match tls_domain.
+pub const UnknownSniAction = enum {
+    /// Forward to the masking backend (current default; no wire change).
+    mask,
+    /// Emit a real `unrecognized_name` TLS alert (like stock nginx), then close.
+    reject,
+    /// Close silently with no response.
+    drop,
+};
+
+fn parseUnknownSniAction(value: []const u8) ?UnknownSniAction {
+    if (std.mem.eql(u8, value, "mask")) return .mask;
+    if (std.mem.eql(u8, value, "reject")) return .reject;
+    if (std.mem.eql(u8, value, "drop")) return .drop;
+    return null;
+}
+
+/// Parse "YYYY-MM-DD" into Unix seconds at 00:00 UTC of that day (Hinnant's
+/// days_from_civil). Returns null on malformed input.
+fn parseExpiryToUnix(value: []const u8) ?i64 {
+    if (value.len != 10 or value[4] != '-' or value[7] != '-') return null;
+    const y = std.fmt.parseInt(i64, value[0..4], 10) catch return null;
+    const m = std.fmt.parseInt(i64, value[5..7], 10) catch return null;
+    const d = std.fmt.parseInt(i64, value[8..10], 10) catch return null;
+    if (m < 1 or m > 12 or d < 1 or d > 31) return null;
+    const ym = y - @as(i64, @intFromBool(m <= 2));
+    const era = @divFloor(if (ym >= 0) ym else ym - 399, 400);
+    const yoe = ym - era * 400;
+    const mp: i64 = if (m > 2) m - 3 else m + 9;
+    const doy = @divTrunc(153 * mp + 2, 5) + d - 1;
+    const doe = yoe * 365 + @divTrunc(yoe, 4) - @divTrunc(yoe, 100) + doy;
+    const days = era * 146097 + doe - 719468;
+    return days * 86400;
+}
+
 fn parseUpstreamMode(value: []const u8) ?UpstreamMode {
     if (std.mem.eql(u8, value, "auto")) return .auto;
     if (std.mem.eql(u8, value, "direct") or std.mem.eql(u8, value, "none")) return .direct;
@@ -171,6 +206,10 @@ pub const Config = struct {
     workers: u16 = 1,
     /// Pre-handshake idle timeout: wait for first client byte
     idle_timeout_sec: u32 = 120,
+    /// Per-connection random jitter (± percent, 0-100) applied to the effective idle
+    /// timeout, so a constant timeout isn't itself a behavioral fingerprint. Computed
+    /// once per slot. 0 disables jitter.
+    idle_timeout_jitter_pct: u8 = 15,
     /// Handshake read timeout after first byte arrives
     handshake_timeout_sec: u32 = 15,
     /// Graceful shutdown drain timeout on SIGTERM.
@@ -197,6 +236,12 @@ pub const Config = struct {
     /// Users that always bypass MiddleProxy and connect to DC directly.
     /// Section: [access.direct_users] (alias: [access.admins])
     direct_users: std.StringHashMap(void),
+    /// Optional per-user concurrent-connection caps. Section [access.user_max_conns]
+    /// (name = N). null/absent = no cap. Hot-reloadable with the access-user reload.
+    user_max_conns: ?std.StringHashMap(u32) = null,
+    /// Optional per-user expiry (Unix seconds). Section [access.user_expirations]
+    /// (name = "YYYY-MM-DD"). null/absent = never expires. Hot-reloadable.
+    user_expirations: ?std.StringHashMap(i64) = null,
     /// Whether to mask bad clients (forward to tls_domain)
     mask: bool = true,
     /// Optional backend host for masked clients. When unset, mask_port=443 uses
@@ -211,6 +256,11 @@ pub const Config = struct {
     /// is plain, DPI-fingerprintable MTProto. Set to false ONLY if you need to
     /// hand out dd links (lower-DPI / compatibility scenarios).
     fake_tls_only: bool = true,
+    /// What to do with a TLS ClientHello whose SNI doesn't match tls_domain:
+    /// `mask` (default — forward to the masking backend, current behavior),
+    /// `reject` (emit a real `unrecognized_name` TLS alert like stock nginx, then
+    /// close), or `drop` (silent close). Default keeps the wire unchanged.
+    unknown_sni_action: UnknownSniAction = .mask,
     /// TCP desync: split ServerHello into 1-byte + rest to evade DPI
     desync: bool = true,
     /// Dynamic Record Sizing: ramp TLS records from 1369→16384 bytes
@@ -425,6 +475,8 @@ pub const Config = struct {
         var lines = std.mem.splitScalar(u8, content, '\n');
         var in_users_section = false;
         var in_direct_users_section = false;
+        var in_user_max_conns_section = false;
+        var in_user_expirations_section = false;
         var in_censorship_section = false;
         var in_server_section = false;
         var in_general_section = false;
@@ -445,6 +497,8 @@ pub const Config = struct {
             if (line[0] == '[') {
                 in_users_section = std.mem.eql(u8, line, "[access.users]");
                 in_direct_users_section = std.mem.eql(u8, line, "[access.direct_users]") or std.mem.eql(u8, line, "[access.admins]");
+                in_user_max_conns_section = std.mem.eql(u8, line, "[access.user_max_conns]");
+                in_user_expirations_section = std.mem.eql(u8, line, "[access.user_expirations]");
                 in_censorship_section = std.mem.eql(u8, line, "[censorship]");
                 in_server_section = std.mem.eql(u8, line, "[server]");
                 in_general_section = std.mem.eql(u8, line, "[general]");
@@ -495,6 +549,23 @@ pub const Config = struct {
                     if (!cfg.direct_users.contains(key)) {
                         const name = try allocator.dupe(u8, key);
                         try cfg.direct_users.put(name, {});
+                    }
+                } else if (in_user_max_conns_section) {
+                    const cap = std.fmt.parseInt(u32, value, 10) catch continue;
+                    if (cap == 0) continue; // 0 == no limit
+                    if (cfg.user_max_conns == null) cfg.user_max_conns = std.StringHashMap(u32).init(allocator);
+                    if (cfg.user_max_conns.?.getKey(key)) |_| {
+                        try cfg.user_max_conns.?.put(key, cap);
+                    } else {
+                        try cfg.user_max_conns.?.put(try allocator.dupe(u8, key), cap);
+                    }
+                } else if (in_user_expirations_section) {
+                    const ts = parseExpiryToUnix(value) orelse continue;
+                    if (cfg.user_expirations == null) cfg.user_expirations = std.StringHashMap(i64).init(allocator);
+                    if (cfg.user_expirations.?.getKey(key)) |_| {
+                        try cfg.user_expirations.?.put(key, ts);
+                    } else {
+                        try cfg.user_expirations.?.put(try allocator.dupe(u8, key), ts);
                     }
                 } else if (in_general_section) {
                     if (std.mem.eql(u8, key, "use_middle_proxy")) {
@@ -584,6 +655,9 @@ pub const Config = struct {
                     } else if (std.mem.eql(u8, key, "handshake_flood_guard_block_sec")) {
                         const parsed = std.fmt.parseInt(u16, value, 10) catch cfg.handshake_flood_guard_block_sec;
                         cfg.handshake_flood_guard_block_sec = @max(@as(u16, 1), parsed);
+                    } else if (std.mem.eql(u8, key, "idle_timeout_jitter_pct")) {
+                        const parsed = std.fmt.parseInt(u8, value, 10) catch cfg.idle_timeout_jitter_pct;
+                        cfg.idle_timeout_jitter_pct = @min(@as(u8, 100), parsed);
                     } else if (std.mem.eql(u8, key, "unsafe_override_limits")) {
                         cfg.unsafe_override_limits = std.mem.eql(u8, value, "true");
                     }
@@ -614,6 +688,8 @@ pub const Config = struct {
                         cfg.drs = std.mem.eql(u8, value, "true");
                     } else if (std.mem.eql(u8, key, "fast_mode")) {
                         cfg.fast_mode = std.mem.eql(u8, value, "true");
+                    } else if (std.mem.eql(u8, key, "unknown_sni_action")) {
+                        if (parseUnknownSniAction(value)) |action| cfg.unknown_sni_action = action;
                     }
                 } else if (in_metrics_section) {
                     if (std.mem.eql(u8, key, "enabled")) {
@@ -677,6 +753,19 @@ pub const Config = struct {
             allocator.free(entry.key_ptr.*);
         }
         direct_users.deinit();
+
+        if (self.user_max_conns) |maxc| {
+            var m = @constCast(&maxc);
+            var mit = m.iterator();
+            while (mit.next()) |entry| allocator.free(entry.key_ptr.*);
+            m.deinit();
+        }
+        if (self.user_expirations) |exps| {
+            var e = @constCast(&exps);
+            var eit = e.iterator();
+            while (eit.next()) |entry| allocator.free(entry.key_ptr.*);
+            e.deinit();
+        }
 
         // Free tls_domain only when it does not point to the compile-time default.
         if (self.tls_domain.ptr != default_tls_domain.ptr) {
@@ -1227,6 +1316,51 @@ test "parse config - handshake flood guard defaults disabled" {
     try std.testing.expectEqual(@as(u16, 20), cfg.handshake_flood_guard_threshold);
     try std.testing.expectEqual(@as(u16, 30), cfg.handshake_flood_guard_window_sec);
     try std.testing.expectEqual(@as(u16, 120), cfg.handshake_flood_guard_block_sec);
+}
+
+test "parse config - evasion/UX knobs (sni action, idle jitter, per-user limits)" {
+    const content =
+        \\[server]
+        \\idle_timeout_jitter_pct = 25
+        \\[censorship]
+        \\unknown_sni_action = reject
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+        \\[access.user_max_conns]
+        \\alice = 3
+        \\bob = 0
+        \\[access.user_expirations]
+        \\alice = "2026-12-31"
+    ;
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u8, 25), cfg.idle_timeout_jitter_pct);
+    try std.testing.expectEqual(UnknownSniAction.reject, cfg.unknown_sni_action);
+    try std.testing.expectEqual(@as(u32, 3), cfg.user_max_conns.?.get("alice").?);
+    // 0 == "no limit" → not stored
+    try std.testing.expect(cfg.user_max_conns.?.get("bob") == null);
+    try std.testing.expect(cfg.user_expirations.?.get("alice").? > 0);
+}
+
+test "parse config - defaults for new knobs" {
+    const content =
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(u8, 15), cfg.idle_timeout_jitter_pct);
+    try std.testing.expectEqual(UnknownSniAction.mask, cfg.unknown_sni_action);
+    try std.testing.expect(cfg.user_max_conns == null);
+    try std.testing.expect(cfg.user_expirations == null);
+}
+
+test "parseExpiryToUnix" {
+    try std.testing.expectEqual(@as(i64, 1609459200), parseExpiryToUnix("2021-01-01").?); // 2021-01-01 00:00 UTC
+    try std.testing.expectEqual(@as(i64, 1640908800), parseExpiryToUnix("2021-12-31").?); // 2021-12-31 00:00 UTC
+    try std.testing.expect(parseExpiryToUnix("not-a-date") == null);
+    try std.testing.expect(parseExpiryToUnix("2021-13-01") == null);
+    try std.testing.expect(parseExpiryToUnix("2021-1-1") == null); // wrong length
 }
 
 test "parse config - handshake flood guard custom values" {

--- a/src/ctl/config_cmd.zig
+++ b/src/ctl/config_cmd.zig
@@ -278,7 +278,8 @@ fn parsePingRttMs(output: []const u8) ?u32 {
     if (end == 0) return null;
     rest = rest[0..end];
     const rtt_f = std.fmt.parseFloat(f64, rest) catch return null;
-    if (rtt_f < 0) return null;
+    // Reject out-of-range values so @intFromFloat can't panic on a garbage RTT.
+    if (rtt_f < 0 or rtt_f > @as(f64, std.math.maxInt(u32))) return null;
     return @intFromFloat(rtt_f);
 }
 
@@ -394,6 +395,7 @@ fn runNetworkDoctorDirect(
         }
     }
 
+    var blackholed = false;
     switch (classifyDcVerdict(reachable_count, telegram_dc_probes.len)) {
         .reachable => ui.ok("Telegram DCs reachable directly"),
         .partial => {
@@ -401,10 +403,14 @@ fn runNetworkDoctorDirect(
             warnings.* += 1;
         },
         .blackholed => {
-            ui.fail("DC IPs look blackholed (SYN timeout) - egress via a tunnel/clean IP");
-            ui.hint("Set upstream=tunnel or upstream=socks5 to route around the IP block.");
-            errors.* += 1;
-            return;
+            // A SYN timeout on every DC IP is *suggestive* of an L3 blackhole, but it
+            // also fires on IPv6-only paths, a local firewall, or transient loss — so
+            // don't hard-fail here. Warn, and let the metadata fetch below arbitrate
+            // (only escalate to an error if that fails too).
+            ui.warn("No SYN-ACK from any probed DC IP (possible L3 blackhole, IPv6-only path, or local firewall)");
+            ui.hint("If the metadata fetch below also fails, egress via a tunnel/clean IP (upstream=tunnel/socks5).");
+            warnings.* += 1;
+            blackholed = true;
         },
     }
 
@@ -415,6 +421,9 @@ fn runNetworkDoctorDirect(
     if (bytes) |body| {
         allocator.free(body);
         ui.ok("Telegram metadata fetch works directly");
+    } else if (blackholed) {
+        ui.fail("DC IPs unreachable (SYN timeout) AND metadata fetch failed - egress via a tunnel/clean IP");
+        errors.* += 1;
     } else {
         ui.warn("Telegram metadata fetch failed directly (DPI/TLS interference or DNS)");
         warnings.* += 1;
@@ -437,6 +446,7 @@ fn runNetworkDoctorTunnel(
     const dc_ip = telegram_dc_probes[telegram_dc_probes.len - 1].ip; // 149.154.175.50
 
     var idx: usize = 0;
+    var probed: usize = 0;
     var any_reachable = false;
     while (cfg.tunnelCandidateAt(idx)) |iface| : (idx += 1) {
         if (!isSafeInterfaceName(iface)) {
@@ -444,6 +454,7 @@ fn runNetworkDoctorTunnel(
             warnings.* += 1;
             continue;
         }
+        probed += 1;
 
         // L7 check: does a DC metadata fetch egress through this interface?
         const reachable = blk: {
@@ -472,13 +483,16 @@ fn runNetworkDoctorTunnel(
         }
     }
 
-    if (idx == 0) {
+    // NOTE: rely on `probed`, not `idx`. A `break` on the first reachable interface
+    // skips the `: (idx += 1)` continuation, so idx stays 0 on the happy path — using
+    // it here would print a bogus "no interface" warning exactly when it worked.
+    if (probed == 0) {
         ui.warn("No tunnel interface configured to probe");
         warnings.* += 1;
-        return;
-    }
-    if (!any_reachable) {
-        ui.fail("Telegram unreachable via tunnel (check the tunnel is up and routes Telegram)");
+    } else if (!any_reachable) {
+        // Glyph matches the counter: a tunnel that can't reach Telegram is a warning
+        // (the proxy may still reach DCs another way), not a hard error.
+        ui.warn("Telegram unreachable via tunnel (check the tunnel is up and routes Telegram)");
         warnings.* += 1;
     }
 }

--- a/src/ctl/config_cmd.zig
+++ b/src/ctl/config_cmd.zig
@@ -76,6 +76,34 @@ test "config command recognizes network doctor flag" {
     try std.testing.expect(!isNetworkFlag("--config"));
 }
 
+test "doctor - classifyDcVerdict maps reachability to verdict" {
+    try std.testing.expectEqual(DcVerdict.reachable, classifyDcVerdict(2, 2));
+    try std.testing.expectEqual(DcVerdict.partial, classifyDcVerdict(1, 2));
+    try std.testing.expectEqual(DcVerdict.blackholed, classifyDcVerdict(0, 2));
+    // Defensive edge: an empty probe set is treated as a blackhole, not "all up".
+    try std.testing.expectEqual(DcVerdict.blackholed, classifyDcVerdict(0, 0));
+}
+
+test "doctor - parsePingRttMs extracts truncated milliseconds" {
+    const line = "64 bytes from 149.154.175.50: icmp_seq=1 ttl=53 time=42.7 ms";
+    try std.testing.expectEqual(@as(?u32, 42), parsePingRttMs(line));
+    // Integer time= (BusyBox-style) and no trailing space before unit.
+    try std.testing.expectEqual(@as(?u32, 7), parsePingRttMs("... time=7ms"));
+    // No time= token (host unreachable / ping blocked) -> null.
+    try std.testing.expectEqual(@as(?u32, null), parsePingRttMs("100% packet loss"));
+    try std.testing.expectEqual(@as(?u32, null), parsePingRttMs("time="));
+}
+
+test "doctor - isSafeInterfaceName rejects shell metacharacters" {
+    try std.testing.expect(isSafeInterfaceName("awg0"));
+    try std.testing.expect(isSafeInterfaceName("wg0"));
+    try std.testing.expect(isSafeInterfaceName("eth0.100"));
+    try std.testing.expect(!isSafeInterfaceName(""));
+    try std.testing.expect(!isSafeInterfaceName("awg0; rm -rf /"));
+    try std.testing.expect(!isSafeInterfaceName("$(reboot)"));
+    try std.testing.expect(!isSafeInterfaceName("a b"));
+}
+
 fn defaultConfigPath() []const u8 {
     if (sys.fileExists(installed_config_path)) return installed_config_path;
     return local_config_path;
@@ -208,6 +236,78 @@ fn doctor(ui: *Tui, allocator: std.mem.Allocator, path: []const u8, network: boo
     if (errors > 0) return error.ConfigDoctorFailed;
 }
 
+/// Well-known primary Telegram DC IPs (DC2 Amsterdam, DC4 Amsterdam). A
+/// non-blocking SYN to :443 either connects (path works) or times out (the
+/// route is an L3 blackhole, the shape of the current RU IP block). Picking two
+/// independent DCs avoids a single-DC maintenance window reading as "blocked".
+const telegram_dc_probes = [_]struct { label: []const u8, ip: []const u8 }{
+    .{ .label = "DC2", .ip = "149.154.167.50" },
+    .{ .label = "DC4", .ip = "149.154.175.50" },
+};
+
+/// Verdict for the direct-reachability probe. `classifyDcVerdict` maps the
+/// per-DC connect results to one of these so the messaging is a pure,
+/// unit-testable function of "how many DCs answered".
+const DcVerdict = enum { reachable, partial, blackholed };
+
+/// Classify direct DC reachability from connect results. Pure helper so the
+/// verdict wording can be tested without touching the network.
+///   all DCs up        -> reachable  ("DCs reachable directly")
+///   some up, some down -> partial   (asymmetric block / one DC in maintenance)
+///   none up           -> blackholed (SYN timeout on every DC == IP blackhole)
+fn classifyDcVerdict(reachable_count: usize, total: usize) DcVerdict {
+    if (total == 0 or reachable_count == 0) return .blackholed;
+    if (reachable_count == total) return .reachable;
+    return .partial;
+}
+
+/// Parse the round-trip time (in whole milliseconds, truncated) out of a line
+/// of `ping` output, e.g. "... time=42.5 ms" or "... time=42 ms". Returns null
+/// when no `time=` token is present (host unreachable, ping blocked, etc.).
+/// Pure helper, unit-tested against real ping wording.
+fn parsePingRttMs(output: []const u8) ?u32 {
+    const marker = "time=";
+    const idx = std.mem.indexOf(u8, output, marker) orelse return null;
+    var rest = output[idx + marker.len ..];
+    // Number runs up to the first non [0-9.] character (space before "ms").
+    var end: usize = 0;
+    while (end < rest.len) : (end += 1) {
+        const c = rest[end];
+        if (!((c >= '0' and c <= '9') or c == '.')) break;
+    }
+    if (end == 0) return null;
+    rest = rest[0..end];
+    const rtt_f = std.fmt.parseFloat(f64, rest) catch return null;
+    if (rtt_f < 0) return null;
+    return @intFromFloat(rtt_f);
+}
+
+/// Linux interface names are short and restricted; reject anything outside that
+/// set defensively so a config value can never smuggle arguments into the
+/// `ping`/`curl` argv (even though we never go through a shell).
+fn isSafeInterfaceName(iface: []const u8) bool {
+    if (iface.len == 0 or iface.len > 32) return false;
+    for (iface) |c| {
+        const ok_char = (c >= 'a' and c <= 'z') or
+            (c >= 'A' and c <= 'Z') or
+            (c >= '0' and c <= '9') or
+            c == '_' or c == '-' or c == '.' or c == '@' or c == ':';
+        if (!ok_char) return false;
+    }
+    return true;
+}
+
+/// Scratch buffer for one-off "prefix + value" status lines. The doctor is
+/// single-threaded and every message is consumed by ui.ok/ui.warn before the
+/// next joinMsg call, so a shared static buffer is safe and avoids per-line
+/// allocations (and the leaks that `ui.ok(allocPrint(...) catch ...)` invites).
+var join_msg_buf: [160]u8 = undefined;
+
+/// Format "prefix"++"value" into the shared scratch buffer for a status line.
+fn joinMsg(prefix: []const u8, value: []const u8) []const u8 {
+    return std.fmt.bufPrint(&join_msg_buf, "{s}{s}", .{ prefix, value }) catch prefix;
+}
+
 fn runNetworkDoctor(
     ui: *Tui,
     allocator: std.mem.Allocator,
@@ -219,81 +319,202 @@ fn runNetworkDoctor(
     ui.section("Network probes");
 
     switch (cfg.upstream_mode) {
-        .socks5, .http => {
-            const host = cfg.upstream_proxy_host orelse {
-                ui.fail("upstream proxy host is missing");
-                errors.* += 1;
-                return;
-            };
-            if (cfg.upstream_proxy_port == 0) {
-                ui.fail("upstream proxy port is missing");
-                errors.* += 1;
-                return;
-            }
+        .socks5, .http => runNetworkDoctorProxy(ui, allocator, cfg, errors, warnings),
+        .tunnel => runNetworkDoctorTunnel(ui, allocator, cfg, errors, warnings),
+        .auto, .direct => runNetworkDoctorDirect(ui, allocator, cfg, errors, warnings),
+    }
 
-            if (probeTcpEndpoint(allocator, host, cfg.upstream_proxy_port, 3000)) {
-                ui.ok("upstream proxy TCP endpoint is reachable");
-            } else {
-                ui.fail("upstream proxy TCP endpoint is not reachable");
-                errors.* += 1;
-            }
+    // Cheap, always-useful: confirm a client link can actually be generated.
+    runNetworkDoctorLink(ui, cfg, warnings);
+}
 
-            const kind: http_fetch.ProxyKind = if (cfg.upstream_mode == .socks5) .socks5 else .http_connect;
-            const bytes = http_fetch.fetchUrlBytesViaProxy(allocator, middle_proxy_config_url, .{
-                .kind = kind,
-                .host = host,
-                .port = cfg.upstream_proxy_port,
-                .username = cfg.upstream_proxy_username,
-                .password = cfg.upstream_proxy_password,
-            }) catch null;
-            if (bytes) |body| {
-                allocator.free(body);
-                ui.ok("Telegram metadata fetch works through configured upstream");
-            } else {
-                ui.fail("Telegram metadata fetch through configured upstream failed");
-                errors.* += 1;
-            }
-        },
-        .tunnel => {
-            if (probeTunnelMetadata(allocator, cfg)) {
-                ui.ok("Telegram metadata fetch works through configured tunnel interface");
-            } else {
-                ui.warn("Telegram metadata fetch through tunnel interface failed");
-                warnings.* += 1;
-            }
-        },
-        .auto, .direct => {
-            if (probeTcpEndpoint(allocator, "149.154.175.50", 443, 3000)) {
-                ui.ok("Telegram DC1 TCP endpoint is reachable");
-            } else {
-                ui.fail("Telegram DC1 TCP endpoint is not reachable");
-                errors.* += 1;
-            }
+fn runNetworkDoctorProxy(
+    ui: *Tui,
+    allocator: std.mem.Allocator,
+    cfg: *const Config,
+    errors: *usize,
+    warnings: *usize,
+) void {
+    _ = warnings;
+    const host = cfg.upstream_proxy_host orelse {
+        ui.fail("upstream proxy host is missing");
+        errors.* += 1;
+        return;
+    };
+    if (cfg.upstream_proxy_port == 0) {
+        ui.fail("upstream proxy port is missing");
+        errors.* += 1;
+        return;
+    }
 
-            // The direct std.http fetch has no explicit timeout; on a blackholed
-            // route it blocks on the OS TCP connect timeout (up to ~2 min). Warn
-            // the operator so a slow probe doesn't look like a hang.
-            ui.hint("Probing core.telegram.org directly (may take up to the OS connect timeout on a censored route)...");
-            const bytes = http_fetch.fetchUrlBytes(allocator, middle_proxy_config_url) catch null;
-            if (bytes) |body| {
-                allocator.free(body);
-                ui.ok("Telegram metadata fetch works directly");
-            } else {
-                ui.warn("Telegram metadata fetch failed directly");
-                warnings.* += 1;
-            }
-        },
+    if (probeTcpEndpoint(allocator, host, cfg.upstream_proxy_port, 3000)) {
+        ui.ok("upstream proxy TCP endpoint is reachable");
+    } else {
+        ui.fail("upstream proxy TCP endpoint is not reachable");
+        errors.* += 1;
+    }
+
+    const kind: http_fetch.ProxyKind = if (cfg.upstream_mode == .socks5) .socks5 else .http_connect;
+    const bytes = http_fetch.fetchUrlBytesViaProxy(allocator, middle_proxy_config_url, .{
+        .kind = kind,
+        .host = host,
+        .port = cfg.upstream_proxy_port,
+        .username = cfg.upstream_proxy_username,
+        .password = cfg.upstream_proxy_password,
+    }) catch null;
+    if (bytes) |body| {
+        allocator.free(body);
+        ui.ok("Telegram metadata fetch works through configured upstream");
+    } else {
+        ui.fail("Telegram metadata fetch through configured upstream failed");
+        errors.* += 1;
     }
 }
 
-fn probeTunnelMetadata(allocator: std.mem.Allocator, cfg: *const Config) bool {
-    var idx: usize = 0;
-    while (cfg.tunnelCandidateAt(idx)) |iface| : (idx += 1) {
-        const bytes = http_fetch.fetchUrlBytesViaInterface(allocator, middle_proxy_config_url, iface) catch continue;
-        allocator.free(bytes);
-        return true;
+/// "Am I blocked?" probe for direct/auto egress. Hits a couple of well-known DC
+/// IPs and prints a single clear verdict so an operator can tell an L3 blackhole
+/// (the current RU block: SYN times out) from a working path.
+fn runNetworkDoctorDirect(
+    ui: *Tui,
+    allocator: std.mem.Allocator,
+    cfg: *const Config,
+    errors: *usize,
+    warnings: *usize,
+) void {
+    _ = cfg; // direct probe uses fixed DC IPs; config is irrelevant here.
+    ui.hint("Probing well-known Telegram DC IPs on :443 (SYN timeout vs connect)...");
+
+    var reachable_count: usize = 0;
+    for (telegram_dc_probes) |dc| {
+        if (probeTcpEndpoint(allocator, dc.ip, 443, 3000)) {
+            reachable_count += 1;
+            ui.ok(joinMsg("reached ", dc.ip));
+        } else {
+            ui.warn(joinMsg("no SYN-ACK from ", dc.ip));
+        }
     }
-    return false;
+
+    switch (classifyDcVerdict(reachable_count, telegram_dc_probes.len)) {
+        .reachable => ui.ok("Telegram DCs reachable directly"),
+        .partial => {
+            ui.warn("Some Telegram DCs reachable, some not (asymmetric block or DC maintenance)");
+            warnings.* += 1;
+        },
+        .blackholed => {
+            ui.fail("DC IPs look blackholed (SYN timeout) - egress via a tunnel/clean IP");
+            ui.hint("Set upstream=tunnel or upstream=socks5 to route around the IP block.");
+            errors.* += 1;
+            return;
+        },
+    }
+
+    // Confirm the full DC handshake, not just TCP: on a censored route this can
+    // block on the OS connect timeout, so warn the operator before it runs.
+    ui.hint("Fetching Telegram metadata directly (may take up to the OS connect timeout on a censored route)...");
+    const bytes = http_fetch.fetchUrlBytes(allocator, middle_proxy_config_url) catch null;
+    if (bytes) |body| {
+        allocator.free(body);
+        ui.ok("Telegram metadata fetch works directly");
+    } else {
+        ui.warn("Telegram metadata fetch failed directly (DPI/TLS interference or DNS)");
+        warnings.* += 1;
+    }
+}
+
+/// "Am I blocked?" probe for tunnel egress. Confirms a DC is reachable *through*
+/// the tunnel interface and reports the bound-interface RTT, so an operator can
+/// see the tunnel is actually carrying traffic (not just that it exists).
+fn runNetworkDoctorTunnel(
+    ui: *Tui,
+    allocator: std.mem.Allocator,
+    cfg: *const Config,
+    errors: *usize,
+    warnings: *usize,
+) void {
+    _ = errors;
+    ui.hint("Probing a Telegram DC through the tunnel interface...");
+
+    const dc_ip = telegram_dc_probes[telegram_dc_probes.len - 1].ip; // 149.154.175.50
+
+    var idx: usize = 0;
+    var any_reachable = false;
+    while (cfg.tunnelCandidateAt(idx)) |iface| : (idx += 1) {
+        if (!isSafeInterfaceName(iface)) {
+            ui.warn(joinMsg("skipping interface with unexpected name: ", iface));
+            warnings.* += 1;
+            continue;
+        }
+
+        // L7 check: does a DC metadata fetch egress through this interface?
+        const reachable = blk: {
+            const bytes = http_fetch.fetchUrlBytesViaInterface(allocator, middle_proxy_config_url, iface) catch break :blk false;
+            allocator.free(bytes);
+            break :blk true;
+        };
+
+        if (reachable) {
+            any_reachable = true;
+            if (probeTunnelRtt(allocator, iface, dc_ip)) |rtt| {
+                var buf: [128]u8 = undefined;
+                const msg = std.fmt.bufPrint(
+                    &buf,
+                    "reachable via tunnel {s} (RTT {d}ms)",
+                    .{ iface, rtt },
+                ) catch joinMsg("reachable via tunnel ", iface);
+                ui.ok(msg);
+            } else {
+                ui.ok(joinMsg("reachable via tunnel ", iface));
+                ui.hint("RTT unavailable (ICMP/ping blocked on this interface).");
+            }
+            break;
+        } else {
+            ui.warn(joinMsg("no Telegram egress via tunnel ", iface));
+        }
+    }
+
+    if (idx == 0) {
+        ui.warn("No tunnel interface configured to probe");
+        warnings.* += 1;
+        return;
+    }
+    if (!any_reachable) {
+        ui.fail("Telegram unreachable via tunnel (check the tunnel is up and routes Telegram)");
+        warnings.* += 1;
+    }
+}
+
+/// Report whether a client tg:// link can be produced from this config. Mirrors
+/// the inputs `links.zig` needs (a server host + at least one user + tls_domain)
+/// rather than re-deriving the secret encoding, which lives in links.zig. Skips
+/// gracefully when the link-building inputs are absent.
+fn runNetworkDoctorLink(ui: *Tui, cfg: *const Config, warnings: *usize) void {
+    if (cfg.users.count() == 0) {
+        ui.warn("No users configured - no tg:// link to generate");
+        warnings.* += 1;
+        return;
+    }
+    if (cfg.public_ip == null) {
+        ui.hint("public_ip not set; links will use the auto-detected egress IP at print time.");
+    }
+
+    var buf: [96]u8 = undefined;
+    const msg = std.fmt.bufPrint(
+        &buf,
+        "tg:// links available for {d} user(s) on port {d} (`mtbuddy links`)",
+        .{ cfg.users.count(), cfg.publicLinkPort() },
+    ) catch "tg:// links available (`mtbuddy links`)";
+    ui.ok(msg);
+}
+
+/// Measure RTT to `host` bound to `iface` via `ping`, returning whole ms or
+/// null on failure/timeout/blocked ICMP. Uses an argv array (no shell) so the
+/// interface name can never be interpreted as additional arguments.
+fn probeTunnelRtt(allocator: std.mem.Allocator, iface: []const u8, host: []const u8) ?u32 {
+    const result = sys.exec(allocator, &.{
+        "ping", "-I", iface, "-c", "1", "-W", "2", host,
+    }) catch return null;
+    defer result.deinit();
+    return parsePingRttMs(result.stdout);
 }
 
 fn probeTcpEndpoint(allocator: std.mem.Allocator, host: []const u8, port: u16, timeout_ms: i32) bool {

--- a/src/ctl/dashboard_assets/server.py
+++ b/src/ctl/dashboard_assets/server.py
@@ -445,6 +445,9 @@ def _proxy_info() -> dict:
 _awg_cache = {"ts": 0, "data": None}
 AWG_CACHE_TTL = 10  # seconds
 
+_egress_cache = {"ts": 0, "data": None}
+EGRESS_CACHE_TTL = 12  # seconds (allows 2-3 quality checks per poll, avoiding hammering)
+
 
 def _awg_status() -> dict:
     """Check AmneziaWG tunnel status (host namespace)."""
@@ -820,6 +823,194 @@ def _probe_tunnel_interface(interface: str) -> dict:
     if r.returncode == 0:
         return {"ok": True, "reason": "Telegram probe ok"}
     return {"ok": False, "reason": "Telegram probe failed"}
+
+
+# ── Egress / tunnel quality probing ──────────────────────────────────────────
+# Surfaces whether the upstream VPN tunnel (awg0/wg0/…) is the bottleneck:
+# link state, last WireGuard/AmneziaWG handshake age, RTT and packet loss to a
+# Telegram DC reached *via that interface*. Everything degrades to None when the
+# deployment is not a tunnel or the tools are missing — never an error.
+
+# A Telegram DC IPv4 (DC2, the canonical core endpoint) so the probe traverses
+# the same path real proxy traffic would, rather than a generic public host.
+EGRESS_PROBE_IP = "149.154.167.51"
+
+
+def _tunnel_handshake_age(interface: str, tool_hint: str | None = None) -> int | None:
+    """Return the age in seconds of the most recent WG/AWG handshake on the
+    interface, or None if no handshake / tool unavailable.
+
+    Uses `<tool> show <iface> latest-handshakes` which reports a unix epoch per
+    peer; age = now - max(epoch). An epoch of 0 means "never" → None.
+    """
+    tools: list[str] = []
+    if tool_hint:
+        tools.append(tool_hint)
+    for name in ("awg", "wg"):
+        if name not in tools:
+            tools.append(name)
+
+    for tool in tools:
+        if not shutil.which(tool):
+            continue
+        try:
+            out = subprocess.check_output(
+                [tool, "show", interface, "latest-handshakes"],
+                text=True,
+                timeout=3,
+                stderr=subprocess.DEVNULL,
+            )
+        except Exception:
+            continue
+
+        best_epoch = 0
+        for line in out.splitlines():
+            parts = line.split()
+            if not parts:
+                continue
+            try:
+                epoch = int(parts[-1])
+            except ValueError:
+                continue
+            if epoch > best_epoch:
+                best_epoch = epoch
+
+        if best_epoch <= 0:
+            return None
+        age = int(time.time()) - best_epoch
+        return age if age >= 0 else 0
+
+    return None
+
+
+def _tunnel_rtt(interface: str, gateway_ip: str = EGRESS_PROBE_IP, timeout: int = 3) -> float | None:
+    """Measure RTT to a DC via the specified interface using ping.
+
+    Returns RTT in milliseconds (float), or None if unavailable/timeout.
+    On error or tool unavailable, returns None silently (dashboard displays as "—").
+    """
+    if not shutil.which("ping"):
+        return None
+
+    try:
+        # Use -I to bind to specific interface, -c 1 for single packet, -W for timeout (ms)
+        result = subprocess.run(
+            ["ping", "-I", interface, "-c", "1", "-W", str(timeout * 1000), gateway_ip],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=timeout + 1,
+        )
+        if result.returncode != 0:
+            return None
+
+        # Parse "time=X.XXX ms" from output
+        m = re.search(r"time=([\d.]+)\s*ms", result.stdout)
+        if m:
+            return float(m[1])
+    except Exception:
+        pass
+
+    return None
+
+
+def _tunnel_packet_loss(interface: str, gateway_ip: str = EGRESS_PROBE_IP, count: int = 10, timeout: int = 5) -> float | None:
+    """Measure packet loss % to DC via interface.
+
+    Sends `count` pings, returns loss as % (0-100), or None if unavailable.
+    """
+    if not shutil.which("ping"):
+        return None
+
+    try:
+        result = subprocess.run(
+            ["ping", "-I", interface, "-c", str(count), "-W", str(timeout * 1000), gateway_ip],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=timeout + 1,
+        )
+
+        # Parse "X% packet loss" (works on Linux, macOS)
+        m = re.search(r"([\d.]+)%\s+(?:packet\s+)?loss", result.stdout)
+        if m:
+            return float(m[1])
+    except Exception:
+        pass
+
+    return None
+
+
+def _tunnel_egress_health(interface: str, tool_hint: str | None = None) -> dict:
+    """Comprehensive egress/tunnel health check.
+
+    Returns:
+    {
+        "interface": str,
+        "up": bool,                    # link is operational
+        "handshake_age_sec": int | None,  # age of last WG/AWG handshake
+        "rtt_ms": float | None,        # round-trip time in ms
+        "packet_loss_pct": float | None,  # 0-100
+        "quality": str,                # "good", "degraded", "poor", or "unknown"
+    }
+    """
+    result = {
+        "interface": interface,
+        "up": False,
+        "handshake_age_sec": None,
+        "rtt_ms": None,
+        "packet_loss_pct": None,
+        "quality": "unknown",
+    }
+
+    # Check if interface is up
+    try:
+        link_check = subprocess.run(
+            ["ip", "link", "show", "dev", interface],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=2,
+        )
+        if link_check.returncode != 0:
+            result["quality"] = "down"
+            return result
+        result["up"] = True
+    except Exception:
+        result["quality"] = "unknown"
+        return result
+
+    # Last WireGuard/AmneziaWG handshake age (advisory; cross-checks RTT/loss)
+    result["handshake_age_sec"] = _tunnel_handshake_age(interface, tool_hint)
+
+    # Measure RTT and packet loss (non-blocking; silent failure if tools unavailable)
+    rtt = _tunnel_rtt(interface)
+    loss = _tunnel_packet_loss(interface, count=5, timeout=3)
+
+    result["rtt_ms"] = rtt
+    result["packet_loss_pct"] = loss
+
+    # Determine quality based on metrics
+    if loss is None and rtt is None:
+        # Tools not available, but interface is up
+        result["quality"] = "up"
+    elif loss is not None and loss > 0:
+        # Packet loss detected
+        if loss > 10:
+            result["quality"] = "poor"
+        else:
+            result["quality"] = "degraded"
+    elif rtt is not None:
+        # RTT-based heuristic (good = <100ms, degraded = 100-300ms, poor = >300ms)
+        if rtt > 300:
+            result["quality"] = "poor"
+        elif rtt > 100:
+            result["quality"] = "degraded"
+        else:
+            result["quality"] = "good"
+    else:
+        result["quality"] = "up"  # up but metrics unavailable
+
+    return result
 
 
 def _detect_tunnel_interface(interface: str, tool_hint: str | None = None) -> dict:
@@ -2232,6 +2423,87 @@ def api_stats():
             "users": _users_status(),
         }
     )
+
+
+@app.get("/api/egress")
+def api_egress():
+    """Return tunnel/egress health metrics for all active interfaces.
+
+    Returns:
+    {
+        "ok": true,
+        "primary_interface": str | None,
+        "tunnels": [
+            {
+                "interface": str,
+                "up": bool,
+                "handshake_age_sec": int | None,
+                "rtt_ms": float | None,
+                "packet_loss_pct": float | None,
+                "quality": str,  // "good", "degraded", "poor", "up", "down", "unknown"
+                "is_primary": bool,
+            }
+        ],
+        "summary": {"en": str, "ru": str},  // overall quality message
+    }
+    """
+    global _egress_cache
+    now = time.time()
+    if now - _egress_cache["ts"] < EGRESS_CACHE_TTL and _egress_cache["data"]:
+        return JSONResponse(_egress_cache["data"])
+
+    cfg = _load_proxy_runtime_config()
+    routing = _routing_status()
+
+    # Determine which interfaces to check
+    tunnels = []
+    primary_iface = routing.get("active_tunnel_interface") or routing.get("selected_tunnel_interface")
+
+    # Gather all tunnel interfaces to monitor
+    candidates = []
+    if routing.get("tunnels"):
+        for tun in routing["tunnels"]:
+            iface = tun.get("interface")
+            if iface and (tun.get("active") or tun.get("link_up") or tun.get("in_pool")):
+                if iface not in candidates:
+                    candidates.append(iface)
+
+    # If upstream_mode is tunnel, check health for all active/pool members
+    upstream_type = str(cfg.get("upstream_type", "auto") or "auto").lower().strip()
+    if upstream_type == "tunnel" and candidates:
+        for iface in candidates:
+            health = _tunnel_egress_health(iface, _tunnel_tool_hint(iface))
+            health["is_primary"] = (iface == primary_iface)
+            tunnels.append(health)
+
+    # Generate summary (bilingual; rendered client-side per LANG)
+    if not tunnels:
+        primary_iface = None
+        summary_en = "Tunnel monitoring not active (upstream mode is not 'tunnel')"
+        summary_ru = "Мониторинг туннеля не активен (режим upstream не 'tunnel')"
+    else:
+        good_count = sum(1 for t in tunnels if t["quality"] in ("good", "up"))
+        total_count = len(tunnels)
+
+        if good_count == total_count:
+            summary_en = f"All {total_count} tunnel(s) healthy"
+            summary_ru = f"Все {total_count} туннель(и) здоровы"
+        elif good_count > 0:
+            summary_en = f"{good_count}/{total_count} tunnel(s) healthy"
+            summary_ru = f"{good_count}/{total_count} туннель(и) здоровы"
+        else:
+            summary_en = "All tunnels degraded or down"
+            summary_ru = "Все туннели деградированы или отключены"
+
+    result = {
+        "ok": True,
+        "primary_interface": primary_iface,
+        "tunnels": tunnels,
+        "summary": {"en": summary_en, "ru": summary_ru},
+    }
+
+    _egress_cache.update(ts=now, data=result)
+    return JSONResponse(result)
 
 
 # ── Routing Management API ──

--- a/src/ctl/dashboard_assets/server.py
+++ b/src/ctl/dashboard_assets/server.py
@@ -893,9 +893,10 @@ def _tunnel_rtt(interface: str, gateway_ip: str = EGRESS_PROBE_IP, timeout: int 
         return None
 
     try:
-        # Use -I to bind to specific interface, -c 1 for single packet, -W for timeout (ms)
+        # -I binds the interface, -c 1 a single packet. On Linux iputils, -W is the
+        # per-reply wait in SECONDS (not ms) — passing timeout*1000 means "wait 3000s".
         result = subprocess.run(
-            ["ping", "-I", interface, "-c", "1", "-W", str(timeout * 1000), gateway_ip],
+            ["ping", "-I", interface, "-c", "1", "-W", "2", gateway_ip],
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             text=True,
@@ -923,12 +924,15 @@ def _tunnel_packet_loss(interface: str, gateway_ip: str = EGRESS_PROBE_IP, count
         return None
 
     try:
+        # -i 0.2 sends the `count` packets in ~count*0.2s (default 1s interval would
+        # blow the subprocess timeout before the summary prints); -W is per-reply wait
+        # in SECONDS on Linux iputils (not ms). Subprocess timeout covers send + waits.
         result = subprocess.run(
-            ["ping", "-I", interface, "-c", str(count), "-W", str(timeout * 1000), gateway_ip],
+            ["ping", "-I", interface, "-c", str(count), "-i", "0.2", "-W", "2", gateway_ip],
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             text=True,
-            timeout=timeout + 1,
+            timeout=count * 0.3 + 3,
         )
 
         # Parse "X% packet loss" (works on Linux, macOS)

--- a/src/ctl/dashboard_assets/static/app.js
+++ b/src/ctl/dashboard_assets/static/app.js
@@ -17,6 +17,11 @@ const I18N = {
     'routing.title': 'Routing & Upstream', 'routing.upstream': 'Upstream', 'routing.tunnelPin': 'Tunnel pin',
     'routing.proxyHost': 'Proxy host', 'routing.port': 'Port', 'routing.user': 'User', 'routing.pass': 'Pass', 'routing.target': 'Target', 'routing.policy': 'Policy',
     'mask.title': 'Masking Health', 'mask.mode': 'Mode', 'mask.endpoint': 'Endpoint', 'mask.timer': 'Health Timer',
+    'egress.title': 'Tunnel Quality', 'egress.interface': 'Interface', 'egress.status': 'Status',
+    'egress.rtt': 'RTT', 'egress.loss': 'Loss', 'egress.handshake': 'Handshake', 'egress.quality': 'Quality',
+    'egress.good': 'Good', 'egress.degraded': 'Degraded', 'egress.poor': 'Poor', 'egress.up': 'Up', 'egress.down': 'Down', 'egress.unknown': 'Unknown',
+    'egress.primary': 'primary', 'egress.bottleneck': 'Tunnel is the bottleneck',
+    'egress.notMonitored': 'Not monitored (not in tunnel mode)',
     'logs.title': '▸ Live Logs', 'logs.error': 'Error', 'logs.warn': 'Warn', 'logs.stats': 'Stats', 'logs.searchPh': 'Search logs', 'logs.jumpLatest': 'Jump to latest',
     'modal.deleteUser': 'Delete User', 'modal.deleteTunnel': 'Delete Tunnel', 'modal.restartNote': 'The proxy will be restarted to apply changes.',
     'share.subtitle': 'Point their phone camera at this code to connect.', 'share.copyLink': 'Copy link', 'share.send': 'Send', 'share.with': 'Share with',
@@ -41,6 +46,11 @@ const I18N = {
     'routing.title': 'Маршрутизация и выход', 'routing.upstream': 'Выход', 'routing.tunnelPin': 'Туннель',
     'routing.proxyHost': 'Хост прокси', 'routing.port': 'Порт', 'routing.user': 'Логин', 'routing.pass': 'Пароль', 'routing.target': 'Цель', 'routing.policy': 'Политика',
     'mask.title': 'Маскировка', 'mask.mode': 'Режим', 'mask.endpoint': 'Эндпоинт', 'mask.timer': 'Таймер проверки',
+    'egress.title': 'Качество туннеля', 'egress.interface': 'Интерфейс', 'egress.status': 'Статус',
+    'egress.rtt': 'RTT', 'egress.loss': 'Потери', 'egress.handshake': 'Хендшейк', 'egress.quality': 'Качество',
+    'egress.good': 'Хорошо', 'egress.degraded': 'Деградация', 'egress.poor': 'Плохо', 'egress.up': 'Включён', 'egress.down': 'Отключён', 'egress.unknown': 'Неизвестно',
+    'egress.primary': 'основной', 'egress.bottleneck': 'Туннель — узкое место',
+    'egress.notMonitored': 'Не отслеживается (не режим туннеля)',
     'logs.title': '▸ Логи', 'logs.error': 'Ошибки', 'logs.warn': 'Предупр.', 'logs.stats': 'Статы', 'logs.searchPh': 'Поиск в логах', 'logs.jumpLatest': 'К последним',
     'modal.deleteUser': 'Удалить пользователя', 'modal.deleteTunnel': 'Удалить туннель', 'modal.restartNote': 'Прокси будет перезапущен для применения изменений.',
     'share.subtitle': 'Наведите камеру их телефона на этот код, чтобы подключиться.', 'share.copyLink': 'Скопировать ссылку', 'share.send': 'Отправить', 'share.with': 'Поделиться с',
@@ -76,6 +86,7 @@ let lastSuccessAt = 0;
 let hasPollError = false;
 let lastData = null; // store last API response for tooltips
 let currentRouting = null;
+let lastEgress = null; // store last /api/egress response for re-render on lang toggle
 
 const tt = $('chartTooltip');
 function showTooltip(e, canvas, padLeft, dataArr, formatCb) {
@@ -1111,6 +1122,70 @@ function renderRouting(routing) {
   });
 }
 
+// ── Egress / tunnel quality ──
+function fmtHandshakeAge(sec) {
+  if (sec === null || sec === undefined) return '—';
+  if (sec < 60) return sec + 's';
+  if (sec < 3600) return Math.floor(sec / 60) + 'm';
+  return Math.floor(sec / 3600) + 'h';
+}
+
+function renderEgress(egress) {
+  lastEgress = egress;
+  const card = $('egressCard');
+  if (!card) return;
+
+  if (!egress || !egress.tunnels || egress.tunnels.length === 0) {
+    card.style.display = 'none';
+    return;
+  }
+
+  card.style.display = '';
+
+  const summary = egress.summary || {};
+  const summaryText = LANG === 'ru' ? summary.ru : summary.en;
+  const summaryEl = $('egressSummary');
+  if (summaryEl) summaryEl.textContent = summaryText || '—';
+
+  const list = $('egressList');
+  if (!list) return;
+
+  list.innerHTML = (egress.tunnels || []).map((tun) => {
+    const iface = esc(tun.interface || '—');
+    const isPrimary = tun.is_primary;
+    const quality = tun.quality || 'unknown';
+    const rttText = tun.rtt_ms !== null && tun.rtt_ms !== undefined
+      ? tun.rtt_ms.toFixed(1) + ' ms'
+      : '—';
+    const lossText = tun.packet_loss_pct !== null && tun.packet_loss_pct !== undefined
+      ? tun.packet_loss_pct.toFixed(1) + '%'
+      : '—';
+    const hsText = fmtHandshakeAge(tun.handshake_age_sec);
+
+    // Color code quality (good, degraded, poor, up, down, unknown)
+    const qualityClass = 'egress-quality-' + quality;
+    const qualityLabel = t('egress.' + quality) || quality;
+
+    // "Tunnel is the bottleneck" hint when quality is degraded/poor.
+    const isBottleneck = quality === 'degraded' || quality === 'poor';
+    const bottleneck = isBottleneck
+      ? '<div class="egress-bottleneck" title="' + t('egress.bottleneck') + '">⚠ ' + t('egress.bottleneck') + '</div>'
+      : '';
+
+    return '<div class="egress-row' + (isBottleneck ? ' is-bottleneck' : '') + '">' +
+      '<div class="egress-iface">' + iface +
+      (isPrimary ? '<span class="routing-tag">' + t('egress.primary') + '</span>' : '') +
+      '</div>' +
+      '<div class="egress-status ' + (tun.up ? 'on' : 'off') + '">' + (tun.up ? t('status.online') : t('status.offline')) + '</div>' +
+      '<div class="egress-quality ' + qualityClass + '">' + qualityLabel + '</div>' +
+      '<div class="egress-rtt" title="' + t('egress.rtt') + '">' + rttText + '</div>' +
+      '<div class="egress-loss" title="' + t('egress.loss') + '">' + lossText + '</div>' +
+      '<div class="egress-hs" title="' + t('egress.handshake') + '">' + hsText + '</div>' +
+      bottleneck +
+      '</div>';
+  }).join('');
+}
+
 // ── Polling ──
 async function poll() {
   const r = await fetch('/api/stats', { cache: 'no-store' });
@@ -1173,6 +1248,17 @@ async function poll() {
   }
 
   renderRouting(d.routing || null);
+
+  // Egress / tunnel quality
+  try {
+    const egressResp = await fetch('/api/egress', { cache: 'no-store' });
+    const egressData = await egressResp.json();
+    if (egressResp.ok && egressData.ok) {
+      renderEgress(egressData);
+    }
+  } catch (e) {
+    // Silent failure; egress monitoring is optional
+  }
 
   // Masking health
   const masking = d.masking;
@@ -1330,6 +1416,7 @@ if (langToggleBtn) {
     setLang(LANG === 'ru' ? 'en' : 'ru');
     updatePollControls();
     updateAutoScrollButton();
+    if (lastEgress) renderEgress(lastEgress);
   });
 }
 applyStaticI18n();

--- a/src/ctl/dashboard_assets/static/app.js
+++ b/src/ctl/dashboard_assets/static/app.js
@@ -1249,16 +1249,13 @@ async function poll() {
 
   renderRouting(d.routing || null);
 
-  // Egress / tunnel quality
-  try {
-    const egressResp = await fetch('/api/egress', { cache: 'no-store' });
-    const egressData = await egressResp.json();
-    if (egressResp.ok && egressData.ok) {
-      renderEgress(egressData);
-    }
-  } catch (e) {
-    // Silent failure; egress monitoring is optional
-  }
+  // Egress / tunnel quality — fire-and-forget so a slow server-side ping/wg probe
+  // never blocks rendering of the already-fetched masking/users data or stalls the
+  // poll cycle. The card updates whenever this resolves.
+  fetch('/api/egress', { cache: 'no-store' })
+    .then((r) => (r.ok ? r.json() : null))
+    .then((egressData) => { if (egressData && egressData.ok) renderEgress(egressData); })
+    .catch(() => {}); // silent; egress monitoring is optional
 
   // Masking health
   const masking = d.masking;

--- a/src/ctl/dashboard_assets/static/index.html
+++ b/src/ctl/dashboard_assets/static/index.html
@@ -214,6 +214,20 @@
     <div class="routing-list" id="routingTunnelsList"></div>
   </div>
 
+  <!-- Egress / Tunnel Quality -->
+  <div class="tunnel-card" id="egressCard" style="display:none">
+    <div class="tunnel-header">
+      <div class="tunnel-icon">📶</div>
+      <div class="tunnel-title" data-i18n="egress.title">Tunnel Quality</div>
+    </div>
+    <div class="tunnel-details">
+      <div class="tunnel-stat">
+        <span class="tunnel-val" id="egressSummary">—</span>
+      </div>
+    </div>
+    <div class="egress-list" id="egressList"></div>
+  </div>
+
   <!-- Masking health -->
   <div class="tunnel-card" id="maskingCard" style="display:none">
     <div class="tunnel-header">

--- a/src/ctl/dashboard_assets/static/style.css
+++ b/src/ctl/dashboard_assets/static/style.css
@@ -1031,3 +1031,121 @@ body::after {
     width: 100%;
   }
 }
+
+/* Egress / Tunnel Quality */
+.egress-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.egress-row {
+  display: grid;
+  grid-template-columns: 1fr 80px 100px 80px 70px 70px;
+  gap: 12px;
+  padding: 10px;
+  background: rgba(127, 127, 127, 0.04);
+  border: 1px solid var(--card-border);
+  border-radius: 8px;
+  align-items: center;
+  font-size: 13px;
+}
+
+.egress-row.is-bottleneck {
+  border-color: rgba(248, 113, 113, 0.35);
+  background: rgba(248, 113, 113, 0.05);
+}
+
+.egress-iface {
+  font-weight: 500;
+  word-break: break-all;
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.egress-status {
+  padding: 4px 6px;
+  border-radius: 4px;
+  text-align: center;
+  font-weight: 500;
+  font-size: 12px;
+}
+
+.egress-status.on {
+  background: rgba(52, 211, 153, 0.15);
+  color: var(--green);
+}
+
+.egress-status.off {
+  background: rgba(255, 80, 80, 0.15);
+  color: var(--red);
+}
+
+.egress-quality {
+  padding: 4px 6px;
+  border-radius: 4px;
+  text-align: center;
+  font-weight: 500;
+  font-size: 12px;
+}
+
+.egress-quality-good {
+  background: rgba(52, 211, 153, 0.15);
+  color: var(--green);
+}
+
+.egress-quality-degraded {
+  background: rgba(240, 180, 40, 0.15);
+  color: var(--amber);
+}
+
+.egress-quality-poor {
+  background: rgba(255, 80, 80, 0.15);
+  color: var(--red);
+}
+
+.egress-quality-up {
+  background: rgba(52, 211, 153, 0.1);
+  color: var(--text-muted);
+}
+
+.egress-quality-down,
+.egress-quality-unknown {
+  background: rgba(127, 127, 127, 0.1);
+  color: var(--text-muted);
+}
+
+.egress-rtt,
+.egress-loss,
+.egress-hs {
+  text-align: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.egress-bottleneck {
+  grid-column: 1 / -1;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--red);
+  margin-top: 2px;
+}
+
+@media (max-width: 1200px) {
+  .egress-row {
+    grid-template-columns: 1fr 70px;
+    gap: 8px;
+  }
+  .egress-quality,
+  .egress-rtt,
+  .egress-loss,
+  .egress-hs {
+    display: none;
+  }
+  .egress-bottleneck {
+    grid-column: 1 / -1;
+  }
+}

--- a/src/ctl/install.zig
+++ b/src/ctl/install.zig
@@ -72,6 +72,10 @@ fn shouldWarnIgnoredSecret(config_exists: bool, secret_provided: bool, config_pa
     return config_exists and secret_provided and !config_path_provided;
 }
 
+fn shouldInstallMinisignPackage(signature_available: bool, insecure_mode: bool, minisign_on_path: bool) bool {
+    return signature_available and !insecure_mode and !minisign_on_path;
+}
+
 pub fn printInstallHelp(ui: *Tui) void {
     ui.writeRaw("\n");
     ui.writeRaw("  mtbuddy install [options]\n\n");
@@ -109,6 +113,13 @@ test "install - explicit secret warning only applies when existing config keeps 
     try std.testing.expect(!shouldWarnIgnoredSecret(false, true, false));
     try std.testing.expect(!shouldWarnIgnoredSecret(true, false, false));
     try std.testing.expect(!shouldWarnIgnoredSecret(true, true, true));
+}
+
+test "install - skips apt minisign package when verifier is already on PATH" {
+    try std.testing.expect(!shouldInstallMinisignPackage(true, false, true));
+    try std.testing.expect(shouldInstallMinisignPackage(true, false, false));
+    try std.testing.expect(!shouldInstallMinisignPackage(true, true, false));
+    try std.testing.expect(!shouldInstallMinisignPackage(false, false, false));
 }
 
 /// Run install in CLI (non-interactive) mode.
@@ -432,7 +443,8 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
             return;
         }
         if (!runRequiredWhileSpinning(ui, allocator, &.{ "env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "-o", "DPkg::Lock::Timeout=600", "update", "-qq" }, "apt-get update failed", &sp)) return;
-        const base_packages: []const []const u8 = if (signature_available and !insecure_mode)
+        const should_install_minisign_package = shouldInstallMinisignPackage(signature_available, insecure_mode, sys.commandExists("minisign"));
+        const base_packages: []const []const u8 = if (should_install_minisign_package)
             &.{
                 "env",                     "DEBIAN_FRONTEND=noninteractive",
                 "apt-get",                 "-o",

--- a/src/protocol/tls.zig
+++ b/src/protocol/tls.zig
@@ -206,6 +206,13 @@ pub fn buildServerHelloWithTemplate(
     return response;
 }
 
+/// A TLS `unrecognized_name` alert record — what stock nginx (ssl_reject_handshake)
+/// emits for a ClientHello whose SNI it doesn't serve. Send this, then close, so a
+/// rejected probe sees a genuine-looking server response instead of a silent drop.
+/// Bytes: record type 0x15 (alert), TLS 1.2 version 0x0303, length 2,
+/// level 1 (warning), description 112 (unrecognized_name, RFC 6066).
+pub const unrecognized_name_alert = [_]u8{ 0x15, 0x03, 0x03, 0x00, 0x02, 0x01, 0x70 };
+
 // ============= Nginx/OpenSSL TLS 1.3 Template =============
 //
 // Pre-built at comptime to match the fingerprint of Nginx 1.25+ with OpenSSL 3.x.
@@ -1116,6 +1123,13 @@ fn buildTlsAuthClientHello(
     out[digest_pos + 31] = computed[31] ^ ts_bytes[3];
 
     return out[0..total_len];
+}
+
+test "unrecognized_name_alert wire format" {
+    // record type 0x15 (alert), TLS 1.2 version, length 2, level 1 (warning),
+    // description 112 (unrecognized_name).
+    try std.testing.expectEqual(@as(usize, 7), unrecognized_name_alert.len);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x15, 0x03, 0x03, 0x00, 0x02, 0x01, 0x70 }, &unrecognized_name_alert);
 }
 
 test "extractSni - fragmented and overlong records" {

--- a/src/protocol/tls.zig
+++ b/src/protocol/tls.zig
@@ -206,12 +206,14 @@ pub fn buildServerHelloWithTemplate(
     return response;
 }
 
-/// A TLS `unrecognized_name` alert record — what stock nginx (ssl_reject_handshake)
-/// emits for a ClientHello whose SNI it doesn't serve. Send this, then close, so a
-/// rejected probe sees a genuine-looking server response instead of a silent drop.
+/// A TLS **fatal** `handshake_failure` alert record — what a server sends when it
+/// refuses to complete the handshake (e.g. nginx `ssl_reject_handshake on`). Send
+/// this, then close, so a rejected probe sees a real server-style teardown. A *fatal*
+/// alert legitimately precedes connection close; a warning-level alert followed by an
+/// immediate close would itself be anomalous (a distinguisher), so this is fatal.
 /// Bytes: record type 0x15 (alert), TLS 1.2 version 0x0303, length 2,
-/// level 1 (warning), description 112 (unrecognized_name, RFC 6066).
-pub const unrecognized_name_alert = [_]u8{ 0x15, 0x03, 0x03, 0x00, 0x02, 0x01, 0x70 };
+/// level 2 (fatal), description 40 (handshake_failure, RFC 8446 §6).
+pub const reject_handshake_alert = [_]u8{ 0x15, 0x03, 0x03, 0x00, 0x02, 0x02, 0x28 };
 
 // ============= Nginx/OpenSSL TLS 1.3 Template =============
 //
@@ -1125,11 +1127,11 @@ fn buildTlsAuthClientHello(
     return out[0..total_len];
 }
 
-test "unrecognized_name_alert wire format" {
-    // record type 0x15 (alert), TLS 1.2 version, length 2, level 1 (warning),
-    // description 112 (unrecognized_name).
-    try std.testing.expectEqual(@as(usize, 7), unrecognized_name_alert.len);
-    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x15, 0x03, 0x03, 0x00, 0x02, 0x01, 0x70 }, &unrecognized_name_alert);
+test "reject_handshake_alert wire format" {
+    // record type 0x15 (alert), TLS 1.2 version, length 2, level 2 (fatal),
+    // description 40 (handshake_failure).
+    try std.testing.expectEqual(@as(usize, 7), reject_handshake_alert.len);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x15, 0x03, 0x03, 0x00, 0x02, 0x02, 0x28 }, &reject_handshake_alert);
 }
 
 test "extractSni - fragmented and overlong records" {

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -3365,19 +3365,21 @@ const EventLoop = struct {
                 }
             }
         }
-        const user_metrics = self.state.findUserMetrics(result.user);
-        if (self.state.config.user_max_conns) |maxc| {
-            if (maxc.get(result.user)) |cap| {
-                const active = if (user_metrics) |e| e.connections_active.load(.monotonic) else 0;
-                if (active >= cap) {
-                    self.closeSlot(slot, "user connection limit");
-                    return;
+        if (self.state.findUserMetrics(result.user)) |entry| {
+            // Optimistic atomic admission: increment first, then roll back + reject if
+            // we exceeded the per-user cap. Avoids a load-then-add TOCTOU where two
+            // SO_REUSEPORT workers both pass a non-atomic check and overshoot the cap.
+            const prev = entry.connections_active.fetchAdd(1, .monotonic);
+            if (self.state.config.user_max_conns) |maxc| {
+                if (maxc.get(result.user)) |cap| {
+                    if (prev >= cap) {
+                        _ = entry.connections_active.fetchSub(1, .monotonic);
+                        self.closeSlot(slot, "user connection limit");
+                        return;
+                    }
                 }
             }
-        }
-        slot.user_metrics = user_metrics;
-        if (slot.user_metrics) |entry| {
-            _ = entry.connections_active.fetchAdd(1, .monotonic);
+            slot.user_metrics = entry;
         }
 
         slot.dc_abs = @intCast(dc_abs);
@@ -3425,9 +3427,9 @@ const EventLoop = struct {
         switch (self.state.config.unknown_sni_action) {
             .mask => self.startMasking(slot, client_hello) catch self.closeSlot(slot, reason),
             .reject => {
-                // Best-effort raw write of the 7-byte alert before close (mirrors
+                // Best-effort raw write of the 7-byte fatal alert before close (mirrors
                 // queue_io's syscall use); a partial/EAGAIN write is fine here.
-                const alert: []const u8 = &tls.unrecognized_name_alert;
+                const alert: []const u8 = &tls.reject_handshake_alert;
                 _ = posix.system.write(slot.client_fd, alert.ptr, alert.len);
                 self.closeSlot(slot, reason);
             },

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -279,6 +279,21 @@ const acceptClient = socket_utils.acceptClient;
 const localSocketAddress = socket_utils.localSocketAddress;
 const setNonBlocking = socket_utils.setNonBlocking;
 const secondsToMs = socket_utils.secondsToMs;
+
+/// Per-connection idle timeout in ms with ±jitter_pct random jitter, so a constant
+/// idle timeout isn't a behavioral fingerprint. `seed` varies per connection. Floored
+/// to half the base (and >= 5s) so jitter never makes the timeout pathologically short.
+fn jitteredIdleTimeoutMs(base_sec: u32, jitter_pct: u8, seed: u64) i64 {
+    const base_ms = secondsToMs(base_sec);
+    if (jitter_pct == 0) return base_ms;
+    const pct: i64 = @min(@as(i64, jitter_pct), 100);
+    const range = @divTrunc(base_ms * pct, 100);
+    if (range <= 0) return base_ms;
+    const span: u64 = @intCast(2 * range + 1);
+    const offset = @as(i64, @intCast(seed % span)) - range;
+    const floor_ms = @max(secondsToMs(5), @divTrunc(base_ms, 2));
+    return @max(floor_ms, base_ms + offset);
+}
 const setTcpNoDelay = socket_utils.setTcpNoDelay;
 const configureRelaySocket = socket_utils.configureRelaySocket;
 const formatAddress = socket_utils.formatAddress;
@@ -402,6 +417,9 @@ const ConnectionSlot = struct {
     created_at_ms: i64 = 0,
     first_byte_at_ms: i64 = 0,
     last_activity_ms: i64 = 0,
+    /// Per-connection idle timeout in ms, with random jitter applied once at setup
+    /// so a constant idle timeout isn't itself a behavioral fingerprint. 0 until set.
+    idle_timeout_ms: i64 = 0,
     desync_deadline_ns: i128 = 0,
 
     // Initial TLS handshake reassembly
@@ -766,6 +784,24 @@ test "MiddleProxyHandshakeStep.awaitingMiddleProxy gates the reactive refresh" {
     try std.testing.expect(MiddleProxyHandshakeStep.waiting_rpc_nonce_response.awaitingMiddleProxy());
     try std.testing.expect(MiddleProxyHandshakeStep.sending_rpc_handshake.awaitingMiddleProxy());
     try std.testing.expect(MiddleProxyHandshakeStep.waiting_rpc_handshake_response.awaitingMiddleProxy());
+}
+
+test "jitteredIdleTimeoutMs stays within bounds and respects the floor" {
+    const base_sec: u32 = 120;
+    const base_ms = secondsToMs(base_sec);
+    // jitter 0 → exactly the base timeout
+    try std.testing.expectEqual(base_ms, jitteredIdleTimeoutMs(base_sec, 0, 0xdeadbeef));
+    // jitter 15% → within [base/2, base + 15%] and never below 5s, across many seeds
+    const max_ms = base_ms + @divTrunc(base_ms * 15, 100);
+    var i: u64 = 0;
+    while (i < 2000) : (i += 1) {
+        const v = jitteredIdleTimeoutMs(base_sec, 15, i *% 2654435761);
+        try std.testing.expect(v >= @divTrunc(base_ms, 2));
+        try std.testing.expect(v >= secondsToMs(5));
+        try std.testing.expect(v <= max_ms);
+    }
+    // not every connection gets the same value (jitter actually varies)
+    try std.testing.expect(jitteredIdleTimeoutMs(base_sec, 15, 1) != jitteredIdleTimeoutMs(base_sec, 15, 2));
 }
 
 pub const ProxyState = struct {
@@ -2257,6 +2293,11 @@ const EventLoop = struct {
             slot.handshake_pos = 0;
             slot.created_at_ms = nowMs();
             slot.last_activity_ms = slot.created_at_ms;
+            slot.idle_timeout_ms = jitteredIdleTimeoutMs(
+                self.state.config.idle_timeout_sec,
+                self.state.config.idle_timeout_jitter_pct,
+                slot.conn_id ^ @as(u64, @bitCast(slot.created_at_ms)),
+            );
             slot.drs = DynamicRecordSizer.init(self.state.config.drs);
 
             if (self.addFd(cfd, true, false)) |_| {
@@ -3065,17 +3106,13 @@ const EventLoop = struct {
 
         const maybe_sni = tls.extractSni(client_hello);
         if (maybe_sni == null) {
-            self.startMasking(slot, client_hello) catch {
-                self.closeSlot(slot, "tls missing sni");
-            };
+            self.handleInvalidSni(slot, client_hello, "tls missing sni");
             return;
         }
 
         const sni = maybe_sni.?;
         if (!std.ascii.eqlIgnoreCase(sni, self.state.config.tls_domain)) {
-            self.startMasking(slot, client_hello) catch {
-                self.closeSlot(slot, "tls sni mismatch");
-            };
+            self.handleInvalidSni(slot, client_hello, "tls sni mismatch");
             return;
         }
 
@@ -3317,7 +3354,28 @@ const EventLoop = struct {
             return;
         }
 
-        slot.user_metrics = self.state.findUserMetrics(result.user);
+        // Per-user limits (read at startup; changing them needs a restart). Checked
+        // BEFORE assigning slot.user_metrics so a rejected connection never touches
+        // the active-connection counter (closeSlot decrements only when it's set).
+        if (self.state.config.user_expirations) |exps| {
+            if (exps.get(result.user)) |expiry_ts| {
+                if (realtimeSeconds() >= expiry_ts) {
+                    self.closeSlot(slot, "user expired");
+                    return;
+                }
+            }
+        }
+        const user_metrics = self.state.findUserMetrics(result.user);
+        if (self.state.config.user_max_conns) |maxc| {
+            if (maxc.get(result.user)) |cap| {
+                const active = if (user_metrics) |e| e.connections_active.load(.monotonic) else 0;
+                if (active >= cap) {
+                    self.closeSlot(slot, "user connection limit");
+                    return;
+                }
+            }
+        }
+        slot.user_metrics = user_metrics;
         if (slot.user_metrics) |entry| {
             _ = entry.connections_active.fetchAdd(1, .monotonic);
         }
@@ -3356,6 +3414,25 @@ const EventLoop = struct {
         self.startConnectUpstream(slot, candidates[0], .dc) catch {
             self.closeSlot(slot, "upstream connect start failed");
         };
+    }
+
+    /// Handle a ClientHello whose SNI is missing or doesn't match tls_domain,
+    /// per `unknown_sni_action`: `mask` forwards to the masking backend (default,
+    /// active-probe defense), `reject` emits a real `unrecognized_name` TLS alert
+    /// like stock nginx and closes, `drop` closes silently. Validation-failed /
+    /// replay cases (SNI matched) keep masking — they're not handled here.
+    fn handleInvalidSni(self: *EventLoop, slot: *ConnectionSlot, client_hello: []const u8, reason: []const u8) void {
+        switch (self.state.config.unknown_sni_action) {
+            .mask => self.startMasking(slot, client_hello) catch self.closeSlot(slot, reason),
+            .reject => {
+                // Best-effort raw write of the 7-byte alert before close (mirrors
+                // queue_io's syscall use); a partial/EAGAIN write is fine here.
+                const alert: []const u8 = &tls.unrecognized_name_alert;
+                _ = posix.system.write(slot.client_fd, alert.ptr, alert.len);
+                self.closeSlot(slot, reason);
+            },
+            .drop => self.closeSlot(slot, reason),
+        }
     }
 
     fn startMasking(self: *EventLoop, slot: *ConnectionSlot, buffered: []const u8) !void {
@@ -3816,7 +3893,7 @@ const EventLoop = struct {
 
             if (slot.handshakeInProgress()) {
                 if (slot.first_byte_at_ms == 0) {
-                    if (now_ms - slot.created_at_ms > secondsToMs(self.state.config.idle_timeout_sec)) {
+                    if (now_ms - slot.created_at_ms > (if (slot.idle_timeout_ms > 0) slot.idle_timeout_ms else secondsToMs(self.state.config.idle_timeout_sec))) {
                         self.closeSlot(slot, "idle pre-first-byte timeout");
                         continue;
                     }
@@ -3844,7 +3921,7 @@ const EventLoop = struct {
                     continue;
                 }
             } else if (slot.phase == .relaying or slot.phase == .mask_relaying) {
-                if (now_ms - slot.last_activity_ms > secondsToMs(self.state.config.idle_timeout_sec)) {
+                if (now_ms - slot.last_activity_ms > (if (slot.idle_timeout_ms > 0) slot.idle_timeout_ms else secondsToMs(self.state.config.idle_timeout_sec))) {
                     self.closeSlot(slot, "relay idle timeout");
                     continue;
                 }


### PR DESCRIPTION
A bundle of circumvention/UX improvements (each **config-gated, defaulting to current behavior**), the maintainer's Ubuntu 20.04 installer fix, and the work that came out of surveying telemt/mtg + the 2025-2026 detection landscape. Designed via a spec workflow and hardened by an adversarial review workflow (24 agents, find-then-verify) — 15 confirmed findings fixed before this PR.

## Installer — Ubuntu 20.04 minisign (maintainer's fix)
Ubuntu 20.04 (focal) ships no `minisign` apt package, so the bootstrap aborted at signature verification. `deploy/bootstrap.sh` now falls back to a pinned, SHA-256-verified upstream minisign 0.12 binary when apt can't provide it (and exports a sane PATH); `install.zig` skips the apt step when a verifier is already on PATH. **The fallback is bootstrap-side** (the documented `curl | bash` install path); a bare `mtbuddy install` on 20.04 without the bootstrap still relies on apt.

## Evasion
- **`[censorship] unknown_sni_action`** (`mask` default | `reject` | `drop`): on a ClientHello whose SNI doesn't match `tls_domain`, `reject` sends a **fatal `handshake_failure` TLS alert** (like a server refusing the handshake) then closes; `drop` closes silently. Right-SNI-but-invalid/replay connections still **mask** (the active-probe defense) — the action only covers the genuinely-unknown-SNI case.
- **`[server] idle_timeout_jitter_pct`** (default 15): a constant idle timeout is itself a behavioral signature, so each connection gets a ±% jittered timeout computed once at setup (floored so jitter never shortens it pathologically).

## Access (shared deployments)
- **`[access.user_max_conns]`** — per-user concurrent-connection cap (atomic admission, no TOCTOU overshoot across workers).
- **`[access.user_expirations]`** — per-user `"YYYY-MM-DD"` expiry, end-of-day-inclusive, with strict calendar validation. Both read at startup (restart to change); optional maps, so existing config is untouched.

## UX / Ops
- **`mtbuddy config doctor --network` → "am I blocked?"**: probes direct DC reachability (SYN-timeout vs connect distinguishes an L3 IP-blackhole — the current RU block — but doesn't hard-fail on it; the metadata fetch arbitrates), probes Telegram via each tunnel interface with a bound-interface RTT, and reports tg:// link availability. Turns "the proxy stopped working — check it" into one command with a verdict.
- **Dashboard "Tunnel Quality" card** (`GET /api/egress`, behind the existing auth): per-interface up/down, last WG/AWG handshake age, RTT + packet loss to a DC via that interface, flagging the bottleneck — so a high-latency tunnel (e.g. awg0 @ 203ms) is *visible*, not guessed. Bilingual EN/RU.

## Deliberately dropped (wrong for our architecture)
- **Plaintext-ServerHello ALPN echo** — TLS 1.3 carries ALPN in the AEAD-encrypted EncryptedExtensions (which our opaque AppData already represents); a *plaintext* echo would be a fingerprint **regression**.
- **App-level ME keepalive** — a connection-pool feature; our middleproxy connections are per-client and already carry tuned TCP keepalive (60/10/3). The app-level ping risked desyncing the per-client ME RPC stream for no gain.

Both belong with a future **ME connection pool**. The other big-ticket items from the landscape survey — **REALITY-style steal-handshake** (strongest active-probe defense; removes the self-signed-mask tell) and **CDN/domain fronting** — are separate tracks (they change the masking model) and intentionally out of scope here.

## Quality process
- Specs produced by a design workflow (7 parallel agents + conflict map).
- Adversarial review workflow over the full diff: 6 dimensions × find-then-independently-verify → 15 real issues fixed (fatal-vs-warning alert, expiry calendar/sign validation, atomic per-user cap, doctor break-vs-idx bug, doctor blackhole false-positive, ping `-W` seconds-not-ms, non-blocking egress fetch, RTT clamp, …). 3 raised findings were rejected as false positives.

## Verified
`zig build test`, `x86_64-linux` + `aarch64-linux` ReleaseFast, `zig fmt`, `py_compile`, `node --check` — all green. New unit tests: config parse + defaults, `parseExpiryToUnix` epoch/calendar math, idle-jitter bounds/floor/variance, the alert wire format, and the doctor helpers.