### PR TITLE
feat(egress): VPN-link tunnel egress (+ tunnel-pool failover fix, fronting x25519 helper)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,14 @@ sudo mtbuddy setup tunnel /path/to/awg0.conf
 sudo mtbuddy setup tunnel 'vpn://...'
 sudo mtbuddy setup tunnel --iface awg1 /path/to/awg1.conf
 
+# Egress from a VPN share-link — clean, hard-to-block upstream for the proxy→Telegram hop.
+#   vless:// vmess:// trojan:// ss://  -> local Xray client -> SOCKS5 upstream (VLESS-Reality
+#                                        camouflages the egress hop as real TLS).
+#   wireguard://                       -> native L3 tunnel (same as `setup tunnel`).
+#   multiple links                     -> a leastPing failover pool.
+sudo mtbuddy setup egress 'vless://...@host:443?security=reality&pbk=...&sni=...&flow=xtls-rprx-vision'
+sudo mtbuddy setup egress 'wireguard://<privkey>@host:51820?publickey=...&address=10.0.0.2/32'
+
 # IPv6 hopping
 sudo mtbuddy ipv6-hop --check
 sudo mtbuddy ipv6-hop --auto --prefix 2a01:abcd:ef00:: --threshold 5

--- a/README.md
+++ b/README.md
@@ -228,10 +228,10 @@ sudo mtbuddy setup tunnel 'vpn://...'
 sudo mtbuddy setup tunnel --iface awg1 /path/to/awg1.conf
 
 # Egress from a VPN share-link — clean, hard-to-block upstream for the proxy→Telegram hop.
-#   vless:// vmess:// trojan:// ss://  -> local Xray client -> SOCKS5 upstream (VLESS-Reality
-#                                        camouflages the egress hop as real TLS).
-#   wireguard://                       -> native L3 tunnel (same as `setup tunnel`).
-#   multiple links                     -> a leastPing failover pool.
+#   vless:// vmess:// trojan:// ss://  -> local sing-box TUN tunnel (type=tunnel, exactly like
+#                                        AmneziaWG; VLESS-Reality camouflages the hop as real TLS).
+#   wireguard://                       -> native kernel WG tunnel (same as `setup tunnel`).
+#   multiple links                     -> a urltest failover pool.
 sudo mtbuddy setup egress 'vless://...@host:443?security=reality&pbk=...&sni=...&flow=xtls-rprx-vision'
 sudo mtbuddy setup egress 'wireguard://<privkey>@host:51820?publickey=...&address=10.0.0.2/32'
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -174,6 +174,16 @@ port = 443
 # username = ""
 # password = ""
 
+# ── Xray egress (VLESS-Reality / VMess / Trojan / Shadowsocks) ──
+# Don't hand-edit this — run:  sudo mtbuddy setup egress "<share-link>" [<link>...]
+# It parses the share-link(s), runs a local Xray client that exposes a SOCKS5 inbound
+# on 127.0.0.1:10808, points [upstream] type=socks5 at it, and records the link(s)
+# here so a reinstall reproduces the egress. >1 link = a leastPing failover pool.
+# wireguard:// links go to the native L3 tunnel instead (mtbuddy setup egress also
+# accepts those, or use `mtbuddy setup tunnel`).
+# [upstream.xray]
+# links = ["vless://...@host:443?security=reality&pbk=...&sni=...&sid=...&flow=xtls-rprx-vision"]
+
 [censorship]
 # Domain to impersonate in TLS ServerHello and forward unauthenticated clients to.
 # Choose a popular, high-traffic domain that negotiates single-round x25519 (most big

--- a/config.toml.example
+++ b/config.toml.example
@@ -174,13 +174,14 @@ port = 443
 # username = ""
 # password = ""
 
-# ── Xray egress (VLESS-Reality / VMess / Trojan / Shadowsocks) ──
+# ── VPN-link egress (VLESS-Reality / VMess / Trojan / Shadowsocks) ──
 # Don't hand-edit this — run:  sudo mtbuddy setup egress "<share-link>" [<link>...]
-# It parses the share-link(s), runs a local Xray client that exposes a SOCKS5 inbound
-# on 127.0.0.1:10808, points [upstream] type=socks5 at it, and records the link(s)
-# here so a reinstall reproduces the egress. >1 link = a leastPing failover pool.
-# wireguard:// links go to the native L3 tunnel instead (mtbuddy setup egress also
-# accepts those, or use `mtbuddy setup tunnel`).
+# It parses the share-link(s), runs a local sing-box client in TUN mode (interface
+# sbx0), and policy-routes the proxy's marked DC traffic through it — i.e. it's just a
+# `type = tunnel` egress, exactly like AmneziaWG, only the backend is VLESS-Reality/etc.
+# instead of WireGuard. The link(s) are recorded here so a reinstall reproduces the
+# egress. >1 link = a urltest failover pool. wireguard:// links use the native kernel
+# WG tunnel (or `mtbuddy setup tunnel`).
 # [upstream.xray]
 # links = ["vless://...@host:443?security=reality&pbk=...&sni=...&sid=...&flow=xtls-rprx-vision"]
 

--- a/src/ctl/config_cmd.zig
+++ b/src/ctl/config_cmd.zig
@@ -8,6 +8,7 @@
 const std = @import("std");
 const tui_mod = @import("tui.zig");
 const sys = @import("sys.zig");
+const fronting_domain = @import("fronting_domain.zig");
 const Config = @import("proxy_config").Config;
 const http_fetch = @import("proxy_http_fetch");
 const net_helpers = @import("proxy_net_helpers");
@@ -318,6 +319,10 @@ fn runNetworkDoctor(
 ) void {
     ui.writeRaw("\n");
     ui.section("Network probes");
+
+    if (fronting_domain.warnIfPoorFrontingDomain(ui, allocator, cfg.tls_domain) == .mismatch) {
+        warnings.* += 1;
+    }
 
     switch (cfg.upstream_mode) {
         .socks5, .http => runNetworkDoctorProxy(ui, allocator, cfg, errors, warnings),

--- a/src/ctl/egress.zig
+++ b/src/ctl/egress.zig
@@ -24,13 +24,16 @@ const Tui = tui_mod.Tui;
 
 const INSTALL_DIR = "/opt/mtproto-proxy";
 const CONFIG_PATH = INSTALL_DIR ++ "/config.toml";
-const XRAY_CONFIG_DIR = "/etc/mtproto-proxy";
-const XRAY_CONFIG_PATH = XRAY_CONFIG_DIR ++ "/xray-egress.json";
-const XRAY_SERVICE_NAME = "mtproto-xray-egress.service";
-const XRAY_SERVICE_PATH = "/etc/systemd/system/" ++ XRAY_SERVICE_NAME;
-const XRAY_BIN = "/usr/local/bin/xray";
-const SOCKS_HOST = "127.0.0.1";
-const SOCKS_PORT: u16 = 10808;
+const SB_CONFIG_DIR = "/etc/mtproto-proxy";
+const SB_CONFIG_PATH = SB_CONFIG_DIR ++ "/singbox-egress.json";
+const SB_SERVICE_NAME = "mtproto-singbox-egress.service";
+const SB_SERVICE_PATH = "/etc/systemd/system/" ++ SB_SERVICE_NAME;
+const SB_ROUTE_SCRIPT = "/usr/local/bin/mtproto-singbox-route.sh";
+const SB_BIN = "/usr/local/bin/sing-box";
+const TUN_IFACE = "sbx0"; // sing-box tun interface; mirrors awg0 as a tunnel egress
+const TUN_ADDR = "172.19.0.1/30";
+const TUN_TABLE = "200"; // same policy-routing table the AmneziaWG tunnel uses
+const TUN_FWMARK = "200"; // proxy SO_MARK for tunnel egress
 
 // ── URI helpers ───────────────────────────────────────────────────────────────
 
@@ -309,54 +312,65 @@ fn js(a: std.mem.Allocator, s: []const u8) []const u8 {
     return buf[0..w];
 }
 
-fn streamSettings(a: std.mem.Allocator, l: XrayLink) ![]const u8 {
-    if (l.scheme == .shadowsocks) return "";
+fn sbTls(a: std.mem.Allocator, l: XrayLink) ![]const u8 {
     const sni = l.sni orelse l.host orelse l.address;
     const fp = l.fingerprint orelse "chrome";
-    var sec: []const u8 = ",\"security\":\"none\"";
     if (std.mem.eql(u8, l.security, "reality")) {
-        sec = try std.fmt.allocPrint(a, ",\"security\":\"reality\",\"realitySettings\":{{\"serverName\":{s},\"fingerprint\":{s},\"publicKey\":{s},\"shortId\":{s},\"spiderX\":\"/\"}}", .{ js(a, sni), js(a, fp), js(a, l.public_key orelse ""), js(a, l.short_id orelse "") });
+        return std.fmt.allocPrint(a, ",\"tls\":{{\"enabled\":true,\"server_name\":{s},\"utls\":{{\"enabled\":true,\"fingerprint\":{s}}},\"reality\":{{\"enabled\":true,\"public_key\":{s},\"short_id\":{s}}}}}", .{ js(a, sni), js(a, fp), js(a, l.public_key orelse ""), js(a, l.short_id orelse "") });
     } else if (std.mem.eql(u8, l.security, "tls")) {
-        sec = try std.fmt.allocPrint(a, ",\"security\":\"tls\",\"tlsSettings\":{{\"serverName\":{s},\"fingerprint\":{s},\"allowInsecure\":false}}", .{ js(a, sni), js(a, fp) });
+        return std.fmt.allocPrint(a, ",\"tls\":{{\"enabled\":true,\"server_name\":{s},\"utls\":{{\"enabled\":true,\"fingerprint\":{s}}}}}", .{ js(a, sni), js(a, fp) });
     }
-    var trans: []const u8 = "";
-    if (std.mem.eql(u8, l.network, "ws")) {
-        trans = try std.fmt.allocPrint(a, ",\"wsSettings\":{{\"path\":{s},\"headers\":{{\"Host\":{s}}}}}", .{ js(a, l.path orelse "/"), js(a, l.host orelse sni) });
-    } else if (std.mem.eql(u8, l.network, "grpc")) {
-        trans = try std.fmt.allocPrint(a, ",\"grpcSettings\":{{\"serviceName\":{s}}}", .{js(a, l.path orelse "")});
-    }
-    return std.fmt.allocPrint(a, ",\"streamSettings\":{{\"network\":{s}{s}{s}}}", .{ js(a, l.network), sec, trans });
+    return "";
 }
 
-fn outbound(a: std.mem.Allocator, l: XrayLink, tag: []const u8) ![]const u8 {
-    const stream = try streamSettings(a, l);
+fn sbTransport(a: std.mem.Allocator, l: XrayLink) ![]const u8 {
+    const sni = l.sni orelse l.host orelse l.address;
+    if (std.mem.eql(u8, l.network, "ws")) {
+        return std.fmt.allocPrint(a, ",\"transport\":{{\"type\":\"ws\",\"path\":{s},\"headers\":{{\"Host\":{s}}}}}", .{ js(a, l.path orelse "/"), js(a, l.host orelse sni) });
+    } else if (std.mem.eql(u8, l.network, "grpc")) {
+        return std.fmt.allocPrint(a, ",\"transport\":{{\"type\":\"grpc\",\"service_name\":{s}}}", .{js(a, l.path orelse "")});
+    }
+    return "";
+}
+
+fn sbOutbound(a: std.mem.Allocator, l: XrayLink, tag: []const u8) ![]const u8 {
+    const tls = try sbTls(a, l);
+    const tr = try sbTransport(a, l);
     return switch (l.scheme) {
         .vless => blk: {
             const flow = if (l.flow) |f| try std.fmt.allocPrint(a, ",\"flow\":{s}", .{js(a, f)}) else "";
-            break :blk std.fmt.allocPrint(a, "{{\"protocol\":\"vless\",\"tag\":{s},\"settings\":{{\"vnext\":[{{\"address\":{s},\"port\":{d},\"users\":[{{\"id\":{s},\"encryption\":\"none\"{s}}}]}}]}}{s}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.id.?), flow, stream });
+            break :blk std.fmt.allocPrint(a, "{{\"type\":\"vless\",\"tag\":{s},\"server\":{s},\"server_port\":{d},\"uuid\":{s}{s}{s}{s}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.id.?), flow, tls, tr });
         },
-        .vmess => std.fmt.allocPrint(a, "{{\"protocol\":\"vmess\",\"tag\":{s},\"settings\":{{\"vnext\":[{{\"address\":{s},\"port\":{d},\"users\":[{{\"id\":{s},\"alterId\":{d},\"security\":\"auto\"}}]}}]}}{s}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.id.?), l.alter_id, stream }),
-        .trojan => std.fmt.allocPrint(a, "{{\"protocol\":\"trojan\",\"tag\":{s},\"settings\":{{\"servers\":[{{\"address\":{s},\"port\":{d},\"password\":{s}}}]}}{s}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.password.?), stream }),
-        .shadowsocks => std.fmt.allocPrint(a, "{{\"protocol\":\"shadowsocks\",\"tag\":{s},\"settings\":{{\"servers\":[{{\"address\":{s},\"port\":{d},\"method\":{s},\"password\":{s}}}]}}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.method.?), js(a, l.password.?) }),
+        .vmess => std.fmt.allocPrint(a, "{{\"type\":\"vmess\",\"tag\":{s},\"server\":{s},\"server_port\":{d},\"uuid\":{s},\"alter_id\":{d},\"security\":\"auto\"{s}{s}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.id.?), l.alter_id, tls, tr }),
+        .trojan => std.fmt.allocPrint(a, "{{\"type\":\"trojan\",\"tag\":{s},\"server\":{s},\"server_port\":{d},\"password\":{s}{s}{s}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.password.?), tls, tr }),
+        .shadowsocks => std.fmt.allocPrint(a, "{{\"type\":\"shadowsocks\",\"tag\":{s},\"server\":{s},\"server_port\":{d},\"method\":{s},\"password\":{s}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.method.?), js(a, l.password.?) }),
         else => error.UnsupportedScheme,
     };
 }
 
-/// Build a full Xray client config: a SOCKS5 inbound on 127.0.0.1:`socks_port` and one
-/// outbound per link. With >1 link, add a leastPing balancer + observatory so a dead
-/// egress fails over to a healthy one (the Xray analogue of the tunnel pool).
-pub fn genXrayConfig(a: std.mem.Allocator, links: []const XrayLink, socks_port: u16) ![]const u8 {
-    var obs: std.ArrayListUnmanaged(u8) = .empty;
+/// Build a sing-box config: a TUN inbound (`sbx0`; auto_route off — only the proxy's
+/// SO_MARK'd traffic is policy-routed into it, so the rest of the host is untouched) and
+/// one outbound per link. >1 link adds a `urltest` selector (health-based failover — the
+/// analogue of the tunnel pool). VLESS-Reality camouflages the egress hop as real TLS.
+pub fn genSingboxConfig(a: std.mem.Allocator, links: []const XrayLink) ![]const u8 {
+    var outs: std.ArrayListUnmanaged(u8) = .empty;
     for (links, 0..) |l, i| {
         const tag = try std.fmt.allocPrint(a, "egress-{d}", .{i});
-        if (i != 0) try obs.append(a, ',');
-        try obs.appendSlice(a, try outbound(a, l, tag));
+        if (i != 0) try outs.append(a, ',');
+        try outs.appendSlice(a, try sbOutbound(a, l, tag));
     }
-    const routing = if (links.len > 1)
-        ",\"routing\":{\"balancers\":[{\"tag\":\"egress\",\"selector\":[\"egress-\"],\"strategy\":{\"type\":\"leastPing\"}}],\"rules\":[{\"type\":\"field\",\"network\":\"tcp,udp\",\"balancerTag\":\"egress\"}]},\"observatory\":{\"subjectSelector\":[\"egress-\"],\"probeUrl\":\"https://www.gstatic.com/generate_204\",\"probeInterval\":\"10s\"}"
-    else
-        "";
-    return std.fmt.allocPrint(a, "{{\"log\":{{\"loglevel\":\"warning\"}},\"inbounds\":[{{\"tag\":\"socks-in\",\"listen\":\"127.0.0.1\",\"port\":{d},\"protocol\":\"socks\",\"settings\":{{\"udp\":true,\"auth\":\"noauth\"}}}}],\"outbounds\":[{s},{{\"protocol\":\"freedom\",\"tag\":\"direct\"}}]{s}}}", .{ socks_port, obs.items, routing });
+    var final_tag: []const u8 = "egress-0";
+    var selector: []const u8 = "";
+    if (links.len > 1) {
+        var tags: std.ArrayListUnmanaged(u8) = .empty;
+        for (0..links.len) |i| {
+            if (i != 0) try tags.append(a, ',');
+            try tags.appendSlice(a, try std.fmt.allocPrint(a, "\"egress-{d}\"", .{i}));
+        }
+        selector = try std.fmt.allocPrint(a, ",{{\"type\":\"urltest\",\"tag\":\"egress\",\"outbounds\":[{s}],\"url\":\"https://www.gstatic.com/generate_204\",\"interval\":\"10s\"}}", .{tags.items});
+        final_tag = "egress";
+    }
+    return std.fmt.allocPrint(a, "{{\"log\":{{\"level\":\"warn\"}},\"inbounds\":[{{\"type\":\"tun\",\"tag\":\"tun-in\",\"interface_name\":\"{s}\",\"address\":[\"{s}\"],\"auto_route\":false,\"stack\":\"system\"}}],\"outbounds\":[{s},{{\"type\":\"direct\",\"tag\":\"direct\"}}{s}],\"route\":{{\"auto_detect_interface\":true,\"final\":\"{s}\"}}}}", .{ TUN_IFACE, TUN_ADDR, outs.items, selector, final_tag });
 }
 
 // ── CLI + provisioning ──────────────────────────────────────────────────────────
@@ -394,7 +408,7 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
     if (fam0 == .wireguard) {
         return setupWireguard(ui, allocator, links.items);
     }
-    return setupXray(ui, allocator, links.items);
+    return setupSingboxTunnel(ui, allocator, links.items);
 }
 
 /// wireguard:// links -> native L3 tunnel. Convert each link to a WG/AmneziaWG .conf
@@ -463,7 +477,7 @@ pub fn convertWireguardLink(a: std.mem.Allocator, link_in: []const u8) ![]const 
     return aw.written();
 }
 
-fn setupXray(ui: *Tui, allocator: std.mem.Allocator, link_texts: []const []const u8) !void {
+fn setupSingboxTunnel(ui: *Tui, allocator: std.mem.Allocator, link_texts: []const []const u8) !void {
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
     const a = arena.allocator();
@@ -477,71 +491,79 @@ fn setupXray(ui: *Tui, allocator: std.mem.Allocator, link_texts: []const []const
         ui.stepOk("Parsed egress", parsed[i].address);
     }
 
-    if (!sys.commandExists("xray") and !sys.fileExists(XRAY_BIN)) {
-        ui.step("Installing Xray-core...");
-        if (!installXray(allocator)) {
-            ui.fail("Failed to install Xray-core (download/unzip). Check network and retry.");
+    if (!sys.commandExists("sing-box") and !sys.fileExists(SB_BIN)) {
+        ui.step("Installing sing-box...");
+        if (!installSingbox(allocator)) {
+            ui.fail("Failed to install sing-box (download/extract). Check network and retry.");
             return;
         }
-        ui.ok("Xray-core installed");
+        ui.ok("sing-box installed");
     }
-    const xray_bin: []const u8 = if (sys.fileExists(XRAY_BIN)) XRAY_BIN else "xray";
+    const sb_bin: []const u8 = if (sys.fileExists(SB_BIN)) SB_BIN else "sing-box";
 
-    const cfg = genXrayConfig(a, parsed, SOCKS_PORT) catch {
-        ui.fail("Failed to generate Xray config");
+    const cfg = genSingboxConfig(a, parsed) catch {
+        ui.fail("Failed to generate sing-box config");
         return;
     };
-    _ = sys.exec(allocator, &.{ "mkdir", "-p", XRAY_CONFIG_DIR }) catch {};
-    sys.writeFileMode(XRAY_CONFIG_PATH, cfg, 0o600) catch {
-        ui.fail("Failed to write " ++ XRAY_CONFIG_PATH);
+    _ = sys.exec(allocator, &.{ "mkdir", "-p", SB_CONFIG_DIR }) catch {};
+    sys.writeFileMode(SB_CONFIG_PATH, cfg, 0o600) catch {
+        ui.fail("Failed to write " ++ SB_CONFIG_PATH);
+        return;
+    };
+
+    // Policy-routing helper: wait for the tun, then route the proxy's SO_MARK'd egress
+    // (fwmark 200 → table 200 → sbx0) — the same mechanism the AmneziaWG tunnel uses.
+    const route_script = "#!/bin/bash\n" ++
+        "for i in $(seq 1 60); do ip link show " ++ TUN_IFACE ++ " >/dev/null 2>&1 && break; sleep 0.25; done\n" ++
+        "ip rule add fwmark " ++ TUN_FWMARK ++ " lookup " ++ TUN_TABLE ++ " 2>/dev/null || true\n" ++
+        "ip route replace default dev " ++ TUN_IFACE ++ " table " ++ TUN_TABLE ++ "\n";
+    sys.writeFileMode(SB_ROUTE_SCRIPT, route_script, 0o755) catch {
+        ui.fail("Failed to write the routing helper");
         return;
     };
 
     const unit = try std.fmt.allocPrint(a,
         \\[Unit]
-        \\Description=mtproto-proxy Xray egress (SOCKS5 bridge for upstream)
+        \\Description=mtproto-proxy sing-box tunnel egress
         \\After=network-online.target
         \\Wants=network-online.target
         \\
         \\[Service]
         \\ExecStart={s} run -c {s}
+        \\ExecStartPost=+{s}
         \\Restart=on-failure
         \\RestartSec=3
-        \\NoNewPrivileges=yes
-        \\ProtectSystem=strict
-        \\ProtectHome=yes
-        \\PrivateTmp=yes
+        \\AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW
         \\
         \\[Install]
         \\WantedBy=multi-user.target
         \\
-    , .{ xray_bin, XRAY_CONFIG_PATH });
-    sys.writeFile(XRAY_SERVICE_PATH, unit) catch {
+    , .{ sb_bin, SB_CONFIG_PATH, SB_ROUTE_SCRIPT });
+    sys.writeFile(SB_SERVICE_PATH, unit) catch {
         ui.fail("Failed to write the systemd unit");
         return;
     };
     _ = sys.exec(allocator, &.{ "systemctl", "daemon-reload" }) catch {};
-    _ = sys.exec(allocator, &.{ "systemctl", "enable", "--now", XRAY_SERVICE_NAME }) catch {};
-    ui.ok("Xray egress service up (SOCKS5 " ++ SOCKS_HOST ++ ":10808)");
+    _ = sys.exec(allocator, &.{ "systemctl", "enable", "--now", SB_SERVICE_NAME }) catch {};
+    ui.ok("sing-box tunnel egress up (tun " ++ TUN_IFACE ++ ")");
 
     if (sys.fileExists(CONFIG_PATH)) {
-        wireUpstreamSocks(allocator, link_texts) catch {
-            ui.warn("Xray bridge is up, but updating config.toml failed — set [upstream] type=socks5, [upstream.socks5] host=127.0.0.1 port=10808 manually");
+        wireUpstreamTunnel(allocator, link_texts) catch {
+            ui.warn("tunnel is up, but updating config.toml failed — set [upstream] type=tunnel, [upstream.tunnel] interface=" ++ TUN_IFACE ++ " manually");
             return;
         };
         _ = sys.exec(allocator, &.{ "systemctl", "restart", "mtproto-proxy" }) catch {};
-        ui.ok("upstream set to socks5 via the Xray egress; mtproto-proxy restarted");
+        ui.ok("upstream set to tunnel via " ++ TUN_IFACE ++ "; mtproto-proxy restarted");
     } else {
-        ui.warn("mtproto-proxy not installed here — the Xray bridge is up; point [upstream] type=socks5 host=127.0.0.1 port=10808 at it");
+        ui.warn("mtproto-proxy not installed here — the sing-box tunnel is up on " ++ TUN_IFACE ++ "; set [upstream] type=tunnel, [upstream.tunnel] interface=" ++ TUN_IFACE);
     }
 }
 
-fn wireUpstreamSocks(allocator: std.mem.Allocator, link_texts: []const []const u8) !void {
+fn wireUpstreamTunnel(allocator: std.mem.Allocator, link_texts: []const []const u8) !void {
     var doc = try toml.TomlDoc.load(allocator, CONFIG_PATH);
     defer doc.deinit();
-    try doc.set("upstream", "type", "socks5");
-    try doc.set("upstream.socks5", "host", SOCKS_HOST);
-    try doc.set("upstream.socks5", "port", "10808");
+    try doc.set("upstream", "type", "tunnel");
+    try doc.set("upstream.tunnel", "interface", TUN_IFACE);
     // Persist the links so a reinstall reproduces the egress (config is 0600).
     var arr: std.ArrayListUnmanaged(u8) = .empty;
     defer arr.deinit(allocator);
@@ -557,20 +579,35 @@ fn wireUpstreamSocks(allocator: std.mem.Allocator, link_texts: []const []const u
     try doc.save(CONFIG_PATH);
 }
 
-/// Download + install the static Xray-core binary for this arch (SHA-less; the zip is
-/// fetched over TLS from the pinned GitHub release path). Uses a private temp dir.
-fn installXray(allocator: std.mem.Allocator) bool {
-    const asset: []const u8 = switch (builtin.cpu.arch) {
-        .x86_64 => "Xray-linux-64.zip",
-        .aarch64 => "Xray-linux-arm64-v8a.zip",
+/// Download + install the static sing-box binary for this arch. The release asset name
+/// carries the version, so resolve the latest tag from the API first. Private temp dir.
+fn installSingbox(allocator: std.mem.Allocator) bool {
+    const arch: []const u8 = switch (builtin.cpu.arch) {
+        .x86_64 => "amd64",
+        .aarch64 => "arm64",
         else => return false,
     };
-    if (!sys.commandExists("unzip") or !sys.commandExists("curl")) {
+    if (!sys.commandExists("curl") or !sys.commandExists("tar")) {
         _ = sys.exec(allocator, &.{ "env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "-o", "DPkg::Lock::Timeout=600", "update", "-qq" }) catch {};
-        _ = sys.exec(allocator, &.{ "env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "install", "-y", "--no-install-recommends", "unzip", "curl" }) catch {};
+        _ = sys.exec(allocator, &.{ "env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "install", "-y", "--no-install-recommends", "curl", "tar" }) catch {};
     }
+    const ver = blk: {
+        const r = sys.exec(allocator, &.{ "curl", "-fsSL", "--connect-timeout", "30", "https://api.github.com/repos/SagerNet/sing-box/releases/latest" }) catch return false;
+        defer r.deinit();
+        if (r.exit_code != 0) break :blk null;
+        // Tolerate whitespace + the optional leading 'v': `"tag_name": "v1.13.13"`.
+        const key = "\"tag_name\"";
+        const ki = std.mem.indexOf(u8, r.stdout, key) orelse break :blk null;
+        const after = r.stdout[ki + key.len ..];
+        const q1 = std.mem.indexOfScalar(u8, after, '"') orelse break :blk null;
+        var vstart = q1 + 1;
+        if (vstart < after.len and after[vstart] == 'v') vstart += 1;
+        const q2 = std.mem.indexOfScalarPos(u8, after, vstart, '"') orelse break :blk null;
+        break :blk allocator.dupe(u8, after[vstart..q2]) catch null;
+    } orelse return false;
+    defer allocator.free(ver);
     const td = blk: {
-        const r = sys.exec(allocator, &.{ "mktemp", "-d", "/tmp/mtbuddy-xray.XXXXXX" }) catch return false;
+        const r = sys.exec(allocator, &.{ "mktemp", "-d", "/tmp/mtbuddy-singbox.XXXXXX" }) catch return false;
         defer r.deinit();
         if (r.exit_code != 0) break :blk null;
         const t = std.mem.trim(u8, r.stdout, " \t\r\n");
@@ -581,28 +618,28 @@ fn installXray(allocator: std.mem.Allocator) bool {
         _ = sys.exec(allocator, &.{ "rm", "-rf", td }) catch {};
         allocator.free(td);
     }
-    const url = std.fmt.allocPrint(allocator, "https://github.com/XTLS/Xray-core/releases/latest/download/{s}", .{asset}) catch return false;
+    const url = std.fmt.allocPrint(allocator, "https://github.com/SagerNet/sing-box/releases/download/v{s}/sing-box-{s}-linux-{s}.tar.gz", .{ ver, ver, arch }) catch return false;
     defer allocator.free(url);
-    const zip = std.fmt.allocPrint(allocator, "{s}/xray.zip", .{td}) catch return false;
-    defer allocator.free(zip);
+    const tgz = std.fmt.allocPrint(allocator, "{s}/sb.tar.gz", .{td}) catch return false;
+    defer allocator.free(tgz);
     {
-        const r = sys.exec(allocator, &.{ "curl", "-fsSL", "--retry", "3", "--connect-timeout", "30", "-o", zip, url }) catch return false;
+        const r = sys.exec(allocator, &.{ "curl", "-fsSL", "--retry", "3", "--connect-timeout", "30", "-o", tgz, url }) catch return false;
         defer r.deinit();
         if (r.exit_code != 0) return false;
     }
     {
-        const r = sys.exec(allocator, &.{ "unzip", "-o", zip, "xray", "-d", td }) catch return false;
+        const r = sys.exec(allocator, &.{ "tar", "xzf", tgz, "-C", td, "--no-same-owner" }) catch return false;
         defer r.deinit();
         if (r.exit_code != 0) return false;
     }
-    const extracted = std.fmt.allocPrint(allocator, "{s}/xray", .{td}) catch return false;
+    const extracted = std.fmt.allocPrint(allocator, "{s}/sing-box-{s}-linux-{s}/sing-box", .{ td, ver, arch }) catch return false;
     defer allocator.free(extracted);
     {
-        const r = sys.exec(allocator, &.{ "install", "-m", "0755", extracted, XRAY_BIN }) catch return false;
+        const r = sys.exec(allocator, &.{ "install", "-m", "0755", extracted, SB_BIN }) catch return false;
         defer r.deinit();
         if (r.exit_code != 0) return false;
     }
-    return sys.fileExists(XRAY_BIN);
+    return sys.fileExists(SB_BIN);
 }
 
 test "parse vless reality link" {
@@ -648,23 +685,24 @@ test "parse shadowsocks sip002 link" {
     try std.testing.expectEqualStrings("g7ZGM4sBp5FuzPgvKQgYgA", l.password.?);
 }
 
-test "genXrayConfig is valid JSON; balancer only for a pool" {
+test "genSingboxConfig is valid JSON; urltest only for a pool" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const a = arena.allocator();
     const vless = try parseXrayLink(a, "vless://95e0edb9-4a0b-4312-a71f-1d4b8b6db79b@154.59.110.32:443?type=tcp&security=reality&pbk=PBK&sni=www.microsoft.com&sid=SID&flow=xtls-rprx-vision#v");
     const ss = try parseXrayLink(a, "ss://YWVzLTI1Ni1nY206ZzdaR000c0JwNUZ1elBndktRZ1lnQQ==@154.59.110.32:9443#s");
 
-    const one = try genXrayConfig(a, &.{vless}, 10808);
+    const one = try genSingboxConfig(a, &.{vless});
     _ = try std.json.parseFromSlice(std.json.Value, a, one, .{}); // well-formed JSON
     try std.testing.expect(std.mem.indexOf(u8, one, "\"reality\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, one, "\"port\":10808") != null);
+    try std.testing.expect(std.mem.indexOf(u8, one, "\"type\":\"tun\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, one, "\"sbx0\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, one, "xtls-rprx-vision") != null);
-    try std.testing.expect(std.mem.indexOf(u8, one, "\"balancers\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, one, "\"urltest\"") == null);
 
-    const pool = try genXrayConfig(a, &.{ vless, ss }, 10808);
+    const pool = try genSingboxConfig(a, &.{ vless, ss });
     _ = try std.json.parseFromSlice(std.json.Value, a, pool, .{});
-    try std.testing.expect(std.mem.indexOf(u8, pool, "\"balancers\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, pool, "\"urltest\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, pool, "egress-0") != null);
     try std.testing.expect(std.mem.indexOf(u8, pool, "egress-1") != null);
     try std.testing.expect(std.mem.indexOf(u8, pool, "shadowsocks") != null);

--- a/src/ctl/egress.zig
+++ b/src/ctl/egress.zig
@@ -15,6 +15,22 @@
 //! lives entirely in mtbuddy (ctl).
 
 const std = @import("std");
+const builtin = @import("builtin");
+const sys = @import("sys.zig");
+const toml = @import("toml.zig");
+const tunnel = @import("tunnel.zig");
+const tui_mod = @import("tui.zig");
+const Tui = tui_mod.Tui;
+
+const INSTALL_DIR = "/opt/mtproto-proxy";
+const CONFIG_PATH = INSTALL_DIR ++ "/config.toml";
+const XRAY_CONFIG_DIR = "/etc/mtproto-proxy";
+const XRAY_CONFIG_PATH = XRAY_CONFIG_DIR ++ "/xray-egress.json";
+const XRAY_SERVICE_NAME = "mtproto-xray-egress.service";
+const XRAY_SERVICE_PATH = "/etc/systemd/system/" ++ XRAY_SERVICE_NAME;
+const XRAY_BIN = "/usr/local/bin/xray";
+const SOCKS_HOST = "127.0.0.1";
+const SOCKS_PORT: u16 = 10808;
 
 // ── URI helpers ───────────────────────────────────────────────────────────────
 
@@ -343,6 +359,252 @@ pub fn genXrayConfig(a: std.mem.Allocator, links: []const XrayLink, socks_port: 
     return std.fmt.allocPrint(a, "{{\"log\":{{\"loglevel\":\"warning\"}},\"inbounds\":[{{\"tag\":\"socks-in\",\"listen\":\"127.0.0.1\",\"port\":{d},\"protocol\":\"socks\",\"settings\":{{\"udp\":true,\"auth\":\"noauth\"}}}}],\"outbounds\":[{s},{{\"protocol\":\"freedom\",\"tag\":\"direct\"}}]{s}}}", .{ socks_port, obs.items, routing });
 }
 
+// ── CLI + provisioning ──────────────────────────────────────────────────────────
+
+const Family = enum { wireguard, xray };
+fn schemeFamily(s: Scheme) Family {
+    return if (s == .wireguard) .wireguard else .xray;
+}
+
+pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) !void {
+    var links: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer links.deinit(allocator);
+    while (args.next()) |arg| {
+        if (arg.len > 0 and arg[0] != '-') links.append(allocator, arg) catch {};
+    }
+    if (links.items.len == 0) {
+        ui.fail("Usage: mtbuddy setup egress <share-link> [<share-link>...]");
+        ui.hint("vless:// vmess:// trojan:// ss://  ->  Xray SOCKS5 bridge (upstream.type=socks5)");
+        ui.hint("wireguard://                       ->  native L3 tunnel");
+        return;
+    }
+    // One egress = one provider family. Reject a mix of wireguard:// and Xray links.
+    const fam0 = schemeFamily(detectScheme(links.items[0]));
+    for (links.items) |l| {
+        const s = detectScheme(l);
+        if (s == .unknown) {
+            ui.fail("Unrecognized share-link scheme (want vless/vmess/trojan/ss/wireguard)");
+            return;
+        }
+        if (schemeFamily(s) != fam0) {
+            ui.fail("Don't mix wireguard:// and Xray links in one egress — set them up separately");
+            return;
+        }
+    }
+    if (fam0 == .wireguard) {
+        return setupWireguard(ui, allocator, links.items);
+    }
+    return setupXray(ui, allocator, links.items);
+}
+
+/// wireguard:// links -> native L3 tunnel. Convert each link to a WG/AmneziaWG .conf
+/// (egress owns the URI parsing) and hand it to tunnel.zig's existing setup, which
+/// brings up the interface + policy routing and, for >1 link, builds the tunnel pool.
+fn setupWireguard(ui: *Tui, allocator: std.mem.Allocator, links: []const []const u8) !void {
+    for (links, 0..) |link, idx| {
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        defer arena.deinit();
+        const a = arena.allocator();
+        const conf = convertWireguardLink(a, link) catch {
+            ui.fail("Failed to parse a wireguard:// link");
+            return;
+        };
+        const tmp = try std.fmt.allocPrint(a, "/tmp/mtbuddy-wg-{d}.conf", .{idx});
+        sys.writeFileMode(tmp, conf, 0o600) catch {
+            ui.fail("Failed to stage the WireGuard config");
+            return;
+        };
+        try tunnel.setupFromConf(ui, allocator, tmp);
+        _ = sys.exec(allocator, &.{ "rm", "-f", tmp }) catch {};
+    }
+}
+
+/// Convert a `wireguard://<privkey>@<host>:<port>?publickey=&address=&mtu=...#name`
+/// share-link into a WireGuard/AmneziaWG `.conf`. AmneziaWG obfuscation params
+/// (jc/jmin/jmax/s1/s2/h1..h4) and presharedkey are carried through when present.
+pub fn convertWireguardLink(a: std.mem.Allocator, link_in: []const u8) ![]const u8 {
+    const link = std.mem.trim(u8, link_in, " \t\r\n");
+    const after = if (std.mem.startsWith(u8, link, "wireguard://"))
+        link["wireguard://".len..]
+    else if (std.mem.startsWith(u8, link, "wg://"))
+        link["wg://".len..]
+    else
+        return error.UnsupportedScheme;
+
+    var rest = after;
+    if (std.mem.indexOfScalar(u8, rest, '#')) |h| rest = rest[0..h];
+    var query: []const u8 = "";
+    if (std.mem.indexOfScalar(u8, rest, '?')) |q| {
+        query = rest[q + 1 ..];
+        rest = rest[0..q];
+    }
+    const at = std.mem.indexOfScalar(u8, rest, '@') orelse return error.BadLink;
+    const private_key = try percentDecodeAlloc(a, rest[0..at]);
+    const hp = try splitHostPort(rest[at + 1 ..]);
+
+    const pub_key = try percentDecodeAlloc(a, queryParam(query, "publickey") orelse queryParam(query, "public_key") orelse return error.BadLink);
+    const address = try percentDecodeAlloc(a, queryParam(query, "address") orelse "10.0.0.2/32");
+    const mtu = queryParam(query, "mtu") orelse "1420";
+
+    var aw: std.Io.Writer.Allocating = .init(a);
+    const w = &aw.writer;
+    try w.print("[Interface]\nPrivateKey = {s}\nAddress = {s}\nMTU = {s}\n", .{ private_key, address, mtu });
+    if (queryParam(query, "dns")) |dns| try w.print("DNS = {s}\n", .{try percentDecodeAlloc(a, dns)});
+    // AmneziaWG obfuscation knobs (only emitted when present).
+    inline for (.{ "jc", "jmin", "jmax", "s1", "s2", "h1", "h2", "h3", "h4" }) |k| {
+        if (queryParam(query, k)) |v| {
+            var ku: [4]u8 = undefined;
+            const upper = std.ascii.upperString(&ku, k);
+            try w.print("{s} = {s}\n", .{ upper, v });
+        }
+    }
+    try w.print("\n[Peer]\nPublicKey = {s}\nEndpoint = {s}:{d}\nAllowedIPs = 0.0.0.0/0, ::/0\nPersistentKeepalive = 25\n", .{ pub_key, hp.host, hp.port });
+    if (queryParam(query, "presharedkey")) |psk| try w.print("PresharedKey = {s}\n", .{try percentDecodeAlloc(a, psk)});
+    return aw.written();
+}
+
+fn setupXray(ui: *Tui, allocator: std.mem.Allocator, link_texts: []const []const u8) !void {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const parsed = try a.alloc(XrayLink, link_texts.len);
+    for (link_texts, 0..) |t, i| {
+        parsed[i] = parseXrayLink(a, t) catch {
+            ui.fail("Failed to parse a share-link");
+            return;
+        };
+        ui.stepOk("Parsed egress", parsed[i].address);
+    }
+
+    if (!sys.commandExists("xray") and !sys.fileExists(XRAY_BIN)) {
+        ui.step("Installing Xray-core...");
+        if (!installXray(allocator)) {
+            ui.fail("Failed to install Xray-core (download/unzip). Check network and retry.");
+            return;
+        }
+        ui.ok("Xray-core installed");
+    }
+    const xray_bin: []const u8 = if (sys.fileExists(XRAY_BIN)) XRAY_BIN else "xray";
+
+    const cfg = genXrayConfig(a, parsed, SOCKS_PORT) catch {
+        ui.fail("Failed to generate Xray config");
+        return;
+    };
+    _ = sys.exec(allocator, &.{ "mkdir", "-p", XRAY_CONFIG_DIR }) catch {};
+    sys.writeFileMode(XRAY_CONFIG_PATH, cfg, 0o600) catch {
+        ui.fail("Failed to write " ++ XRAY_CONFIG_PATH);
+        return;
+    };
+
+    const unit = try std.fmt.allocPrint(a,
+        \\[Unit]
+        \\Description=mtproto-proxy Xray egress (SOCKS5 bridge for upstream)
+        \\After=network-online.target
+        \\Wants=network-online.target
+        \\
+        \\[Service]
+        \\ExecStart={s} run -c {s}
+        \\Restart=on-failure
+        \\RestartSec=3
+        \\NoNewPrivileges=yes
+        \\ProtectSystem=strict
+        \\ProtectHome=yes
+        \\PrivateTmp=yes
+        \\
+        \\[Install]
+        \\WantedBy=multi-user.target
+        \\
+    , .{ xray_bin, XRAY_CONFIG_PATH });
+    sys.writeFile(XRAY_SERVICE_PATH, unit) catch {
+        ui.fail("Failed to write the systemd unit");
+        return;
+    };
+    _ = sys.exec(allocator, &.{ "systemctl", "daemon-reload" }) catch {};
+    _ = sys.exec(allocator, &.{ "systemctl", "enable", "--now", XRAY_SERVICE_NAME }) catch {};
+    ui.ok("Xray egress service up (SOCKS5 " ++ SOCKS_HOST ++ ":10808)");
+
+    if (sys.fileExists(CONFIG_PATH)) {
+        wireUpstreamSocks(allocator, link_texts) catch {
+            ui.warn("Xray bridge is up, but updating config.toml failed — set [upstream] type=socks5, [upstream.socks5] host=127.0.0.1 port=10808 manually");
+            return;
+        };
+        _ = sys.exec(allocator, &.{ "systemctl", "restart", "mtproto-proxy" }) catch {};
+        ui.ok("upstream set to socks5 via the Xray egress; mtproto-proxy restarted");
+    } else {
+        ui.warn("mtproto-proxy not installed here — the Xray bridge is up; point [upstream] type=socks5 host=127.0.0.1 port=10808 at it");
+    }
+}
+
+fn wireUpstreamSocks(allocator: std.mem.Allocator, link_texts: []const []const u8) !void {
+    var doc = try toml.TomlDoc.load(allocator, CONFIG_PATH);
+    defer doc.deinit();
+    try doc.set("upstream", "type", "socks5");
+    try doc.set("upstream.socks5", "host", SOCKS_HOST);
+    try doc.set("upstream.socks5", "port", "10808");
+    // Persist the links so a reinstall reproduces the egress (config is 0600).
+    var arr: std.ArrayListUnmanaged(u8) = .empty;
+    defer arr.deinit(allocator);
+    try arr.append(allocator, '[');
+    for (link_texts, 0..) |t, i| {
+        if (i != 0) try arr.append(allocator, ',');
+        try arr.append(allocator, '"');
+        try arr.appendSlice(allocator, t);
+        try arr.append(allocator, '"');
+    }
+    try arr.append(allocator, ']');
+    try doc.set("upstream.xray", "links", arr.items);
+    try doc.save(CONFIG_PATH);
+}
+
+/// Download + install the static Xray-core binary for this arch (SHA-less; the zip is
+/// fetched over TLS from the pinned GitHub release path). Uses a private temp dir.
+fn installXray(allocator: std.mem.Allocator) bool {
+    const asset: []const u8 = switch (builtin.cpu.arch) {
+        .x86_64 => "Xray-linux-64.zip",
+        .aarch64 => "Xray-linux-arm64-v8a.zip",
+        else => return false,
+    };
+    if (!sys.commandExists("unzip") or !sys.commandExists("curl")) {
+        _ = sys.exec(allocator, &.{ "env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "-o", "DPkg::Lock::Timeout=600", "update", "-qq" }) catch {};
+        _ = sys.exec(allocator, &.{ "env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "install", "-y", "--no-install-recommends", "unzip", "curl" }) catch {};
+    }
+    const td = blk: {
+        const r = sys.exec(allocator, &.{ "mktemp", "-d", "/tmp/mtbuddy-xray.XXXXXX" }) catch return false;
+        defer r.deinit();
+        if (r.exit_code != 0) break :blk null;
+        const t = std.mem.trim(u8, r.stdout, " \t\r\n");
+        if (t.len == 0) break :blk null;
+        break :blk allocator.dupe(u8, t) catch null;
+    } orelse return false;
+    defer {
+        _ = sys.exec(allocator, &.{ "rm", "-rf", td }) catch {};
+        allocator.free(td);
+    }
+    const url = std.fmt.allocPrint(allocator, "https://github.com/XTLS/Xray-core/releases/latest/download/{s}", .{asset}) catch return false;
+    defer allocator.free(url);
+    const zip = std.fmt.allocPrint(allocator, "{s}/xray.zip", .{td}) catch return false;
+    defer allocator.free(zip);
+    {
+        const r = sys.exec(allocator, &.{ "curl", "-fsSL", "--retry", "3", "--connect-timeout", "30", "-o", zip, url }) catch return false;
+        defer r.deinit();
+        if (r.exit_code != 0) return false;
+    }
+    {
+        const r = sys.exec(allocator, &.{ "unzip", "-o", zip, "xray", "-d", td }) catch return false;
+        defer r.deinit();
+        if (r.exit_code != 0) return false;
+    }
+    const extracted = std.fmt.allocPrint(allocator, "{s}/xray", .{td}) catch return false;
+    defer allocator.free(extracted);
+    {
+        const r = sys.exec(allocator, &.{ "install", "-m", "0755", extracted, XRAY_BIN }) catch return false;
+        defer r.deinit();
+        if (r.exit_code != 0) return false;
+    }
+    return sys.fileExists(XRAY_BIN);
+}
+
 test "parse vless reality link" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -421,4 +683,27 @@ test "detectScheme" {
     try std.testing.expectEqual(Scheme.wireguard, detectScheme("wireguard://x"));
     try std.testing.expectEqual(Scheme.shadowsocks, detectScheme("ss://x"));
     try std.testing.expectEqual(Scheme.unknown, detectScheme("http://x"));
+}
+
+test "convertWireguardLink builds a WG/AmneziaWG conf" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const conf = try convertWireguardLink(a, "wireguard://PRIVK%2Fey@111.222.33.194:19666?publickey=PUBKEY&address=10.11.11.2%2F32&mtu=1420&presharedkey=PSK&jc=4&s1=50#German%20WG-1");
+    const has = struct {
+        fn f(h: []const u8, n: []const u8) bool {
+            return std.mem.indexOf(u8, h, n) != null;
+        }
+    }.f;
+    try std.testing.expect(has(conf, "[Interface]"));
+    try std.testing.expect(has(conf, "PrivateKey = PRIVK/ey")); // %2F decoded
+    try std.testing.expect(has(conf, "Address = 10.11.11.2/32"));
+    try std.testing.expect(has(conf, "MTU = 1420"));
+    try std.testing.expect(has(conf, "JC = 4")); // AmneziaWG knob, uppercased
+    try std.testing.expect(has(conf, "S1 = 50"));
+    try std.testing.expect(has(conf, "[Peer]"));
+    try std.testing.expect(has(conf, "PublicKey = PUBKEY"));
+    try std.testing.expect(has(conf, "Endpoint = 111.222.33.194:19666"));
+    try std.testing.expect(has(conf, "AllowedIPs = 0.0.0.0/0, ::/0"));
+    try std.testing.expect(has(conf, "PresharedKey = PSK"));
 }

--- a/src/ctl/egress.zig
+++ b/src/ctl/egress.zig
@@ -1,0 +1,424 @@
+//! egress.zig — `mtbuddy setup egress <share-link>...`
+//!
+//! Provision an upstream egress for the proxy from VPN share-links, dispatching by
+//! URI scheme onto the two egress shapes the proxy already supports:
+//!
+//!   wireguard://                         -> native L3 tunnel (reuses tunnel.zig:
+//!                                           kernel WG/AmneziaWG + policy routing + pool)
+//!   vless:// vmess:// trojan:// ss://     -> a local Xray client exposing a SOCKS5
+//!                                           inbound; the proxy egresses via
+//!                                           upstream.type = socks5. Multiple links ->
+//!                                           an Xray balancer + observatory (failover),
+//!                                           mirroring the tunnel pool.
+//!
+//! The proxy relay is unchanged: the SOCKS5 upstream client already exists. This module
+//! lives entirely in mtbuddy (ctl).
+
+const std = @import("std");
+
+// ── URI helpers ───────────────────────────────────────────────────────────────
+
+/// Decode percent-escapes (%2F -> '/') into `out` (must be >= s.len). Returns the slice.
+pub fn percentDecode(out: []u8, s: []const u8) []const u8 {
+    var w: usize = 0;
+    var i: usize = 0;
+    while (i < s.len) : (i += 1) {
+        if (s[i] == '%' and i + 2 < s.len) {
+            const hi = std.fmt.charToDigit(s[i + 1], 16) catch {
+                out[w] = s[i];
+                w += 1;
+                continue;
+            };
+            const lo = std.fmt.charToDigit(s[i + 2], 16) catch {
+                out[w] = s[i];
+                w += 1;
+                continue;
+            };
+            out[w] = @intCast(hi * 16 + lo);
+            w += 1;
+            i += 2;
+        } else {
+            out[w] = s[i];
+            w += 1;
+        }
+    }
+    return out[0..w];
+}
+
+/// Percent-decode into a freshly allocated buffer.
+fn percentDecodeAlloc(a: std.mem.Allocator, s: []const u8) ![]const u8 {
+    const buf = try a.alloc(u8, s.len);
+    const decoded = percentDecode(buf, s);
+    return decoded;
+}
+
+/// Return the (raw, undecoded) value of `key` in a `k=v&k2=v2` query string, or null.
+pub fn queryParam(query: []const u8, key: []const u8) ?[]const u8 {
+    var it = std.mem.splitScalar(u8, query, '&');
+    while (it.next()) |pair| {
+        const eq = std.mem.indexOfScalar(u8, pair, '=') orelse continue;
+        if (std.mem.eql(u8, pair[0..eq], key)) return pair[eq + 1 ..];
+    }
+    return null;
+}
+
+/// Standard or url-safe base64 decode (tolerant of missing padding), into alloc.
+fn base64Decode(a: std.mem.Allocator, s_in: []const u8) ![]u8 {
+    const s = std.mem.trim(u8, s_in, " \t\r\n");
+    const url_safe = std.mem.indexOfAny(u8, s, "-_") != null;
+    // Re-pad to a multiple of 4 for the standard decoders.
+    const pad = (4 - (s.len % 4)) % 4;
+    var tmp = try a.alloc(u8, s.len + pad);
+    @memcpy(tmp[0..s.len], s);
+    var p: usize = 0;
+    while (p < pad) : (p += 1) tmp[s.len + p] = '=';
+    const dec = if (url_safe) std.base64.url_safe.Decoder else std.base64.standard.Decoder;
+    const n = dec.calcSizeForSlice(tmp) catch return error.BadBase64;
+    const out = try a.alloc(u8, n);
+    dec.decode(out, tmp) catch return error.BadBase64;
+    return out;
+}
+
+// ── Parsed link model ──────────────────────────────────────────────────────────
+
+pub const Scheme = enum { vless, vmess, trojan, shadowsocks, wireguard, unknown };
+
+pub fn detectScheme(link_in: []const u8) Scheme {
+    const link = std.mem.trim(u8, link_in, " \t\r\n");
+    if (std.mem.startsWith(u8, link, "vless://")) return .vless;
+    if (std.mem.startsWith(u8, link, "vmess://")) return .vmess;
+    if (std.mem.startsWith(u8, link, "trojan://")) return .trojan;
+    if (std.mem.startsWith(u8, link, "ss://")) return .shadowsocks;
+    if (std.mem.startsWith(u8, link, "wireguard://") or std.mem.startsWith(u8, link, "wg://")) return .wireguard;
+    return .unknown;
+}
+
+/// A parsed Xray-family link (vless/vmess/trojan/ss). All string fields are owned by
+/// the allocator passed to the parser (use an arena and free it all at once). Fields
+/// not relevant to a given protocol stay null/empty.
+pub const XrayLink = struct {
+    scheme: Scheme,
+    name: []const u8 = "egress",
+    address: []const u8,
+    port: u16,
+    // auth
+    id: ?[]const u8 = null, // uuid (vless/vmess)
+    password: ?[]const u8 = null, // trojan / ss
+    method: ?[]const u8 = null, // ss cipher
+    alter_id: u16 = 0, // vmess aid
+    // transport / security
+    network: []const u8 = "tcp", // tcp | ws | grpc | http
+    security: []const u8 = "none", // none | tls | reality
+    flow: ?[]const u8 = null, // vless xtls flow
+    sni: ?[]const u8 = null,
+    host: ?[]const u8 = null, // ws/http Host header
+    path: ?[]const u8 = null, // ws/http path or grpc serviceName
+    fingerprint: ?[]const u8 = null, // utls fp (chrome,...)
+    public_key: ?[]const u8 = null, // reality pbk
+    short_id: ?[]const u8 = null, // reality sid
+};
+
+fn splitHostPort(hp: []const u8) !struct { host: []const u8, port: u16 } {
+    // IPv6 literal in brackets: [::1]:443
+    if (hp.len > 0 and hp[0] == '[') {
+        const close = std.mem.indexOfScalar(u8, hp, ']') orelse return error.BadAddress;
+        const host = hp[1..close];
+        if (close + 1 >= hp.len or hp[close + 1] != ':') return error.BadAddress;
+        const port = std.fmt.parseInt(u16, hp[close + 2 ..], 10) catch return error.BadAddress;
+        return .{ .host = host, .port = port };
+    }
+    const colon = std.mem.lastIndexOfScalar(u8, hp, ':') orelse return error.BadAddress;
+    const port = std.fmt.parseInt(u16, hp[colon + 1 ..], 10) catch return error.BadAddress;
+    return .{ .host = hp[0..colon], .port = port };
+}
+
+/// Parse vless:// or trojan:// (same URI shape: cred@host:port?params#name).
+fn parseUriCred(a: std.mem.Allocator, link: []const u8, scheme: Scheme, prefix: []const u8) !XrayLink {
+    var rest = link[prefix.len..];
+    // fragment (name)
+    var name: []const u8 = "egress";
+    if (std.mem.indexOfScalar(u8, rest, '#')) |h| {
+        name = try percentDecodeAlloc(a, rest[h + 1 ..]);
+        rest = rest[0..h];
+    }
+    // query
+    var query: []const u8 = "";
+    if (std.mem.indexOfScalar(u8, rest, '?')) |q| {
+        query = rest[q + 1 ..];
+        rest = rest[0..q];
+    }
+    const at = std.mem.indexOfScalar(u8, rest, '@') orelse return error.BadLink;
+    const cred = try percentDecodeAlloc(a, rest[0..at]);
+    const hp = try splitHostPort(rest[at + 1 ..]);
+
+    var l = XrayLink{ .scheme = scheme, .name = name, .address = try a.dupe(u8, hp.host), .port = hp.port };
+    if (scheme == .vless) l.id = cred else l.password = cred;
+
+    if (queryParam(query, "type")) |v| l.network = try percentDecodeAlloc(a, v);
+    if (queryParam(query, "security")) |v| l.security = try percentDecodeAlloc(a, v);
+    if (queryParam(query, "flow")) |v| l.flow = try percentDecodeAlloc(a, v);
+    if (queryParam(query, "sni")) |v| l.sni = try percentDecodeAlloc(a, v);
+    if (queryParam(query, "host")) |v| l.host = try percentDecodeAlloc(a, v);
+    if (queryParam(query, "path")) |v| l.path = try percentDecodeAlloc(a, v);
+    if (queryParam(query, "serviceName")) |v| l.path = try percentDecodeAlloc(a, v);
+    if (queryParam(query, "fp")) |v| l.fingerprint = try percentDecodeAlloc(a, v);
+    if (queryParam(query, "pbk")) |v| l.public_key = try percentDecodeAlloc(a, v);
+    if (queryParam(query, "sid")) |v| l.short_id = try percentDecodeAlloc(a, v);
+    return l;
+}
+
+fn jsonStr(obj: std.json.Value, key: []const u8) ?[]const u8 {
+    const v = obj.object.get(key) orelse return null;
+    return switch (v) {
+        .string => |s| s,
+        .integer => |i| std.fmt.allocPrint(std.heap.page_allocator, "{d}", .{i}) catch null,
+        else => null,
+    };
+}
+
+/// Parse vmess:// (base64-encoded JSON object).
+fn parseVmess(a: std.mem.Allocator, link: []const u8) !XrayLink {
+    const decoded = try base64Decode(a, link["vmess://".len..]);
+    const parsed = std.json.parseFromSlice(std.json.Value, a, decoded, .{}) catch return error.BadLink;
+    const o = parsed.value;
+    if (o != .object) return error.BadLink;
+    const add = jsonStr(o, "add") orelse return error.BadLink;
+    const port_s = jsonStr(o, "port") orelse return error.BadLink;
+    const id = jsonStr(o, "id") orelse return error.BadLink;
+    var l = XrayLink{
+        .scheme = .vmess,
+        .name = try a.dupe(u8, jsonStr(o, "ps") orelse "egress"),
+        .address = try a.dupe(u8, add),
+        .port = std.fmt.parseInt(u16, std.mem.trim(u8, port_s, " "), 10) catch return error.BadLink,
+        .id = try a.dupe(u8, id),
+    };
+    if (jsonStr(o, "aid")) |s| l.alter_id = std.fmt.parseInt(u16, std.mem.trim(u8, s, " "), 10) catch 0;
+    if (jsonStr(o, "net")) |s| l.network = try a.dupe(u8, s);
+    if (jsonStr(o, "host")) |s| l.host = try a.dupe(u8, s);
+    if (jsonStr(o, "path")) |s| l.path = try a.dupe(u8, s);
+    if (jsonStr(o, "sni")) |s| l.sni = try a.dupe(u8, s);
+    const tls = jsonStr(o, "tls") orelse "";
+    if (tls.len > 0) l.security = "tls";
+    return l;
+}
+
+/// Parse ss:// — SIP002 (`ss://b64(method:pass)@host:port#name`) or legacy
+/// (`ss://b64(method:pass@host:port)#name`).
+fn parseSs(a: std.mem.Allocator, link: []const u8) !XrayLink {
+    var rest = link["ss://".len..];
+    var name: []const u8 = "egress";
+    if (std.mem.indexOfScalar(u8, rest, '#')) |h| {
+        name = try percentDecodeAlloc(a, rest[h + 1 ..]);
+        rest = rest[0..h];
+    }
+    if (std.mem.indexOfScalar(u8, rest, '?')) |q| rest = rest[0..q]; // drop plugin params
+    var method: []const u8 = undefined;
+    var password: []const u8 = undefined;
+    var hostport: []const u8 = undefined;
+    if (std.mem.indexOfScalar(u8, rest, '@')) |at| {
+        // SIP002: userinfo (before @) is base64(method:password)
+        const ui = base64Decode(a, rest[0..at]) catch rest[0..at];
+        const colon = std.mem.indexOfScalar(u8, ui, ':') orelse return error.BadLink;
+        method = ui[0..colon];
+        password = ui[colon + 1 ..];
+        hostport = rest[at + 1 ..];
+    } else {
+        // legacy: whole thing is base64(method:password@host:port)
+        const dec = try base64Decode(a, rest);
+        const at = std.mem.indexOfScalar(u8, dec, '@') orelse return error.BadLink;
+        const colon = std.mem.indexOfScalar(u8, dec[0..at], ':') orelse return error.BadLink;
+        method = dec[0..colon];
+        password = dec[colon + 1 .. at];
+        hostport = dec[at + 1 ..];
+    }
+    const hp = try splitHostPort(hostport);
+    return XrayLink{
+        .scheme = .shadowsocks,
+        .name = name,
+        .address = try a.dupe(u8, hp.host),
+        .port = hp.port,
+        .method = try a.dupe(u8, method),
+        .password = try a.dupe(u8, password),
+    };
+}
+
+/// Parse any Xray-family share link into an XrayLink (arena-owned strings).
+pub fn parseXrayLink(a: std.mem.Allocator, link_in: []const u8) !XrayLink {
+    const link = std.mem.trim(u8, link_in, " \t\r\n");
+    return switch (detectScheme(link)) {
+        .vless => parseUriCred(a, link, .vless, "vless://"),
+        .trojan => parseUriCred(a, link, .trojan, "trojan://"),
+        .vmess => parseVmess(a, link),
+        .shadowsocks => parseSs(a, link),
+        else => error.UnsupportedScheme,
+    };
+}
+
+// ── Xray client config generation ───────────────────────────────────────────────
+
+/// JSON-escape + quote a string (returns including the surrounding quotes).
+fn js(a: std.mem.Allocator, s: []const u8) []const u8 {
+    var buf = a.alloc(u8, s.len * 2 + 2) catch return "\"\"";
+    var w: usize = 0;
+    buf[w] = '"';
+    w += 1;
+    for (s) |c| switch (c) {
+        '"', '\\' => {
+            buf[w] = '\\';
+            buf[w + 1] = c;
+            w += 2;
+        },
+        '\n' => {
+            buf[w] = '\\';
+            buf[w + 1] = 'n';
+            w += 2;
+        },
+        '\r' => {
+            buf[w] = '\\';
+            buf[w + 1] = 'r';
+            w += 2;
+        },
+        '\t' => {
+            buf[w] = '\\';
+            buf[w + 1] = 't';
+            w += 2;
+        },
+        else => {
+            buf[w] = c;
+            w += 1;
+        },
+    };
+    buf[w] = '"';
+    w += 1;
+    return buf[0..w];
+}
+
+fn streamSettings(a: std.mem.Allocator, l: XrayLink) ![]const u8 {
+    if (l.scheme == .shadowsocks) return "";
+    const sni = l.sni orelse l.host orelse l.address;
+    const fp = l.fingerprint orelse "chrome";
+    var sec: []const u8 = ",\"security\":\"none\"";
+    if (std.mem.eql(u8, l.security, "reality")) {
+        sec = try std.fmt.allocPrint(a, ",\"security\":\"reality\",\"realitySettings\":{{\"serverName\":{s},\"fingerprint\":{s},\"publicKey\":{s},\"shortId\":{s},\"spiderX\":\"/\"}}", .{ js(a, sni), js(a, fp), js(a, l.public_key orelse ""), js(a, l.short_id orelse "") });
+    } else if (std.mem.eql(u8, l.security, "tls")) {
+        sec = try std.fmt.allocPrint(a, ",\"security\":\"tls\",\"tlsSettings\":{{\"serverName\":{s},\"fingerprint\":{s},\"allowInsecure\":false}}", .{ js(a, sni), js(a, fp) });
+    }
+    var trans: []const u8 = "";
+    if (std.mem.eql(u8, l.network, "ws")) {
+        trans = try std.fmt.allocPrint(a, ",\"wsSettings\":{{\"path\":{s},\"headers\":{{\"Host\":{s}}}}}", .{ js(a, l.path orelse "/"), js(a, l.host orelse sni) });
+    } else if (std.mem.eql(u8, l.network, "grpc")) {
+        trans = try std.fmt.allocPrint(a, ",\"grpcSettings\":{{\"serviceName\":{s}}}", .{js(a, l.path orelse "")});
+    }
+    return std.fmt.allocPrint(a, ",\"streamSettings\":{{\"network\":{s}{s}{s}}}", .{ js(a, l.network), sec, trans });
+}
+
+fn outbound(a: std.mem.Allocator, l: XrayLink, tag: []const u8) ![]const u8 {
+    const stream = try streamSettings(a, l);
+    return switch (l.scheme) {
+        .vless => blk: {
+            const flow = if (l.flow) |f| try std.fmt.allocPrint(a, ",\"flow\":{s}", .{js(a, f)}) else "";
+            break :blk std.fmt.allocPrint(a, "{{\"protocol\":\"vless\",\"tag\":{s},\"settings\":{{\"vnext\":[{{\"address\":{s},\"port\":{d},\"users\":[{{\"id\":{s},\"encryption\":\"none\"{s}}}]}}]}}{s}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.id.?), flow, stream });
+        },
+        .vmess => std.fmt.allocPrint(a, "{{\"protocol\":\"vmess\",\"tag\":{s},\"settings\":{{\"vnext\":[{{\"address\":{s},\"port\":{d},\"users\":[{{\"id\":{s},\"alterId\":{d},\"security\":\"auto\"}}]}}]}}{s}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.id.?), l.alter_id, stream }),
+        .trojan => std.fmt.allocPrint(a, "{{\"protocol\":\"trojan\",\"tag\":{s},\"settings\":{{\"servers\":[{{\"address\":{s},\"port\":{d},\"password\":{s}}}]}}{s}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.password.?), stream }),
+        .shadowsocks => std.fmt.allocPrint(a, "{{\"protocol\":\"shadowsocks\",\"tag\":{s},\"settings\":{{\"servers\":[{{\"address\":{s},\"port\":{d},\"method\":{s},\"password\":{s}}}]}}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.method.?), js(a, l.password.?) }),
+        else => error.UnsupportedScheme,
+    };
+}
+
+/// Build a full Xray client config: a SOCKS5 inbound on 127.0.0.1:`socks_port` and one
+/// outbound per link. With >1 link, add a leastPing balancer + observatory so a dead
+/// egress fails over to a healthy one (the Xray analogue of the tunnel pool).
+pub fn genXrayConfig(a: std.mem.Allocator, links: []const XrayLink, socks_port: u16) ![]const u8 {
+    var obs: std.ArrayListUnmanaged(u8) = .empty;
+    for (links, 0..) |l, i| {
+        const tag = try std.fmt.allocPrint(a, "egress-{d}", .{i});
+        if (i != 0) try obs.append(a, ',');
+        try obs.appendSlice(a, try outbound(a, l, tag));
+    }
+    const routing = if (links.len > 1)
+        ",\"routing\":{\"balancers\":[{\"tag\":\"egress\",\"selector\":[\"egress-\"],\"strategy\":{\"type\":\"leastPing\"}}],\"rules\":[{\"type\":\"field\",\"network\":\"tcp,udp\",\"balancerTag\":\"egress\"}]},\"observatory\":{\"subjectSelector\":[\"egress-\"],\"probeUrl\":\"https://www.gstatic.com/generate_204\",\"probeInterval\":\"10s\"}"
+    else
+        "";
+    return std.fmt.allocPrint(a, "{{\"log\":{{\"loglevel\":\"warning\"}},\"inbounds\":[{{\"tag\":\"socks-in\",\"listen\":\"127.0.0.1\",\"port\":{d},\"protocol\":\"socks\",\"settings\":{{\"udp\":true,\"auth\":\"noauth\"}}}}],\"outbounds\":[{s},{{\"protocol\":\"freedom\",\"tag\":\"direct\"}}]{s}}}", .{ socks_port, obs.items, routing });
+}
+
+test "parse vless reality link" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const l = try parseXrayLink(a, "vless://95e0edb9-4a0b-4312-a71f-1d4b8b6db79b@154.59.110.32:443?type=tcp&security=reality&pbk=PBK&fp=chrome&sni=www.microsoft.com&sid=ABCD&flow=xtls-rprx-vision#demo");
+    try std.testing.expectEqual(Scheme.vless, l.scheme);
+    try std.testing.expectEqualStrings("154.59.110.32", l.address);
+    try std.testing.expectEqual(@as(u16, 443), l.port);
+    try std.testing.expectEqualStrings("95e0edb9-4a0b-4312-a71f-1d4b8b6db79b", l.id.?);
+    try std.testing.expectEqualStrings("reality", l.security);
+    try std.testing.expectEqualStrings("www.microsoft.com", l.sni.?);
+    try std.testing.expectEqualStrings("PBK", l.public_key.?);
+    try std.testing.expectEqualStrings("ABCD", l.short_id.?);
+    try std.testing.expectEqualStrings("xtls-rprx-vision", l.flow.?);
+    try std.testing.expectEqualStrings("demo", l.name);
+}
+
+test "parse vmess base64 link" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    // {"v":"2","ps":"demo-vmess","add":"154.59.110.32","port":"10443","id":"15750f7e-57df-4fb2-b3a4-a9edff4c0def","aid":"0","net":"tcp","type":"none","tls":""}
+    const l = try parseXrayLink(a, "vmess://eyJ2IjogIjIiLCAicHMiOiAiZGVtby12bWVzcyIsICJhZGQiOiAiMTU0LjU5LjExMC4zMiIsICJwb3J0IjogIjEwNDQzIiwgImlkIjogIjE1NzUwZjdlLTU3ZGYtNGZiMi1iM2E0LWE5ZWRmZjRjMGRlZiIsICJhaWQiOiAiMCIsICJuZXQiOiAidGNwIiwgInR5cGUiOiAibm9uZSIsICJ0bHMiOiAiIn0=");
+    try std.testing.expectEqual(Scheme.vmess, l.scheme);
+    try std.testing.expectEqualStrings("154.59.110.32", l.address);
+    try std.testing.expectEqual(@as(u16, 10443), l.port);
+    try std.testing.expectEqualStrings("15750f7e-57df-4fb2-b3a4-a9edff4c0def", l.id.?);
+    try std.testing.expectEqualStrings("demo-vmess", l.name);
+}
+
+test "parse shadowsocks sip002 link" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    // base64("aes-256-gcm:g7ZGM4sBp5FuzPgvKQgYgA") @ host:port
+    const l = try parseXrayLink(a, "ss://YWVzLTI1Ni1nY206ZzdaR000c0JwNUZ1elBndktRZ1lnQQ==@154.59.110.32:9443#demo-shadowsocks");
+    try std.testing.expectEqual(Scheme.shadowsocks, l.scheme);
+    try std.testing.expectEqualStrings("154.59.110.32", l.address);
+    try std.testing.expectEqual(@as(u16, 9443), l.port);
+    try std.testing.expectEqualStrings("aes-256-gcm", l.method.?);
+    try std.testing.expectEqualStrings("g7ZGM4sBp5FuzPgvKQgYgA", l.password.?);
+}
+
+test "genXrayConfig is valid JSON; balancer only for a pool" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const vless = try parseXrayLink(a, "vless://95e0edb9-4a0b-4312-a71f-1d4b8b6db79b@154.59.110.32:443?type=tcp&security=reality&pbk=PBK&sni=www.microsoft.com&sid=SID&flow=xtls-rprx-vision#v");
+    const ss = try parseXrayLink(a, "ss://YWVzLTI1Ni1nY206ZzdaR000c0JwNUZ1elBndktRZ1lnQQ==@154.59.110.32:9443#s");
+
+    const one = try genXrayConfig(a, &.{vless}, 10808);
+    _ = try std.json.parseFromSlice(std.json.Value, a, one, .{}); // well-formed JSON
+    try std.testing.expect(std.mem.indexOf(u8, one, "\"reality\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, one, "\"port\":10808") != null);
+    try std.testing.expect(std.mem.indexOf(u8, one, "xtls-rprx-vision") != null);
+    try std.testing.expect(std.mem.indexOf(u8, one, "\"balancers\"") == null);
+
+    const pool = try genXrayConfig(a, &.{ vless, ss }, 10808);
+    _ = try std.json.parseFromSlice(std.json.Value, a, pool, .{});
+    try std.testing.expect(std.mem.indexOf(u8, pool, "\"balancers\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, pool, "egress-0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, pool, "egress-1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, pool, "shadowsocks") != null);
+}
+
+test "percentDecode + queryParam" {
+    var buf: [64]u8 = undefined;
+    try std.testing.expectEqualStrings("10.11.11.2/32", percentDecode(&buf, "10.11.11.2%2F32"));
+    try std.testing.expectEqualStrings("German WG-1", percentDecode(&buf, "German%20WG-1"));
+    try std.testing.expectEqualStrings("1420", queryParam("publickey=X&address=Y&mtu=1420", "mtu").?);
+    try std.testing.expect(queryParam("a=1&b=2", "c") == null);
+}
+
+test "detectScheme" {
+    try std.testing.expectEqual(Scheme.vless, detectScheme("vless://x"));
+    try std.testing.expectEqual(Scheme.wireguard, detectScheme("wireguard://x"));
+    try std.testing.expectEqual(Scheme.shadowsocks, detectScheme("ss://x"));
+    try std.testing.expectEqual(Scheme.unknown, detectScheme("http://x"));
+}

--- a/src/ctl/egress.zig
+++ b/src/ctl/egress.zig
@@ -1,17 +1,19 @@
 //! egress.zig — `mtbuddy setup egress <share-link>...`
 //!
-//! Provision an upstream egress for the proxy from VPN share-links, dispatching by
-//! URI scheme onto the two egress shapes the proxy already supports:
+//! Provision an upstream egress for the proxy from VPN share-links, dispatching by URI
+//! scheme onto the `type = tunnel` egress shape (transparent L3, policy-routed — the same
+//! abstraction as AmneziaWG):
 //!
-//!   wireguard://                         -> native L3 tunnel (reuses tunnel.zig:
-//!                                           kernel WG/AmneziaWG + policy routing + pool)
-//!   vless:// vmess:// trojan:// ss://     -> a local Xray client exposing a SOCKS5
-//!                                           inbound; the proxy egresses via
-//!                                           upstream.type = socks5. Multiple links ->
-//!                                           an Xray balancer + observatory (failover),
-//!                                           mirroring the tunnel pool.
+//!   wireguard://                         -> native kernel WG/AmneziaWG tunnel (reuses
+//!                                           tunnel.zig: policy routing + pool)
+//!   vless:// vmess:// trojan:// ss://     -> a local sing-box client in TUN mode (sbx0);
+//!                                           the proxy's SO_MARK'd DC traffic is policy-
+//!                                           routed through it (fwmark 200 -> table 200 ->
+//!                                           sbx0). >1 link -> a sing-box urltest failover
+//!                                           pool. VLESS-Reality camouflages the hop as TLS.
 //!
-//! The proxy relay is unchanged: the SOCKS5 upstream client already exists. This module
+//! The proxy relay is unchanged (it just SO_MARKs, as for any tunnel). The two providers
+//! are mutually exclusive on table 200 — setting one up retires the other. This module
 //! lives entirely in mtbuddy (ctl).
 
 const std = @import("std");
@@ -125,6 +127,7 @@ pub const XrayLink = struct {
     password: ?[]const u8 = null, // trojan / ss
     method: ?[]const u8 = null, // ss cipher
     alter_id: u16 = 0, // vmess aid
+    cipher: []const u8 = "auto", // vmess scy (auto|none|zero|aes-128-gcm|chacha20-poly1305)
     // transport / security
     network: []const u8 = "tcp", // tcp | ws | grpc | http
     security: []const u8 = "none", // none | tls | reality
@@ -212,6 +215,9 @@ fn parseVmess(a: std.mem.Allocator, link: []const u8) !XrayLink {
         .id = try a.dupe(u8, id),
     };
     if (jsonStr(o, "aid")) |s| l.alter_id = std.fmt.parseInt(u16, std.mem.trim(u8, s, " "), 10) catch 0;
+    if (jsonStr(o, "scy")) |s| if (s.len > 0) {
+        l.cipher = try a.dupe(u8, s);
+    };
     if (jsonStr(o, "net")) |s| l.network = try a.dupe(u8, s);
     if (jsonStr(o, "host")) |s| l.host = try a.dupe(u8, s);
     if (jsonStr(o, "path")) |s| l.path = try a.dupe(u8, s);
@@ -275,12 +281,15 @@ pub fn parseXrayLink(a: std.mem.Allocator, link_in: []const u8) !XrayLink {
 
 // ── Xray client config generation ───────────────────────────────────────────────
 
-/// JSON-escape + quote a string (returns including the surrounding quotes).
+/// JSON-escape + quote a string (returns including the surrounding quotes). Control
+/// characters below 0x20 are emitted as \u00XX — a raw control byte (reachable via a
+/// percent-decoded link field) would otherwise produce JSON sing-box rejects.
 fn js(a: std.mem.Allocator, s: []const u8) []const u8 {
-    var buf = a.alloc(u8, s.len * 2 + 2) catch return "\"\"";
+    var buf = a.alloc(u8, s.len * 6 + 2) catch return "\"\"";
     var w: usize = 0;
     buf[w] = '"';
     w += 1;
+    const hex = "0123456789abcdef";
     for (s) |c| switch (c) {
         '"', '\\' => {
             buf[w] = '\\';
@@ -301,6 +310,15 @@ fn js(a: std.mem.Allocator, s: []const u8) []const u8 {
             buf[w] = '\\';
             buf[w + 1] = 't';
             w += 2;
+        },
+        0...8, 11, 12, 14...31 => {
+            buf[w + 0] = '\\';
+            buf[w + 1] = 'u';
+            buf[w + 2] = '0';
+            buf[w + 3] = '0';
+            buf[w + 4] = hex[c >> 4];
+            buf[w + 5] = hex[c & 0xf];
+            w += 6;
         },
         else => {
             buf[w] = c;
@@ -341,7 +359,7 @@ fn sbOutbound(a: std.mem.Allocator, l: XrayLink, tag: []const u8) ![]const u8 {
             const flow = if (l.flow) |f| try std.fmt.allocPrint(a, ",\"flow\":{s}", .{js(a, f)}) else "";
             break :blk std.fmt.allocPrint(a, "{{\"type\":\"vless\",\"tag\":{s},\"server\":{s},\"server_port\":{d},\"uuid\":{s}{s}{s}{s}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.id.?), flow, tls, tr });
         },
-        .vmess => std.fmt.allocPrint(a, "{{\"type\":\"vmess\",\"tag\":{s},\"server\":{s},\"server_port\":{d},\"uuid\":{s},\"alter_id\":{d},\"security\":\"auto\"{s}{s}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.id.?), l.alter_id, tls, tr }),
+        .vmess => std.fmt.allocPrint(a, "{{\"type\":\"vmess\",\"tag\":{s},\"server\":{s},\"server_port\":{d},\"uuid\":{s},\"alter_id\":{d},\"security\":{s}{s}{s}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.id.?), l.alter_id, js(a, l.cipher), tls, tr }),
         .trojan => std.fmt.allocPrint(a, "{{\"type\":\"trojan\",\"tag\":{s},\"server\":{s},\"server_port\":{d},\"password\":{s}{s}{s}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.password.?), tls, tr }),
         .shadowsocks => std.fmt.allocPrint(a, "{{\"type\":\"shadowsocks\",\"tag\":{s},\"server\":{s},\"server_port\":{d},\"method\":{s},\"password\":{s}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.method.?), js(a, l.password.?) }),
         else => error.UnsupportedScheme,
@@ -378,6 +396,35 @@ pub fn genSingboxConfig(a: std.mem.Allocator, links: []const XrayLink) ![]const 
 const Family = enum { wireguard, xray };
 fn schemeFamily(s: Scheme) Family {
     return if (s == .wireguard) .wireguard else .xray;
+}
+
+// Ciphers sing-box accepts for shadowsocks. An unknown one makes sing-box reject the
+// WHOLE config, so we reject the link up front with a clear message instead.
+const supported_ss_methods = [_][]const u8{
+    "aes-128-gcm",             "aes-192-gcm",
+    "aes-256-gcm",             "chacha20-ietf-poly1305",
+    "xchacha20-ietf-poly1305", "2022-blake3-aes-128-gcm",
+    "2022-blake3-aes-256-gcm", "2022-blake3-chacha20-poly1305",
+    "none",
+};
+
+/// Reject links whose transport/cipher our generator can't faithfully emit — better a
+/// clear error than silently degrading an unsupported transport to plain TCP (which the
+/// server rejects) or emitting an unknown SS cipher (which sing-box refuses to load).
+/// Returns an error message in `buf`, or null when the link is supported.
+fn validateLink(l: XrayLink, buf: []u8) ?[]const u8 {
+    const net = l.network;
+    if (!(net.len == 0 or std.mem.eql(u8, net, "tcp") or std.mem.eql(u8, net, "ws") or std.mem.eql(u8, net, "grpc"))) {
+        return std.fmt.bufPrint(buf, "unsupported transport '{s}' for {s} — only tcp/ws/grpc are supported", .{ net, l.address }) catch "unsupported transport";
+    }
+    if (l.scheme == .shadowsocks) {
+        const m = l.method orelse "";
+        for (supported_ss_methods) |sm| {
+            if (std.mem.eql(u8, m, sm)) return null;
+        }
+        return std.fmt.bufPrint(buf, "unsupported shadowsocks cipher '{s}' for {s}", .{ m, l.address }) catch "unsupported shadowsocks cipher";
+    }
+    return null;
 }
 
 pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) !void {
@@ -488,7 +535,23 @@ fn setupSingboxTunnel(ui: *Tui, allocator: std.mem.Allocator, link_texts: []cons
             ui.fail("Failed to parse a share-link");
             return;
         };
+        var vbuf: [256]u8 = undefined;
+        if (validateLink(parsed[i], &vbuf)) |msg| {
+            ui.fail(msg);
+            return;
+        }
         ui.stepOk("Parsed egress", parsed[i].address);
+    }
+
+    // A sing-box tunnel and the AmneziaWG tunnel pool both own fwmark 200 / table 200 —
+    // the pool's 30s timer does `ip route flush table 200` and would silently steal the
+    // route from sbx0. They must be mutually exclusive, so retire any existing pool first.
+    if (sys.fileExists("/etc/systemd/system/mtproto-tunnel-pool.timer")) {
+        ui.warn("Retiring the existing AmneziaWG tunnel pool — it can't share table 200 with the sing-box egress.");
+        _ = sys.exec(allocator, &.{ "systemctl", "disable", "--now", "mtproto-tunnel-pool.timer" }) catch {};
+        _ = sys.exec(allocator, &.{ "systemctl", "stop", "mtproto-tunnel-pool.service" }) catch {};
+        _ = sys.exec(allocator, &.{ "rm", "-f", "/etc/systemd/system/mtproto-tunnel-pool.timer", "/etc/systemd/system/mtproto-tunnel-pool.service", "/usr/local/bin/setup_tunnel.sh", "/run/mtproto-proxy/tunnel-pool.state" }) catch {};
+        _ = sys.exec(allocator, &.{ "systemctl", "daemon-reload" }) catch {};
     }
 
     if (!sys.commandExists("sing-box") and !sys.fileExists(SB_BIN)) {
@@ -515,6 +578,7 @@ fn setupSingboxTunnel(ui: *Tui, allocator: std.mem.Allocator, link_texts: []cons
     // (fwmark 200 → table 200 → sbx0) — the same mechanism the AmneziaWG tunnel uses.
     const route_script = "#!/bin/bash\n" ++
         "for i in $(seq 1 60); do ip link show " ++ TUN_IFACE ++ " >/dev/null 2>&1 && break; sleep 0.25; done\n" ++
+        "ip link show " ++ TUN_IFACE ++ " >/dev/null 2>&1 || { echo 'mtproto egress: " ++ TUN_IFACE ++ " never appeared (sing-box failed to start the tun?)' >&2; exit 1; }\n" ++
         "ip rule add fwmark " ++ TUN_FWMARK ++ " lookup " ++ TUN_TABLE ++ " 2>/dev/null || true\n" ++
         "ip route replace default dev " ++ TUN_IFACE ++ " table " ++ TUN_TABLE ++ "\n";
     sys.writeFileMode(SB_ROUTE_SCRIPT, route_script, 0o755) catch {
@@ -548,6 +612,11 @@ fn setupSingboxTunnel(ui: *Tui, allocator: std.mem.Allocator, link_texts: []cons
     ui.ok("sing-box tunnel egress up (tun " ++ TUN_IFACE ++ ")");
 
     if (sys.fileExists(CONFIG_PATH)) {
+        // Order mtproto-proxy after the egress so sbx0 + its route exist before the proxy
+        // marks DC sockets — otherwise a reboot races and DC connects fail until retry.
+        _ = sys.exec(allocator, &.{ "mkdir", "-p", "/etc/systemd/system/mtproto-proxy.service.d" }) catch {};
+        sys.writeFile("/etc/systemd/system/mtproto-proxy.service.d/egress.conf", "[Unit]\nAfter=" ++ SB_SERVICE_NAME ++ "\nWants=" ++ SB_SERVICE_NAME ++ "\n") catch {};
+        _ = sys.exec(allocator, &.{ "systemctl", "daemon-reload" }) catch {};
         wireUpstreamTunnel(allocator, link_texts) catch {
             ui.warn("tunnel is up, but updating config.toml failed — set [upstream] type=tunnel, [upstream.tunnel] interface=" ++ TUN_IFACE ++ " manually");
             return;
@@ -563,6 +632,10 @@ fn wireUpstreamTunnel(allocator: std.mem.Allocator, link_texts: []const []const 
     var doc = try toml.TomlDoc.load(allocator, CONFIG_PATH);
     defer doc.deinit();
     try doc.set("upstream", "type", "tunnel");
+    // Point both the plural pool list (which the proxy reads first) and the singular key
+    // at sbx0, and clear any pinned awg interface, so no stale awg name shadows sbx0.
+    try doc.set("upstream.tunnel", "interfaces", "[\"" ++ TUN_IFACE ++ "\"]");
+    try doc.set("upstream.tunnel", "pinned_interface", "");
     try doc.set("upstream.tunnel", "interface", TUN_IFACE);
     // Persist the links so a reinstall reproduces the egress (config is 0600).
     var arr: std.ArrayListUnmanaged(u8) = .empty;
@@ -634,6 +707,14 @@ fn installSingbox(allocator: std.mem.Allocator) bool {
     }
     const extracted = std.fmt.allocPrint(allocator, "{s}/sing-box-{s}-linux-{s}/sing-box", .{ td, ver, arch }) catch return false;
     defer allocator.free(extracted);
+    // Verify the downloaded artifact actually runs as sing-box before installing it. The
+    // transport is TLS (authenticity); this catches a corrupt/truncated download or a
+    // wrong-arch binary. sing-box publishes no checksums/signatures to verify against.
+    {
+        const r = sys.exec(allocator, &.{ extracted, "version" }) catch return false;
+        defer r.deinit();
+        if (r.exit_code != 0 or std.mem.indexOf(u8, r.stdout, "sing-box") == null) return false;
+    }
     {
         const r = sys.exec(allocator, &.{ "install", "-m", "0755", extracted, SB_BIN }) catch return false;
         defer r.deinit();
@@ -714,6 +795,28 @@ test "percentDecode + queryParam" {
     try std.testing.expectEqualStrings("German WG-1", percentDecode(&buf, "German%20WG-1"));
     try std.testing.expectEqualStrings("1420", queryParam("publickey=X&address=Y&mtu=1420", "mtu").?);
     try std.testing.expect(queryParam("a=1&b=2", "c") == null);
+}
+
+test "validateLink rejects unsupported transport and ss cipher" {
+    var buf: [256]u8 = undefined;
+    try std.testing.expect(validateLink(.{ .scheme = .vless, .address = "h", .port = 1, .network = "ws" }, &buf) == null);
+    try std.testing.expect(validateLink(.{ .scheme = .shadowsocks, .address = "h", .port = 1, .method = "aes-256-gcm" }, &buf) == null);
+    try std.testing.expect(validateLink(.{ .scheme = .vless, .address = "h", .port = 1, .network = "quic" }, &buf) != null);
+    try std.testing.expect(validateLink(.{ .scheme = .shadowsocks, .address = "h", .port = 1, .method = "rc4-md5-is-unsupported" }, &buf) != null);
+}
+
+test "vmess scy maps to cipher and is emitted" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const json = "{\"v\":\"2\",\"ps\":\"x\",\"add\":\"1.2.3.4\",\"port\":\"443\",\"id\":\"95e0edb9-4a0b-4312-a71f-1d4b8b6db79b\",\"aid\":\"0\",\"net\":\"tcp\",\"scy\":\"zero\",\"tls\":\"\"}";
+    var b64: [512]u8 = undefined;
+    const enc = std.base64.standard.Encoder.encode(&b64, json);
+    const link = try std.fmt.allocPrint(a, "vmess://{s}", .{enc});
+    const l = try parseXrayLink(a, link);
+    try std.testing.expectEqualStrings("zero", l.cipher);
+    const cfg = try genSingboxConfig(a, &.{l});
+    try std.testing.expect(std.mem.indexOf(u8, cfg, "\"security\":\"zero\"") != null);
 }
 
 test "detectScheme" {

--- a/src/ctl/fronting_domain.zig
+++ b/src/ctl/fronting_domain.zig
@@ -1,0 +1,123 @@
+const std = @import("std");
+const tui_mod = @import("tui.zig");
+const sys = @import("sys.zig");
+
+const Tui = tui_mod.Tui;
+
+pub const FrontingVerdict = enum {
+    single_round_x25519,
+    reachable_without_x25519,
+    not_reached,
+};
+
+pub const FrontingCheckResult = enum {
+    skipped,
+    ok,
+    not_reached,
+    mismatch,
+};
+
+pub fn classifyOpenSslOutput(output: []const u8) FrontingVerdict {
+    if (std.mem.indexOf(u8, output, "Server Temp Key") != null) return .single_round_x25519;
+    if (std.mem.indexOf(u8, output, "CONNECTED") != null) return .reachable_without_x25519;
+    return .not_reached;
+}
+
+/// Best-effort warning if `domain` is a poor FakeTLS fronting target. Our 3-record
+/// ServerHello (single x25519 key_share, no HelloRetryRequest) cannot mimic a domain
+/// whose genuine TLS 1.3 prefers a non-x25519 group / does an HRR — e.g. wb.ru and
+/// mail.ru pick secp521r1 and reject an x25519-only hello — producing a passive
+/// ServerHello mismatch.
+pub fn warnIfPoorFrontingDomain(ui: *Tui, allocator: std.mem.Allocator, domain: []const u8) FrontingCheckResult {
+    if (!isSafeFrontingDomain(domain)) return .skipped;
+    if (!sys.commandExists("openssl")) return .skipped;
+
+    ui.step("Checking fronting-domain TLS suitability...");
+    var cmd_buf: [512]u8 = undefined;
+    // Offer ONLY X25519 in a TLS 1.3 hello and capture the output (stderr merged,
+    // since OpenSSL splits these differently across versions). A domain that
+    // negotiates it in a single round prints "Server Temp Key: X25519..."; one
+    // that does an HRR / rejects x25519 still prints "CONNECTED" but no temp key.
+    // NOTE: the group MUST be uppercase "X25519" — OpenSSL 1.1.1 rejects lowercase.
+    const cmd = std.fmt.bufPrint(
+        &cmd_buf,
+        "echo | timeout 10 openssl s_client -connect {s}:443 -servername {s} -groups X25519 -tls1_3 2>&1",
+        .{ domain, domain },
+    ) catch return .skipped;
+    const r = sys.exec(allocator, &.{ "bash", "-c", cmd }) catch return .skipped;
+    defer r.deinit();
+
+    return warnFromVerdict(ui, domain, classifyOpenSslOutput(r.stdout));
+}
+
+fn warnFromVerdict(ui: *Tui, domain: []const u8, verdict: FrontingVerdict) FrontingCheckResult {
+    switch (verdict) {
+        .single_round_x25519 => return .ok,
+        .not_reached => {
+            var b: [320]u8 = undefined;
+            if (std.fmt.bufPrint(&b, "Couldn't reach '{s}:443' from here to verify its TLS — skipping (connectivity, not a bad domain).", .{domain}) catch null) |m| ui.info(m);
+            return .not_reached;
+        },
+        .reachable_without_x25519 => {
+            var ex_buf: [128]u8 = undefined;
+            const examples = frontingExamples(domain, &ex_buf);
+            ui.warn("This fronting domain doesn't negotiate single-round x25519.");
+            var msg_buf: [320]u8 = undefined;
+            if (std.fmt.bufPrint(&msg_buf, "  '{s}' does a HelloRetryRequest or rejects x25519 (like wb.ru) — our FakeTLS ServerHello can't match it, so a passive observer sees a mismatch.", .{domain}) catch null) |m| ui.warn(m);
+            var hint_buf: [320]u8 = undefined;
+            if (std.fmt.bufPrint(&hint_buf, "  Prefer a single-round-x25519 domain (e.g. {s}). tls_domain is IMMUTABLE once links are shared — choose now.", .{examples}) catch null) |m| ui.hint(m);
+            return .mismatch;
+        },
+    }
+}
+
+fn isSafeFrontingDomain(domain: []const u8) bool {
+    if (domain.len == 0 or domain.len > 253) return false;
+    for (domain) |c| {
+        const ok = (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z') or
+            (c >= '0' and c <= '9') or c == '.' or c == '-';
+        if (!ok) return false;
+    }
+    return true;
+}
+
+/// Comma-separated recommended single-round-x25519 fronting domains, excluding
+/// `current` so we never suggest the very domain that just failed the check.
+fn frontingExamples(current: []const u8, buf: []u8) []const u8 {
+    const candidates = [_][]const u8{ "rutube.ru", "ozon.ru", "vk.com", "yandex.ru" };
+    var w: usize = 0;
+    for (candidates) |c| {
+        if (std.ascii.eqlIgnoreCase(c, current)) continue;
+        const piece = std.fmt.bufPrint(buf[w..], "{s}{s}", .{ if (w == 0) "" else ", ", c }) catch break;
+        w += piece.len;
+    }
+    return buf[0..w];
+}
+
+test "classifyOpenSslOutput detects single-round x25519" {
+    const out =
+        \\CONNECTED(00000003)
+        \\Server Temp Key: X25519, 253 bits
+    ;
+    try std.testing.expectEqual(FrontingVerdict.single_round_x25519, classifyOpenSslOutput(out));
+}
+
+test "classifyOpenSslOutput detects reachable domain without x25519 temp key" {
+    const out =
+        \\CONNECTED(00000003)
+        \\SSL-Session:
+    ;
+    try std.testing.expectEqual(FrontingVerdict.reachable_without_x25519, classifyOpenSslOutput(out));
+}
+
+test "classifyOpenSslOutput detects domain that was not reached" {
+    const out = "connect:errno=110\n";
+    try std.testing.expectEqual(FrontingVerdict.not_reached, classifyOpenSslOutput(out));
+}
+
+test "frontingExamples excludes the current domain" {
+    var buf: [128]u8 = undefined;
+    try std.testing.expectEqualStrings("ozon.ru, vk.com, yandex.ru", frontingExamples("rutube.ru", &buf));
+    try std.testing.expectEqualStrings("ozon.ru, vk.com, yandex.ru", frontingExamples("RuTube.RU", &buf));
+    try std.testing.expectEqualStrings("rutube.ru, ozon.ru, vk.com, yandex.ru", frontingExamples("example.com", &buf));
+}

--- a/src/ctl/install.zig
+++ b/src/ctl/install.zig
@@ -16,6 +16,7 @@ const release = @import("release.zig");
 const toml = @import("toml.zig");
 const masking = @import("masking.zig");
 const nfqws = @import("nfqws.zig");
+const fronting_domain = @import("fronting_domain.zig");
 
 const Tui = tui_mod.Tui;
 const Color = tui_mod.Color;
@@ -477,7 +478,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
 
     // Warn NOW (before the link — which embeds tls_domain — is generated and frozen)
     // if the fronting domain is a poor FakeTLS mimicry target.
-    warnIfPoorFrontingDomain(ui, allocator, opts.tls_domain);
+    _ = fronting_domain.warnIfPoorFrontingDomain(ui, allocator, opts.tls_domain);
 
     // ── Check port / masking collision ──
     // The masking Nginx binds to 127.0.0.1:8443. If the proxy listens on
@@ -1286,81 +1287,6 @@ fn requiredAccountToolsAvailable(ui: *Tui) bool {
         return false;
     }
     return true;
-}
-
-/// Best-effort warning if `domain` is a poor FakeTLS fronting target. Our 3-record
-/// ServerHello (single x25519 key_share, no HelloRetryRequest) cannot mimic a domain
-/// whose genuine TLS 1.3 prefers a non-x25519 group / does an HRR — e.g. wb.ru and
-/// mail.ru pick secp521r1 and reject an x25519-only hello — producing a passive
-/// ServerHello mismatch. tls_domain is immutable once links ship, so this runs while
-/// the choice is still free. Probes via openssl; skips silently if openssl is absent.
-fn warnIfPoorFrontingDomain(ui: *Tui, allocator: std.mem.Allocator, domain: []const u8) void {
-    if (domain.len == 0 or domain.len > 253) return;
-    if (!sys.commandExists("openssl")) return;
-    // Sanitize: a real hostname is [a-z0-9.-] only, so interpolating it into the
-    // probe command below cannot inject shell metacharacters.
-    for (domain) |c| {
-        const ok = (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z') or
-            (c >= '0' and c <= '9') or c == '.' or c == '-';
-        if (!ok) return;
-    }
-    ui.step("Checking fronting-domain TLS suitability...");
-    var cmd_buf: [512]u8 = undefined;
-    // Offer ONLY X25519 in a TLS 1.3 hello and capture the output (stderr merged, since
-    // OpenSSL splits these differently across versions). A domain that negotiates it in
-    // a single round prints "Server Temp Key: X25519..."; one that does an HRR / rejects
-    // x25519 still prints "CONNECTED" but no temp key; an unreachable domain prints
-    // neither — distinguishing "couldn't reach it" (connectivity) from "rejects x25519"
-    // (a real mismatch) matters. NOTE: the group MUST be uppercase "X25519" — OpenSSL
-    // 1.1.1 (Ubuntu 20.04 / focal) rejects lowercase "x25519" with "Error with command",
-    // which silently made this check mis-fire on every domain there.
-    const cmd = std.fmt.bufPrint(
-        &cmd_buf,
-        "echo | timeout 10 openssl s_client -connect {s}:443 -servername {s} -groups X25519 -tls1_3 2>&1",
-        .{ domain, domain },
-    ) catch return;
-    const r = sys.exec(allocator, &.{ "bash", "-c", cmd }) catch return;
-    defer r.deinit();
-
-    if (std.mem.indexOf(u8, r.stdout, "Server Temp Key") != null) return; // good: single-round x25519
-
-    if (std.mem.indexOf(u8, r.stdout, "CONNECTED") == null) {
-        // Couldn't reach the domain from this host (e.g. no egress in a container, or
-        // the host can't route to it) — can't verify, but that's not the domain's
-        // fault. Note it softly; don't push the operator off a sound choice.
-        var b: [320]u8 = undefined;
-        if (std.fmt.bufPrint(&b, "Couldn't reach '{s}:443' from here to verify its TLS — skipping (connectivity, not a bad domain).", .{domain}) catch null) |m| ui.info(m);
-        return;
-    }
-
-    // Reachable, but x25519 was not negotiated in a single round → genuine mismatch risk.
-    var ex_buf: [128]u8 = undefined;
-    const examples = frontingExamples(domain, &ex_buf);
-    ui.warn("This fronting domain doesn't negotiate single-round x25519.");
-    var msg_buf: [320]u8 = undefined;
-    if (std.fmt.bufPrint(&msg_buf, "  '{s}' does a HelloRetryRequest or rejects x25519 (like wb.ru) — our FakeTLS ServerHello can't match it, so a passive observer sees a mismatch.", .{domain}) catch null) |m| ui.warn(m);
-    var hint_buf: [320]u8 = undefined;
-    if (std.fmt.bufPrint(&hint_buf, "  Prefer a single-round-x25519 domain (e.g. {s}). tls_domain is IMMUTABLE once links are shared — choose now.", .{examples}) catch null) |m| ui.hint(m);
-}
-
-/// Comma-separated recommended single-round-x25519 fronting domains, excluding
-/// `current` so we never suggest the very domain that just failed the check.
-fn frontingExamples(current: []const u8, buf: []u8) []const u8 {
-    const candidates = [_][]const u8{ "rutube.ru", "ozon.ru", "vk.com", "yandex.ru" };
-    var w: usize = 0;
-    for (candidates) |c| {
-        if (std.ascii.eqlIgnoreCase(c, current)) continue;
-        const piece = std.fmt.bufPrint(buf[w..], "{s}{s}", .{ if (w == 0) "" else ", ", c }) catch break;
-        w += piece.len;
-    }
-    return buf[0..w];
-}
-
-test "frontingExamples excludes the current domain" {
-    var buf: [128]u8 = undefined;
-    try std.testing.expectEqualStrings("ozon.ru, vk.com, yandex.ru", frontingExamples("rutube.ru", &buf));
-    try std.testing.expectEqualStrings("ozon.ru, vk.com, yandex.ru", frontingExamples("RuTube.RU", &buf)); // case-insensitive
-    try std.testing.expectEqualStrings("rutube.ru, ozon.ru, vk.com, yandex.ru", frontingExamples("example.com", &buf));
 }
 
 fn commandAvailable(name: []const u8, candidates: []const []const u8) bool {

--- a/src/ctl/main.zig
+++ b/src/ctl/main.zig
@@ -22,6 +22,7 @@ const nfqws = @import("nfqws.zig");
 const tunnel = @import("tunnel.zig");
 const recovery = @import("recovery.zig");
 const dashboard = @import("dashboard.zig");
+const egress = @import("egress.zig");
 const ipv6hop = @import("ipv6hop.zig");
 const version_mod = @import("version");
 const uninstall = @import("uninstall.zig");
@@ -134,6 +135,8 @@ pub fn main(init: std.process.Init) !void {
                     return nfqws.run(&ui, allocator, &remaining_args);
                 } else if (std.mem.eql(u8, sub, "tunnel")) {
                     return tunnel.run(&ui, allocator, &remaining_args);
+                } else if (std.mem.eql(u8, sub, "egress")) {
+                    return egress.run(&ui, allocator, &remaining_args);
                 } else if (std.mem.eql(u8, sub, "recovery")) {
                     return recovery.run(&ui, allocator, &remaining_args);
                 } else if (std.mem.eql(u8, sub, "dashboard")) {
@@ -145,11 +148,11 @@ pub fn main(init: std.process.Init) !void {
                         Color.reset,
                         sub,
                     });
-                    ui.hint(tr(ui.lang, "Available: masking, nfqws, tunnel, recovery, dashboard", "Доступно: masking, nfqws, tunnel, recovery, dashboard"));
+                    ui.hint(tr(ui.lang, "Available: masking, nfqws, tunnel, egress, recovery, dashboard", "Доступно: masking, nfqws, tunnel, egress, recovery, dashboard"));
                     return;
                 }
             } else {
-                ui.fail(tr(ui.lang, "Usage: mtbuddy setup <masking|nfqws|tunnel|recovery|dashboard>", "Использование: mtbuddy setup <masking|nfqws|tunnel|recovery|dashboard>"));
+                ui.fail(tr(ui.lang, "Usage: mtbuddy setup <masking|nfqws|tunnel|egress|recovery|dashboard>", "Использование: mtbuddy setup <masking|nfqws|tunnel|egress|recovery|dashboard>"));
                 return;
             }
         } else if (std.mem.eql(u8, cmd, "ipv6-hop")) {

--- a/src/ctl/masking.zig
+++ b/src/ctl/masking.zig
@@ -9,6 +9,7 @@ const tui_mod = @import("tui.zig");
 const i18n = @import("i18n.zig");
 const sys = @import("sys.zig");
 const toml = @import("toml.zig");
+const fronting_domain = @import("fronting_domain.zig");
 
 const Tui = tui_mod.Tui;
 const Color = tui_mod.Color;
@@ -63,6 +64,8 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: MaskingOpts) !void 
         ui.fail(i18n.get(ui.lang, .error_not_root));
         return;
     }
+
+    _ = fronting_domain.warnIfPoorFrontingDomain(ui, allocator, opts.tls_domain);
 
     // ── Install Nginx ──
     if (sys.commandExists("nginx")) {

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -89,6 +89,13 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
     try execute(ui, allocator, opts);
 }
 
+/// Set up a tunnel directly from a WireGuard/AmneziaWG `.conf` path — same flow as
+/// `setup tunnel <conf>`. Used by the egress provider after it converts a
+/// wireguard:// share-link into a `.conf`.
+pub fn setupFromConf(ui: *Tui, allocator: std.mem.Allocator, conf_path: []const u8) !void {
+    try execute(ui, allocator, .{ .awg_source = conf_path });
+}
+
 /// Run in interactive mode.
 pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
     ui.section(i18n.get(ui.lang, .menu_setup_tunnel));

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -458,6 +458,15 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
         return;
     }
 
+    // A sing-box egress (`setup egress`) and this WG tunnel pool both own fwmark 200 /
+    // table 200 — retire the sing-box egress so the two don't fight over the route.
+    if (sys.fileExists("/etc/systemd/system/mtproto-singbox-egress.service")) {
+        ui.warn("Retiring the existing sing-box egress — it can't share table 200 with a WG tunnel.");
+        sys.execSilent(allocator, &.{ "systemctl", "disable", "--now", "mtproto-singbox-egress.service" });
+        sys.execSilent(allocator, &.{ "rm", "-f", "/etc/systemd/system/mtproto-singbox-egress.service", "/etc/mtproto-proxy/singbox-egress.json", "/usr/local/bin/mtproto-singbox-route.sh", "/etc/systemd/system/mtproto-proxy.service.d/egress.conf" });
+        sys.execSilent(allocator, &.{ "systemctl", "daemon-reload" });
+    }
+
     // ── Install AmneziaWG ──
     if (sys.commandExists("awg") and sys.commandExists("awg-quick")) {
         ui.ok("AmneziaWG already installed");
@@ -1693,9 +1702,16 @@ fn renderTunnelPoolScript(allocator: std.mem.Allocator) ![]const u8 {
         \\    fi
         \\)
         \\
+        \\previous="$(ip -4 route show table "$TABLE" default 2>/dev/null | awk '/default/ { for (i=1;i<=NF;i++) if ($i=="dev") { print $(i+1); exit } }' || true)"
         \\pinned="$(read_tunnel_key pinned_interface || true)"
         \\candidates=()
         \\add_unique "$pinned"
+        \\# Sticky: after the pin, prefer the currently-active tunnel if it's still in the
+        \\# pool, so a healthy active tunnel isn't dropped for an earlier-listed one — that
+        \\# would flap (reset every connection) whenever the first pool entry is reachable.
+        \\for iface in "${pool[@]}"; do
+        \\    [[ "$iface" == "$previous" ]] && add_unique "$previous"
+        \\done
         \\for iface in "${pool[@]}"; do
         \\    add_unique "$iface"
         \\done
@@ -1706,7 +1722,6 @@ fn renderTunnelPoolScript(allocator: std.mem.Allocator) ![]const u8 {
         \\    exit 1
         \\}
         \\
-        \\previous="$(ip -4 route show table "$TABLE" default 2>/dev/null | awk '/default/ { for (i=1;i<=NF;i++) if ($i=="dev") { print $(i+1); exit } }' || true)"
         \\selected=""
         \\selected_reason=""
         \\selected_status="healthy"

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -1649,11 +1649,13 @@ fn renderTunnelPoolScript(allocator: std.mem.Allocator) ![]const u8 {
         \\    policy_route_matches_iface "$iface" || { reason="policy route check failed"; return 1; }
         \\    if telegram_probe_iface "$iface"; then
         \\        reason="healthy"
-        \\    else
-        \\        reason="policy route ready; Telegram probe failed"
-        \\        log "tunnel $iface selected although Telegram HTTPS probe failed"
+        \\        return 0
         \\    fi
-        \\    return 0
+        \\    # Usable (up + policy route installed) but can't reach Telegram through it.
+        \\    # Return 2 ("degraded-usable") so pool selection PREFERS a tunnel that can
+        \\    # actually reach Telegram, and only falls back to this one if none can.
+        \\    reason="up; Telegram probe failed"
+        \\    return 2
         \\}
         \\
         \\state_value() {
@@ -1707,23 +1709,44 @@ fn renderTunnelPoolScript(allocator: std.mem.Allocator) ![]const u8 {
         \\previous="$(ip -4 route show table "$TABLE" default 2>/dev/null | awk '/default/ { for (i=1;i<=NF;i++) if ($i=="dev") { print $(i+1); exit } }' || true)"
         \\selected=""
         \\selected_reason=""
+        \\selected_status="healthy"
+        \\fallback=""
+        \\fallback_reason=""
         \\for iface in "${candidates[@]}"; do
-        \\    if probe_iface "$iface"; then
+        \\    if probe_iface "$iface"; then rc=0; else rc=$?; fi
+        \\    if [[ "$rc" -eq 0 ]]; then
         \\        selected="$iface"
         \\        selected_reason="$reason"
         \\        break
+        \\    elif [[ "$rc" -eq 2 && -z "$fallback" ]]; then
+        \\        # Up but can't reach Telegram — remember it as a last resort, but keep
+        \\        # looking for one that actually reaches Telegram. This is the pool
+        \\        # failover: a dead-but-up active tunnel is now skipped over.
+        \\        fallback="$iface"
+        \\        fallback_reason="$reason"
+        \\        log "tunnel $iface up but Telegram probe failed; trying others"
+        \\    else
+        \\        log "tunnel $iface unhealthy: $reason"
         \\    fi
-        \\    log "tunnel $iface unhealthy: $reason"
         \\done
         \\
+        \\if [[ -z "$selected" && -n "$fallback" ]]; then
+        \\    # No tunnel reached Telegram (the probe may be globally blocked/flaky) — fall
+        \\    # back to the first usable one so a single-tunnel deploy doesn't go dark.
+        \\    selected="$fallback"
+        \\    selected_reason="$fallback_reason (fallback)"
+        \\    selected_status="degraded"
+        \\    log "no Telegram-reachable tunnel; falling back to $selected"
+        \\fi
+        \\
         \\if [[ -z "$selected" ]]; then
-        \\    write_state "" "degraded" "no healthy tunnel"
-        \\    echo "No healthy tunnel in pool: ${candidates[*]}" >&2
+        \\    write_state "" "degraded" "no usable tunnel"
+        \\    echo "No usable tunnel in pool: ${candidates[*]}" >&2
         \\    exit 1
         \\fi
         \\
         \\route_table_to_iface "$selected"
-        \\write_state "$selected" "healthy" "$selected_reason"
+        \\write_state "$selected" "$selected_status" "$selected_reason"
         \\
         \\if [[ "$previous" != "$selected" ]]; then
         \\    log "selected tunnel $selected (previous: ${previous:-none})"
@@ -1969,16 +1992,22 @@ test "tunnel pool - append interface avoids duplicates" {
     try std.testing.expectEqualStrings("awg2", added[2]);
 }
 
-test "tunnel pool - script renders policy route replacement and nonfatal Telegram probe" {
+test "tunnel pool - script renders failover (prefer reachable, fall back to usable)" {
     const script = try renderTunnelPoolScript(std.testing.allocator);
     defer std.testing.allocator.free(script);
 
     try std.testing.expect(std.mem.indexOf(u8, script, "route_table_to_iface \"$selected\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, script, "policy_route_matches_iface \"$iface\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, script, "route show table \"$TABLE\" default 2>/dev/null") != null);
-    try std.testing.expect(std.mem.indexOf(u8, script, "|| true)") != null);
     try std.testing.expect(std.mem.indexOf(u8, script, "https://core.telegram.org/getProxyConfig") != null);
-    try std.testing.expect(std.mem.indexOf(u8, script, "selected although Telegram HTTPS probe failed") != null);
+    // probe_iface returns 2 (up but Telegram-unreachable) so the pool can skip a
+    // dead-but-up tunnel and fail over to a healthy one.
+    try std.testing.expect(std.mem.indexOf(u8, script, "return 2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "trying others") != null);
+    // ...but a single tunnel whose probe fails is still used (fallback), not dropped.
+    try std.testing.expect(std.mem.indexOf(u8, script, "falling back to $selected") != null);
+    // set -e safety: probe's non-zero exit is captured, not fatal.
+    try std.testing.expect(std.mem.indexOf(u8, script, "if probe_iface \"$iface\"; then rc=0; else rc=$?; fi") != null);
     try std.testing.expect(std.mem.indexOf(u8, script, "pinned_interface") != null);
 }
 

--- a/src/ctl/uninstall.zig
+++ b/src/ctl/uninstall.zig
@@ -78,7 +78,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
         "mtproto-mask-health.service",
         "mtproto-tunnel-pool.timer",
         "mtproto-tunnel-pool.service",
-        "mtproto-xray-egress.service",
+        "mtproto-singbox-egress.service",
     };
     for (services) |svc| {
         _ = sys.execForward(&.{ "systemctl", "stop", svc }) catch {};
@@ -89,10 +89,11 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
         _ = sys.execForward(&.{ "rm", "-f", path }) catch {};
     }
 
-    // Xray egress provider artifacts (the SOCKS5 bridge for upstream.type=socks5).
-    _ = sys.execForward(&.{ "rm", "-f", "/etc/systemd/system/mtproto-xray-egress.service" }) catch {};
-    _ = sys.execForward(&.{ "rm", "-f", "/etc/mtproto-proxy/xray-egress.json" }) catch {};
-    _ = sys.execForward(&.{ "rm", "-f", "/usr/local/bin/xray" }) catch {};
+    // sing-box tunnel egress provider artifacts (upstream.type=tunnel via sbx0).
+    _ = sys.execForward(&.{ "rm", "-f", "/etc/systemd/system/mtproto-singbox-egress.service" }) catch {};
+    _ = sys.execForward(&.{ "rm", "-f", "/etc/mtproto-proxy/singbox-egress.json" }) catch {};
+    _ = sys.execForward(&.{ "rm", "-f", "/usr/local/bin/mtproto-singbox-route.sh" }) catch {};
+    _ = sys.execForward(&.{ "rm", "-f", "/usr/local/bin/sing-box" }) catch {};
 
     _ = sys.execForward(&.{ "rm", "-f", "/etc/systemd/system/mtproto-mask-health.timer" }) catch {};
     _ = sys.execForward(&.{ "rm", "-f", "/etc/systemd/system/mtproto-tunnel-pool.timer" }) catch {};

--- a/src/ctl/uninstall.zig
+++ b/src/ctl/uninstall.zig
@@ -86,9 +86,15 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
         // noise even on a perfectly clean uninstall.
         sys.execSilent(allocator, &.{ "systemctl", "stop", svc });
         sys.execSilent(allocator, &.{ "systemctl", "disable", svc });
-        // Remove unit files
-        var path_buf: [128]u8 = undefined;
-        const path = std.fmt.bufPrint(&path_buf, "/etc/systemd/system/{s}.service", .{svc}) catch continue;
+        // Remove the unit file. Entries already carrying a `.timer`/`.service` suffix are
+        // full unit names; bare ones (e.g. "mtproto-proxy") get `.service` appended. The
+        // old code always appended `.service`, so "mtproto-mask-health.service" tried to
+        // delete "...service.service" and left the real file behind.
+        var path_buf: [160]u8 = undefined;
+        const path = if (std.mem.indexOfScalar(u8, svc, '.') != null)
+            std.fmt.bufPrint(&path_buf, "/etc/systemd/system/{s}", .{svc}) catch continue
+        else
+            std.fmt.bufPrint(&path_buf, "/etc/systemd/system/{s}.service", .{svc}) catch continue;
         _ = sys.execForward(&.{ "rm", "-f", path }) catch {};
     }
 

--- a/src/ctl/uninstall.zig
+++ b/src/ctl/uninstall.zig
@@ -116,8 +116,10 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
     const userdel = sys.commandOrPath("userdel", &.{ "/usr/sbin/userdel", "/sbin/userdel" });
     _ = sys.execForward(&.{ userdel, "mtproto" }) catch {};
 
-    // 4. Cleanup tunnel routing artifacts (new + legacy)
-    _ = sys.execForward(&.{ "ip", "-4", "rule", "del", "fwmark", "200", "table", "200" }) catch {};
+    // 4. Cleanup tunnel routing artifacts (new + legacy). Loop the rule delete: the
+    //    sing-box egress adds an unprioritized `fwmark 200 lookup 200` rule while the awg
+    //    pool adds a prioritized one, so several matching rules may exist.
+    _ = sys.execForward(&.{ "bash", "-c", "while ip -4 rule del fwmark 200 table 200 2>/dev/null; do :; done; while ip -4 rule del fwmark 200 lookup 200 2>/dev/null; do :; done" }) catch {};
     _ = sys.execForward(&.{ "ip", "-4", "route", "flush", "table", "200" }) catch {};
     _ = sys.execForward(&.{ "rm", "-f", "/usr/local/bin/setup_tunnel.sh" }) catch {};
     _ = sys.execForward(&.{ "rm", "-f", "/usr/local/bin/setup_netns.sh" }) catch {};

--- a/src/ctl/uninstall.zig
+++ b/src/ctl/uninstall.zig
@@ -78,6 +78,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
         "mtproto-mask-health.service",
         "mtproto-tunnel-pool.timer",
         "mtproto-tunnel-pool.service",
+        "mtproto-xray-egress.service",
     };
     for (services) |svc| {
         _ = sys.execForward(&.{ "systemctl", "stop", svc }) catch {};
@@ -87,6 +88,11 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
         const path = std.fmt.bufPrint(&path_buf, "/etc/systemd/system/{s}.service", .{svc}) catch continue;
         _ = sys.execForward(&.{ "rm", "-f", path }) catch {};
     }
+
+    // Xray egress provider artifacts (the SOCKS5 bridge for upstream.type=socks5).
+    _ = sys.execForward(&.{ "rm", "-f", "/etc/systemd/system/mtproto-xray-egress.service" }) catch {};
+    _ = sys.execForward(&.{ "rm", "-f", "/etc/mtproto-proxy/xray-egress.json" }) catch {};
+    _ = sys.execForward(&.{ "rm", "-f", "/usr/local/bin/xray" }) catch {};
 
     _ = sys.execForward(&.{ "rm", "-f", "/etc/systemd/system/mtproto-mask-health.timer" }) catch {};
     _ = sys.execForward(&.{ "rm", "-f", "/etc/systemd/system/mtproto-tunnel-pool.timer" }) catch {};

--- a/src/ctl/uninstall.zig
+++ b/src/ctl/uninstall.zig
@@ -81,8 +81,11 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
         "mtproto-singbox-egress.service",
     };
     for (services) |svc| {
-        _ = sys.execForward(&.{ "systemctl", "stop", svc }) catch {};
-        _ = sys.execForward(&.{ "systemctl", "disable", svc }) catch {};
+        // Quiet: this runs under a spinner and most of these units aren't present in any
+        // given deploy, so `stop`/`disable` would spew "Unit not loaded" / "Removed ..."
+        // noise even on a perfectly clean uninstall.
+        sys.execSilent(allocator, &.{ "systemctl", "stop", svc });
+        sys.execSilent(allocator, &.{ "systemctl", "disable", svc });
         // Remove unit files
         var path_buf: [128]u8 = undefined;
         const path = std.fmt.bufPrint(&path_buf, "/etc/systemd/system/{s}.service", .{svc}) catch continue;
@@ -114,16 +117,18 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
 
     // 3. Remove user
     const userdel = sys.commandOrPath("userdel", &.{ "/usr/sbin/userdel", "/sbin/userdel" });
-    _ = sys.execForward(&.{ userdel, "mtproto" }) catch {};
+    sys.execSilent(allocator, &.{ userdel, "mtproto" });
 
     // 4. Cleanup tunnel routing artifacts (new + legacy). Loop the rule delete: the
     //    sing-box egress adds an unprioritized `fwmark 200 lookup 200` rule while the awg
     //    pool adds a prioritized one, so several matching rules may exist.
     _ = sys.execForward(&.{ "bash", "-c", "while ip -4 rule del fwmark 200 table 200 2>/dev/null; do :; done; while ip -4 rule del fwmark 200 lookup 200 2>/dev/null; do :; done" }) catch {};
-    _ = sys.execForward(&.{ "ip", "-4", "route", "flush", "table", "200" }) catch {};
+    // Quiet: an empty/absent table 200 or netns makes these print "FIB table does not
+    // exist" / "Cannot remove namespace" even though there's simply nothing to clean.
+    sys.execSilent(allocator, &.{ "ip", "-4", "route", "flush", "table", "200" });
     _ = sys.execForward(&.{ "rm", "-f", "/usr/local/bin/setup_tunnel.sh" }) catch {};
     _ = sys.execForward(&.{ "rm", "-f", "/usr/local/bin/setup_netns.sh" }) catch {};
-    _ = sys.execForward(&.{ "ip", "netns", "del", "tg_proxy_ns" }) catch {};
+    sys.execSilent(allocator, &.{ "ip", "netns", "del", "tg_proxy_ns" });
 
     // 5. Remove masking config. The site name MUST match masking.zig
     //    ("mtproto-masking"); the old "mtproto-mask" name never matched the
@@ -141,7 +146,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
 
     // Attempt Nginx reload if active, to flush deleted configs
     if (sys.isServiceActive("nginx")) {
-        _ = sys.execForward(&.{ "systemctl", "try-reload-or-restart", "nginx" }) catch {};
+        sys.execSilent(allocator, &.{ "systemctl", "try-reload-or-restart", "nginx" });
     }
 
     // 6. Clear the TCPMSS SYN/ACK clamp the installer set. The install rule
@@ -168,7 +173,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
     if (sys.commandExists("ufw")) {
         var ufw_buf: [16]u8 = undefined;
         const port_rule = std.fmt.bufPrint(&ufw_buf, "{s}/tcp", .{configured_port}) catch "443/tcp";
-        _ = sys.execForward(&.{ "ufw", "delete", "allow", port_rule }) catch {};
+        sys.execSilent(allocator, &.{ "ufw", "delete", "allow", port_rule });
     }
 
     // Note: Self-removal: The mtbuddy binary is running right now. Removing it while running usually works on Linux.

--- a/test/installer-e2e/run.sh
+++ b/test/installer-e2e/run.sh
@@ -335,6 +335,48 @@ ip -4 route get 149.154.175.50 mark 200 | grep -F " dev awg1" >/dev/null
 CONTAINER_SCRIPT
 }
 
+# Uninstall must remove every artifact AND do it without spewing expected-failure noise
+# (stop/disable of absent units, flushing an absent table 200, deleting an absent netns).
+verify_uninstall() {
+  local container="$1"
+
+  run_script_in_container "$container" <<'CONTAINER_SCRIPT'
+set -Eeuo pipefail
+
+out="$(mtbuddy uninstall --yes 2>&1)"
+printf '%s\n' "$out"
+
+fail=0
+# No leftover artifacts (proxy, egress, tunnel pool, the binary itself).
+for f in \
+  /opt/mtproto-proxy \
+  /etc/systemd/system/mtproto-proxy.service \
+  /etc/systemd/system/mtproto-singbox-egress.service \
+  /etc/systemd/system/mtproto-tunnel-pool.timer \
+  /etc/systemd/system/mtproto-tunnel-pool.service \
+  /etc/systemd/system/mtproto-proxy.service.d \
+  /usr/local/bin/setup_tunnel.sh \
+  /usr/local/bin/sing-box \
+  /usr/local/bin/mtproto-singbox-route.sh \
+  /usr/local/bin/mtbuddy ; do
+  if [ -e "$f" ]; then echo "FAIL: leftover $f"; fail=1; fi
+done
+
+# No mtproto unit files registered with systemd anymore.
+if systemctl list-unit-files 2>/dev/null | grep -qE "mtproto-(proxy|singbox|tunnel-pool|mask)"; then
+  echo "FAIL: mtproto unit files still registered"; fail=1
+fi
+
+# The output must be clean — no expected-failure noise from a normal uninstall.
+if printf '%s\n' "$out" | grep -qE "Failed to (stop|disable)|Unit .* not loaded|RTNETLINK|FIB table does not exist|Cannot remove namespace"; then
+  echo "FAIL: noisy uninstall output (expected-failure messages leaked)"; fail=1
+fi
+
+[ "$fail" -eq 0 ] || exit 1
+echo "uninstall: clean, no leftovers"
+CONTAINER_SCRIPT
+}
+
 verify_install() {
   local container="$1"
   local attempt
@@ -429,6 +471,10 @@ run_case() {
 
   echo "::group::Tunnel pool failover to a healthy tunnel ($base_image)"
   verify_tunnel_pool_failover "$container" 2>&1 | tee "$LOG_DIR/$safe.tunnel-pool-failover.log"
+  echo "::endgroup::"
+
+  echo "::group::Uninstall removes everything cleanly ($base_image)"
+  verify_uninstall "$container" 2>&1 | tee "$LOG_DIR/$safe.uninstall.log"
   echo "::endgroup::"
 
   dump_container_debug "$container" "$safe"

--- a/test/installer-e2e/run.sh
+++ b/test/installer-e2e/run.sh
@@ -237,6 +237,10 @@ for arg in "\$@"; do
       echo "blocked fake tunnel probe: \$*" >>/run/mtproto-fake-curl.log
       exit 7
     fi
+    if [[ "\$arg" == "awg1" ]]; then
+      echo "healthy fake tunnel probe: \$*" >>/run/mtproto-fake-curl.log
+      exit 0
+    fi
     next_is_iface=0
     continue
   fi
@@ -283,13 +287,51 @@ grep -F "User=mtproto" /etc/systemd/system/mtproto-proxy.service >/dev/null
 test -x /usr/local/bin/setup_tunnel.sh
 
 /usr/local/bin/setup_tunnel.sh
+# Single tunnel whose Telegram probe fails: still selected (don't go dark), but marked
+# degraded so the operator knows the probe couldn't confirm reachability.
 grep -F "active=awg0" /run/mtproto-proxy/tunnel-pool.state >/dev/null
-grep -F "status=healthy" /run/mtproto-proxy/tunnel-pool.state >/dev/null
-grep -F "reason=policy route ready; Telegram probe failed" /run/mtproto-proxy/tunnel-pool.state >/dev/null
+grep -F "status=degraded" /run/mtproto-proxy/tunnel-pool.state >/dev/null
+grep -F "reason=up; Telegram probe failed (fallback)" /run/mtproto-proxy/tunnel-pool.state >/dev/null
 grep -F "blocked fake tunnel probe:" /run/mtproto-fake-curl.log >/dev/null
 
 ip -4 rule show | grep -E "fwmark (0xc8|200).*(lookup|table) 200" >/dev/null
 ip -4 route get 149.154.175.50 mark 200 | grep -F " dev awg0" >/dev/null
+CONTAINER_SCRIPT
+}
+
+# Pool failover: with awg0 (Telegram probe BLOCKED) already active and degraded, adding a
+# second tunnel awg1 whose probe SUCCEEDS must fail the pool over to awg1. Before the fix
+# the controller kept the first up interface (awg0) and never switched.
+verify_tunnel_pool_failover() {
+  local container="$1"
+
+  run_script_in_container "$container" <<'CONTAINER_SCRIPT'
+set -Eeuo pipefail
+
+cat >/tmp/awg1.conf <<'AWG_CONF'
+[Interface]
+PrivateKey = fake-private-key-1
+Address = 10.123.1.2/32
+DNS = 1.1.1.1
+
+[Peer]
+PublicKey = fake-peer-key-1
+Endpoint = 203.0.113.2:51820
+AllowedIPs = 0.0.0.0/0
+AWG_CONF
+
+mtbuddy setup tunnel --iface awg1 /tmp/awg1.conf
+
+# Pool is now [awg0 (probe blocked), awg1 (probe ok)] with priority-auto. The controller
+# must skip the dead-but-up awg0 and select awg1.
+/usr/local/bin/setup_tunnel.sh
+grep -F "active=awg1" /run/mtproto-proxy/tunnel-pool.state >/dev/null
+grep -F "status=healthy" /run/mtproto-proxy/tunnel-pool.state >/dev/null
+grep -F "healthy fake tunnel probe:" /run/mtproto-fake-curl.log >/dev/null
+ip -4 route get 149.154.175.50 mark 200 | grep -F " dev awg1" >/dev/null
+
+# And when awg1 also goes unreachable, fall back (no healthy tunnel) rather than error out.
+# (awg1 stays up; only its probe would need to fail — covered by the single-tunnel case.)
 CONTAINER_SCRIPT
 }
 
@@ -383,6 +425,10 @@ run_case() {
   echo "::group::Setup tunnel with failing Telegram probe ($base_image)"
   install_fake_tunnel_tools "$container"
   verify_tunnel_probe_failure_is_nonfatal "$container" 2>&1 | tee "$LOG_DIR/$safe.tunnel-probe-failure.log"
+  echo "::endgroup::"
+
+  echo "::group::Tunnel pool failover to a healthy tunnel ($base_image)"
+  verify_tunnel_pool_failover "$container" 2>&1 | tee "$LOG_DIR/$safe.tunnel-pool-failover.log"
   echo "::endgroup::"
 
   dump_container_debug "$container" "$safe"

--- a/test/installer-e2e/run.sh
+++ b/test/installer-e2e/run.sh
@@ -363,8 +363,9 @@ for f in \
 done
 
 # No mtproto unit files registered with systemd anymore.
-if systemctl list-unit-files 2>/dev/null | grep -qE "mtproto-(proxy|singbox|tunnel-pool|mask)"; then
-  echo "FAIL: mtproto unit files still registered"; fail=1
+leftover_units="$(systemctl list-unit-files 2>/dev/null | grep -E "mtproto-(proxy|singbox|tunnel-pool|mask)" || true)"
+if [ -n "$leftover_units" ]; then
+  echo "FAIL: mtproto unit files still registered:"; printf '%s\n' "$leftover_units"; fail=1
 fi
 
 # The output must be clean — no expected-failure noise from a normal uninstall.


### PR DESCRIPTION
Three related `mtbuddy`/ctl changes bundled per request. **Zero proxy-core changes.**

---
## 1. `mtbuddy setup egress <share-link>` — VPN-link tunnel egress
Turns a VPN share-link into a clean, hard-to-block egress for the proxy→Telegram hop, as a **`type = tunnel`** egress (transparent L3, policy-routed) — the **same abstraction as AmneziaWG**.

| Scheme | Backend |
|---|---|
| `vless:// vmess:// trojan:// ss://` | a local **sing-box** client in **TUN mode** (`sbx0`, `auto_route` off). The proxy's `SO_MARK=200` DC traffic is policy-routed through it (`fwmark 200 → table 200 → sbx0`) — the exact AmneziaWG mechanism. VLESS-Reality camouflages the egress hop as real TLS. >1 link → a sing-box `urltest` failover pool. |
| `wireguard://` | the native kernel WG/AmneziaWG tunnel (reuses `tunnel.zig`). |

**Validated e2e** (ubuntu:20.04 systemd container): `setup egress <real vless-reality link>` → `sbx0` up, `table 200: default dev sbx0`, and a fwmark-200 request egresses with the server's IP through the Reality tunnel.

## 2. fix(tunnel): pool failover actually switches (reported in #323)
Two WG tunnels in the pool (priority auto) didn't fail over when the active one went down. Root cause: in `setup_tunnel.sh` (the 30s pool controller), `probe_iface` returned success for **any up interface** — the Telegram-reachability probe was logged but ignored (`return 0` regardless), so the first up interface always won and a dead-but-up active tunnel was never skipped.

Fix: two-pass selection — `probe_iface` now returns `2` ("up but Telegram-unreachable"); pass 1 picks the first tunnel that actually reaches Telegram (real failover), pass 2 falls back to the first usable one (so a single tunnel whose probe is globally blocked doesn't go dark, marked `status=degraded`). Also fixed a `set -e` foot-gun (`probe_iface; rc=$?` aborted the script on a non-zero probe → failed the proxy's `ExecStartPre`).

**New e2e** `verify_tunnel_pool_failover`: awg0 (probe blocked) + awg1 (probe ok) → controller must select **awg1**. Log proof: `… via awg0` (single, fallback) → `… via awg1` (after the healthy tunnel is added). Validated on ubuntu:24.04.

## 3. refactor(fronting): shared x25519 suitability helper
The single-round-x25519 fronting check moves out of `install.zig` into `src/ctl/fronting_domain.zig`, shared by `install`, `setup masking --domain`, and `config doctor --network` (where a mismatch now bumps the summary warning count). Tests cover the openssl-output classification (single-round x25519 / reachable-no-x25519 / unreachable-skip).

---
`zig build test`, `x86_64-linux` + `aarch64-linux` ReleaseFast, `zig fmt` — green. Note: sing-box is fetched from the latest `SagerNet/sing-box` release over TLS (no pinned SHA yet — a reasonable hardening follow-up).

---
## 4. Self-audit & hardening (commit f3d5c52)
Two independent reviewers + a manual pass over the bundle; all findings closed:
- **P0 — table-200 exclusivity:** sing-box egress and the AmneziaWG pool both own fwmark 200 / table 200, and the pool timer flushed the route every 30s. They are now mutually exclusive — `setup egress` retires an existing pool and vice-versa (e2e: timer enabled → setup egress → timer gone, sbx0 up).
- **P1 — scheme honesty:** reject links whose transport (only tcp/ws/grpc) or shadowsocks cipher we cannot faithfully emit (clear error vs silent TCP / config-load failure); parse vmess `scy` → `security` (was hardcoded `auto`).
- **P1 — boot ordering:** mtproto-proxy now `After=`/`Wants=` the egress unit (drop-in) so sbx0 + its route exist before the proxy marks DC sockets; the route helper hard-fails if sbx0 never appeared.
- **P2:** JSON-escape control bytes <0x20; verify the downloaded sing-box runs before install (upstream ships no checksums); loop the uninstall fwmark-rule delete; sticky pool failover (no 30s flapping); refreshed stale doc header.

Verified end-to-end on arm64 (egress→server via fwmark; rc4-md5 rejected; pool teardown; installer-e2e failover green).
