### PR TITLE
feat(egress): interactive share-link egress + split egress/tunnel into sharelink/wg/singbox modules

### DIFF
--- a/src/ctl/egress.zig
+++ b/src/ctl/egress.zig
@@ -427,21 +427,16 @@ fn validateLink(l: XrayLink, buf: []u8) ?[]const u8 {
     return null;
 }
 
-pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) !void {
-    var links: std.ArrayListUnmanaged([]const u8) = .empty;
-    defer links.deinit(allocator);
-    while (args.next()) |arg| {
-        if (arg.len > 0 and arg[0] != '-') links.append(allocator, arg) catch {};
-    }
-    if (links.items.len == 0) {
-        ui.fail("Usage: mtbuddy setup egress <share-link> [<share-link>...]");
-        ui.hint("vless:// vmess:// trojan:// ss://  ->  Xray SOCKS5 bridge (upstream.type=socks5)");
-        ui.hint("wireguard://                       ->  native L3 tunnel");
-        return;
-    }
+fn trL(ui: *Tui, en: []const u8, ru: []const u8) []const u8 {
+    return if (ui.lang == .ru) ru else en;
+}
+
+/// Validate the links are one provider family, then dispatch: wireguard:// -> native WG
+/// tunnel, everything else -> the sing-box TUN tunnel. Shared by `run` and `runInteractive`.
+fn dispatchLinks(ui: *Tui, allocator: std.mem.Allocator, link_list: []const []const u8) !void {
     // One egress = one provider family. Reject a mix of wireguard:// and Xray links.
-    const fam0 = schemeFamily(detectScheme(links.items[0]));
-    for (links.items) |l| {
+    const fam0 = schemeFamily(detectScheme(link_list[0]));
+    for (link_list) |l| {
         const s = detectScheme(l);
         if (s == .unknown) {
             ui.fail("Unrecognized share-link scheme (want vless/vmess/trojan/ss/wireguard)");
@@ -453,9 +448,51 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
         }
     }
     if (fam0 == .wireguard) {
-        return setupWireguard(ui, allocator, links.items);
+        return setupWireguard(ui, allocator, link_list);
     }
-    return setupSingboxTunnel(ui, allocator, links.items);
+    return setupSingboxTunnel(ui, allocator, link_list);
+}
+
+pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) !void {
+    var links: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer links.deinit(allocator);
+    while (args.next()) |arg| {
+        if (arg.len > 0 and arg[0] != '-') links.append(allocator, arg) catch {};
+    }
+    if (links.items.len == 0) {
+        ui.fail("Usage: mtbuddy setup egress <share-link> [<share-link>...]");
+        ui.hint("vless:// vmess:// trojan:// ss://  ->  sing-box TUN tunnel (upstream.type=tunnel)");
+        ui.hint("wireguard://                       ->  native kernel WG tunnel");
+        return;
+    }
+    return dispatchLinks(ui, allocator, links.items);
+}
+
+/// Interactive entry: prompt for a share-link (or several, for a failover pool), then run
+/// the same dispatch as `run`. Reached from the interactive "Setup tunnel" VPN-type chooser.
+pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
+    ui.info(trL(ui, "VPN share-link egress — paste a link. Several links (space/newline/comma-separated) form a failover pool.", "Egress из VPN-ссылки — вставь ссылку. Несколько ссылок (через пробел/перенос/запятую) образуют failover-пул."));
+    var buf: [16 * 1024]u8 = undefined;
+    const input = ui.input(
+        trL(ui, "Share-link(s)", "Ссылка(и)"),
+        trL(ui, "vless:// vmess:// trojan:// ss://  (sing-box tunnel)  |  wireguard://  (native tunnel)", "vless:// vmess:// trojan:// ss://  (sing-box-туннель)  |  wireguard://  (нативный туннель)"),
+        null,
+        &buf,
+    ) catch return;
+
+    var links: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer links.deinit(allocator);
+    var it = std.mem.tokenizeAny(u8, input, " \t\r\n,");
+    while (it.next()) |tok| links.append(allocator, tok) catch {};
+    if (links.items.len == 0) {
+        ui.fail(trL(ui, "No share-link provided.", "Ссылка не введена."));
+        return;
+    }
+    if (!(ui.confirm(trL(ui, "Proceed?", "Продолжить?"), true) catch false)) {
+        ui.info(trL(ui, "Aborting.", "Отмена."));
+        return;
+    }
+    return dispatchLinks(ui, allocator, links.items);
 }
 
 /// wireguard:// links -> native L3 tunnel. Convert each link to a WG/AmneziaWG .conf

--- a/src/ctl/main.zig
+++ b/src/ctl/main.zig
@@ -22,7 +22,7 @@ const nfqws = @import("nfqws.zig");
 const tunnel = @import("tunnel.zig");
 const recovery = @import("recovery.zig");
 const dashboard = @import("dashboard.zig");
-const egress = @import("egress.zig");
+const tunnel_singbox = @import("tunnel_singbox.zig");
 const ipv6hop = @import("ipv6hop.zig");
 const version_mod = @import("version");
 const uninstall = @import("uninstall.zig");
@@ -136,7 +136,7 @@ pub fn main(init: std.process.Init) !void {
                 } else if (std.mem.eql(u8, sub, "tunnel")) {
                     return tunnel.run(&ui, allocator, &remaining_args);
                 } else if (std.mem.eql(u8, sub, "egress")) {
-                    return egress.run(&ui, allocator, &remaining_args);
+                    return tunnel_singbox.run(&ui, allocator, &remaining_args);
                 } else if (std.mem.eql(u8, sub, "recovery")) {
                     return recovery.run(&ui, allocator, &remaining_args);
                 } else if (std.mem.eql(u8, sub, "dashboard")) {
@@ -278,7 +278,7 @@ fn tunnelOrEgressInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
         tr(ui.lang, "VPN share-link (VLESS-Reality / VMess / Trojan / Shadowsocks / WireGuard)", "VPN-ссылка (VLESS-Reality / VMess / Trojan / Shadowsocks / WireGuard)"),
     };
     const idx = try ui.menu(i18n.get(ui.lang, .tunnel_vpn_type_prompt), &items);
-    if (idx == 1) return egress.runInteractive(ui, allocator);
+    if (idx == 1) return tunnel_singbox.runInteractive(ui, allocator);
     return tunnel.runInteractive(ui, allocator);
 }
 

--- a/src/ctl/main.zig
+++ b/src/ctl/main.zig
@@ -256,7 +256,7 @@ fn interactiveMain(ui: *Tui, allocator: std.mem.Allocator) !void {
             .install => try install.runInteractive(ui, allocator),
             .update => try update.runInteractive(ui, allocator),
             .masking => try masking.runInteractive(ui, allocator),
-            .tunnel => try tunnel.runInteractive(ui, allocator),
+            .tunnel => try tunnelOrEgressInteractive(ui, allocator),
             .dashboard => try dashboard.runInteractive(ui, allocator),
             .recovery => try recovery.runInteractive(ui, allocator),
             .ipv6hop => try ipv6hop.runInteractive(ui, allocator),
@@ -266,6 +266,20 @@ fn interactiveMain(ui: *Tui, allocator: std.mem.Allocator) !void {
             .exit => return,
         }
     }
+}
+
+// "Setup tunnel" now asks for the upstream egress type first: AmneziaWG config (the
+// existing flow) or a VPN share-link (vless/vmess/trojan/ss -> sing-box TUN tunnel,
+// wireguard:// -> native WG tunnel). Dispatched here (not inside tunnel.zig) so tunnel
+// and egress don't import each other.
+fn tunnelOrEgressInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
+    const items = [_][]const u8{
+        i18n.get(ui.lang, .tunnel_vpn_amneziawg),
+        tr(ui.lang, "VPN share-link (VLESS-Reality / VMess / Trojan / Shadowsocks / WireGuard)", "VPN-ссылка (VLESS-Reality / VMess / Trojan / Shadowsocks / WireGuard)"),
+    };
+    const idx = try ui.menu(i18n.get(ui.lang, .tunnel_vpn_type_prompt), &items);
+    if (idx == 1) return egress.runInteractive(ui, allocator);
+    return tunnel.runInteractive(ui, allocator);
 }
 
 fn restartProxy(ui: *Tui, allocator: std.mem.Allocator) void {

--- a/src/ctl/sharelink.zig
+++ b/src/ctl/sharelink.zig
@@ -1,0 +1,426 @@
+//! sharelink.zig — VPN share-link parsing & transforms (std-only, no I/O).
+//!
+//! Pure functions that turn VPN share-links into structured data or alternate config
+//! formats. The transport/security knobs of Xray-family links (vless/vmess/trojan/ss)
+//! are parsed into `XrayLink`; wireguard:// links are rendered to a WG/AmneziaWG `.conf`.
+//! Nothing here touches the filesystem, the network, or systemd — callers own all I/O.
+//!
+//!   detectScheme / parseXrayLink   -> classify + parse an Xray-family link
+//!   validateLink                   -> reject transports/ciphers a generator can't emit
+//!   schemeFamily                   -> wireguard:// vs Xray (one egress = one family)
+//!   convertWireguardLink           -> wireguard:// share-link -> WG/AmneziaWG .conf
+
+const std = @import("std");
+
+// ── URI helpers ───────────────────────────────────────────────────────────────
+
+/// Decode percent-escapes (%2F -> '/') into `out` (must be >= s.len). Returns the slice.
+pub fn percentDecode(out: []u8, s: []const u8) []const u8 {
+    var w: usize = 0;
+    var i: usize = 0;
+    while (i < s.len) : (i += 1) {
+        if (s[i] == '%' and i + 2 < s.len) {
+            const hi = std.fmt.charToDigit(s[i + 1], 16) catch {
+                out[w] = s[i];
+                w += 1;
+                continue;
+            };
+            const lo = std.fmt.charToDigit(s[i + 2], 16) catch {
+                out[w] = s[i];
+                w += 1;
+                continue;
+            };
+            out[w] = @intCast(hi * 16 + lo);
+            w += 1;
+            i += 2;
+        } else {
+            out[w] = s[i];
+            w += 1;
+        }
+    }
+    return out[0..w];
+}
+
+/// Percent-decode into a freshly allocated buffer.
+fn percentDecodeAlloc(a: std.mem.Allocator, s: []const u8) ![]const u8 {
+    const buf = try a.alloc(u8, s.len);
+    const decoded = percentDecode(buf, s);
+    return decoded;
+}
+
+/// Return the (raw, undecoded) value of `key` in a `k=v&k2=v2` query string, or null.
+pub fn queryParam(query: []const u8, key: []const u8) ?[]const u8 {
+    var it = std.mem.splitScalar(u8, query, '&');
+    while (it.next()) |pair| {
+        const eq = std.mem.indexOfScalar(u8, pair, '=') orelse continue;
+        if (std.mem.eql(u8, pair[0..eq], key)) return pair[eq + 1 ..];
+    }
+    return null;
+}
+
+/// Standard or url-safe base64 decode (tolerant of missing padding), into alloc.
+fn base64Decode(a: std.mem.Allocator, s_in: []const u8) ![]u8 {
+    const s = std.mem.trim(u8, s_in, " \t\r\n");
+    const url_safe = std.mem.indexOfAny(u8, s, "-_") != null;
+    // Re-pad to a multiple of 4 for the standard decoders.
+    const pad = (4 - (s.len % 4)) % 4;
+    var tmp = try a.alloc(u8, s.len + pad);
+    @memcpy(tmp[0..s.len], s);
+    var p: usize = 0;
+    while (p < pad) : (p += 1) tmp[s.len + p] = '=';
+    const dec = if (url_safe) std.base64.url_safe.Decoder else std.base64.standard.Decoder;
+    const n = dec.calcSizeForSlice(tmp) catch return error.BadBase64;
+    const out = try a.alloc(u8, n);
+    dec.decode(out, tmp) catch return error.BadBase64;
+    return out;
+}
+
+// ── Parsed link model ──────────────────────────────────────────────────────────
+
+pub const Scheme = enum { vless, vmess, trojan, shadowsocks, wireguard, unknown };
+
+pub fn detectScheme(link_in: []const u8) Scheme {
+    const link = std.mem.trim(u8, link_in, " \t\r\n");
+    if (std.mem.startsWith(u8, link, "vless://")) return .vless;
+    if (std.mem.startsWith(u8, link, "vmess://")) return .vmess;
+    if (std.mem.startsWith(u8, link, "trojan://")) return .trojan;
+    if (std.mem.startsWith(u8, link, "ss://")) return .shadowsocks;
+    if (std.mem.startsWith(u8, link, "wireguard://") or std.mem.startsWith(u8, link, "wg://")) return .wireguard;
+    return .unknown;
+}
+
+/// A parsed Xray-family link (vless/vmess/trojan/ss). All string fields are owned by
+/// the allocator passed to the parser (use an arena and free it all at once). Fields
+/// not relevant to a given protocol stay null/empty.
+pub const XrayLink = struct {
+    scheme: Scheme,
+    name: []const u8 = "egress",
+    address: []const u8,
+    port: u16,
+    // auth
+    id: ?[]const u8 = null, // uuid (vless/vmess)
+    password: ?[]const u8 = null, // trojan / ss
+    method: ?[]const u8 = null, // ss cipher
+    alter_id: u16 = 0, // vmess aid
+    cipher: []const u8 = "auto", // vmess scy (auto|none|zero|aes-128-gcm|chacha20-poly1305)
+    // transport / security
+    network: []const u8 = "tcp", // tcp | ws | grpc | http
+    security: []const u8 = "none", // none | tls | reality
+    flow: ?[]const u8 = null, // vless xtls flow
+    sni: ?[]const u8 = null,
+    host: ?[]const u8 = null, // ws/http Host header
+    path: ?[]const u8 = null, // ws/http path or grpc serviceName
+    fingerprint: ?[]const u8 = null, // utls fp (chrome,...)
+    public_key: ?[]const u8 = null, // reality pbk
+    short_id: ?[]const u8 = null, // reality sid
+};
+
+fn splitHostPort(hp: []const u8) !struct { host: []const u8, port: u16 } {
+    // IPv6 literal in brackets: [::1]:443
+    if (hp.len > 0 and hp[0] == '[') {
+        const close = std.mem.indexOfScalar(u8, hp, ']') orelse return error.BadAddress;
+        const host = hp[1..close];
+        if (close + 1 >= hp.len or hp[close + 1] != ':') return error.BadAddress;
+        const port = std.fmt.parseInt(u16, hp[close + 2 ..], 10) catch return error.BadAddress;
+        return .{ .host = host, .port = port };
+    }
+    const colon = std.mem.lastIndexOfScalar(u8, hp, ':') orelse return error.BadAddress;
+    const port = std.fmt.parseInt(u16, hp[colon + 1 ..], 10) catch return error.BadAddress;
+    return .{ .host = hp[0..colon], .port = port };
+}
+
+/// Parse vless:// or trojan:// (same URI shape: cred@host:port?params#name).
+fn parseUriCred(a: std.mem.Allocator, link: []const u8, scheme: Scheme, prefix: []const u8) !XrayLink {
+    var rest = link[prefix.len..];
+    // fragment (name)
+    var name: []const u8 = "egress";
+    if (std.mem.indexOfScalar(u8, rest, '#')) |h| {
+        name = try percentDecodeAlloc(a, rest[h + 1 ..]);
+        rest = rest[0..h];
+    }
+    // query
+    var query: []const u8 = "";
+    if (std.mem.indexOfScalar(u8, rest, '?')) |q| {
+        query = rest[q + 1 ..];
+        rest = rest[0..q];
+    }
+    const at = std.mem.indexOfScalar(u8, rest, '@') orelse return error.BadLink;
+    const cred = try percentDecodeAlloc(a, rest[0..at]);
+    const hp = try splitHostPort(rest[at + 1 ..]);
+
+    var l = XrayLink{ .scheme = scheme, .name = name, .address = try a.dupe(u8, hp.host), .port = hp.port };
+    if (scheme == .vless) l.id = cred else l.password = cred;
+
+    if (queryParam(query, "type")) |v| l.network = try percentDecodeAlloc(a, v);
+    if (queryParam(query, "security")) |v| l.security = try percentDecodeAlloc(a, v);
+    if (queryParam(query, "flow")) |v| l.flow = try percentDecodeAlloc(a, v);
+    if (queryParam(query, "sni")) |v| l.sni = try percentDecodeAlloc(a, v);
+    if (queryParam(query, "host")) |v| l.host = try percentDecodeAlloc(a, v);
+    if (queryParam(query, "path")) |v| l.path = try percentDecodeAlloc(a, v);
+    if (queryParam(query, "serviceName")) |v| l.path = try percentDecodeAlloc(a, v);
+    if (queryParam(query, "fp")) |v| l.fingerprint = try percentDecodeAlloc(a, v);
+    if (queryParam(query, "pbk")) |v| l.public_key = try percentDecodeAlloc(a, v);
+    if (queryParam(query, "sid")) |v| l.short_id = try percentDecodeAlloc(a, v);
+    return l;
+}
+
+fn jsonStr(obj: std.json.Value, key: []const u8) ?[]const u8 {
+    const v = obj.object.get(key) orelse return null;
+    return switch (v) {
+        .string => |s| s,
+        .integer => |i| std.fmt.allocPrint(std.heap.page_allocator, "{d}", .{i}) catch null,
+        else => null,
+    };
+}
+
+/// Parse vmess:// (base64-encoded JSON object).
+fn parseVmess(a: std.mem.Allocator, link: []const u8) !XrayLink {
+    const decoded = try base64Decode(a, link["vmess://".len..]);
+    const parsed = std.json.parseFromSlice(std.json.Value, a, decoded, .{}) catch return error.BadLink;
+    const o = parsed.value;
+    if (o != .object) return error.BadLink;
+    const add = jsonStr(o, "add") orelse return error.BadLink;
+    const port_s = jsonStr(o, "port") orelse return error.BadLink;
+    const id = jsonStr(o, "id") orelse return error.BadLink;
+    var l = XrayLink{
+        .scheme = .vmess,
+        .name = try a.dupe(u8, jsonStr(o, "ps") orelse "egress"),
+        .address = try a.dupe(u8, add),
+        .port = std.fmt.parseInt(u16, std.mem.trim(u8, port_s, " "), 10) catch return error.BadLink,
+        .id = try a.dupe(u8, id),
+    };
+    if (jsonStr(o, "aid")) |s| l.alter_id = std.fmt.parseInt(u16, std.mem.trim(u8, s, " "), 10) catch 0;
+    if (jsonStr(o, "scy")) |s| if (s.len > 0) {
+        l.cipher = try a.dupe(u8, s);
+    };
+    if (jsonStr(o, "net")) |s| l.network = try a.dupe(u8, s);
+    if (jsonStr(o, "host")) |s| l.host = try a.dupe(u8, s);
+    if (jsonStr(o, "path")) |s| l.path = try a.dupe(u8, s);
+    if (jsonStr(o, "sni")) |s| l.sni = try a.dupe(u8, s);
+    const tls = jsonStr(o, "tls") orelse "";
+    if (tls.len > 0) l.security = "tls";
+    return l;
+}
+
+/// Parse ss:// — SIP002 (`ss://b64(method:pass)@host:port#name`) or legacy
+/// (`ss://b64(method:pass@host:port)#name`).
+fn parseSs(a: std.mem.Allocator, link: []const u8) !XrayLink {
+    var rest = link["ss://".len..];
+    var name: []const u8 = "egress";
+    if (std.mem.indexOfScalar(u8, rest, '#')) |h| {
+        name = try percentDecodeAlloc(a, rest[h + 1 ..]);
+        rest = rest[0..h];
+    }
+    if (std.mem.indexOfScalar(u8, rest, '?')) |q| rest = rest[0..q]; // drop plugin params
+    var method: []const u8 = undefined;
+    var password: []const u8 = undefined;
+    var hostport: []const u8 = undefined;
+    if (std.mem.indexOfScalar(u8, rest, '@')) |at| {
+        // SIP002: userinfo (before @) is base64(method:password)
+        const ui = base64Decode(a, rest[0..at]) catch rest[0..at];
+        const colon = std.mem.indexOfScalar(u8, ui, ':') orelse return error.BadLink;
+        method = ui[0..colon];
+        password = ui[colon + 1 ..];
+        hostport = rest[at + 1 ..];
+    } else {
+        // legacy: whole thing is base64(method:password@host:port)
+        const dec = try base64Decode(a, rest);
+        const at = std.mem.indexOfScalar(u8, dec, '@') orelse return error.BadLink;
+        const colon = std.mem.indexOfScalar(u8, dec[0..at], ':') orelse return error.BadLink;
+        method = dec[0..colon];
+        password = dec[colon + 1 .. at];
+        hostport = dec[at + 1 ..];
+    }
+    const hp = try splitHostPort(hostport);
+    return XrayLink{
+        .scheme = .shadowsocks,
+        .name = name,
+        .address = try a.dupe(u8, hp.host),
+        .port = hp.port,
+        .method = try a.dupe(u8, method),
+        .password = try a.dupe(u8, password),
+    };
+}
+
+/// Parse any Xray-family share link into an XrayLink (arena-owned strings).
+pub fn parseXrayLink(a: std.mem.Allocator, link_in: []const u8) !XrayLink {
+    const link = std.mem.trim(u8, link_in, " \t\r\n");
+    return switch (detectScheme(link)) {
+        .vless => parseUriCred(a, link, .vless, "vless://"),
+        .trojan => parseUriCred(a, link, .trojan, "trojan://"),
+        .vmess => parseVmess(a, link),
+        .shadowsocks => parseSs(a, link),
+        else => error.UnsupportedScheme,
+    };
+}
+
+// ── Link family + validation ────────────────────────────────────────────────────
+
+pub const Family = enum { wireguard, xray };
+pub fn schemeFamily(s: Scheme) Family {
+    return if (s == .wireguard) .wireguard else .xray;
+}
+
+// Ciphers sing-box accepts for shadowsocks. An unknown one makes sing-box reject the
+// WHOLE config, so we reject the link up front with a clear message instead.
+const supported_ss_methods = [_][]const u8{
+    "aes-128-gcm",             "aes-192-gcm",
+    "aes-256-gcm",             "chacha20-ietf-poly1305",
+    "xchacha20-ietf-poly1305", "2022-blake3-aes-128-gcm",
+    "2022-blake3-aes-256-gcm", "2022-blake3-chacha20-poly1305",
+    "none",
+};
+
+/// Reject links whose transport/cipher our generator can't faithfully emit — better a
+/// clear error than silently degrading an unsupported transport to plain TCP (which the
+/// server rejects) or emitting an unknown SS cipher (which sing-box refuses to load).
+/// Returns an error message in `buf`, or null when the link is supported.
+pub fn validateLink(l: XrayLink, buf: []u8) ?[]const u8 {
+    const net = l.network;
+    if (!(net.len == 0 or std.mem.eql(u8, net, "tcp") or std.mem.eql(u8, net, "ws") or std.mem.eql(u8, net, "grpc"))) {
+        return std.fmt.bufPrint(buf, "unsupported transport '{s}' for {s} — only tcp/ws/grpc are supported", .{ net, l.address }) catch "unsupported transport";
+    }
+    if (l.scheme == .shadowsocks) {
+        const m = l.method orelse "";
+        for (supported_ss_methods) |sm| {
+            if (std.mem.eql(u8, m, sm)) return null;
+        }
+        return std.fmt.bufPrint(buf, "unsupported shadowsocks cipher '{s}' for {s}", .{ m, l.address }) catch "unsupported shadowsocks cipher";
+    }
+    return null;
+}
+
+// ── wireguard:// -> .conf transform ──────────────────────────────────────────────
+
+/// Convert a `wireguard://<privkey>@<host>:<port>?publickey=&address=&mtu=...#name`
+/// share-link into a WireGuard/AmneziaWG `.conf`. AmneziaWG obfuscation params
+/// (jc/jmin/jmax/s1/s2/h1..h4) and presharedkey are carried through when present.
+pub fn convertWireguardLink(a: std.mem.Allocator, link_in: []const u8) ![]const u8 {
+    const link = std.mem.trim(u8, link_in, " \t\r\n");
+    const after = if (std.mem.startsWith(u8, link, "wireguard://"))
+        link["wireguard://".len..]
+    else if (std.mem.startsWith(u8, link, "wg://"))
+        link["wg://".len..]
+    else
+        return error.UnsupportedScheme;
+
+    var rest = after;
+    if (std.mem.indexOfScalar(u8, rest, '#')) |h| rest = rest[0..h];
+    var query: []const u8 = "";
+    if (std.mem.indexOfScalar(u8, rest, '?')) |q| {
+        query = rest[q + 1 ..];
+        rest = rest[0..q];
+    }
+    const at = std.mem.indexOfScalar(u8, rest, '@') orelse return error.BadLink;
+    const private_key = try percentDecodeAlloc(a, rest[0..at]);
+    const hp = try splitHostPort(rest[at + 1 ..]);
+
+    const pub_key = try percentDecodeAlloc(a, queryParam(query, "publickey") orelse queryParam(query, "public_key") orelse return error.BadLink);
+    const address = try percentDecodeAlloc(a, queryParam(query, "address") orelse "10.0.0.2/32");
+    const mtu = queryParam(query, "mtu") orelse "1420";
+
+    var aw: std.Io.Writer.Allocating = .init(a);
+    const w = &aw.writer;
+    try w.print("[Interface]\nPrivateKey = {s}\nAddress = {s}\nMTU = {s}\n", .{ private_key, address, mtu });
+    if (queryParam(query, "dns")) |dns| try w.print("DNS = {s}\n", .{try percentDecodeAlloc(a, dns)});
+    // AmneziaWG obfuscation knobs (only emitted when present).
+    inline for (.{ "jc", "jmin", "jmax", "s1", "s2", "h1", "h2", "h3", "h4" }) |k| {
+        if (queryParam(query, k)) |v| {
+            var ku: [4]u8 = undefined;
+            const upper = std.ascii.upperString(&ku, k);
+            try w.print("{s} = {s}\n", .{ upper, v });
+        }
+    }
+    try w.print("\n[Peer]\nPublicKey = {s}\nEndpoint = {s}:{d}\nAllowedIPs = 0.0.0.0/0, ::/0\nPersistentKeepalive = 25\n", .{ pub_key, hp.host, hp.port });
+    if (queryParam(query, "presharedkey")) |psk| try w.print("PresharedKey = {s}\n", .{try percentDecodeAlloc(a, psk)});
+    return aw.written();
+}
+
+test "parse vless reality link" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const l = try parseXrayLink(a, "vless://95e0edb9-4a0b-4312-a71f-1d4b8b6db79b@154.59.110.32:443?type=tcp&security=reality&pbk=PBK&fp=chrome&sni=www.microsoft.com&sid=ABCD&flow=xtls-rprx-vision#demo");
+    try std.testing.expectEqual(Scheme.vless, l.scheme);
+    try std.testing.expectEqualStrings("154.59.110.32", l.address);
+    try std.testing.expectEqual(@as(u16, 443), l.port);
+    try std.testing.expectEqualStrings("95e0edb9-4a0b-4312-a71f-1d4b8b6db79b", l.id.?);
+    try std.testing.expectEqualStrings("reality", l.security);
+    try std.testing.expectEqualStrings("www.microsoft.com", l.sni.?);
+    try std.testing.expectEqualStrings("PBK", l.public_key.?);
+    try std.testing.expectEqualStrings("ABCD", l.short_id.?);
+    try std.testing.expectEqualStrings("xtls-rprx-vision", l.flow.?);
+    try std.testing.expectEqualStrings("demo", l.name);
+}
+
+test "parse vmess base64 link" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    // {"v":"2","ps":"demo-vmess","add":"154.59.110.32","port":"10443","id":"15750f7e-57df-4fb2-b3a4-a9edff4c0def","aid":"0","net":"tcp","type":"none","tls":""}
+    const l = try parseXrayLink(a, "vmess://eyJ2IjogIjIiLCAicHMiOiAiZGVtby12bWVzcyIsICJhZGQiOiAiMTU0LjU5LjExMC4zMiIsICJwb3J0IjogIjEwNDQzIiwgImlkIjogIjE1NzUwZjdlLTU3ZGYtNGZiMi1iM2E0LWE5ZWRmZjRjMGRlZiIsICJhaWQiOiAiMCIsICJuZXQiOiAidGNwIiwgInR5cGUiOiAibm9uZSIsICJ0bHMiOiAiIn0=");
+    try std.testing.expectEqual(Scheme.vmess, l.scheme);
+    try std.testing.expectEqualStrings("154.59.110.32", l.address);
+    try std.testing.expectEqual(@as(u16, 10443), l.port);
+    try std.testing.expectEqualStrings("15750f7e-57df-4fb2-b3a4-a9edff4c0def", l.id.?);
+    try std.testing.expectEqualStrings("demo-vmess", l.name);
+}
+
+test "parse shadowsocks sip002 link" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    // base64("aes-256-gcm:g7ZGM4sBp5FuzPgvKQgYgA") @ host:port
+    const l = try parseXrayLink(a, "ss://YWVzLTI1Ni1nY206ZzdaR000c0JwNUZ1elBndktRZ1lnQQ==@154.59.110.32:9443#demo-shadowsocks");
+    try std.testing.expectEqual(Scheme.shadowsocks, l.scheme);
+    try std.testing.expectEqualStrings("154.59.110.32", l.address);
+    try std.testing.expectEqual(@as(u16, 9443), l.port);
+    try std.testing.expectEqualStrings("aes-256-gcm", l.method.?);
+    try std.testing.expectEqualStrings("g7ZGM4sBp5FuzPgvKQgYgA", l.password.?);
+}
+
+test "percentDecode + queryParam" {
+    var buf: [64]u8 = undefined;
+    try std.testing.expectEqualStrings("10.11.11.2/32", percentDecode(&buf, "10.11.11.2%2F32"));
+    try std.testing.expectEqualStrings("German WG-1", percentDecode(&buf, "German%20WG-1"));
+    try std.testing.expectEqualStrings("1420", queryParam("publickey=X&address=Y&mtu=1420", "mtu").?);
+    try std.testing.expect(queryParam("a=1&b=2", "c") == null);
+}
+
+test "validateLink rejects unsupported transport and ss cipher" {
+    var buf: [256]u8 = undefined;
+    try std.testing.expect(validateLink(.{ .scheme = .vless, .address = "h", .port = 1, .network = "ws" }, &buf) == null);
+    try std.testing.expect(validateLink(.{ .scheme = .shadowsocks, .address = "h", .port = 1, .method = "aes-256-gcm" }, &buf) == null);
+    try std.testing.expect(validateLink(.{ .scheme = .vless, .address = "h", .port = 1, .network = "quic" }, &buf) != null);
+    try std.testing.expect(validateLink(.{ .scheme = .shadowsocks, .address = "h", .port = 1, .method = "rc4-md5-is-unsupported" }, &buf) != null);
+}
+
+test "detectScheme" {
+    try std.testing.expectEqual(Scheme.vless, detectScheme("vless://x"));
+    try std.testing.expectEqual(Scheme.wireguard, detectScheme("wireguard://x"));
+    try std.testing.expectEqual(Scheme.shadowsocks, detectScheme("ss://x"));
+    try std.testing.expectEqual(Scheme.unknown, detectScheme("http://x"));
+}
+
+test "convertWireguardLink builds a WG/AmneziaWG conf" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const conf = try convertWireguardLink(a, "wireguard://PRIVK%2Fey@111.222.33.194:19666?publickey=PUBKEY&address=10.11.11.2%2F32&mtu=1420&presharedkey=PSK&jc=4&s1=50#German%20WG-1");
+    const has = struct {
+        fn f(h: []const u8, n: []const u8) bool {
+            return std.mem.indexOf(u8, h, n) != null;
+        }
+    }.f;
+    try std.testing.expect(has(conf, "[Interface]"));
+    try std.testing.expect(has(conf, "PrivateKey = PRIVK/ey")); // %2F decoded
+    try std.testing.expect(has(conf, "Address = 10.11.11.2/32"));
+    try std.testing.expect(has(conf, "MTU = 1420"));
+    try std.testing.expect(has(conf, "JC = 4")); // AmneziaWG knob, uppercased
+    try std.testing.expect(has(conf, "S1 = 50"));
+    try std.testing.expect(has(conf, "[Peer]"));
+    try std.testing.expect(has(conf, "PublicKey = PUBKEY"));
+    try std.testing.expect(has(conf, "Endpoint = 111.222.33.194:19666"));
+    try std.testing.expect(has(conf, "AllowedIPs = 0.0.0.0/0, ::/0"));
+    try std.testing.expect(has(conf, "PresharedKey = PSK"));
+}

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -9,45 +9,18 @@ const i18n = @import("i18n.zig");
 const sys = @import("sys.zig");
 const toml = @import("toml.zig");
 const release = @import("release.zig");
+const tunnel_wg = @import("tunnel_wg.zig");
 const Tunnel = @import("tunnel").Tunnel;
 
 const Tui = tui_mod.Tui;
 const Color = tui_mod.Color;
 
 const INSTALL_DIR = "/opt/mtproto-proxy";
-const AWG_CONF_DIR = "/etc/amnezia/amneziawg";
 const AWG_IFACE_CONF_PATH = "/etc/amnezia/awg0.conf";
 const TUNNEL_SCRIPT = "/usr/local/bin/setup_tunnel.sh";
 const TUNNEL_POOL_SERVICE = "/etc/systemd/system/mtproto-tunnel-pool.service";
 const TUNNEL_POOL_TIMER = "/etc/systemd/system/mtproto-tunnel-pool.timer";
 const TUNNEL_POOL_STATE = "/run/mtproto-proxy/tunnel-pool.state";
-const SERVICE_FILE = "/etc/systemd/system/mtproto-proxy.service";
-const TUNNEL_MARK: u32 = 200;
-const TUNNEL_TABLE: u32 = 200;
-
-fn io() std.Io {
-    return std.Io.Threaded.global_single_threaded.io();
-}
-
-fn readFileAllocCwd(allocator: std.mem.Allocator, path: []const u8, limit: usize) ![]u8 {
-    return std.Io.Dir.cwd().readFileAlloc(io(), path, allocator, .limited(limit));
-}
-
-pub const TunnelOpts = struct {
-    awg_source: []const u8 = "",
-    iface: []const u8 = "",
-};
-
-const AwgConfigKind = enum {
-    native_conf,
-    amnezia_vpn_link,
-};
-
-const AwgQuickValidation = enum {
-    ok,
-    missing_binary,
-    invalid_config,
-};
 
 const InteractiveTunnelSelection = struct {
     iface: []const u8,
@@ -62,7 +35,7 @@ const InteractiveTunnelAction = enum {
 
 /// Run in CLI mode.
 pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) !void {
-    var opts = TunnelOpts{};
+    var opts = tunnel_wg.TunnelOpts{};
 
     while (args.next()) |arg| {
         if (std.mem.eql(u8, arg, "--mode") or std.mem.eql(u8, arg, "-m")) {
@@ -86,14 +59,7 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
         return;
     }
 
-    try execute(ui, allocator, opts);
-}
-
-/// Set up a tunnel directly from a WireGuard/AmneziaWG `.conf` path — same flow as
-/// `setup tunnel <conf>`. Used by the egress provider after it converts a
-/// wireguard:// share-link into a `.conf`.
-pub fn setupFromConf(ui: *Tui, allocator: std.mem.Allocator, conf_path: []const u8) !void {
-    try execute(ui, allocator, .{ .awg_source = conf_path });
+    try tunnel_wg.execute(ui, allocator, opts);
 }
 
 /// Run in interactive mode.
@@ -135,7 +101,7 @@ pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
         return;
     }
 
-    try execute(ui, allocator, .{ .awg_source = conf_source, .iface = selection.iface });
+    try tunnel_wg.execute(ui, allocator, .{ .awg_source = conf_source, .iface = selection.iface });
 }
 
 fn tr(lang: i18n.Lang, en: []const u8, ru: []const u8) []const u8 {
@@ -144,9 +110,9 @@ fn tr(lang: i18n.Lang, en: []const u8, ru: []const u8) []const u8 {
 
 fn chooseInteractiveTunnelTarget(ui: *Tui, allocator: std.mem.Allocator) !InteractiveTunnelSelection {
     const pool = try loadConfiguredTunnelPool(allocator);
-    defer freeOwnedStringSlice(allocator, pool);
+    defer tunnel_wg.freeOwnedStringSlice(allocator, pool);
     const known = try loadKnownTunnelInterfaces(allocator);
-    defer freeOwnedStringSlice(allocator, known);
+    defer tunnel_wg.freeOwnedStringSlice(allocator, known);
 
     if (known.len == 0) {
         ui.info(i18n.get(ui.lang, .tunnel_pool_empty));
@@ -155,7 +121,7 @@ fn chooseInteractiveTunnelTarget(ui: *Tui, allocator: std.mem.Allocator) !Intera
         printTunnelPoolRuntimeStatus(ui, allocator, known, pool);
     }
 
-    const next_iface = try selectTunnelInterface(allocator, "");
+    const next_iface = try tunnel_wg.selectTunnelInterface(allocator, "");
     defer allocator.free(next_iface);
 
     var items: std.ArrayList([]const u8) = .empty;
@@ -271,7 +237,7 @@ fn tunnelRuntimeStatus(allocator: std.mem.Allocator, iface: []const u8) []const 
 fn printTunnelPoolRuntimeStatus(ui: *Tui, allocator: std.mem.Allocator, interfaces: []const []const u8, pool: []const []const u8) void {
     for (interfaces, 0..) |iface, idx| {
         const status = tunnelRuntimeStatus(allocator, iface);
-        const source = if (containsInterface(pool, iface)) "pool" else "config";
+        const source = if (tunnel_wg.containsInterface(pool, iface)) "pool" else "config";
         const status_color = if (std.mem.eql(u8, status, "active"))
             Color.ok
         else if (std.mem.startsWith(u8, status, "up"))
@@ -339,16 +305,16 @@ fn deleteTunnelInteractive(ui: *Tui, allocator: std.mem.Allocator, iface: []cons
 }
 
 fn deleteTunnelPoolMember(allocator: std.mem.Allocator, iface: []const u8) !TunnelDeleteResult {
-    if (!isValidTunnelInterfaceName(iface)) return error.InvalidInterfaceName;
+    if (!tunnel_wg.isValidTunnelInterfaceName(iface)) return error.InvalidInterfaceName;
 
     const known_before = try loadKnownTunnelInterfaces(allocator);
-    defer freeOwnedStringSlice(allocator, known_before);
+    defer tunnel_wg.freeOwnedStringSlice(allocator, known_before);
 
     var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch return error.ConfigSourceNotFound;
     defer doc.deinit();
 
     const config_result = try removeTunnelFromDoc(allocator, &doc, iface);
-    defer freeOwnedStringSlice(allocator, config_result.remaining_pool);
+    defer tunnel_wg.freeOwnedStringSlice(allocator, config_result.remaining_pool);
     if (!config_result.removed and !tunnelConfigExists(iface)) return error.TunnelNotInPool;
 
     const stale_last = !config_result.removed and config_result.remaining_pool.len == 0 and known_before.len <= 1;
@@ -385,7 +351,7 @@ fn stopTunnelInterface(allocator: std.mem.Allocator, iface: []const u8) void {
     const quick = quickToolForInterface(iface);
 
     var awg_buf: [256]u8 = undefined;
-    const awg_path = awgConfigPath(&awg_buf, iface) catch "";
+    const awg_path = tunnel_wg.awgConfigPath(&awg_buf, iface) catch "";
     var wg_buf: [256]u8 = undefined;
     const wg_path = std.fmt.bufPrint(&wg_buf, "/etc/wireguard/{s}.conf", .{iface}) catch "";
 
@@ -399,7 +365,7 @@ fn stopTunnelInterface(allocator: std.mem.Allocator, iface: []const u8) void {
 
 fn tunnelConfigExists(iface: []const u8) bool {
     var awg_buf: [256]u8 = undefined;
-    const awg_path = awgConfigPath(&awg_buf, iface) catch "";
+    const awg_path = tunnel_wg.awgConfigPath(&awg_buf, iface) catch "";
     var wg_buf: [256]u8 = undefined;
     const wg_path = std.fmt.bufPrint(&wg_buf, "/etc/wireguard/{s}.conf", .{iface}) catch "";
 
@@ -411,7 +377,7 @@ fn tunnelConfigExists(iface: []const u8) bool {
 
 fn deleteTunnelConfigFiles(allocator: std.mem.Allocator, iface: []const u8) void {
     var awg_buf: [256]u8 = undefined;
-    const awg_path = awgConfigPath(&awg_buf, iface) catch "";
+    const awg_path = tunnel_wg.awgConfigPath(&awg_buf, iface) catch "";
     var wg_buf: [256]u8 = undefined;
     const wg_path = std.fmt.bufPrint(&wg_buf, "/etc/wireguard/{s}.conf", .{iface}) catch "";
 
@@ -434,781 +400,11 @@ fn refreshTunnelPoolRuntime(allocator: std.mem.Allocator) void {
     sys.execSilent(allocator, &.{TUNNEL_SCRIPT});
 }
 
-fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
-    if (!sys.isRoot()) {
-        ui.fail(i18n.get(ui.lang, .error_not_root));
-        return;
-    }
-
-    const awg_source = std.mem.trim(u8, opts.awg_source, &[_]u8{ ' ', '\t', '\r', '\n' });
-    if (awg_source.len == 0) {
-        ui.fail("VPN config source is empty");
-        return;
-    }
-    if (!sys.fileExists(INSTALL_DIR ++ "/mtproto-proxy")) {
-        ui.fail("mtproto-proxy not installed. Run install first.");
-        return;
-    }
-
-    // A sing-box egress (`setup egress`) and this WG tunnel pool both own fwmark 200 /
-    // table 200 — retire the sing-box egress so the two don't fight over the route.
-    if (sys.fileExists("/etc/systemd/system/mtproto-singbox-egress.service")) {
-        ui.warn("Retiring the existing sing-box egress — it can't share table 200 with a WG tunnel.");
-        sys.execSilent(allocator, &.{ "systemctl", "disable", "--now", "mtproto-singbox-egress.service" });
-        sys.execSilent(allocator, &.{ "rm", "-f", "/etc/systemd/system/mtproto-singbox-egress.service", "/etc/mtproto-proxy/singbox-egress.json", "/usr/local/bin/mtproto-singbox-route.sh", "/etc/systemd/system/mtproto-proxy.service.d/egress.conf" });
-        sys.execSilent(allocator, &.{ "systemctl", "daemon-reload" });
-    }
-
-    // ── Install AmneziaWG ──
-    if (sys.commandExists("awg") and sys.commandExists("awg-quick")) {
-        ui.ok("AmneziaWG already installed");
-    } else {
-        if (sys.commandExists("awg") != sys.commandExists("awg-quick")) {
-            ui.warn("Detected partial AmneziaWG installation; repairing package setup");
-        }
-        ui.step("Installing AmneziaWG...");
-        if (!ensureAmneziaWgInstalled(ui, allocator)) {
-            return;
-        }
-        ui.ok("AmneziaWG installed");
-    }
-
-    const iface = selectTunnelInterface(allocator, opts.iface) catch |err| {
-        switch (err) {
-            error.InvalidInterfaceName => ui.fail("Invalid tunnel interface name. Use names like awg0, awg1, wg0."),
-            error.NoFreeInterface => ui.fail("No free awgN interface name found"),
-            else => ui.fail("Failed to select tunnel interface"),
-        }
-        return;
-    };
-    defer allocator.free(iface);
-
-    var config_path_buf: [256]u8 = undefined;
-    const awg_config_path = awgConfigPath(&config_path_buf, iface) catch {
-        ui.fail("Tunnel interface name is too long");
-        return;
-    };
-
-    // ── Copy AWG config ──
-    ui.step("Installing AmneziaWG config...");
-    _ = sys.exec(allocator, &.{ "mkdir", "-p", "/etc/amnezia" }) catch {};
-    _ = sys.exec(allocator, &.{ "mkdir", "-p", AWG_CONF_DIR }) catch {};
-
-    const config_kind = installAwgConfigSource(allocator, awg_source, awg_config_path) catch |err| {
-        switch (err) {
-            error.ConfigSourceNotFound => ui.fail("Config file not found"),
-            error.UnsupportedConfigFormat => ui.fail("Unsupported VPN config format. Use a WireGuard/AmneziaWG .conf file, or an Amnezia vpn:// share link."),
-            error.InvalidAmneziaVpnLink => ui.fail("Invalid Amnezia vpn:// link. Export/share an AmneziaWG configuration again and retry."),
-            error.AwgConfigNotFound => ui.fail("Amnezia vpn:// link does not contain an AmneziaWG configuration."),
-            else => ui.fail("Failed to prepare AmneziaWG config"),
-        }
-        return;
-    };
-    if (config_kind == .amnezia_vpn_link) {
-        ui.warn("Converted Amnezia vpn:// link to AmneziaWG config");
-    }
-    if (std.mem.eql(u8, iface, "awg0")) {
-        _ = sys.execForward(&.{ "ln", "-sfn", awg_config_path, AWG_IFACE_CONF_PATH }) catch {};
-    }
-
-    const dns_removed = stripAwgDnsLines(allocator, awg_config_path) catch false;
-    if (dns_removed) {
-        ui.warn("Removed DNS from tunnel config (host resolver will be used)");
-    }
-
-    const empty_removed = stripAwgEmptyAssignments(allocator, awg_config_path) catch false;
-    if (empty_removed) {
-        ui.warn("Removed empty AmneziaWG parameters from tunnel config");
-    }
-
-    const table_off_added = ensureAwgTableOff(allocator, awg_config_path) catch false;
-    if (table_off_added) {
-        ui.warn("Added Table = off to [Interface] in tunnel config");
-    }
-
-    switch (validateAwgQuickConfig(allocator, awg_config_path)) {
-        .ok => {},
-        .missing_binary => {
-            ui.fail("AmneziaWG tools are not available (`awg-quick` was not found). Install amneziawg-tools and retry.");
-            return;
-        },
-        .invalid_config => {
-            ui.fail("AmneziaWG config is not accepted by awg-quick. Check that the input is an AWG/WG client config.");
-            return;
-        },
-    }
-
-    ui.stepOk("Config installed", awg_config_path);
-
-    // ── Create tunnel policy script ──
-    ui.step("Creating tunnel policy routing script...");
-
-    const tunnel_script = renderTunnelPoolScript(allocator) catch {
-        ui.fail("Failed to render tunnel setup script");
-        return;
-    };
-    defer allocator.free(tunnel_script);
-
-    sys.writeFileMode(TUNNEL_SCRIPT, tunnel_script, 0o755) catch {
-        ui.fail("Failed to write tunnel setup script");
-        return;
-    };
-    ui.ok("Created " ++ TUNNEL_SCRIPT);
-
-    // ── Patch systemd service ──
-    ui.step("Patching systemd service for tunnel policy routing...");
-    const svc_content =
-        \\[Unit]
-        \\Description=MTProto Proxy (Zig) via Tunnel Policy Routing
-        \\Documentation=https://github.com/sleep3r/mtproto.zig
-        \\After=network-online.target
-        \\Wants=network-online.target
-        \\
-        \\[Service]
-        \\# Type=simple (not notify): containerized systemd (Docker/LXC) often fails to
-        \\# deliver the sd_notify datagram, which would restart-loop a healthy proxy.
-        \\# simple is robust everywhere; Restart=always still recovers crashes.
-        \\Type=simple
-        \\User=mtproto
-        \\Group=mtproto
-        \\WorkingDirectory=/opt/mtproto-proxy
-        \\# Routing/policy setup needs root; the '+' prefix runs ONLY this command
-        \\# with full privileges while the proxy itself drops to User=mtproto.
-        \\ExecStartPre=+/usr/local/bin/setup_tunnel.sh
-        \\ExecStart=/opt/mtproto-proxy/mtproto-proxy /opt/mtproto-proxy/config.toml
-        \\ExecReload=/bin/kill -HUP $MAINPID
-        \\KillSignal=SIGTERM
-        \\TimeoutStopSec=25
-        \\Restart=on-failure
-        \\RestartSec=5
-        \\
-        \\# Security hardening — mirrors the default unit so tunnel mode does NOT
-        \\# silently run the internet-facing proxy as unsandboxed root. CAP_NET_ADMIN
-        \\# is added (on top of CAP_NET_BIND_SERVICE) for the SO_MARK policy routing
-        \\# the tunnel data path uses. Only the device/netlink-safe subset of the
-        \\# default unit's syscall hardening is applied: ExecStartPre runs ip/wg
-        \\# setup (netlink, possibly modprobe) that an aggressive SystemCallFilter /
-        \\# RestrictAddressFamilies / PrivateDevices would break.
-        \\NoNewPrivileges=yes
-        \\ProtectSystem=strict
-        \\ProtectHome=yes
-        \\PrivateTmp=yes
-        \\ReadOnlyPaths=/opt/mtproto-proxy
-        \\LockPersonality=yes
-        \\RestrictRealtime=yes
-        \\RestrictSUIDSGID=yes
-        \\ProtectClock=yes
-        \\ProtectHostname=yes
-        \\ProtectKernelLogs=yes
-        \\UMask=0077
-        \\AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_ADMIN
-        \\CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_ADMIN
-        \\LimitNOFILE=131582
-        \\TasksMax=65535
-        \\
-        \\[Install]
-        \\WantedBy=multi-user.target
-    ;
-
-    sys.writeFile(SERVICE_FILE, svc_content) catch {
-        ui.fail("Failed to write systemd service");
-        return;
-    };
-
-    _ = sys.execForward(&.{ "systemctl", "daemon-reload" }) catch {};
-    ui.ok("Systemd service patched for tunnel policy routing");
-
-    installTunnelPoolUnits(ui, allocator);
-
-    // ── Configure proxy egress mode ──
-    setTunnelPoolConfig(allocator, iface);
-    ui.stepOk("Set [upstream].type", "tunnel");
-    ui.stepOk("Added tunnel pool interface", iface);
-    ui.stepOk("Preserved [general].use_middle_proxy", "unchanged");
-
-    // ── Inject public IP (preserve existing custom value) ──
-    var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch null;
-    if (doc) |*d| {
-        defer d.deinit();
-
-        var should_inject = true;
-        if (d.get("server", "public_ip")) |configured_public_ip| {
-            const configured = std.mem.trim(u8, configured_public_ip, &[_]u8{ ' ', '\t' });
-            if (configured.len > 0 and !std.mem.eql(u8, configured, "<SERVER_IP>")) {
-                should_inject = false;
-                ui.stepOk("Keeping configured public IP", configured);
-            }
-        }
-
-        if (should_inject) {
-            const public_ip = sys.detectPublicIp(allocator) orelse "";
-            if (public_ip.len > 0) {
-                var quoted_buf: [64]u8 = undefined;
-                const quoted = std.fmt.bufPrint(&quoted_buf, "\"{s}\"", .{public_ip}) catch "";
-                if (quoted.len > 0) {
-                    d.set("server", "public_ip", quoted) catch {};
-                    d.save(INSTALL_DIR ++ "/config.toml") catch {};
-                    ui.stepOk("Injected public IP", public_ip);
-                }
-            }
-        }
-    }
-
-    // ── Preserve promotion tag from env.sh ──
-    if (sys.readEnvFile(allocator, INSTALL_DIR ++ "/env.sh", "TAG")) |tag| {
-        defer allocator.free(tag);
-
-        var doc2 = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch null;
-        if (doc2) |*d| {
-            defer d.deinit();
-            var tag_buf: [128]u8 = undefined;
-            const quoted_tag = std.fmt.bufPrint(&tag_buf, "\"{s}\"", .{tag}) catch "";
-            if (quoted_tag.len > 0) {
-                d.set("server", "tag", quoted_tag) catch {};
-                d.save(INSTALL_DIR ++ "/config.toml") catch {};
-            }
-        }
-        ui.stepOk("Preserved promotion tag", tag);
-    }
-
-    // ── Cleanup legacy netns nginx listen directives ──
-    const nginx_cleaned = cleanupNetnsNginxListen(allocator);
-    if (nginx_cleaned) {
-        ui.ok("Removed legacy netns listen directives from nginx masking config");
-        _ = sys.execForward(&.{ "systemctl", "try-reload-or-restart", "nginx" }) catch {};
-    }
-
-    // ── Apply masking monitor (if recovery is already installed) ──
-    if (sys.isServiceActive("mtproto-mask-health.timer") or sys.fileExists("/usr/local/bin/mtproto-mask-health.sh")) {
-        const recovery = @import("recovery.zig");
-        recovery.execute(ui, allocator, .{ .quiet = true }) catch {};
-    }
-
-    // ── Restart proxy ──
-    ui.step("Restarting proxy...");
-    _ = sys.execForward(&.{ "systemctl", "restart", "mtproto-proxy" }) catch {};
-
-    if (sys.isServiceActive("mtproto-proxy")) {
-        ui.ok("Proxy running with tunnel policy routing");
-    } else {
-        ui.fail("Proxy failed to start. Check: journalctl -u mtproto-proxy -n 30");
-        return;
-    }
-
-    // ── Validate tunnel routing ──
-    ui.step("Validating policy routing to Telegram DCs...");
-
-    _ = sys.execForward(&.{TUNNEL_SCRIPT}) catch {};
-
-    const awg_status = sys.exec(allocator, &.{ "awg", "show", iface }) catch null;
-    if (awg_status) |result| {
-        defer result.deinit();
-        if (result.exit_code == 0) {
-            ui.stepOk("Tunnel interface active", iface);
-        } else {
-            ui.warn("Tunnel interface is not active (check AWG config and endpoint)");
-        }
-    }
-
-    const dc_ips = [_][]const u8{
-        "149.154.175.50", "149.154.167.50", "149.154.175.100",
-        "149.154.167.91", "91.108.56.100",
-    };
-
-    for (dc_ips) |dc_ip| {
-        const r = sys.exec(allocator, &.{
-            "ip", "-4", "route", "get", dc_ip, "mark", "200",
-        }) catch null;
-
-        if (r) |route_result| {
-            defer route_result.deinit();
-            if (route_result.exit_code == 0 and std.mem.indexOf(u8, route_result.stdout, "dev ") != null) {
-                ui.stepOk("Policy route via tunnel pool", dc_ip);
-            } else {
-                var warn_buf: [96]u8 = undefined;
-                const warn_msg = std.fmt.bufPrint(&warn_buf, "Policy route check failed for {s}", .{dc_ip}) catch "Policy route check failed";
-                ui.warn(warn_msg);
-            }
-        }
-    }
-
-    // ── Summary ──
-    ui.summaryBox("VPN Tunnel Configured", &.{
-        .{ .label = "Status:", .value = "systemctl status mtproto-proxy" },
-        .{ .label = "Logs:", .value = "journalctl -u mtproto-proxy -f" },
-        .{ .label = "Tunnel:", .value = "awg show <iface>" },
-        .{ .label = "Pool:", .value = "systemctl status mtproto-tunnel-pool.timer" },
-        .{ .label = "Policy:", .value = "ip -4 rule show | grep fwmark" },
-        .{ .label = "Mark:", .value = "SO_MARK=200 -> table 200" },
-        .{ .label = "", .style = .blank },
-        .{ .label = "Proxy runs in host network namespace", .style = .success },
-        .{ .label = "Tunnel pool failover is socket-level and explicit", .style = .success },
-        .{ .label = "SOCKS5/HTTP upstream stay orthogonal", .style = .success },
-    });
-}
-
-fn isAmneziaVpnLinkSource(source: []const u8) bool {
-    const trimmed = std.mem.trim(u8, source, &[_]u8{ ' ', '\t', '\r', '\n' });
-    return std.mem.startsWith(u8, trimmed, "vpn://");
-}
-
-fn installAwgConfigSource(allocator: std.mem.Allocator, source: []const u8, dest_path: []const u8) !AwgConfigKind {
-    const trimmed = std.mem.trim(u8, source, &[_]u8{ ' ', '\t', '\r', '\n' });
-    if (trimmed.len == 0) return error.ConfigSourceNotFound;
-
-    if (isAmneziaVpnLinkSource(trimmed)) {
-        try sys.writeFileMode(dest_path, trimmed, 0o600);
-    } else {
-        const content = readFileAllocCwd(allocator, trimmed, 1024 * 1024) catch |err| switch (err) {
-            error.FileNotFound => return error.ConfigSourceNotFound,
-            else => return err,
-        };
-        defer allocator.free(content);
-
-        try sys.writeFileMode(dest_path, content, 0o600);
-    }
-
-    return normalizeAwgConfig(allocator, dest_path);
-}
-
-fn normalizeAwgConfig(allocator: std.mem.Allocator, path: []const u8) !AwgConfigKind {
-    const content = try readFileAllocCwd(allocator, path, 1024 * 1024);
-    defer allocator.free(content);
-
-    const trimmed = std.mem.trim(u8, content, &[_]u8{ ' ', '\t', '\r', '\n' });
-    if (std.mem.startsWith(u8, trimmed, "vpn://")) {
-        const converted = convertAmneziaVpnLink(allocator, trimmed) catch |err| switch (err) {
-            error.OutOfMemory => return error.OutOfMemory,
-            error.AwgConfigNotFound => return error.AwgConfigNotFound,
-            else => return error.InvalidAmneziaVpnLink,
-        };
-        defer allocator.free(converted);
-
-        try sys.writeFileMode(path, converted, 0o600);
-        return .amnezia_vpn_link;
-    }
-
-    if (!looksLikeAwgConfig(trimmed)) return error.UnsupportedConfigFormat;
-    return .native_conf;
-}
-
-fn convertAmneziaVpnLink(allocator: std.mem.Allocator, link: []const u8) ![]u8 {
-    const encoded = std.mem.trim(u8, link["vpn://".len..], &[_]u8{ ' ', '\t', '\r', '\n' });
-    if (encoded.len == 0) return error.InvalidAmneziaVpnLink;
-
-    const decoded = decodeVpnBase64(allocator, encoded) catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
-        else => return error.InvalidAmneziaVpnLink,
-    };
-    defer allocator.free(decoded);
-    if (decoded.len <= 4) return error.InvalidAmneziaVpnLink;
-
-    var compressed_reader: std.Io.Reader = .fixed(decoded[4..]);
-    var json_writer: std.Io.Writer.Allocating = .init(allocator);
-    defer json_writer.deinit();
-
-    var decompress_buffer: [std.compress.flate.max_window_len]u8 = undefined;
-    var decompressor: std.compress.flate.Decompress = .init(&compressed_reader, .zlib, &decompress_buffer);
-    _ = decompressor.reader.streamRemaining(&json_writer.writer) catch return error.InvalidAmneziaVpnLink;
-
-    var parsed = std.json.parseFromSlice(std.json.Value, allocator, json_writer.written(), .{}) catch return error.InvalidAmneziaVpnLink;
-    defer parsed.deinit();
-
-    const root = switch (parsed.value) {
-        .object => |obj| obj,
-        else => return error.InvalidAmneziaVpnLink,
-    };
-
-    const containers_value = root.get("containers") orelse return error.AwgConfigNotFound;
-    const containers = switch (containers_value) {
-        .array => |array| array,
-        else => return error.AwgConfigNotFound,
-    };
-
-    const dns1 = jsonObjectString(root, "dns1") orelse "";
-    const dns2 = jsonObjectString(root, "dns2") orelse "";
-
-    for (containers.items) |container| {
-        const container_obj = switch (container) {
-            .object => |obj| obj,
-            else => continue,
-        };
-        const awg_value = container_obj.get("awg") orelse continue;
-        const awg_obj = switch (awg_value) {
-            .object => |obj| obj,
-            else => continue,
-        };
-
-        const last_config = jsonObjectString(awg_obj, "last_config") orelse continue;
-        return convertAmneziaLastConfig(allocator, last_config, dns1, dns2);
-    }
-
-    return error.AwgConfigNotFound;
-}
-
-fn decodeVpnBase64(allocator: std.mem.Allocator, encoded: []const u8) ![]u8 {
-    const padding_len = (4 - (encoded.len % 4)) % 4;
-    const padded = try allocator.alloc(u8, encoded.len + padding_len);
-    defer allocator.free(padded);
-
-    @memcpy(padded[0..encoded.len], encoded);
-    @memset(padded[encoded.len..], '=');
-
-    const decoded_len = std.base64.url_safe.Decoder.calcSizeForSlice(padded) catch return error.InvalidAmneziaVpnLink;
-    const decoded = try allocator.alloc(u8, decoded_len);
-    errdefer allocator.free(decoded);
-
-    std.base64.url_safe.Decoder.decode(decoded, padded) catch return error.InvalidAmneziaVpnLink;
-    return decoded;
-}
-
-fn convertAmneziaLastConfig(
-    allocator: std.mem.Allocator,
-    last_config_json: []const u8,
-    dns1: []const u8,
-    dns2: []const u8,
-) ![]u8 {
-    var parsed = std.json.parseFromSlice(std.json.Value, allocator, last_config_json, .{}) catch return error.InvalidAmneziaVpnLink;
-    defer parsed.deinit();
-
-    const root = switch (parsed.value) {
-        .object => |obj| obj,
-        else => return error.InvalidAmneziaVpnLink,
-    };
-
-    const config = jsonObjectString(root, "config") orelse return error.AwgConfigNotFound;
-
-    const primary_replaced = try std.mem.replaceOwned(u8, allocator, config, "$PRIMARY_DNS", dns1);
-    defer allocator.free(primary_replaced);
-
-    var prepared = try std.mem.replaceOwned(u8, allocator, primary_replaced, "$SECONDARY_DNS", dns2);
-    errdefer allocator.free(prepared);
-
-    var value_buf: [64]u8 = undefined;
-    if (jsonObjectText(root, "mtu", &value_buf)) |mtu| {
-        const updated = try setInterfaceKeyInContent(allocator, prepared, "MTU", mtu);
-        allocator.free(prepared);
-        prepared = updated;
-    }
-
-    var port_buf: [64]u8 = undefined;
-    if (jsonObjectText(root, "port", &port_buf)) |port| {
-        const updated = try setInterfaceKeyInContent(allocator, prepared, "ListenPort", port);
-        allocator.free(prepared);
-        prepared = updated;
-    }
-
-    return prepared;
-}
-
-fn jsonObjectString(object: std.json.ObjectMap, key: []const u8) ?[]const u8 {
-    const value = object.get(key) orelse return null;
-    return switch (value) {
-        .string => |s| s,
-        else => null,
-    };
-}
-
-fn jsonObjectText(object: std.json.ObjectMap, key: []const u8, buf: *[64]u8) ?[]const u8 {
-    const value = object.get(key) orelse return null;
-    return switch (value) {
-        .string => |s| s,
-        .number_string => |s| s,
-        .integer => |i| std.fmt.bufPrint(buf, "{d}", .{i}) catch null,
-        .float => |f| std.fmt.bufPrint(buf, "{d}", .{f}) catch null,
-        else => null,
-    };
-}
-
-fn setInterfaceKeyInContent(
-    allocator: std.mem.Allocator,
-    content: []const u8,
-    key: []const u8,
-    value: []const u8,
-) ![]u8 {
-    var output: std.ArrayList(u8) = .empty;
-    defer output.deinit(allocator);
-
-    var in_interface = false;
-    var saw_interface = false;
-    var key_written = false;
-    var wrote_any = false;
-
-    var lines = std.mem.splitScalar(u8, content, '\n');
-    while (lines.next()) |line| {
-        const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r' });
-        const is_section = trimmed.len >= 2 and trimmed[0] == '[' and trimmed[trimmed.len - 1] == ']';
-
-        if (is_section and in_interface and !key_written) {
-            try appendConfigLine(allocator, &output, &wrote_any, key, value);
-            key_written = true;
-        }
-
-        if (is_section) {
-            in_interface = std.ascii.eqlIgnoreCase(trimmed, "[Interface]");
-            if (in_interface) saw_interface = true;
-            try appendOriginalLine(allocator, &output, &wrote_any, line);
-            continue;
-        }
-
-        if (in_interface and trimmed.len > 0 and trimmed[0] != '#' and trimmed[0] != ';') {
-            if (std.mem.indexOfScalar(u8, trimmed, '=')) |eq_pos| {
-                const existing_key = std.mem.trim(u8, trimmed[0..eq_pos], &[_]u8{ ' ', '\t' });
-                if (std.ascii.eqlIgnoreCase(existing_key, key)) {
-                    try appendConfigLine(allocator, &output, &wrote_any, key, value);
-                    key_written = true;
-                    continue;
-                }
-            }
-        }
-
-        try appendOriginalLine(allocator, &output, &wrote_any, line);
-    }
-
-    if (!saw_interface) return error.UnsupportedConfigFormat;
-    if (in_interface and !key_written) {
-        try appendConfigLine(allocator, &output, &wrote_any, key, value);
-    }
-
-    return try output.toOwnedSlice(allocator);
-}
-
-fn appendOriginalLine(
-    allocator: std.mem.Allocator,
-    output: *std.ArrayList(u8),
-    wrote_any: *bool,
-    line: []const u8,
-) !void {
-    if (wrote_any.*) try output.append(allocator, '\n');
-    try output.appendSlice(allocator, line);
-    wrote_any.* = true;
-}
-
-fn appendConfigLine(
-    allocator: std.mem.Allocator,
-    output: *std.ArrayList(u8),
-    wrote_any: *bool,
-    key: []const u8,
-    value: []const u8,
-) !void {
-    if (wrote_any.*) try output.append(allocator, '\n');
-    try output.appendSlice(allocator, key);
-    try output.appendSlice(allocator, " = ");
-    try output.appendSlice(allocator, value);
-    wrote_any.* = true;
-}
-
-fn looksLikeAwgConfig(content: []const u8) bool {
-    var has_interface = false;
-    var has_peer = false;
-
-    var lines = std.mem.splitScalar(u8, content, '\n');
-    while (lines.next()) |line| {
-        const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r' });
-        if (std.ascii.eqlIgnoreCase(trimmed, "[Interface]")) {
-            has_interface = true;
-        } else if (std.ascii.eqlIgnoreCase(trimmed, "[Peer]")) {
-            has_peer = true;
-        }
-    }
-
-    return has_interface and has_peer;
-}
-
-fn ensureAmneziaWgInstalled(ui: *Tui, allocator: std.mem.Allocator) bool {
-    if (!runCommandChecked(
-        ui,
-        allocator,
-        &.{ "apt-get", "-o", "DPkg::Lock::Timeout=600", "-o", "APT::Update::Error-Mode=any", "update", "-qq" },
-        "Failed to refresh apt package index",
-    )) return false;
-
-    if (!runCommandChecked(
-        ui,
-        allocator,
-        &.{ "apt-get", "-o", "DPkg::Lock::Timeout=600", "install", "-y", "software-properties-common" },
-        "Failed to install software-properties-common",
-    )) return false;
-
-    if (!runCommandChecked(
-        ui,
-        allocator,
-        &.{ "add-apt-repository", "-y", "ppa:amnezia/ppa" },
-        "Failed to add Amnezia PPA",
-    )) return false;
-
-    if (!runCommandChecked(
-        ui,
-        allocator,
-        &.{ "apt-get", "-o", "DPkg::Lock::Timeout=600", "-o", "APT::Update::Error-Mode=any", "update", "-qq" },
-        "Failed to refresh apt index after adding Amnezia PPA",
-    )) return false;
-
-    if (!runCommandChecked(
-        ui,
-        allocator,
-        &.{ "apt-get", "-o", "DPkg::Lock::Timeout=600", "install", "-y", "amneziawg-tools" },
-        "Failed to install amneziawg-tools",
-    )) return false;
-
-    if (!sys.commandExists("awg") or !sys.commandExists("awg-quick")) {
-        ui.fail("amneziawg-tools installation finished but awg/awg-quick were not found in PATH");
-        ui.warn("Run `apt-cache policy amneziawg-tools` and verify package availability for your distro.");
-        return false;
-    }
-
-    return true;
-}
-
-fn runCommandChecked(
-    ui: *Tui,
-    allocator: std.mem.Allocator,
-    argv: []const []const u8,
-    fail_summary: []const u8,
-) bool {
-    const result = sys.exec(allocator, argv) catch {
-        ui.fail(fail_summary);
-        ui.warn("Failed to execute system command.");
-        return false;
-    };
-    defer result.deinit();
-
-    if (result.exit_code != 0) {
-        ui.fail(fail_summary);
-
-        if (firstDiagnosticLine(result.stderr)) |line| {
-            ui.warn(line);
-        } else if (firstDiagnosticLine(result.stdout)) |line| {
-            ui.warn(line);
-        }
-
-        if (looksLikeLaunchpadPpaIssue(result.stdout) or looksLikeLaunchpadPpaIssue(result.stderr)) {
-            ui.warn("Detected Launchpad PPA outage/block (ppa.launchpadcontent.net). This is usually temporary.");
-            ui.warn("Retry later or install `amneziawg-tools` from a reachable mirror, then rerun `mtbuddy setup tunnel`.");
-        }
-
-        return false;
-    }
-
-    return true;
-}
-
-fn looksLikeLaunchpadPpaIssue(output: []const u8) bool {
-    if (std.mem.indexOf(u8, output, "ppa.launchpadcontent.net") == null) return false;
-
-    return std.mem.indexOf(u8, output, "Failed to fetch") != null or
-        std.mem.indexOf(u8, output, "Could not resolve") != null or
-        std.mem.indexOf(u8, output, "Temporary failure") != null or
-        std.mem.indexOf(u8, output, "Connection timed out") != null or
-        std.mem.indexOf(u8, output, "Network is unreachable") != null;
-}
-
-fn firstDiagnosticLine(output: []const u8) ?[]const u8 {
-    var first_non_empty: ?[]const u8 = null;
-    var lines = std.mem.splitScalar(u8, output, '\n');
-    while (lines.next()) |line| {
-        const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r' });
-        if (trimmed.len == 0) continue;
-        if (first_non_empty == null) first_non_empty = trimmed;
-
-        if (std.mem.startsWith(u8, trimmed, "E:") or
-            std.mem.startsWith(u8, trimmed, "Err:") or
-            std.mem.startsWith(u8, trimmed, "W:"))
-        {
-            return trimmed;
-        }
-    }
-
-    return first_non_empty;
-}
-
-fn validateAwgQuickConfig(allocator: std.mem.Allocator, path: []const u8) AwgQuickValidation {
-    if (!sys.commandExists("awg-quick")) return .missing_binary;
-
-    const result = sys.exec(allocator, &.{ "awg-quick", "strip", path }) catch return .missing_binary;
-    defer result.deinit();
-    return if (result.exit_code == 0) .ok else .invalid_config;
-}
-
-fn awgConfigPath(buf: []u8, iface: []const u8) ![]const u8 {
-    return try std.fmt.bufPrint(buf, "{s}/{s}.conf", .{ AWG_CONF_DIR, iface });
-}
-
-fn isValidTunnelInterfaceName(iface: []const u8) bool {
-    if (iface.len == 0 or iface.len > 32) return false;
-    for (iface) |ch| {
-        if (std.ascii.isAlphanumeric(ch) or ch == '_' or ch == '-' or ch == '.') continue;
-        return false;
-    }
-    return true;
-}
-
-fn freeOwnedStringSlice(allocator: std.mem.Allocator, values: []const []const u8) void {
-    if (values.len == 0) return;
-    for (values) |value| allocator.free(value);
-    allocator.free(values);
-}
-
-fn parseTunnelInterfaceArray(allocator: std.mem.Allocator, value: []const u8) ![]const []const u8 {
-    const trimmed = std.mem.trim(u8, value, &[_]u8{ ' ', '\t', '\r', '\n' });
-    if (trimmed.len < 2 or trimmed[0] != '[' or trimmed[trimmed.len - 1] != ']') {
-        return error.InvalidInterfaceArray;
-    }
-
-    var list: std.ArrayList([]const u8) = .empty;
-    errdefer {
-        for (list.items) |item| allocator.free(item);
-        list.deinit(allocator);
-    }
-
-    var i: usize = 1;
-    while (i + 1 < trimmed.len) {
-        while (i + 1 < trimmed.len and (trimmed[i] == ' ' or trimmed[i] == '\t' or trimmed[i] == ',')) : (i += 1) {}
-        if (i + 1 >= trimmed.len or trimmed[i] == ']') break;
-
-        const quoted = trimmed[i] == '"';
-        const start: usize = if (quoted) blk: {
-            i += 1;
-            break :blk i;
-        } else i;
-        while (i < trimmed.len and ((quoted and trimmed[i] != '"') or (!quoted and trimmed[i] != ',' and trimmed[i] != ']'))) : (i += 1) {}
-        const item = std.mem.trim(u8, trimmed[start..i], &[_]u8{ ' ', '\t', '\r', '\n' });
-        if (quoted and i < trimmed.len and trimmed[i] == '"') i += 1;
-        if (item.len > 0 and isValidTunnelInterfaceName(item)) {
-            try list.append(allocator, try allocator.dupe(u8, item));
-        }
-    }
-
-    if (list.items.len == 0) {
-        list.deinit(allocator);
-        return &.{};
-    }
-    return try list.toOwnedSlice(allocator);
-}
-
-fn loadTunnelPoolFromDoc(allocator: std.mem.Allocator, doc: *toml.TomlDoc) ![]const []const u8 {
-    if (doc.get("upstream.tunnel", "interfaces")) |raw_interfaces| {
-        const parsed = parseTunnelInterfaceArray(allocator, raw_interfaces) catch &.{};
-        if (parsed.len > 0) return parsed;
-    }
-
-    if (doc.get("upstream.tunnel", "interface")) |legacy_iface| {
-        const trimmed = std.mem.trim(u8, legacy_iface, &[_]u8{ ' ', '\t', '\r', '\n' });
-        if (isValidTunnelInterfaceName(trimmed)) {
-            const values = try allocator.alloc([]const u8, 1);
-            values[0] = try allocator.dupe(u8, trimmed);
-            return values;
-        }
-    }
-
-    return &.{};
-}
-
 fn loadConfiguredTunnelPool(allocator: std.mem.Allocator) ![]const []const u8 {
     var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch return &.{};
     defer doc.deinit();
 
-    return try loadTunnelPoolFromDoc(allocator, &doc);
+    return try tunnel_wg.loadTunnelPoolFromDoc(allocator, &doc);
 }
 
 fn loadKnownTunnelInterfaces(allocator: std.mem.Allocator) ![]const []const u8 {
@@ -1219,9 +415,9 @@ fn loadKnownTunnelInterfaces(allocator: std.mem.Allocator) ![]const []const u8 {
     }
 
     const pool = try loadConfiguredTunnelPool(allocator);
-    defer freeOwnedStringSlice(allocator, pool);
+    defer tunnel_wg.freeOwnedStringSlice(allocator, pool);
     for (pool) |iface| {
-        if (!containsInterface(list.items, iface)) {
+        if (!tunnel_wg.containsInterface(list.items, iface)) {
             try list.append(allocator, try allocator.dupe(u8, iface));
         }
     }
@@ -1246,8 +442,8 @@ fn loadKnownTunnelInterfaces(allocator: std.mem.Allocator) ![]const []const u8 {
             const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r', '\n' });
             if (!std.mem.endsWith(u8, trimmed, ".conf")) continue;
             const iface = trimmed[0 .. trimmed.len - ".conf".len];
-            if (!isValidTunnelInterfaceName(iface)) continue;
-            if (!containsInterface(list.items, iface)) {
+            if (!tunnel_wg.isValidTunnelInterfaceName(iface)) continue;
+            if (!tunnel_wg.containsInterface(list.items, iface)) {
                 try list.append(allocator, try allocator.dupe(u8, iface));
             }
         }
@@ -1258,33 +454,6 @@ fn loadKnownTunnelInterfaces(allocator: std.mem.Allocator) ![]const []const u8 {
         return &.{};
     }
     return try list.toOwnedSlice(allocator);
-}
-
-fn containsInterface(values: []const []const u8, iface: []const u8) bool {
-    for (values) |value| {
-        if (std.mem.eql(u8, value, iface)) return true;
-    }
-    return false;
-}
-
-fn appendInterfaceIfMissing(allocator: std.mem.Allocator, values: []const []const u8, iface: []const u8) ![]const []const u8 {
-    var out: std.ArrayList([]const u8) = .empty;
-    errdefer {
-        for (out.items) |value| allocator.free(value);
-        out.deinit(allocator);
-    }
-
-    for (values) |value| {
-        try out.append(allocator, try allocator.dupe(u8, value));
-    }
-    if (!containsInterface(values, iface)) {
-        try out.append(allocator, try allocator.dupe(u8, iface));
-    }
-    if (out.items.len == 0) {
-        out.deinit(allocator);
-        return &.{};
-    }
-    return try out.toOwnedSlice(allocator);
 }
 
 const TunnelRemovalConfigResult = struct {
@@ -1317,11 +486,11 @@ fn removeInterfaceFromPool(allocator: std.mem.Allocator, values: []const []const
 }
 
 fn removeTunnelFromDoc(allocator: std.mem.Allocator, doc: *toml.TomlDoc, iface: []const u8) !TunnelRemovalConfigResult {
-    const existing = try loadTunnelPoolFromDoc(allocator, doc);
-    defer freeOwnedStringSlice(allocator, existing);
+    const existing = try tunnel_wg.loadTunnelPoolFromDoc(allocator, doc);
+    defer tunnel_wg.freeOwnedStringSlice(allocator, existing);
 
     const result = try removeInterfaceFromPool(allocator, existing, iface);
-    errdefer freeOwnedStringSlice(allocator, result.remaining_pool);
+    errdefer tunnel_wg.freeOwnedStringSlice(allocator, result.remaining_pool);
 
     if (!result.removed) return result;
 
@@ -1333,7 +502,7 @@ fn removeTunnelFromDoc(allocator: std.mem.Allocator, doc: *toml.TomlDoc, iface: 
         try clearTunnelConfigInDoc(doc);
     }
 
-    const array_literal = try formatInterfaceArrayLiteral(allocator, result.remaining_pool);
+    const array_literal = try tunnel_wg.formatInterfaceArrayLiteral(allocator, result.remaining_pool);
     defer allocator.free(array_literal);
     try doc.set("upstream.tunnel", "interfaces", array_literal);
 
@@ -1357,598 +526,13 @@ fn nextAwgInterfaceNameFromPool(allocator: std.mem.Allocator, used: []const []co
     while (i < 64) : (i += 1) {
         var buf: [16]u8 = undefined;
         const candidate = try std.fmt.bufPrint(&buf, "awg{d}", .{i});
-        if (!containsInterface(used, candidate)) return try allocator.dupe(u8, candidate);
+        if (!tunnel_wg.containsInterface(used, candidate)) return try allocator.dupe(u8, candidate);
     }
     return error.NoFreeInterface;
 }
-
-fn selectTunnelInterface(allocator: std.mem.Allocator, requested: []const u8) ![]u8 {
-    const trimmed_requested = std.mem.trim(u8, requested, &[_]u8{ ' ', '\t', '\r', '\n' });
-    if (trimmed_requested.len > 0) {
-        if (!isValidTunnelInterfaceName(trimmed_requested)) return error.InvalidInterfaceName;
-        return try allocator.dupe(u8, trimmed_requested);
-    }
-
-    var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch {
-        return try allocator.dupe(u8, "awg0");
-    };
-    defer doc.deinit();
-
-    const pool = try loadTunnelPoolFromDoc(allocator, &doc);
-    defer freeOwnedStringSlice(allocator, pool);
-
-    var i: usize = 0;
-    while (i < 64) : (i += 1) {
-        var name_buf: [16]u8 = undefined;
-        const candidate = try std.fmt.bufPrint(&name_buf, "awg{d}", .{i});
-        var path_buf: [256]u8 = undefined;
-        const path = awgConfigPath(&path_buf, candidate) catch continue;
-        if (!containsInterface(pool, candidate) and !sys.fileExists(path)) {
-            return try allocator.dupe(u8, candidate);
-        }
-    }
-
-    return error.NoFreeInterface;
-}
-
-fn formatInterfaceArrayLiteral(allocator: std.mem.Allocator, values: []const []const u8) ![]const u8 {
-    var out: std.ArrayList(u8) = .empty;
-    errdefer out.deinit(allocator);
-
-    try out.append(allocator, '[');
-    for (values, 0..) |value, idx| {
-        if (idx > 0) try out.appendSlice(allocator, ", ");
-        try out.append(allocator, '"');
-        try out.appendSlice(allocator, value);
-        try out.append(allocator, '"');
-    }
-    try out.append(allocator, ']');
-    return try out.toOwnedSlice(allocator);
-}
-
-fn setTunnelPoolConfig(allocator: std.mem.Allocator, iface: []const u8) void {
-    var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch return;
-    defer doc.deinit();
-
-    doc.set("upstream", "type", "\"tunnel\"") catch return;
-
-    const existing = loadTunnelPoolFromDoc(allocator, &doc) catch &.{};
-    defer freeOwnedStringSlice(allocator, existing);
-
-    const pool = appendInterfaceIfMissing(allocator, existing, iface) catch return;
-    defer freeOwnedStringSlice(allocator, pool);
-
-    if (pool.len > 0) {
-        var first_buf: [64]u8 = undefined;
-        const first = std.fmt.bufPrint(&first_buf, "\"{s}\"", .{pool[0]}) catch return;
-        doc.set("upstream.tunnel", "interface", first) catch return;
-    }
-
-    const array_literal = formatInterfaceArrayLiteral(allocator, pool) catch return;
-    defer allocator.free(array_literal);
-    doc.set("upstream.tunnel", "interfaces", array_literal) catch return;
-
-    doc.save(INSTALL_DIR ++ "/config.toml") catch {};
-}
-
-fn installTunnelPoolUnits(ui: *Tui, allocator: std.mem.Allocator) void {
-    const service =
-        \\[Unit]
-        \\Description=MTProto tunnel pool failover
-        \\Documentation=https://github.com/sleep3r/mtproto.zig
-        \\After=network-online.target
-        \\Wants=network-online.target
-        \\
-        \\[Service]
-        \\Type=oneshot
-        \\ExecStart=/usr/local/bin/setup_tunnel.sh
-        \\AmbientCapabilities=CAP_NET_ADMIN
-    ;
-
-    const timer =
-        \\[Unit]
-        \\Description=Run MTProto tunnel pool failover checks
-        \\
-        \\[Timer]
-        \\OnBootSec=30s
-        \\OnUnitInactiveSec=30s
-        \\RandomizedDelaySec=5s
-        \\Persistent=true
-        \\
-        \\[Install]
-        \\WantedBy=timers.target
-    ;
-
-    sys.writeFile(TUNNEL_POOL_SERVICE, service) catch {
-        ui.warn("Failed to write mtproto-tunnel-pool.service");
-        return;
-    };
-    sys.writeFile(TUNNEL_POOL_TIMER, timer) catch {
-        ui.warn("Failed to write mtproto-tunnel-pool.timer");
-        return;
-    };
-
-    _ = sys.execForward(&.{ "systemctl", "daemon-reload" }) catch {};
-    _ = sys.exec(allocator, &.{ "systemctl", "enable", "--now", "mtproto-tunnel-pool.timer" }) catch {};
-    ui.ok("Tunnel pool failover timer installed");
-}
-
-fn renderTunnelPoolScript(allocator: std.mem.Allocator) ![]const u8 {
-    return try allocator.dupe(u8,
-        \\#!/usr/bin/env bash
-        \\set -euo pipefail
-        \\
-        \\CONFIG_FILE="/opt/mtproto-proxy/config.toml"
-        \\CONF_DIR="/etc/amnezia/amneziawg"
-        \\STATE_DIR="/run/mtproto-proxy"
-        \\STATE_FILE="$STATE_DIR/tunnel-pool.state"
-        \\MARK=200
-        \\TABLE=200
-        \\RULE_PRIORITY=1200
-        \\PROBE_URL="https://core.telegram.org/getProxyConfig"
-        \\
-        \\mkdir -p "$STATE_DIR"
-        \\
-        \\log() {
-        \\    logger -t mtproto-tunnel-pool "$*" 2>/dev/null || true
-        \\}
-        \\
-        \\read_tunnel_key() {
-        \\    local want_key="$1"
-        \\    [[ -f "$CONFIG_FILE" ]] || return 1
-        \\    awk -v want_key="$want_key" '
-        \\        BEGIN { in_section=0; value="" }
-        \\        /^[[:space:]]*\[upstream\.tunnel\][[:space:]]*$/ { in_section=1; next }
-        \\        /^[[:space:]]*\[[^]]+\][[:space:]]*$/ { in_section=0; next }
-        \\        in_section {
-        \\            line=$0
-        \\            sub(/[;#].*/, "", line)
-        \\            if (line ~ "^[[:space:]]*" want_key "[[:space:]]*=") {
-        \\                sub(/^[^=]*=/, "", line)
-        \\                gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
-        \\                gsub(/^"|"$/, "", line)
-        \\                value=line
-        \\            }
-        \\        }
-        \\        END { if (value != "") print value }
-        \\    ' "$CONFIG_FILE"
-        \\}
-        \\
-        \\trim() {
-        \\    local v="$1"
-        \\    v="${v#"${v%%[![:space:]]*}"}"
-        \\    v="${v%"${v##*[![:space:]]}"}"
-        \\    printf '%s\n' "$v"
-        \\}
-        \\
-        \\parse_interfaces() {
-        \\    local raw="$1"
-        \\    raw="${raw#[}"
-        \\    raw="${raw%]}"
-        \\    raw="${raw//\"/}"
-        \\    local old_ifs="$IFS"
-        \\    IFS=','
-        \\    read -r -a parts <<< "$raw"
-        \\    IFS="$old_ifs"
-        \\    for item in "${parts[@]}"; do
-        \\        item="$(trim "$item")"
-        \\        [[ -n "$item" ]] && printf '%s\n' "$item"
-        \\    done
-        \\}
-        \\
-        \\add_unique() {
-        \\    local item="$1"
-        \\    [[ -n "$item" ]] || return 0
-        \\    local existing
-        \\    for existing in "${candidates[@]}"; do
-        \\        [[ "$existing" == "$item" ]] && return 0
-        \\    done
-        \\    candidates+=("$item")
-        \\}
-        \\
-        \\conf_path_for() {
-        \\    local iface="$1"
-        \\    if [[ -f "$CONF_DIR/${iface}.conf" ]]; then
-        \\        printf '%s/%s.conf\n' "$CONF_DIR" "$iface"
-        \\    elif [[ -f "/etc/wireguard/${iface}.conf" ]]; then
-        \\        printf '/etc/wireguard/%s.conf\n' "$iface"
-        \\    else
-        \\        printf '%s/%s.conf\n' "$CONF_DIR" "$iface"
-        \\    fi
-        \\}
-        \\
-        \\quick_tool_for() {
-        \\    local iface="$1"
-        \\    if [[ "$iface" == wg* ]] && command -v wg-quick >/dev/null 2>&1; then
-        \\        printf 'wg-quick\n'
-        \\        return
-        \\    fi
-        \\    if command -v awg-quick >/dev/null 2>&1; then
-        \\        printf 'awg-quick\n'
-        \\        return
-        \\    fi
-        \\    if command -v wg-quick >/dev/null 2>&1; then
-        \\        printf 'wg-quick\n'
-        \\        return
-        \\    fi
-        \\    return 1
-        \\}
-        \\
-        \\show_tool_for() {
-        \\    local iface="$1"
-        \\    if [[ "$iface" == wg* ]] && command -v wg >/dev/null 2>&1; then
-        \\        printf 'wg\n'
-        \\        return
-        \\    fi
-        \\    if command -v awg >/dev/null 2>&1; then
-        \\        printf 'awg\n'
-        \\        return
-        \\    fi
-        \\    if command -v wg >/dev/null 2>&1; then
-        \\        printf 'wg\n'
-        \\        return
-        \\    fi
-        \\    return 1
-        \\}
-        \\
-        \\ensure_iface_up() {
-        \\    local iface="$1"
-        \\    ip link show dev "$iface" >/dev/null 2>&1 && return 0
-        \\    local quick conf
-        \\    quick="$(quick_tool_for "$iface")" || return 1
-        \\    conf="$(conf_path_for "$iface")"
-        \\    [[ -f "$conf" ]] || return 1
-        \\    "$quick" up "$conf" >/dev/null 2>&1
-        \\}
-        \\
-        \\policy_rule_exists() {
-        \\    local mark_hex
-        \\    mark_hex="$(printf '0x%x' "$MARK")"
-        \\    ip -4 rule show | awk -v mark="$MARK" -v mark_hex="$mark_hex" -v table="$TABLE" '
-        \\        (($0 ~ "fwmark " mark || $0 ~ "fwmark " mark_hex) && ($0 ~ "lookup " table || $0 ~ "table " table)) { found = 1 }
-        \\        END { exit found ? 0 : 1 }
-        \\    '
-        \\}
-        \\
-        \\ensure_policy_rule() {
-        \\    while ip -4 rule del priority "$RULE_PRIORITY" fwmark "$MARK" table "$TABLE" 2>/dev/null; do :; done
-        \\    while ip -4 rule del fwmark "$MARK" table "$TABLE" 2>/dev/null; do :; done
-        \\    ip -4 rule add fwmark "$MARK" table "$TABLE" priority "$RULE_PRIORITY" 2>/dev/null || true
-        \\    policy_rule_exists
-        \\}
-        \\
-        \\route_table_to_iface() {
-        \\    local iface="$1"
-        \\    ip -4 route flush table "$TABLE" 2>/dev/null || true
-        \\    ip -4 route replace default dev "$iface" table "$TABLE"
-        \\}
-        \\
-        \\policy_route_matches_iface() {
-        \\    local iface="$1" target="${2:-149.154.175.50}"
-        \\    ip -4 route get "$target" mark "$MARK" 2>/dev/null |
-        \\        awk -v iface="$iface" '
-        \\            { for (i = 1; i < NF; i++) if ($i == "dev" && $(i + 1) == iface) found = 1 }
-        \\            END { exit found ? 0 : 1 }
-        \\        '
-        \\}
-        \\
-        \\telegram_probe_iface() {
-        \\    local iface="$1"
-        \\    command -v curl >/dev/null 2>&1 || return 2
-        \\    curl --interface "$iface" -fsS --connect-timeout 3 --max-time 5 "$PROBE_URL" >/dev/null 2>&1
-        \\}
-        \\
-        \\probe_iface() {
-        \\    local iface="$1"
-        \\    reason=""
-        \\    ensure_iface_up "$iface" || { reason="failed to bring interface up"; return 1; }
-        \\    ip link show dev "$iface" >/dev/null 2>&1 || { reason="interface missing"; return 1; }
-        \\    local show_tool
-        \\    show_tool="$(show_tool_for "$iface")" || { reason="awg/wg show tool missing"; return 1; }
-        \\    "$show_tool" show "$iface" >/dev/null 2>&1 || { reason="tunnel show failed"; return 1; }
-        \\    route_table_to_iface "$iface" || { reason="failed to install policy route"; return 1; }
-        \\    policy_route_matches_iface "$iface" || { reason="policy route check failed"; return 1; }
-        \\    if telegram_probe_iface "$iface"; then
-        \\        reason="healthy"
-        \\        return 0
-        \\    fi
-        \\    # Usable (up + policy route installed) but can't reach Telegram through it.
-        \\    # Return 2 ("degraded-usable") so pool selection PREFERS a tunnel that can
-        \\    # actually reach Telegram, and only falls back to this one if none can.
-        \\    reason="up; Telegram probe failed"
-        \\    return 2
-        \\}
-        \\
-        \\state_value() {
-        \\    local key="$1"
-        \\    [[ -f "$STATE_FILE" ]] || return 0
-        \\    awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' "$STATE_FILE"
-        \\}
-        \\
-        \\write_state() {
-        \\    local active="$1" status="$2" reason="$3"
-        \\    local prev_active prev_last now last_switch
-        \\    prev_active="$(state_value active || true)"
-        \\    prev_last="$(state_value last_switch || true)"
-        \\    now="$(date -Is)"
-        \\    last_switch="${prev_last:-$now}"
-        \\    [[ "$active" != "$prev_active" ]] && last_switch="$now"
-        \\    {
-        \\        printf 'active=%s\n' "$active"
-        \\        printf 'status=%s\n' "$status"
-        \\        printf 'reason=%s\n' "$reason"
-        \\        printf 'pinned=%s\n' "$pinned"
-        \\        printf 'pool=%s\n' "${pool[*]}"
-        \\        printf 'last_switch=%s\n' "$last_switch"
-        \\        printf 'checked_at=%s\n' "$now"
-        \\    } > "$STATE_FILE"
-        \\}
-        \\
-        \\mapfile -t pool < <(
-        \\    raw_interfaces="$(read_tunnel_key interfaces || true)"
-        \\    if [[ -n "${raw_interfaces:-}" ]]; then
-        \\        parse_interfaces "$raw_interfaces"
-        \\    else
-        \\        legacy="$(read_tunnel_key interface || true)"
-        \\        printf '%s\n' "${legacy:-awg0}"
-        \\    fi
-        \\)
-        \\
-        \\previous="$(ip -4 route show table "$TABLE" default 2>/dev/null | awk '/default/ { for (i=1;i<=NF;i++) if ($i=="dev") { print $(i+1); exit } }' || true)"
-        \\pinned="$(read_tunnel_key pinned_interface || true)"
-        \\candidates=()
-        \\add_unique "$pinned"
-        \\# Sticky: after the pin, prefer the currently-active tunnel if it's still in the
-        \\# pool, so a healthy active tunnel isn't dropped for an earlier-listed one — that
-        \\# would flap (reset every connection) whenever the first pool entry is reachable.
-        \\for iface in "${pool[@]}"; do
-        \\    [[ "$iface" == "$previous" ]] && add_unique "$previous"
-        \\done
-        \\for iface in "${pool[@]}"; do
-        \\    add_unique "$iface"
-        \\done
-        \\
-        \\ensure_policy_rule || {
-        \\    write_state "" "degraded" "failed to install policy rule"
-        \\    echo "Failed to install tunnel policy rule: fwmark=$MARK table=$TABLE" >&2
-        \\    exit 1
-        \\}
-        \\
-        \\selected=""
-        \\selected_reason=""
-        \\selected_status="healthy"
-        \\fallback=""
-        \\fallback_reason=""
-        \\for iface in "${candidates[@]}"; do
-        \\    if probe_iface "$iface"; then rc=0; else rc=$?; fi
-        \\    if [[ "$rc" -eq 0 ]]; then
-        \\        selected="$iface"
-        \\        selected_reason="$reason"
-        \\        break
-        \\    elif [[ "$rc" -eq 2 && -z "$fallback" ]]; then
-        \\        # Up but can't reach Telegram — remember it as a last resort, but keep
-        \\        # looking for one that actually reaches Telegram. This is the pool
-        \\        # failover: a dead-but-up active tunnel is now skipped over.
-        \\        fallback="$iface"
-        \\        fallback_reason="$reason"
-        \\        log "tunnel $iface up but Telegram probe failed; trying others"
-        \\    else
-        \\        log "tunnel $iface unhealthy: $reason"
-        \\    fi
-        \\done
-        \\
-        \\if [[ -z "$selected" && -n "$fallback" ]]; then
-        \\    # No tunnel reached Telegram (the probe may be globally blocked/flaky) — fall
-        \\    # back to the first usable one so a single-tunnel deploy doesn't go dark.
-        \\    selected="$fallback"
-        \\    selected_reason="$fallback_reason (fallback)"
-        \\    selected_status="degraded"
-        \\    log "no Telegram-reachable tunnel; falling back to $selected"
-        \\fi
-        \\
-        \\if [[ -z "$selected" ]]; then
-        \\    write_state "" "degraded" "no usable tunnel"
-        \\    echo "No usable tunnel in pool: ${candidates[*]}" >&2
-        \\    exit 1
-        \\fi
-        \\
-        \\route_table_to_iface "$selected"
-        \\write_state "$selected" "$selected_status" "$selected_reason"
-        \\
-        \\if [[ "$previous" != "$selected" ]]; then
-        \\    log "selected tunnel $selected (previous: ${previous:-none})"
-        \\fi
-        \\echo "Tunnel routing ready: fwmark=$MARK -> table $TABLE via $selected"
-    );
-}
-
-fn stripAwgDnsLines(allocator: std.mem.Allocator, path: []const u8) !bool {
-    const content = try readFileAllocCwd(allocator, path, 1024 * 1024);
-    defer allocator.free(content);
-
-    var output: std.ArrayList(u8) = .empty;
-    defer output.deinit(allocator);
-
-    var removed_any = false;
-    var wrote_any = false;
-
-    var lines = std.mem.splitScalar(u8, content, '\n');
-    while (lines.next()) |line| {
-        const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r' });
-
-        var skip = false;
-        if (trimmed.len > 0 and trimmed[0] != '#') {
-            if (std.mem.indexOfScalar(u8, trimmed, '=')) |eq_pos| {
-                const key = std.mem.trim(u8, trimmed[0..eq_pos], &[_]u8{ ' ', '\t' });
-                if (std.ascii.eqlIgnoreCase(key, "DNS")) {
-                    skip = true;
-                }
-            }
-        }
-
-        if (skip) {
-            removed_any = true;
-            continue;
-        }
-
-        if (wrote_any) try output.append(allocator, '\n');
-        try output.appendSlice(allocator, line);
-        wrote_any = true;
-    }
-
-    if (!removed_any) return false;
-
-    const sanitized = try output.toOwnedSlice(allocator);
-    defer allocator.free(sanitized);
-
-    try sys.writeFileMode(path, sanitized, 0o600);
-    return true;
-}
-
-fn stripAwgEmptyAssignments(allocator: std.mem.Allocator, path: []const u8) !bool {
-    const content = try readFileAllocCwd(allocator, path, 1024 * 1024);
-    defer allocator.free(content);
-
-    var output: std.ArrayList(u8) = .empty;
-    defer output.deinit(allocator);
-
-    var removed_any = false;
-    var wrote_any = false;
-
-    var lines = std.mem.splitScalar(u8, content, '\n');
-    while (lines.next()) |line| {
-        const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r' });
-
-        var skip = false;
-        if (trimmed.len > 0 and trimmed[0] != '#' and trimmed[0] != ';') {
-            if (std.mem.indexOfScalar(u8, trimmed, '=')) |eq_pos| {
-                const key = std.mem.trim(u8, trimmed[0..eq_pos], &[_]u8{ ' ', '\t' });
-                const value = std.mem.trim(u8, trimmed[eq_pos + 1 ..], &[_]u8{ ' ', '\t' });
-                if (key.len > 0 and value.len == 0) {
-                    skip = true;
-                }
-            }
-        }
-
-        if (skip) {
-            removed_any = true;
-            continue;
-        }
-
-        if (wrote_any) try output.append(allocator, '\n');
-        try output.appendSlice(allocator, line);
-        wrote_any = true;
-    }
-
-    if (!removed_any) return false;
-
-    const sanitized = try output.toOwnedSlice(allocator);
-    defer allocator.free(sanitized);
-
-    try sys.writeFileMode(path, sanitized, 0o600);
-    return true;
-}
-
-fn ensureAwgTableOff(allocator: std.mem.Allocator, path: []const u8) !bool {
-    const content = try readFileAllocCwd(allocator, path, 1024 * 1024);
-    defer allocator.free(content);
-
-    var in_interface = false;
-    var has_interface = false;
-    var has_table = false;
-    var interface_header_idx: ?usize = null;
-
-    var idx: usize = 0;
-    var lines_scan = std.mem.splitScalar(u8, content, '\n');
-    while (lines_scan.next()) |line| : (idx += 1) {
-        const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r' });
-
-        if (trimmed.len >= 2 and trimmed[0] == '[' and trimmed[trimmed.len - 1] == ']') {
-            in_interface = std.ascii.eqlIgnoreCase(trimmed, "[Interface]");
-            if (in_interface) {
-                has_interface = true;
-                if (interface_header_idx == null) interface_header_idx = idx;
-            }
-            continue;
-        }
-
-        if (!in_interface) continue;
-        if (trimmed.len == 0 or trimmed[0] == '#' or trimmed[0] == ';') continue;
-
-        if (std.mem.indexOfScalar(u8, trimmed, '=')) |eq_pos| {
-            const key = std.mem.trim(u8, trimmed[0..eq_pos], &[_]u8{ ' ', '\t' });
-            if (std.ascii.eqlIgnoreCase(key, "Table")) {
-                has_table = true;
-                break;
-            }
-        }
-    }
-
-    if (!has_interface or has_table or interface_header_idx == null) return false;
-
-    var out: std.ArrayList(u8) = .empty;
-    defer out.deinit(allocator);
-
-    var out_idx: usize = 0;
-    var wrote_any = false;
-    var lines_write = std.mem.splitScalar(u8, content, '\n');
-    while (lines_write.next()) |line| : (out_idx += 1) {
-        if (wrote_any) try out.append(allocator, '\n');
-        try out.appendSlice(allocator, line);
-        wrote_any = true;
-
-        if (out_idx == interface_header_idx.?) {
-            try out.appendSlice(allocator, "\nTable = off");
-        }
-    }
-
-    const sanitized = try out.toOwnedSlice(allocator);
-    defer allocator.free(sanitized);
-
-    try sys.writeFileMode(path, sanitized, 0o600);
-    return true;
-}
-
-const NGINX_MASKING_CONF = "/etc/nginx/sites-available/mtproto-masking";
 
 /// Strip legacy netns listen directives (e.g. `listen 10.200.200.1:8443 ssl;`)
 /// from the nginx masking config. Returns true if any lines were removed.
-fn cleanupNetnsNginxListen(allocator: std.mem.Allocator) bool {
-    const content = readFileAllocCwd(allocator, NGINX_MASKING_CONF, 256 * 1024) catch return false;
-    defer allocator.free(content);
-
-    var output: std.ArrayList(u8) = .empty;
-    defer output.deinit(allocator);
-
-    var removed_any = false;
-    var wrote_any = false;
-
-    var lines = std.mem.splitScalar(u8, content, '\n');
-    while (lines.next()) |line| {
-        const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r' });
-
-        // Match directives like: listen 10.200.200.1:8443 ssl;
-        if (std.mem.startsWith(u8, trimmed, "listen ") and
-            std.mem.indexOf(u8, trimmed, "10.200.200.") != null)
-        {
-            removed_any = true;
-            continue;
-        }
-
-        if (wrote_any) output.append(allocator, '\n') catch return false;
-        output.appendSlice(allocator, line) catch return false;
-        wrote_any = true;
-    }
-
-    if (!removed_any) return false;
-
-    const sanitized = output.toOwnedSlice(allocator) catch return false;
-    defer allocator.free(sanitized);
-
-    sys.writeFile(NGINX_MASKING_CONF, sanitized) catch return false;
-    return true;
-}
-
 /// Detect the currently active tunnel by inspecting runtime state.
 /// Returns the `Tunnel.Tag` corresponding to the detected tunnel,
 /// or `.none` if no known tunnel is active.
@@ -1974,9 +558,6 @@ pub fn detectActiveTunnel(allocator: std.mem.Allocator) Tunnel.Tag {
     return .none;
 }
 
-const test_amnezia_vpn_link =
-    "vpn://AAABPXicLY9Ra8IwFIX_Srn4WGoSHZSCD6I-lDEX9Gm0IrG5jkKbliSdG6X_fTdWTiA53wn3JCNo4zhkwJOnIA5AEEiTpwhUnfGqNmgdZMUI6vEN2QiNcv5K0b0mC2MJ87mELCqhyI1He1cVXsrSbLW26Fy0iThLgsRyJYhLW_8oj-_4R1FPhtj-eCazkKf8Y3v6upKNo8X5sPs87l-eLuUi2tBGq5CINnTI4dbU1WvUcAutTdM9UOcyFM-9bMkoOBjdd7XxhPFXtX2DSdW12Xq9CjMhpve3fpg_wkXKZtR31gf2xlPBJpimy_QPWglhtw";
-
 test "tunnel pool - next awg interface skips used names" {
     const used = [_][]const u8{ "awg0", "awg1" };
     const next = try nextAwgInterfaceNameFromPool(std.testing.allocator, &used);
@@ -1987,46 +568,21 @@ test "tunnel pool - next awg interface skips used names" {
 test "tunnel pool - append interface avoids duplicates" {
     const existing = [_][]const u8{ "awg0", "awg1" };
 
-    const same = try appendInterfaceIfMissing(std.testing.allocator, &existing, "awg1");
-    defer freeOwnedStringSlice(std.testing.allocator, same);
+    const same = try tunnel_wg.appendInterfaceIfMissing(std.testing.allocator, &existing, "awg1");
+    defer tunnel_wg.freeOwnedStringSlice(std.testing.allocator, same);
     try std.testing.expectEqual(@as(usize, 2), same.len);
     try std.testing.expectEqualStrings("awg0", same[0]);
     try std.testing.expectEqualStrings("awg1", same[1]);
 
-    const added = try appendInterfaceIfMissing(std.testing.allocator, &existing, "awg2");
-    defer freeOwnedStringSlice(std.testing.allocator, added);
+    const added = try tunnel_wg.appendInterfaceIfMissing(std.testing.allocator, &existing, "awg2");
+    defer tunnel_wg.freeOwnedStringSlice(std.testing.allocator, added);
     try std.testing.expectEqual(@as(usize, 3), added.len);
     try std.testing.expectEqualStrings("awg2", added[2]);
 }
 
-test "tunnel pool - script renders failover (prefer reachable, fall back to usable)" {
-    const script = try renderTunnelPoolScript(std.testing.allocator);
-    defer std.testing.allocator.free(script);
-
-    try std.testing.expect(std.mem.indexOf(u8, script, "route_table_to_iface \"$selected\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, script, "policy_route_matches_iface \"$iface\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, script, "route show table \"$TABLE\" default 2>/dev/null") != null);
-    try std.testing.expect(std.mem.indexOf(u8, script, "https://core.telegram.org/getProxyConfig") != null);
-    // probe_iface returns 2 (up but Telegram-unreachable) so the pool can skip a
-    // dead-but-up tunnel and fail over to a healthy one.
-    try std.testing.expect(std.mem.indexOf(u8, script, "return 2") != null);
-    try std.testing.expect(std.mem.indexOf(u8, script, "trying others") != null);
-    // ...but a single tunnel whose probe fails is still used (fallback), not dropped.
-    try std.testing.expect(std.mem.indexOf(u8, script, "falling back to $selected") != null);
-    // set -e safety: probe's non-zero exit is captured, not fatal.
-    try std.testing.expect(std.mem.indexOf(u8, script, "if probe_iface \"$iface\"; then rc=0; else rc=$?; fi") != null);
-    try std.testing.expect(std.mem.indexOf(u8, script, "pinned_interface") != null);
-}
-
-test "tunnel pool timer repeats after oneshot service exits" {
-    const source = @embedFile("tunnel.zig");
-    const needle = "OnUnitInactiveSec" ++ "=30s";
-    try std.testing.expect(std.mem.indexOf(u8, source, needle) != null);
-}
-
 test "tunnel pool - parses interface array" {
-    const pool = try parseTunnelInterfaceArray(std.testing.allocator, "[\"awg0\", \"awg1\"]");
-    defer freeOwnedStringSlice(std.testing.allocator, pool);
+    const pool = try tunnel_wg.parseTunnelInterfaceArray(std.testing.allocator, "[\"awg0\", \"awg1\"]");
+    defer tunnel_wg.freeOwnedStringSlice(std.testing.allocator, pool);
 
     try std.testing.expectEqual(@as(usize, 2), pool.len);
     try std.testing.expectEqualStrings("awg0", pool[0]);
@@ -2045,7 +601,7 @@ test "tunnel pool - remove interface from doc clears matching pin" {
     try doc.addKvStr("pinned_interface", "awg1");
 
     const result = try removeTunnelFromDoc(std.testing.allocator, &doc, "awg1");
-    defer freeOwnedStringSlice(std.testing.allocator, result.remaining_pool);
+    defer tunnel_wg.freeOwnedStringSlice(std.testing.allocator, result.remaining_pool);
 
     try std.testing.expect(result.removed);
     try std.testing.expect(!result.removed_last);
@@ -2070,7 +626,7 @@ test "tunnel pool - remove last interface disables tunnel upstream" {
     try doc.addKvStr("pinned_interface", "awg0");
 
     const result = try removeTunnelFromDoc(std.testing.allocator, &doc, "awg0");
-    defer freeOwnedStringSlice(std.testing.allocator, result.remaining_pool);
+    defer tunnel_wg.freeOwnedStringSlice(std.testing.allocator, result.remaining_pool);
 
     try std.testing.expect(result.removed);
     try std.testing.expect(result.removed_last);
@@ -2079,66 +635,4 @@ test "tunnel pool - remove last interface disables tunnel upstream" {
     try std.testing.expectEqualStrings("", doc.get("upstream.tunnel", "interface").?);
     try std.testing.expectEqualStrings("[]", doc.get("upstream.tunnel", "interfaces").?);
     try std.testing.expectEqualStrings("", doc.get("upstream.tunnel", "pinned_interface").?);
-}
-
-test "tunnel - converts Amnezia vpn link to AWG config" {
-    const conf = try convertAmneziaVpnLink(std.testing.allocator, test_amnezia_vpn_link);
-    defer std.testing.allocator.free(conf);
-
-    try std.testing.expect(std.mem.indexOf(u8, conf, "[Interface]") != null);
-    try std.testing.expect(std.mem.indexOf(u8, conf, "[Peer]") != null);
-    try std.testing.expect(std.mem.indexOf(u8, conf, "DNS = 1.1.1.1, 8.8.8.8") != null);
-    try std.testing.expect(std.mem.indexOf(u8, conf, "MTU = 1280") != null);
-    try std.testing.expect(std.mem.indexOf(u8, conf, "ListenPort = 51820") != null);
-}
-
-test "tunnel - installs Amnezia vpn link source directly" {
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-
-    var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
-    const dest_path = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}/awg0.conf", .{tmp.sub_path});
-
-    const kind = try installAwgConfigSource(std.testing.allocator, " \n" ++ test_amnezia_vpn_link ++ "\n", dest_path);
-    try std.testing.expectEqual(AwgConfigKind.amnezia_vpn_link, kind);
-
-    const installed = try std.Io.Dir.cwd().readFileAlloc(io(), dest_path, std.testing.allocator, .limited(4096));
-    defer std.testing.allocator.free(installed);
-
-    try std.testing.expect(std.mem.indexOf(u8, installed, "vpn://") == null);
-    try std.testing.expect(std.mem.indexOf(u8, installed, "[Interface]") != null);
-    try std.testing.expect(std.mem.indexOf(u8, installed, "[Peer]") != null);
-}
-
-test "tunnel - strips empty AWG assignments" {
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-
-    const name = "awg0.conf";
-    try tmp.dir.writeFile(io(), .{
-        .sub_path = name,
-        .data =
-        \\[Interface]
-        \\PrivateKey = key
-        \\I2 =
-        \\I3 =
-        \\Jc = 6
-        \\
-        \\[Peer]
-        \\PublicKey = peer
-        \\
-        ,
-    });
-
-    var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
-    const path = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}/{s}", .{ tmp.sub_path, name });
-
-    try std.testing.expect(try stripAwgEmptyAssignments(std.testing.allocator, path));
-
-    const sanitized = try tmp.dir.readFileAlloc(io(), name, std.testing.allocator, .limited(4096));
-    defer std.testing.allocator.free(sanitized);
-
-    try std.testing.expect(std.mem.indexOf(u8, sanitized, "I2") == null);
-    try std.testing.expect(std.mem.indexOf(u8, sanitized, "I3") == null);
-    try std.testing.expect(std.mem.indexOf(u8, sanitized, "Jc = 6") != null);
 }

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -115,8 +115,8 @@ pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
         return;
     }
 
-    try chooseInteractiveVpnType(ui);
-
+    // VPN type was already chosen in the interactive menu (AmneziaWG vs share-link); this
+    // path is the AmneziaWG flow.
     if (selection.action == .replace) {
         ui.warn(i18n.get(ui.lang, .tunnel_pool_replace_warn));
     }
@@ -140,14 +140,6 @@ pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
 
 fn tr(lang: i18n.Lang, en: []const u8, ru: []const u8) []const u8 {
     return if (lang == .ru) ru else en;
-}
-
-fn chooseInteractiveVpnType(ui: *Tui) !void {
-    const items = [_][]const u8{
-        i18n.get(ui.lang, .tunnel_vpn_amneziawg),
-    };
-    _ = try ui.menu(i18n.get(ui.lang, .tunnel_vpn_type_prompt), &items);
-    ui.stepOk(i18n.get(ui.lang, .tunnel_vpn_type_prompt), i18n.get(ui.lang, .tunnel_vpn_amneziawg));
 }
 
 fn chooseInteractiveTunnelTarget(ui: *Tui, allocator: std.mem.Allocator) !InteractiveTunnelSelection {

--- a/src/ctl/tunnel_singbox.zig
+++ b/src/ctl/tunnel_singbox.zig
@@ -1,11 +1,12 @@
-//! egress.zig — `mtbuddy setup egress <share-link>...`
+//! tunnel_singbox.zig — `mtbuddy setup egress <share-link>...`
 //!
-//! Provision an upstream egress for the proxy from VPN share-links, dispatching by URI
-//! scheme onto the `type = tunnel` egress shape (transparent L3, policy-routed — the same
-//! abstraction as AmneziaWG):
+//! The sing-box tunnel backend + the share-link egress command. Provisions an upstream
+//! egress for the proxy from VPN share-links, dispatching by URI scheme onto the
+//! `type = tunnel` egress shape (transparent L3, policy-routed — the same abstraction as
+//! AmneziaWG):
 //!
 //!   wireguard://                         -> native kernel WG/AmneziaWG tunnel (reuses
-//!                                           tunnel.zig: policy routing + pool)
+//!                                           tunnel_wg.zig: policy routing + pool)
 //!   vless:// vmess:// trojan:// ss://     -> a local sing-box client in TUN mode (sbx0);
 //!                                           the proxy's SO_MARK'd DC traffic is policy-
 //!                                           routed through it (fwmark 200 -> table 200 ->
@@ -13,16 +14,28 @@
 //!                                           pool. VLESS-Reality camouflages the hop as TLS.
 //!
 //! The proxy relay is unchanged (it just SO_MARKs, as for any tunnel). The two providers
-//! are mutually exclusive on table 200 — setting one up retires the other. This module
-//! lives entirely in mtbuddy (ctl).
+//! are mutually exclusive on table 200 — setting one up retires the other. Share-link
+//! parsing lives in sharelink.zig; the native WG bring-up lives in tunnel_wg.zig.
 
 const std = @import("std");
 const builtin = @import("builtin");
 const sys = @import("sys.zig");
 const toml = @import("toml.zig");
-const tunnel = @import("tunnel.zig");
+const tunnel_wg = @import("tunnel_wg.zig");
+const sharelink = @import("sharelink.zig");
 const tui_mod = @import("tui.zig");
 const Tui = tui_mod.Tui;
+
+// Share-link parsing/transforms live in sharelink.zig; alias them so the bodies below
+// (and their existing references) compile unchanged.
+const XrayLink = sharelink.XrayLink;
+const Scheme = sharelink.Scheme;
+const detectScheme = sharelink.detectScheme;
+const parseXrayLink = sharelink.parseXrayLink;
+const schemeFamily = sharelink.schemeFamily;
+const Family = sharelink.Family;
+const validateLink = sharelink.validateLink;
+const convertWireguardLink = sharelink.convertWireguardLink;
 
 const INSTALL_DIR = "/opt/mtproto-proxy";
 const CONFIG_PATH = INSTALL_DIR ++ "/config.toml";
@@ -36,248 +49,6 @@ const TUN_IFACE = "sbx0"; // sing-box tun interface; mirrors awg0 as a tunnel eg
 const TUN_ADDR = "172.19.0.1/30";
 const TUN_TABLE = "200"; // same policy-routing table the AmneziaWG tunnel uses
 const TUN_FWMARK = "200"; // proxy SO_MARK for tunnel egress
-
-// ── URI helpers ───────────────────────────────────────────────────────────────
-
-/// Decode percent-escapes (%2F -> '/') into `out` (must be >= s.len). Returns the slice.
-pub fn percentDecode(out: []u8, s: []const u8) []const u8 {
-    var w: usize = 0;
-    var i: usize = 0;
-    while (i < s.len) : (i += 1) {
-        if (s[i] == '%' and i + 2 < s.len) {
-            const hi = std.fmt.charToDigit(s[i + 1], 16) catch {
-                out[w] = s[i];
-                w += 1;
-                continue;
-            };
-            const lo = std.fmt.charToDigit(s[i + 2], 16) catch {
-                out[w] = s[i];
-                w += 1;
-                continue;
-            };
-            out[w] = @intCast(hi * 16 + lo);
-            w += 1;
-            i += 2;
-        } else {
-            out[w] = s[i];
-            w += 1;
-        }
-    }
-    return out[0..w];
-}
-
-/// Percent-decode into a freshly allocated buffer.
-fn percentDecodeAlloc(a: std.mem.Allocator, s: []const u8) ![]const u8 {
-    const buf = try a.alloc(u8, s.len);
-    const decoded = percentDecode(buf, s);
-    return decoded;
-}
-
-/// Return the (raw, undecoded) value of `key` in a `k=v&k2=v2` query string, or null.
-pub fn queryParam(query: []const u8, key: []const u8) ?[]const u8 {
-    var it = std.mem.splitScalar(u8, query, '&');
-    while (it.next()) |pair| {
-        const eq = std.mem.indexOfScalar(u8, pair, '=') orelse continue;
-        if (std.mem.eql(u8, pair[0..eq], key)) return pair[eq + 1 ..];
-    }
-    return null;
-}
-
-/// Standard or url-safe base64 decode (tolerant of missing padding), into alloc.
-fn base64Decode(a: std.mem.Allocator, s_in: []const u8) ![]u8 {
-    const s = std.mem.trim(u8, s_in, " \t\r\n");
-    const url_safe = std.mem.indexOfAny(u8, s, "-_") != null;
-    // Re-pad to a multiple of 4 for the standard decoders.
-    const pad = (4 - (s.len % 4)) % 4;
-    var tmp = try a.alloc(u8, s.len + pad);
-    @memcpy(tmp[0..s.len], s);
-    var p: usize = 0;
-    while (p < pad) : (p += 1) tmp[s.len + p] = '=';
-    const dec = if (url_safe) std.base64.url_safe.Decoder else std.base64.standard.Decoder;
-    const n = dec.calcSizeForSlice(tmp) catch return error.BadBase64;
-    const out = try a.alloc(u8, n);
-    dec.decode(out, tmp) catch return error.BadBase64;
-    return out;
-}
-
-// ── Parsed link model ──────────────────────────────────────────────────────────
-
-pub const Scheme = enum { vless, vmess, trojan, shadowsocks, wireguard, unknown };
-
-pub fn detectScheme(link_in: []const u8) Scheme {
-    const link = std.mem.trim(u8, link_in, " \t\r\n");
-    if (std.mem.startsWith(u8, link, "vless://")) return .vless;
-    if (std.mem.startsWith(u8, link, "vmess://")) return .vmess;
-    if (std.mem.startsWith(u8, link, "trojan://")) return .trojan;
-    if (std.mem.startsWith(u8, link, "ss://")) return .shadowsocks;
-    if (std.mem.startsWith(u8, link, "wireguard://") or std.mem.startsWith(u8, link, "wg://")) return .wireguard;
-    return .unknown;
-}
-
-/// A parsed Xray-family link (vless/vmess/trojan/ss). All string fields are owned by
-/// the allocator passed to the parser (use an arena and free it all at once). Fields
-/// not relevant to a given protocol stay null/empty.
-pub const XrayLink = struct {
-    scheme: Scheme,
-    name: []const u8 = "egress",
-    address: []const u8,
-    port: u16,
-    // auth
-    id: ?[]const u8 = null, // uuid (vless/vmess)
-    password: ?[]const u8 = null, // trojan / ss
-    method: ?[]const u8 = null, // ss cipher
-    alter_id: u16 = 0, // vmess aid
-    cipher: []const u8 = "auto", // vmess scy (auto|none|zero|aes-128-gcm|chacha20-poly1305)
-    // transport / security
-    network: []const u8 = "tcp", // tcp | ws | grpc | http
-    security: []const u8 = "none", // none | tls | reality
-    flow: ?[]const u8 = null, // vless xtls flow
-    sni: ?[]const u8 = null,
-    host: ?[]const u8 = null, // ws/http Host header
-    path: ?[]const u8 = null, // ws/http path or grpc serviceName
-    fingerprint: ?[]const u8 = null, // utls fp (chrome,...)
-    public_key: ?[]const u8 = null, // reality pbk
-    short_id: ?[]const u8 = null, // reality sid
-};
-
-fn splitHostPort(hp: []const u8) !struct { host: []const u8, port: u16 } {
-    // IPv6 literal in brackets: [::1]:443
-    if (hp.len > 0 and hp[0] == '[') {
-        const close = std.mem.indexOfScalar(u8, hp, ']') orelse return error.BadAddress;
-        const host = hp[1..close];
-        if (close + 1 >= hp.len or hp[close + 1] != ':') return error.BadAddress;
-        const port = std.fmt.parseInt(u16, hp[close + 2 ..], 10) catch return error.BadAddress;
-        return .{ .host = host, .port = port };
-    }
-    const colon = std.mem.lastIndexOfScalar(u8, hp, ':') orelse return error.BadAddress;
-    const port = std.fmt.parseInt(u16, hp[colon + 1 ..], 10) catch return error.BadAddress;
-    return .{ .host = hp[0..colon], .port = port };
-}
-
-/// Parse vless:// or trojan:// (same URI shape: cred@host:port?params#name).
-fn parseUriCred(a: std.mem.Allocator, link: []const u8, scheme: Scheme, prefix: []const u8) !XrayLink {
-    var rest = link[prefix.len..];
-    // fragment (name)
-    var name: []const u8 = "egress";
-    if (std.mem.indexOfScalar(u8, rest, '#')) |h| {
-        name = try percentDecodeAlloc(a, rest[h + 1 ..]);
-        rest = rest[0..h];
-    }
-    // query
-    var query: []const u8 = "";
-    if (std.mem.indexOfScalar(u8, rest, '?')) |q| {
-        query = rest[q + 1 ..];
-        rest = rest[0..q];
-    }
-    const at = std.mem.indexOfScalar(u8, rest, '@') orelse return error.BadLink;
-    const cred = try percentDecodeAlloc(a, rest[0..at]);
-    const hp = try splitHostPort(rest[at + 1 ..]);
-
-    var l = XrayLink{ .scheme = scheme, .name = name, .address = try a.dupe(u8, hp.host), .port = hp.port };
-    if (scheme == .vless) l.id = cred else l.password = cred;
-
-    if (queryParam(query, "type")) |v| l.network = try percentDecodeAlloc(a, v);
-    if (queryParam(query, "security")) |v| l.security = try percentDecodeAlloc(a, v);
-    if (queryParam(query, "flow")) |v| l.flow = try percentDecodeAlloc(a, v);
-    if (queryParam(query, "sni")) |v| l.sni = try percentDecodeAlloc(a, v);
-    if (queryParam(query, "host")) |v| l.host = try percentDecodeAlloc(a, v);
-    if (queryParam(query, "path")) |v| l.path = try percentDecodeAlloc(a, v);
-    if (queryParam(query, "serviceName")) |v| l.path = try percentDecodeAlloc(a, v);
-    if (queryParam(query, "fp")) |v| l.fingerprint = try percentDecodeAlloc(a, v);
-    if (queryParam(query, "pbk")) |v| l.public_key = try percentDecodeAlloc(a, v);
-    if (queryParam(query, "sid")) |v| l.short_id = try percentDecodeAlloc(a, v);
-    return l;
-}
-
-fn jsonStr(obj: std.json.Value, key: []const u8) ?[]const u8 {
-    const v = obj.object.get(key) orelse return null;
-    return switch (v) {
-        .string => |s| s,
-        .integer => |i| std.fmt.allocPrint(std.heap.page_allocator, "{d}", .{i}) catch null,
-        else => null,
-    };
-}
-
-/// Parse vmess:// (base64-encoded JSON object).
-fn parseVmess(a: std.mem.Allocator, link: []const u8) !XrayLink {
-    const decoded = try base64Decode(a, link["vmess://".len..]);
-    const parsed = std.json.parseFromSlice(std.json.Value, a, decoded, .{}) catch return error.BadLink;
-    const o = parsed.value;
-    if (o != .object) return error.BadLink;
-    const add = jsonStr(o, "add") orelse return error.BadLink;
-    const port_s = jsonStr(o, "port") orelse return error.BadLink;
-    const id = jsonStr(o, "id") orelse return error.BadLink;
-    var l = XrayLink{
-        .scheme = .vmess,
-        .name = try a.dupe(u8, jsonStr(o, "ps") orelse "egress"),
-        .address = try a.dupe(u8, add),
-        .port = std.fmt.parseInt(u16, std.mem.trim(u8, port_s, " "), 10) catch return error.BadLink,
-        .id = try a.dupe(u8, id),
-    };
-    if (jsonStr(o, "aid")) |s| l.alter_id = std.fmt.parseInt(u16, std.mem.trim(u8, s, " "), 10) catch 0;
-    if (jsonStr(o, "scy")) |s| if (s.len > 0) {
-        l.cipher = try a.dupe(u8, s);
-    };
-    if (jsonStr(o, "net")) |s| l.network = try a.dupe(u8, s);
-    if (jsonStr(o, "host")) |s| l.host = try a.dupe(u8, s);
-    if (jsonStr(o, "path")) |s| l.path = try a.dupe(u8, s);
-    if (jsonStr(o, "sni")) |s| l.sni = try a.dupe(u8, s);
-    const tls = jsonStr(o, "tls") orelse "";
-    if (tls.len > 0) l.security = "tls";
-    return l;
-}
-
-/// Parse ss:// — SIP002 (`ss://b64(method:pass)@host:port#name`) or legacy
-/// (`ss://b64(method:pass@host:port)#name`).
-fn parseSs(a: std.mem.Allocator, link: []const u8) !XrayLink {
-    var rest = link["ss://".len..];
-    var name: []const u8 = "egress";
-    if (std.mem.indexOfScalar(u8, rest, '#')) |h| {
-        name = try percentDecodeAlloc(a, rest[h + 1 ..]);
-        rest = rest[0..h];
-    }
-    if (std.mem.indexOfScalar(u8, rest, '?')) |q| rest = rest[0..q]; // drop plugin params
-    var method: []const u8 = undefined;
-    var password: []const u8 = undefined;
-    var hostport: []const u8 = undefined;
-    if (std.mem.indexOfScalar(u8, rest, '@')) |at| {
-        // SIP002: userinfo (before @) is base64(method:password)
-        const ui = base64Decode(a, rest[0..at]) catch rest[0..at];
-        const colon = std.mem.indexOfScalar(u8, ui, ':') orelse return error.BadLink;
-        method = ui[0..colon];
-        password = ui[colon + 1 ..];
-        hostport = rest[at + 1 ..];
-    } else {
-        // legacy: whole thing is base64(method:password@host:port)
-        const dec = try base64Decode(a, rest);
-        const at = std.mem.indexOfScalar(u8, dec, '@') orelse return error.BadLink;
-        const colon = std.mem.indexOfScalar(u8, dec[0..at], ':') orelse return error.BadLink;
-        method = dec[0..colon];
-        password = dec[colon + 1 .. at];
-        hostport = dec[at + 1 ..];
-    }
-    const hp = try splitHostPort(hostport);
-    return XrayLink{
-        .scheme = .shadowsocks,
-        .name = name,
-        .address = try a.dupe(u8, hp.host),
-        .port = hp.port,
-        .method = try a.dupe(u8, method),
-        .password = try a.dupe(u8, password),
-    };
-}
-
-/// Parse any Xray-family share link into an XrayLink (arena-owned strings).
-pub fn parseXrayLink(a: std.mem.Allocator, link_in: []const u8) !XrayLink {
-    const link = std.mem.trim(u8, link_in, " \t\r\n");
-    return switch (detectScheme(link)) {
-        .vless => parseUriCred(a, link, .vless, "vless://"),
-        .trojan => parseUriCred(a, link, .trojan, "trojan://"),
-        .vmess => parseVmess(a, link),
-        .shadowsocks => parseSs(a, link),
-        else => error.UnsupportedScheme,
-    };
-}
 
 // ── Xray client config generation ───────────────────────────────────────────────
 
@@ -393,40 +164,6 @@ pub fn genSingboxConfig(a: std.mem.Allocator, links: []const XrayLink) ![]const 
 
 // ── CLI + provisioning ──────────────────────────────────────────────────────────
 
-const Family = enum { wireguard, xray };
-fn schemeFamily(s: Scheme) Family {
-    return if (s == .wireguard) .wireguard else .xray;
-}
-
-// Ciphers sing-box accepts for shadowsocks. An unknown one makes sing-box reject the
-// WHOLE config, so we reject the link up front with a clear message instead.
-const supported_ss_methods = [_][]const u8{
-    "aes-128-gcm",             "aes-192-gcm",
-    "aes-256-gcm",             "chacha20-ietf-poly1305",
-    "xchacha20-ietf-poly1305", "2022-blake3-aes-128-gcm",
-    "2022-blake3-aes-256-gcm", "2022-blake3-chacha20-poly1305",
-    "none",
-};
-
-/// Reject links whose transport/cipher our generator can't faithfully emit — better a
-/// clear error than silently degrading an unsupported transport to plain TCP (which the
-/// server rejects) or emitting an unknown SS cipher (which sing-box refuses to load).
-/// Returns an error message in `buf`, or null when the link is supported.
-fn validateLink(l: XrayLink, buf: []u8) ?[]const u8 {
-    const net = l.network;
-    if (!(net.len == 0 or std.mem.eql(u8, net, "tcp") or std.mem.eql(u8, net, "ws") or std.mem.eql(u8, net, "grpc"))) {
-        return std.fmt.bufPrint(buf, "unsupported transport '{s}' for {s} — only tcp/ws/grpc are supported", .{ net, l.address }) catch "unsupported transport";
-    }
-    if (l.scheme == .shadowsocks) {
-        const m = l.method orelse "";
-        for (supported_ss_methods) |sm| {
-            if (std.mem.eql(u8, m, sm)) return null;
-        }
-        return std.fmt.bufPrint(buf, "unsupported shadowsocks cipher '{s}' for {s}", .{ m, l.address }) catch "unsupported shadowsocks cipher";
-    }
-    return null;
-}
-
 fn trL(ui: *Tui, en: []const u8, ru: []const u8) []const u8 {
     return if (ui.lang == .ru) ru else en;
 }
@@ -496,8 +233,8 @@ pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
 }
 
 /// wireguard:// links -> native L3 tunnel. Convert each link to a WG/AmneziaWG .conf
-/// (egress owns the URI parsing) and hand it to tunnel.zig's existing setup, which
-/// brings up the interface + policy routing and, for >1 link, builds the tunnel pool.
+/// (sharelink.zig owns the URI parsing) and hand it to tunnel_wg.zig's existing setup,
+/// which brings up the interface + policy routing and, for >1 link, builds the tunnel pool.
 fn setupWireguard(ui: *Tui, allocator: std.mem.Allocator, links: []const []const u8) !void {
     for (links, 0..) |link, idx| {
         var arena = std.heap.ArenaAllocator.init(allocator);
@@ -512,53 +249,9 @@ fn setupWireguard(ui: *Tui, allocator: std.mem.Allocator, links: []const []const
             ui.fail("Failed to stage the WireGuard config");
             return;
         };
-        try tunnel.setupFromConf(ui, allocator, tmp);
+        try tunnel_wg.setupFromConf(ui, allocator, tmp);
         _ = sys.exec(allocator, &.{ "rm", "-f", tmp }) catch {};
     }
-}
-
-/// Convert a `wireguard://<privkey>@<host>:<port>?publickey=&address=&mtu=...#name`
-/// share-link into a WireGuard/AmneziaWG `.conf`. AmneziaWG obfuscation params
-/// (jc/jmin/jmax/s1/s2/h1..h4) and presharedkey are carried through when present.
-pub fn convertWireguardLink(a: std.mem.Allocator, link_in: []const u8) ![]const u8 {
-    const link = std.mem.trim(u8, link_in, " \t\r\n");
-    const after = if (std.mem.startsWith(u8, link, "wireguard://"))
-        link["wireguard://".len..]
-    else if (std.mem.startsWith(u8, link, "wg://"))
-        link["wg://".len..]
-    else
-        return error.UnsupportedScheme;
-
-    var rest = after;
-    if (std.mem.indexOfScalar(u8, rest, '#')) |h| rest = rest[0..h];
-    var query: []const u8 = "";
-    if (std.mem.indexOfScalar(u8, rest, '?')) |q| {
-        query = rest[q + 1 ..];
-        rest = rest[0..q];
-    }
-    const at = std.mem.indexOfScalar(u8, rest, '@') orelse return error.BadLink;
-    const private_key = try percentDecodeAlloc(a, rest[0..at]);
-    const hp = try splitHostPort(rest[at + 1 ..]);
-
-    const pub_key = try percentDecodeAlloc(a, queryParam(query, "publickey") orelse queryParam(query, "public_key") orelse return error.BadLink);
-    const address = try percentDecodeAlloc(a, queryParam(query, "address") orelse "10.0.0.2/32");
-    const mtu = queryParam(query, "mtu") orelse "1420";
-
-    var aw: std.Io.Writer.Allocating = .init(a);
-    const w = &aw.writer;
-    try w.print("[Interface]\nPrivateKey = {s}\nAddress = {s}\nMTU = {s}\n", .{ private_key, address, mtu });
-    if (queryParam(query, "dns")) |dns| try w.print("DNS = {s}\n", .{try percentDecodeAlloc(a, dns)});
-    // AmneziaWG obfuscation knobs (only emitted when present).
-    inline for (.{ "jc", "jmin", "jmax", "s1", "s2", "h1", "h2", "h3", "h4" }) |k| {
-        if (queryParam(query, k)) |v| {
-            var ku: [4]u8 = undefined;
-            const upper = std.ascii.upperString(&ku, k);
-            try w.print("{s} = {s}\n", .{ upper, v });
-        }
-    }
-    try w.print("\n[Peer]\nPublicKey = {s}\nEndpoint = {s}:{d}\nAllowedIPs = 0.0.0.0/0, ::/0\nPersistentKeepalive = 25\n", .{ pub_key, hp.host, hp.port });
-    if (queryParam(query, "presharedkey")) |psk| try w.print("PresharedKey = {s}\n", .{try percentDecodeAlloc(a, psk)});
-    return aw.written();
 }
 
 fn setupSingboxTunnel(ui: *Tui, allocator: std.mem.Allocator, link_texts: []const []const u8) !void {
@@ -760,49 +453,6 @@ fn installSingbox(allocator: std.mem.Allocator) bool {
     return sys.fileExists(SB_BIN);
 }
 
-test "parse vless reality link" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const a = arena.allocator();
-    const l = try parseXrayLink(a, "vless://95e0edb9-4a0b-4312-a71f-1d4b8b6db79b@154.59.110.32:443?type=tcp&security=reality&pbk=PBK&fp=chrome&sni=www.microsoft.com&sid=ABCD&flow=xtls-rprx-vision#demo");
-    try std.testing.expectEqual(Scheme.vless, l.scheme);
-    try std.testing.expectEqualStrings("154.59.110.32", l.address);
-    try std.testing.expectEqual(@as(u16, 443), l.port);
-    try std.testing.expectEqualStrings("95e0edb9-4a0b-4312-a71f-1d4b8b6db79b", l.id.?);
-    try std.testing.expectEqualStrings("reality", l.security);
-    try std.testing.expectEqualStrings("www.microsoft.com", l.sni.?);
-    try std.testing.expectEqualStrings("PBK", l.public_key.?);
-    try std.testing.expectEqualStrings("ABCD", l.short_id.?);
-    try std.testing.expectEqualStrings("xtls-rprx-vision", l.flow.?);
-    try std.testing.expectEqualStrings("demo", l.name);
-}
-
-test "parse vmess base64 link" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const a = arena.allocator();
-    // {"v":"2","ps":"demo-vmess","add":"154.59.110.32","port":"10443","id":"15750f7e-57df-4fb2-b3a4-a9edff4c0def","aid":"0","net":"tcp","type":"none","tls":""}
-    const l = try parseXrayLink(a, "vmess://eyJ2IjogIjIiLCAicHMiOiAiZGVtby12bWVzcyIsICJhZGQiOiAiMTU0LjU5LjExMC4zMiIsICJwb3J0IjogIjEwNDQzIiwgImlkIjogIjE1NzUwZjdlLTU3ZGYtNGZiMi1iM2E0LWE5ZWRmZjRjMGRlZiIsICJhaWQiOiAiMCIsICJuZXQiOiAidGNwIiwgInR5cGUiOiAibm9uZSIsICJ0bHMiOiAiIn0=");
-    try std.testing.expectEqual(Scheme.vmess, l.scheme);
-    try std.testing.expectEqualStrings("154.59.110.32", l.address);
-    try std.testing.expectEqual(@as(u16, 10443), l.port);
-    try std.testing.expectEqualStrings("15750f7e-57df-4fb2-b3a4-a9edff4c0def", l.id.?);
-    try std.testing.expectEqualStrings("demo-vmess", l.name);
-}
-
-test "parse shadowsocks sip002 link" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const a = arena.allocator();
-    // base64("aes-256-gcm:g7ZGM4sBp5FuzPgvKQgYgA") @ host:port
-    const l = try parseXrayLink(a, "ss://YWVzLTI1Ni1nY206ZzdaR000c0JwNUZ1elBndktRZ1lnQQ==@154.59.110.32:9443#demo-shadowsocks");
-    try std.testing.expectEqual(Scheme.shadowsocks, l.scheme);
-    try std.testing.expectEqualStrings("154.59.110.32", l.address);
-    try std.testing.expectEqual(@as(u16, 9443), l.port);
-    try std.testing.expectEqualStrings("aes-256-gcm", l.method.?);
-    try std.testing.expectEqualStrings("g7ZGM4sBp5FuzPgvKQgYgA", l.password.?);
-}
-
 test "genSingboxConfig is valid JSON; urltest only for a pool" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -826,22 +476,6 @@ test "genSingboxConfig is valid JSON; urltest only for a pool" {
     try std.testing.expect(std.mem.indexOf(u8, pool, "shadowsocks") != null);
 }
 
-test "percentDecode + queryParam" {
-    var buf: [64]u8 = undefined;
-    try std.testing.expectEqualStrings("10.11.11.2/32", percentDecode(&buf, "10.11.11.2%2F32"));
-    try std.testing.expectEqualStrings("German WG-1", percentDecode(&buf, "German%20WG-1"));
-    try std.testing.expectEqualStrings("1420", queryParam("publickey=X&address=Y&mtu=1420", "mtu").?);
-    try std.testing.expect(queryParam("a=1&b=2", "c") == null);
-}
-
-test "validateLink rejects unsupported transport and ss cipher" {
-    var buf: [256]u8 = undefined;
-    try std.testing.expect(validateLink(.{ .scheme = .vless, .address = "h", .port = 1, .network = "ws" }, &buf) == null);
-    try std.testing.expect(validateLink(.{ .scheme = .shadowsocks, .address = "h", .port = 1, .method = "aes-256-gcm" }, &buf) == null);
-    try std.testing.expect(validateLink(.{ .scheme = .vless, .address = "h", .port = 1, .network = "quic" }, &buf) != null);
-    try std.testing.expect(validateLink(.{ .scheme = .shadowsocks, .address = "h", .port = 1, .method = "rc4-md5-is-unsupported" }, &buf) != null);
-}
-
 test "vmess scy maps to cipher and is emitted" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -854,34 +488,4 @@ test "vmess scy maps to cipher and is emitted" {
     try std.testing.expectEqualStrings("zero", l.cipher);
     const cfg = try genSingboxConfig(a, &.{l});
     try std.testing.expect(std.mem.indexOf(u8, cfg, "\"security\":\"zero\"") != null);
-}
-
-test "detectScheme" {
-    try std.testing.expectEqual(Scheme.vless, detectScheme("vless://x"));
-    try std.testing.expectEqual(Scheme.wireguard, detectScheme("wireguard://x"));
-    try std.testing.expectEqual(Scheme.shadowsocks, detectScheme("ss://x"));
-    try std.testing.expectEqual(Scheme.unknown, detectScheme("http://x"));
-}
-
-test "convertWireguardLink builds a WG/AmneziaWG conf" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const a = arena.allocator();
-    const conf = try convertWireguardLink(a, "wireguard://PRIVK%2Fey@111.222.33.194:19666?publickey=PUBKEY&address=10.11.11.2%2F32&mtu=1420&presharedkey=PSK&jc=4&s1=50#German%20WG-1");
-    const has = struct {
-        fn f(h: []const u8, n: []const u8) bool {
-            return std.mem.indexOf(u8, h, n) != null;
-        }
-    }.f;
-    try std.testing.expect(has(conf, "[Interface]"));
-    try std.testing.expect(has(conf, "PrivateKey = PRIVK/ey")); // %2F decoded
-    try std.testing.expect(has(conf, "Address = 10.11.11.2/32"));
-    try std.testing.expect(has(conf, "MTU = 1420"));
-    try std.testing.expect(has(conf, "JC = 4")); // AmneziaWG knob, uppercased
-    try std.testing.expect(has(conf, "S1 = 50"));
-    try std.testing.expect(has(conf, "[Peer]"));
-    try std.testing.expect(has(conf, "PublicKey = PUBKEY"));
-    try std.testing.expect(has(conf, "Endpoint = 111.222.33.194:19666"));
-    try std.testing.expect(has(conf, "AllowedIPs = 0.0.0.0/0, ::/0"));
-    try std.testing.expect(has(conf, "PresharedKey = PSK"));
 }

--- a/src/ctl/tunnel_wg.zig
+++ b/src/ctl/tunnel_wg.zig
@@ -1,0 +1,1491 @@
+//! tunnel_wg.zig — AmneziaWG / WireGuard kernel-tunnel backend for `setup tunnel`.
+//!
+//! Brings up a WG/AmneziaWG interface from a `.conf` path or an Amnezia `vpn://` share
+//! link and wires the proxy's SO_MARK'd egress through it (`SO_MARK=200 -> table 200`)
+//! without network namespaces: install AmneziaWG, normalize/validate the config, render
+//! the policy-routing pool script, and patch the systemd unit. `execute` is the shared
+//! entry point used by the `setup tunnel` orchestration in tunnel.zig (CLI + interactive)
+//! and by the sing-box egress when it converts a wireguard:// link into a `.conf`.
+
+const std = @import("std");
+const tui_mod = @import("tui.zig");
+const i18n = @import("i18n.zig");
+const sys = @import("sys.zig");
+const toml = @import("toml.zig");
+
+const Tui = tui_mod.Tui;
+
+const INSTALL_DIR = "/opt/mtproto-proxy";
+const AWG_CONF_DIR = "/etc/amnezia/amneziawg";
+const AWG_IFACE_CONF_PATH = "/etc/amnezia/awg0.conf";
+const TUNNEL_SCRIPT = "/usr/local/bin/setup_tunnel.sh";
+const TUNNEL_POOL_SERVICE = "/etc/systemd/system/mtproto-tunnel-pool.service";
+const TUNNEL_POOL_TIMER = "/etc/systemd/system/mtproto-tunnel-pool.timer";
+const TUNNEL_POOL_STATE = "/run/mtproto-proxy/tunnel-pool.state";
+const SERVICE_FILE = "/etc/systemd/system/mtproto-proxy.service";
+const NGINX_MASKING_CONF = "/etc/nginx/sites-available/mtproto-masking";
+
+const AwgConfigKind = enum {
+    native_conf,
+    amnezia_vpn_link,
+};
+
+const AwgQuickValidation = enum {
+    ok,
+    missing_binary,
+    invalid_config,
+};
+
+fn io() std.Io {
+    return std.Io.Threaded.global_single_threaded.io();
+}
+
+fn readFileAllocCwd(allocator: std.mem.Allocator, path: []const u8, limit: usize) ![]u8 {
+    return std.Io.Dir.cwd().readFileAlloc(io(), path, allocator, .limited(limit));
+}
+
+pub const TunnelOpts = struct {
+    awg_source: []const u8 = "",
+    iface: []const u8 = "",
+};
+
+/// Set up a tunnel directly from a WireGuard/AmneziaWG `.conf` path — same flow as
+/// `setup tunnel <conf>`. Used by the sing-box egress provider after it converts a
+/// wireguard:// share-link into a `.conf`.
+pub fn setupFromConf(ui: *Tui, allocator: std.mem.Allocator, conf_path: []const u8) !void {
+    try execute(ui, allocator, .{ .awg_source = conf_path });
+}
+
+pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
+    if (!sys.isRoot()) {
+        ui.fail(i18n.get(ui.lang, .error_not_root));
+        return;
+    }
+
+    const awg_source = std.mem.trim(u8, opts.awg_source, &[_]u8{ ' ', '\t', '\r', '\n' });
+    if (awg_source.len == 0) {
+        ui.fail("VPN config source is empty");
+        return;
+    }
+    if (!sys.fileExists(INSTALL_DIR ++ "/mtproto-proxy")) {
+        ui.fail("mtproto-proxy not installed. Run install first.");
+        return;
+    }
+
+    // A sing-box egress (`setup egress`) and this WG tunnel pool both own fwmark 200 /
+    // table 200 — retire the sing-box egress so the two don't fight over the route.
+    if (sys.fileExists("/etc/systemd/system/mtproto-singbox-egress.service")) {
+        ui.warn("Retiring the existing sing-box egress — it can't share table 200 with a WG tunnel.");
+        sys.execSilent(allocator, &.{ "systemctl", "disable", "--now", "mtproto-singbox-egress.service" });
+        sys.execSilent(allocator, &.{ "rm", "-f", "/etc/systemd/system/mtproto-singbox-egress.service", "/etc/mtproto-proxy/singbox-egress.json", "/usr/local/bin/mtproto-singbox-route.sh", "/etc/systemd/system/mtproto-proxy.service.d/egress.conf" });
+        sys.execSilent(allocator, &.{ "systemctl", "daemon-reload" });
+    }
+
+    // ── Install AmneziaWG ──
+    if (sys.commandExists("awg") and sys.commandExists("awg-quick")) {
+        ui.ok("AmneziaWG already installed");
+    } else {
+        if (sys.commandExists("awg") != sys.commandExists("awg-quick")) {
+            ui.warn("Detected partial AmneziaWG installation; repairing package setup");
+        }
+        ui.step("Installing AmneziaWG...");
+        if (!ensureAmneziaWgInstalled(ui, allocator)) {
+            return;
+        }
+        ui.ok("AmneziaWG installed");
+    }
+
+    const iface = selectTunnelInterface(allocator, opts.iface) catch |err| {
+        switch (err) {
+            error.InvalidInterfaceName => ui.fail("Invalid tunnel interface name. Use names like awg0, awg1, wg0."),
+            error.NoFreeInterface => ui.fail("No free awgN interface name found"),
+            else => ui.fail("Failed to select tunnel interface"),
+        }
+        return;
+    };
+    defer allocator.free(iface);
+
+    var config_path_buf: [256]u8 = undefined;
+    const awg_config_path = awgConfigPath(&config_path_buf, iface) catch {
+        ui.fail("Tunnel interface name is too long");
+        return;
+    };
+
+    // ── Copy AWG config ──
+    ui.step("Installing AmneziaWG config...");
+    _ = sys.exec(allocator, &.{ "mkdir", "-p", "/etc/amnezia" }) catch {};
+    _ = sys.exec(allocator, &.{ "mkdir", "-p", AWG_CONF_DIR }) catch {};
+
+    const config_kind = installAwgConfigSource(allocator, awg_source, awg_config_path) catch |err| {
+        switch (err) {
+            error.ConfigSourceNotFound => ui.fail("Config file not found"),
+            error.UnsupportedConfigFormat => ui.fail("Unsupported VPN config format. Use a WireGuard/AmneziaWG .conf file, or an Amnezia vpn:// share link."),
+            error.InvalidAmneziaVpnLink => ui.fail("Invalid Amnezia vpn:// link. Export/share an AmneziaWG configuration again and retry."),
+            error.AwgConfigNotFound => ui.fail("Amnezia vpn:// link does not contain an AmneziaWG configuration."),
+            else => ui.fail("Failed to prepare AmneziaWG config"),
+        }
+        return;
+    };
+    if (config_kind == .amnezia_vpn_link) {
+        ui.warn("Converted Amnezia vpn:// link to AmneziaWG config");
+    }
+    if (std.mem.eql(u8, iface, "awg0")) {
+        _ = sys.execForward(&.{ "ln", "-sfn", awg_config_path, AWG_IFACE_CONF_PATH }) catch {};
+    }
+
+    const dns_removed = stripAwgDnsLines(allocator, awg_config_path) catch false;
+    if (dns_removed) {
+        ui.warn("Removed DNS from tunnel config (host resolver will be used)");
+    }
+
+    const empty_removed = stripAwgEmptyAssignments(allocator, awg_config_path) catch false;
+    if (empty_removed) {
+        ui.warn("Removed empty AmneziaWG parameters from tunnel config");
+    }
+
+    const table_off_added = ensureAwgTableOff(allocator, awg_config_path) catch false;
+    if (table_off_added) {
+        ui.warn("Added Table = off to [Interface] in tunnel config");
+    }
+
+    switch (validateAwgQuickConfig(allocator, awg_config_path)) {
+        .ok => {},
+        .missing_binary => {
+            ui.fail("AmneziaWG tools are not available (`awg-quick` was not found). Install amneziawg-tools and retry.");
+            return;
+        },
+        .invalid_config => {
+            ui.fail("AmneziaWG config is not accepted by awg-quick. Check that the input is an AWG/WG client config.");
+            return;
+        },
+    }
+
+    ui.stepOk("Config installed", awg_config_path);
+
+    // ── Create tunnel policy script ──
+    ui.step("Creating tunnel policy routing script...");
+
+    const tunnel_script = renderTunnelPoolScript(allocator) catch {
+        ui.fail("Failed to render tunnel setup script");
+        return;
+    };
+    defer allocator.free(tunnel_script);
+
+    sys.writeFileMode(TUNNEL_SCRIPT, tunnel_script, 0o755) catch {
+        ui.fail("Failed to write tunnel setup script");
+        return;
+    };
+    ui.ok("Created " ++ TUNNEL_SCRIPT);
+
+    // ── Patch systemd service ──
+    ui.step("Patching systemd service for tunnel policy routing...");
+    const svc_content =
+        \\[Unit]
+        \\Description=MTProto Proxy (Zig) via Tunnel Policy Routing
+        \\Documentation=https://github.com/sleep3r/mtproto.zig
+        \\After=network-online.target
+        \\Wants=network-online.target
+        \\
+        \\[Service]
+        \\# Type=simple (not notify): containerized systemd (Docker/LXC) often fails to
+        \\# deliver the sd_notify datagram, which would restart-loop a healthy proxy.
+        \\# simple is robust everywhere; Restart=always still recovers crashes.
+        \\Type=simple
+        \\User=mtproto
+        \\Group=mtproto
+        \\WorkingDirectory=/opt/mtproto-proxy
+        \\# Routing/policy setup needs root; the '+' prefix runs ONLY this command
+        \\# with full privileges while the proxy itself drops to User=mtproto.
+        \\ExecStartPre=+/usr/local/bin/setup_tunnel.sh
+        \\ExecStart=/opt/mtproto-proxy/mtproto-proxy /opt/mtproto-proxy/config.toml
+        \\ExecReload=/bin/kill -HUP $MAINPID
+        \\KillSignal=SIGTERM
+        \\TimeoutStopSec=25
+        \\Restart=on-failure
+        \\RestartSec=5
+        \\
+        \\# Security hardening — mirrors the default unit so tunnel mode does NOT
+        \\# silently run the internet-facing proxy as unsandboxed root. CAP_NET_ADMIN
+        \\# is added (on top of CAP_NET_BIND_SERVICE) for the SO_MARK policy routing
+        \\# the tunnel data path uses. Only the device/netlink-safe subset of the
+        \\# default unit's syscall hardening is applied: ExecStartPre runs ip/wg
+        \\# setup (netlink, possibly modprobe) that an aggressive SystemCallFilter /
+        \\# RestrictAddressFamilies / PrivateDevices would break.
+        \\NoNewPrivileges=yes
+        \\ProtectSystem=strict
+        \\ProtectHome=yes
+        \\PrivateTmp=yes
+        \\ReadOnlyPaths=/opt/mtproto-proxy
+        \\LockPersonality=yes
+        \\RestrictRealtime=yes
+        \\RestrictSUIDSGID=yes
+        \\ProtectClock=yes
+        \\ProtectHostname=yes
+        \\ProtectKernelLogs=yes
+        \\UMask=0077
+        \\AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_ADMIN
+        \\CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_ADMIN
+        \\LimitNOFILE=131582
+        \\TasksMax=65535
+        \\
+        \\[Install]
+        \\WantedBy=multi-user.target
+    ;
+
+    sys.writeFile(SERVICE_FILE, svc_content) catch {
+        ui.fail("Failed to write systemd service");
+        return;
+    };
+
+    _ = sys.execForward(&.{ "systemctl", "daemon-reload" }) catch {};
+    ui.ok("Systemd service patched for tunnel policy routing");
+
+    installTunnelPoolUnits(ui, allocator);
+
+    // ── Configure proxy egress mode ──
+    setTunnelPoolConfig(allocator, iface);
+    ui.stepOk("Set [upstream].type", "tunnel");
+    ui.stepOk("Added tunnel pool interface", iface);
+    ui.stepOk("Preserved [general].use_middle_proxy", "unchanged");
+
+    // ── Inject public IP (preserve existing custom value) ──
+    var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch null;
+    if (doc) |*d| {
+        defer d.deinit();
+
+        var should_inject = true;
+        if (d.get("server", "public_ip")) |configured_public_ip| {
+            const configured = std.mem.trim(u8, configured_public_ip, &[_]u8{ ' ', '\t' });
+            if (configured.len > 0 and !std.mem.eql(u8, configured, "<SERVER_IP>")) {
+                should_inject = false;
+                ui.stepOk("Keeping configured public IP", configured);
+            }
+        }
+
+        if (should_inject) {
+            const public_ip = sys.detectPublicIp(allocator) orelse "";
+            if (public_ip.len > 0) {
+                var quoted_buf: [64]u8 = undefined;
+                const quoted = std.fmt.bufPrint(&quoted_buf, "\"{s}\"", .{public_ip}) catch "";
+                if (quoted.len > 0) {
+                    d.set("server", "public_ip", quoted) catch {};
+                    d.save(INSTALL_DIR ++ "/config.toml") catch {};
+                    ui.stepOk("Injected public IP", public_ip);
+                }
+            }
+        }
+    }
+
+    // ── Preserve promotion tag from env.sh ──
+    if (sys.readEnvFile(allocator, INSTALL_DIR ++ "/env.sh", "TAG")) |tag| {
+        defer allocator.free(tag);
+
+        var doc2 = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch null;
+        if (doc2) |*d| {
+            defer d.deinit();
+            var tag_buf: [128]u8 = undefined;
+            const quoted_tag = std.fmt.bufPrint(&tag_buf, "\"{s}\"", .{tag}) catch "";
+            if (quoted_tag.len > 0) {
+                d.set("server", "tag", quoted_tag) catch {};
+                d.save(INSTALL_DIR ++ "/config.toml") catch {};
+            }
+        }
+        ui.stepOk("Preserved promotion tag", tag);
+    }
+
+    // ── Cleanup legacy netns nginx listen directives ──
+    const nginx_cleaned = cleanupNetnsNginxListen(allocator);
+    if (nginx_cleaned) {
+        ui.ok("Removed legacy netns listen directives from nginx masking config");
+        _ = sys.execForward(&.{ "systemctl", "try-reload-or-restart", "nginx" }) catch {};
+    }
+
+    // ── Apply masking monitor (if recovery is already installed) ──
+    if (sys.isServiceActive("mtproto-mask-health.timer") or sys.fileExists("/usr/local/bin/mtproto-mask-health.sh")) {
+        const recovery = @import("recovery.zig");
+        recovery.execute(ui, allocator, .{ .quiet = true }) catch {};
+    }
+
+    // ── Restart proxy ──
+    ui.step("Restarting proxy...");
+    _ = sys.execForward(&.{ "systemctl", "restart", "mtproto-proxy" }) catch {};
+
+    if (sys.isServiceActive("mtproto-proxy")) {
+        ui.ok("Proxy running with tunnel policy routing");
+    } else {
+        ui.fail("Proxy failed to start. Check: journalctl -u mtproto-proxy -n 30");
+        return;
+    }
+
+    // ── Validate tunnel routing ──
+    ui.step("Validating policy routing to Telegram DCs...");
+
+    _ = sys.execForward(&.{TUNNEL_SCRIPT}) catch {};
+
+    const awg_status = sys.exec(allocator, &.{ "awg", "show", iface }) catch null;
+    if (awg_status) |result| {
+        defer result.deinit();
+        if (result.exit_code == 0) {
+            ui.stepOk("Tunnel interface active", iface);
+        } else {
+            ui.warn("Tunnel interface is not active (check AWG config and endpoint)");
+        }
+    }
+
+    const dc_ips = [_][]const u8{
+        "149.154.175.50", "149.154.167.50", "149.154.175.100",
+        "149.154.167.91", "91.108.56.100",
+    };
+
+    for (dc_ips) |dc_ip| {
+        const r = sys.exec(allocator, &.{
+            "ip", "-4", "route", "get", dc_ip, "mark", "200",
+        }) catch null;
+
+        if (r) |route_result| {
+            defer route_result.deinit();
+            if (route_result.exit_code == 0 and std.mem.indexOf(u8, route_result.stdout, "dev ") != null) {
+                ui.stepOk("Policy route via tunnel pool", dc_ip);
+            } else {
+                var warn_buf: [96]u8 = undefined;
+                const warn_msg = std.fmt.bufPrint(&warn_buf, "Policy route check failed for {s}", .{dc_ip}) catch "Policy route check failed";
+                ui.warn(warn_msg);
+            }
+        }
+    }
+
+    // ── Summary ──
+    ui.summaryBox("VPN Tunnel Configured", &.{
+        .{ .label = "Status:", .value = "systemctl status mtproto-proxy" },
+        .{ .label = "Logs:", .value = "journalctl -u mtproto-proxy -f" },
+        .{ .label = "Tunnel:", .value = "awg show <iface>" },
+        .{ .label = "Pool:", .value = "systemctl status mtproto-tunnel-pool.timer" },
+        .{ .label = "Policy:", .value = "ip -4 rule show | grep fwmark" },
+        .{ .label = "Mark:", .value = "SO_MARK=200 -> table 200" },
+        .{ .label = "", .style = .blank },
+        .{ .label = "Proxy runs in host network namespace", .style = .success },
+        .{ .label = "Tunnel pool failover is socket-level and explicit", .style = .success },
+        .{ .label = "SOCKS5/HTTP upstream stay orthogonal", .style = .success },
+    });
+}
+fn isAmneziaVpnLinkSource(source: []const u8) bool {
+    const trimmed = std.mem.trim(u8, source, &[_]u8{ ' ', '\t', '\r', '\n' });
+    return std.mem.startsWith(u8, trimmed, "vpn://");
+}
+fn installAwgConfigSource(allocator: std.mem.Allocator, source: []const u8, dest_path: []const u8) !AwgConfigKind {
+    const trimmed = std.mem.trim(u8, source, &[_]u8{ ' ', '\t', '\r', '\n' });
+    if (trimmed.len == 0) return error.ConfigSourceNotFound;
+
+    if (isAmneziaVpnLinkSource(trimmed)) {
+        try sys.writeFileMode(dest_path, trimmed, 0o600);
+    } else {
+        const content = readFileAllocCwd(allocator, trimmed, 1024 * 1024) catch |err| switch (err) {
+            error.FileNotFound => return error.ConfigSourceNotFound,
+            else => return err,
+        };
+        defer allocator.free(content);
+
+        try sys.writeFileMode(dest_path, content, 0o600);
+    }
+
+    return normalizeAwgConfig(allocator, dest_path);
+}
+fn normalizeAwgConfig(allocator: std.mem.Allocator, path: []const u8) !AwgConfigKind {
+    const content = try readFileAllocCwd(allocator, path, 1024 * 1024);
+    defer allocator.free(content);
+
+    const trimmed = std.mem.trim(u8, content, &[_]u8{ ' ', '\t', '\r', '\n' });
+    if (std.mem.startsWith(u8, trimmed, "vpn://")) {
+        const converted = convertAmneziaVpnLink(allocator, trimmed) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.AwgConfigNotFound => return error.AwgConfigNotFound,
+            else => return error.InvalidAmneziaVpnLink,
+        };
+        defer allocator.free(converted);
+
+        try sys.writeFileMode(path, converted, 0o600);
+        return .amnezia_vpn_link;
+    }
+
+    if (!looksLikeAwgConfig(trimmed)) return error.UnsupportedConfigFormat;
+    return .native_conf;
+}
+fn convertAmneziaVpnLink(allocator: std.mem.Allocator, link: []const u8) ![]u8 {
+    const encoded = std.mem.trim(u8, link["vpn://".len..], &[_]u8{ ' ', '\t', '\r', '\n' });
+    if (encoded.len == 0) return error.InvalidAmneziaVpnLink;
+
+    const decoded = decodeVpnBase64(allocator, encoded) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.InvalidAmneziaVpnLink,
+    };
+    defer allocator.free(decoded);
+    if (decoded.len <= 4) return error.InvalidAmneziaVpnLink;
+
+    var compressed_reader: std.Io.Reader = .fixed(decoded[4..]);
+    var json_writer: std.Io.Writer.Allocating = .init(allocator);
+    defer json_writer.deinit();
+
+    var decompress_buffer: [std.compress.flate.max_window_len]u8 = undefined;
+    var decompressor: std.compress.flate.Decompress = .init(&compressed_reader, .zlib, &decompress_buffer);
+    _ = decompressor.reader.streamRemaining(&json_writer.writer) catch return error.InvalidAmneziaVpnLink;
+
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, json_writer.written(), .{}) catch return error.InvalidAmneziaVpnLink;
+    defer parsed.deinit();
+
+    const root = switch (parsed.value) {
+        .object => |obj| obj,
+        else => return error.InvalidAmneziaVpnLink,
+    };
+
+    const containers_value = root.get("containers") orelse return error.AwgConfigNotFound;
+    const containers = switch (containers_value) {
+        .array => |array| array,
+        else => return error.AwgConfigNotFound,
+    };
+
+    const dns1 = jsonObjectString(root, "dns1") orelse "";
+    const dns2 = jsonObjectString(root, "dns2") orelse "";
+
+    for (containers.items) |container| {
+        const container_obj = switch (container) {
+            .object => |obj| obj,
+            else => continue,
+        };
+        const awg_value = container_obj.get("awg") orelse continue;
+        const awg_obj = switch (awg_value) {
+            .object => |obj| obj,
+            else => continue,
+        };
+
+        const last_config = jsonObjectString(awg_obj, "last_config") orelse continue;
+        return convertAmneziaLastConfig(allocator, last_config, dns1, dns2);
+    }
+
+    return error.AwgConfigNotFound;
+}
+fn decodeVpnBase64(allocator: std.mem.Allocator, encoded: []const u8) ![]u8 {
+    const padding_len = (4 - (encoded.len % 4)) % 4;
+    const padded = try allocator.alloc(u8, encoded.len + padding_len);
+    defer allocator.free(padded);
+
+    @memcpy(padded[0..encoded.len], encoded);
+    @memset(padded[encoded.len..], '=');
+
+    const decoded_len = std.base64.url_safe.Decoder.calcSizeForSlice(padded) catch return error.InvalidAmneziaVpnLink;
+    const decoded = try allocator.alloc(u8, decoded_len);
+    errdefer allocator.free(decoded);
+
+    std.base64.url_safe.Decoder.decode(decoded, padded) catch return error.InvalidAmneziaVpnLink;
+    return decoded;
+}
+fn convertAmneziaLastConfig(
+    allocator: std.mem.Allocator,
+    last_config_json: []const u8,
+    dns1: []const u8,
+    dns2: []const u8,
+) ![]u8 {
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, last_config_json, .{}) catch return error.InvalidAmneziaVpnLink;
+    defer parsed.deinit();
+
+    const root = switch (parsed.value) {
+        .object => |obj| obj,
+        else => return error.InvalidAmneziaVpnLink,
+    };
+
+    const config = jsonObjectString(root, "config") orelse return error.AwgConfigNotFound;
+
+    const primary_replaced = try std.mem.replaceOwned(u8, allocator, config, "$PRIMARY_DNS", dns1);
+    defer allocator.free(primary_replaced);
+
+    var prepared = try std.mem.replaceOwned(u8, allocator, primary_replaced, "$SECONDARY_DNS", dns2);
+    errdefer allocator.free(prepared);
+
+    var value_buf: [64]u8 = undefined;
+    if (jsonObjectText(root, "mtu", &value_buf)) |mtu| {
+        const updated = try setInterfaceKeyInContent(allocator, prepared, "MTU", mtu);
+        allocator.free(prepared);
+        prepared = updated;
+    }
+
+    var port_buf: [64]u8 = undefined;
+    if (jsonObjectText(root, "port", &port_buf)) |port| {
+        const updated = try setInterfaceKeyInContent(allocator, prepared, "ListenPort", port);
+        allocator.free(prepared);
+        prepared = updated;
+    }
+
+    return prepared;
+}
+fn jsonObjectString(object: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = object.get(key) orelse return null;
+    return switch (value) {
+        .string => |s| s,
+        else => null,
+    };
+}
+fn jsonObjectText(object: std.json.ObjectMap, key: []const u8, buf: *[64]u8) ?[]const u8 {
+    const value = object.get(key) orelse return null;
+    return switch (value) {
+        .string => |s| s,
+        .number_string => |s| s,
+        .integer => |i| std.fmt.bufPrint(buf, "{d}", .{i}) catch null,
+        .float => |f| std.fmt.bufPrint(buf, "{d}", .{f}) catch null,
+        else => null,
+    };
+}
+fn setInterfaceKeyInContent(
+    allocator: std.mem.Allocator,
+    content: []const u8,
+    key: []const u8,
+    value: []const u8,
+) ![]u8 {
+    var output: std.ArrayList(u8) = .empty;
+    defer output.deinit(allocator);
+
+    var in_interface = false;
+    var saw_interface = false;
+    var key_written = false;
+    var wrote_any = false;
+
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r' });
+        const is_section = trimmed.len >= 2 and trimmed[0] == '[' and trimmed[trimmed.len - 1] == ']';
+
+        if (is_section and in_interface and !key_written) {
+            try appendConfigLine(allocator, &output, &wrote_any, key, value);
+            key_written = true;
+        }
+
+        if (is_section) {
+            in_interface = std.ascii.eqlIgnoreCase(trimmed, "[Interface]");
+            if (in_interface) saw_interface = true;
+            try appendOriginalLine(allocator, &output, &wrote_any, line);
+            continue;
+        }
+
+        if (in_interface and trimmed.len > 0 and trimmed[0] != '#' and trimmed[0] != ';') {
+            if (std.mem.indexOfScalar(u8, trimmed, '=')) |eq_pos| {
+                const existing_key = std.mem.trim(u8, trimmed[0..eq_pos], &[_]u8{ ' ', '\t' });
+                if (std.ascii.eqlIgnoreCase(existing_key, key)) {
+                    try appendConfigLine(allocator, &output, &wrote_any, key, value);
+                    key_written = true;
+                    continue;
+                }
+            }
+        }
+
+        try appendOriginalLine(allocator, &output, &wrote_any, line);
+    }
+
+    if (!saw_interface) return error.UnsupportedConfigFormat;
+    if (in_interface and !key_written) {
+        try appendConfigLine(allocator, &output, &wrote_any, key, value);
+    }
+
+    return try output.toOwnedSlice(allocator);
+}
+fn appendOriginalLine(
+    allocator: std.mem.Allocator,
+    output: *std.ArrayList(u8),
+    wrote_any: *bool,
+    line: []const u8,
+) !void {
+    if (wrote_any.*) try output.append(allocator, '\n');
+    try output.appendSlice(allocator, line);
+    wrote_any.* = true;
+}
+fn appendConfigLine(
+    allocator: std.mem.Allocator,
+    output: *std.ArrayList(u8),
+    wrote_any: *bool,
+    key: []const u8,
+    value: []const u8,
+) !void {
+    if (wrote_any.*) try output.append(allocator, '\n');
+    try output.appendSlice(allocator, key);
+    try output.appendSlice(allocator, " = ");
+    try output.appendSlice(allocator, value);
+    wrote_any.* = true;
+}
+fn looksLikeAwgConfig(content: []const u8) bool {
+    var has_interface = false;
+    var has_peer = false;
+
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r' });
+        if (std.ascii.eqlIgnoreCase(trimmed, "[Interface]")) {
+            has_interface = true;
+        } else if (std.ascii.eqlIgnoreCase(trimmed, "[Peer]")) {
+            has_peer = true;
+        }
+    }
+
+    return has_interface and has_peer;
+}
+fn ensureAmneziaWgInstalled(ui: *Tui, allocator: std.mem.Allocator) bool {
+    if (!runCommandChecked(
+        ui,
+        allocator,
+        &.{ "apt-get", "-o", "DPkg::Lock::Timeout=600", "-o", "APT::Update::Error-Mode=any", "update", "-qq" },
+        "Failed to refresh apt package index",
+    )) return false;
+
+    if (!runCommandChecked(
+        ui,
+        allocator,
+        &.{ "apt-get", "-o", "DPkg::Lock::Timeout=600", "install", "-y", "software-properties-common" },
+        "Failed to install software-properties-common",
+    )) return false;
+
+    if (!runCommandChecked(
+        ui,
+        allocator,
+        &.{ "add-apt-repository", "-y", "ppa:amnezia/ppa" },
+        "Failed to add Amnezia PPA",
+    )) return false;
+
+    if (!runCommandChecked(
+        ui,
+        allocator,
+        &.{ "apt-get", "-o", "DPkg::Lock::Timeout=600", "-o", "APT::Update::Error-Mode=any", "update", "-qq" },
+        "Failed to refresh apt index after adding Amnezia PPA",
+    )) return false;
+
+    if (!runCommandChecked(
+        ui,
+        allocator,
+        &.{ "apt-get", "-o", "DPkg::Lock::Timeout=600", "install", "-y", "amneziawg-tools" },
+        "Failed to install amneziawg-tools",
+    )) return false;
+
+    if (!sys.commandExists("awg") or !sys.commandExists("awg-quick")) {
+        ui.fail("amneziawg-tools installation finished but awg/awg-quick were not found in PATH");
+        ui.warn("Run `apt-cache policy amneziawg-tools` and verify package availability for your distro.");
+        return false;
+    }
+
+    return true;
+}
+fn runCommandChecked(
+    ui: *Tui,
+    allocator: std.mem.Allocator,
+    argv: []const []const u8,
+    fail_summary: []const u8,
+) bool {
+    const result = sys.exec(allocator, argv) catch {
+        ui.fail(fail_summary);
+        ui.warn("Failed to execute system command.");
+        return false;
+    };
+    defer result.deinit();
+
+    if (result.exit_code != 0) {
+        ui.fail(fail_summary);
+
+        if (firstDiagnosticLine(result.stderr)) |line| {
+            ui.warn(line);
+        } else if (firstDiagnosticLine(result.stdout)) |line| {
+            ui.warn(line);
+        }
+
+        if (looksLikeLaunchpadPpaIssue(result.stdout) or looksLikeLaunchpadPpaIssue(result.stderr)) {
+            ui.warn("Detected Launchpad PPA outage/block (ppa.launchpadcontent.net). This is usually temporary.");
+            ui.warn("Retry later or install `amneziawg-tools` from a reachable mirror, then rerun `mtbuddy setup tunnel`.");
+        }
+
+        return false;
+    }
+
+    return true;
+}
+fn looksLikeLaunchpadPpaIssue(output: []const u8) bool {
+    if (std.mem.indexOf(u8, output, "ppa.launchpadcontent.net") == null) return false;
+
+    return std.mem.indexOf(u8, output, "Failed to fetch") != null or
+        std.mem.indexOf(u8, output, "Could not resolve") != null or
+        std.mem.indexOf(u8, output, "Temporary failure") != null or
+        std.mem.indexOf(u8, output, "Connection timed out") != null or
+        std.mem.indexOf(u8, output, "Network is unreachable") != null;
+}
+fn firstDiagnosticLine(output: []const u8) ?[]const u8 {
+    var first_non_empty: ?[]const u8 = null;
+    var lines = std.mem.splitScalar(u8, output, '\n');
+    while (lines.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r' });
+        if (trimmed.len == 0) continue;
+        if (first_non_empty == null) first_non_empty = trimmed;
+
+        if (std.mem.startsWith(u8, trimmed, "E:") or
+            std.mem.startsWith(u8, trimmed, "Err:") or
+            std.mem.startsWith(u8, trimmed, "W:"))
+        {
+            return trimmed;
+        }
+    }
+
+    return first_non_empty;
+}
+fn validateAwgQuickConfig(allocator: std.mem.Allocator, path: []const u8) AwgQuickValidation {
+    if (!sys.commandExists("awg-quick")) return .missing_binary;
+
+    const result = sys.exec(allocator, &.{ "awg-quick", "strip", path }) catch return .missing_binary;
+    defer result.deinit();
+    return if (result.exit_code == 0) .ok else .invalid_config;
+}
+pub fn awgConfigPath(buf: []u8, iface: []const u8) ![]const u8 {
+    return try std.fmt.bufPrint(buf, "{s}/{s}.conf", .{ AWG_CONF_DIR, iface });
+}
+pub fn isValidTunnelInterfaceName(iface: []const u8) bool {
+    if (iface.len == 0 or iface.len > 32) return false;
+    for (iface) |ch| {
+        if (std.ascii.isAlphanumeric(ch) or ch == '_' or ch == '-' or ch == '.') continue;
+        return false;
+    }
+    return true;
+}
+pub fn freeOwnedStringSlice(allocator: std.mem.Allocator, values: []const []const u8) void {
+    if (values.len == 0) return;
+    for (values) |value| allocator.free(value);
+    allocator.free(values);
+}
+pub fn parseTunnelInterfaceArray(allocator: std.mem.Allocator, value: []const u8) ![]const []const u8 {
+    const trimmed = std.mem.trim(u8, value, &[_]u8{ ' ', '\t', '\r', '\n' });
+    if (trimmed.len < 2 or trimmed[0] != '[' or trimmed[trimmed.len - 1] != ']') {
+        return error.InvalidInterfaceArray;
+    }
+
+    var list: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (list.items) |item| allocator.free(item);
+        list.deinit(allocator);
+    }
+
+    var i: usize = 1;
+    while (i + 1 < trimmed.len) {
+        while (i + 1 < trimmed.len and (trimmed[i] == ' ' or trimmed[i] == '\t' or trimmed[i] == ',')) : (i += 1) {}
+        if (i + 1 >= trimmed.len or trimmed[i] == ']') break;
+
+        const quoted = trimmed[i] == '"';
+        const start: usize = if (quoted) blk: {
+            i += 1;
+            break :blk i;
+        } else i;
+        while (i < trimmed.len and ((quoted and trimmed[i] != '"') or (!quoted and trimmed[i] != ',' and trimmed[i] != ']'))) : (i += 1) {}
+        const item = std.mem.trim(u8, trimmed[start..i], &[_]u8{ ' ', '\t', '\r', '\n' });
+        if (quoted and i < trimmed.len and trimmed[i] == '"') i += 1;
+        if (item.len > 0 and isValidTunnelInterfaceName(item)) {
+            try list.append(allocator, try allocator.dupe(u8, item));
+        }
+    }
+
+    if (list.items.len == 0) {
+        list.deinit(allocator);
+        return &.{};
+    }
+    return try list.toOwnedSlice(allocator);
+}
+pub fn loadTunnelPoolFromDoc(allocator: std.mem.Allocator, doc: *toml.TomlDoc) ![]const []const u8 {
+    if (doc.get("upstream.tunnel", "interfaces")) |raw_interfaces| {
+        const parsed = parseTunnelInterfaceArray(allocator, raw_interfaces) catch &.{};
+        if (parsed.len > 0) return parsed;
+    }
+
+    if (doc.get("upstream.tunnel", "interface")) |legacy_iface| {
+        const trimmed = std.mem.trim(u8, legacy_iface, &[_]u8{ ' ', '\t', '\r', '\n' });
+        if (isValidTunnelInterfaceName(trimmed)) {
+            const values = try allocator.alloc([]const u8, 1);
+            values[0] = try allocator.dupe(u8, trimmed);
+            return values;
+        }
+    }
+
+    return &.{};
+}
+pub fn containsInterface(values: []const []const u8, iface: []const u8) bool {
+    for (values) |value| {
+        if (std.mem.eql(u8, value, iface)) return true;
+    }
+    return false;
+}
+pub fn selectTunnelInterface(allocator: std.mem.Allocator, requested: []const u8) ![]u8 {
+    const trimmed_requested = std.mem.trim(u8, requested, &[_]u8{ ' ', '\t', '\r', '\n' });
+    if (trimmed_requested.len > 0) {
+        if (!isValidTunnelInterfaceName(trimmed_requested)) return error.InvalidInterfaceName;
+        return try allocator.dupe(u8, trimmed_requested);
+    }
+
+    var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch {
+        return try allocator.dupe(u8, "awg0");
+    };
+    defer doc.deinit();
+
+    const pool = try loadTunnelPoolFromDoc(allocator, &doc);
+    defer freeOwnedStringSlice(allocator, pool);
+
+    var i: usize = 0;
+    while (i < 64) : (i += 1) {
+        var name_buf: [16]u8 = undefined;
+        const candidate = try std.fmt.bufPrint(&name_buf, "awg{d}", .{i});
+        var path_buf: [256]u8 = undefined;
+        const path = awgConfigPath(&path_buf, candidate) catch continue;
+        if (!containsInterface(pool, candidate) and !sys.fileExists(path)) {
+            return try allocator.dupe(u8, candidate);
+        }
+    }
+
+    return error.NoFreeInterface;
+}
+pub fn formatInterfaceArrayLiteral(allocator: std.mem.Allocator, values: []const []const u8) ![]const u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.append(allocator, '[');
+    for (values, 0..) |value, idx| {
+        if (idx > 0) try out.appendSlice(allocator, ", ");
+        try out.append(allocator, '"');
+        try out.appendSlice(allocator, value);
+        try out.append(allocator, '"');
+    }
+    try out.append(allocator, ']');
+    return try out.toOwnedSlice(allocator);
+}
+fn setTunnelPoolConfig(allocator: std.mem.Allocator, iface: []const u8) void {
+    var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch return;
+    defer doc.deinit();
+
+    doc.set("upstream", "type", "\"tunnel\"") catch return;
+
+    const existing = loadTunnelPoolFromDoc(allocator, &doc) catch &.{};
+    defer freeOwnedStringSlice(allocator, existing);
+
+    const pool = appendInterfaceIfMissing(allocator, existing, iface) catch return;
+    defer freeOwnedStringSlice(allocator, pool);
+
+    if (pool.len > 0) {
+        var first_buf: [64]u8 = undefined;
+        const first = std.fmt.bufPrint(&first_buf, "\"{s}\"", .{pool[0]}) catch return;
+        doc.set("upstream.tunnel", "interface", first) catch return;
+    }
+
+    const array_literal = formatInterfaceArrayLiteral(allocator, pool) catch return;
+    defer allocator.free(array_literal);
+    doc.set("upstream.tunnel", "interfaces", array_literal) catch return;
+
+    doc.save(INSTALL_DIR ++ "/config.toml") catch {};
+}
+fn installTunnelPoolUnits(ui: *Tui, allocator: std.mem.Allocator) void {
+    const service =
+        \\[Unit]
+        \\Description=MTProto tunnel pool failover
+        \\Documentation=https://github.com/sleep3r/mtproto.zig
+        \\After=network-online.target
+        \\Wants=network-online.target
+        \\
+        \\[Service]
+        \\Type=oneshot
+        \\ExecStart=/usr/local/bin/setup_tunnel.sh
+        \\AmbientCapabilities=CAP_NET_ADMIN
+    ;
+
+    const timer =
+        \\[Unit]
+        \\Description=Run MTProto tunnel pool failover checks
+        \\
+        \\[Timer]
+        \\OnBootSec=30s
+        \\OnUnitInactiveSec=30s
+        \\RandomizedDelaySec=5s
+        \\Persistent=true
+        \\
+        \\[Install]
+        \\WantedBy=timers.target
+    ;
+
+    sys.writeFile(TUNNEL_POOL_SERVICE, service) catch {
+        ui.warn("Failed to write mtproto-tunnel-pool.service");
+        return;
+    };
+    sys.writeFile(TUNNEL_POOL_TIMER, timer) catch {
+        ui.warn("Failed to write mtproto-tunnel-pool.timer");
+        return;
+    };
+
+    _ = sys.execForward(&.{ "systemctl", "daemon-reload" }) catch {};
+    _ = sys.exec(allocator, &.{ "systemctl", "enable", "--now", "mtproto-tunnel-pool.timer" }) catch {};
+    ui.ok("Tunnel pool failover timer installed");
+}
+fn renderTunnelPoolScript(allocator: std.mem.Allocator) ![]const u8 {
+    return try allocator.dupe(u8,
+        \\#!/usr/bin/env bash
+        \\set -euo pipefail
+        \\
+        \\CONFIG_FILE="/opt/mtproto-proxy/config.toml"
+        \\CONF_DIR="/etc/amnezia/amneziawg"
+        \\STATE_DIR="/run/mtproto-proxy"
+        \\STATE_FILE="$STATE_DIR/tunnel-pool.state"
+        \\MARK=200
+        \\TABLE=200
+        \\RULE_PRIORITY=1200
+        \\PROBE_URL="https://core.telegram.org/getProxyConfig"
+        \\
+        \\mkdir -p "$STATE_DIR"
+        \\
+        \\log() {
+        \\    logger -t mtproto-tunnel-pool "$*" 2>/dev/null || true
+        \\}
+        \\
+        \\read_tunnel_key() {
+        \\    local want_key="$1"
+        \\    [[ -f "$CONFIG_FILE" ]] || return 1
+        \\    awk -v want_key="$want_key" '
+        \\        BEGIN { in_section=0; value="" }
+        \\        /^[[:space:]]*\[upstream\.tunnel\][[:space:]]*$/ { in_section=1; next }
+        \\        /^[[:space:]]*\[[^]]+\][[:space:]]*$/ { in_section=0; next }
+        \\        in_section {
+        \\            line=$0
+        \\            sub(/[;#].*/, "", line)
+        \\            if (line ~ "^[[:space:]]*" want_key "[[:space:]]*=") {
+        \\                sub(/^[^=]*=/, "", line)
+        \\                gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+        \\                gsub(/^"|"$/, "", line)
+        \\                value=line
+        \\            }
+        \\        }
+        \\        END { if (value != "") print value }
+        \\    ' "$CONFIG_FILE"
+        \\}
+        \\
+        \\trim() {
+        \\    local v="$1"
+        \\    v="${v#"${v%%[![:space:]]*}"}"
+        \\    v="${v%"${v##*[![:space:]]}"}"
+        \\    printf '%s\n' "$v"
+        \\}
+        \\
+        \\parse_interfaces() {
+        \\    local raw="$1"
+        \\    raw="${raw#[}"
+        \\    raw="${raw%]}"
+        \\    raw="${raw//\"/}"
+        \\    local old_ifs="$IFS"
+        \\    IFS=','
+        \\    read -r -a parts <<< "$raw"
+        \\    IFS="$old_ifs"
+        \\    for item in "${parts[@]}"; do
+        \\        item="$(trim "$item")"
+        \\        [[ -n "$item" ]] && printf '%s\n' "$item"
+        \\    done
+        \\}
+        \\
+        \\add_unique() {
+        \\    local item="$1"
+        \\    [[ -n "$item" ]] || return 0
+        \\    local existing
+        \\    for existing in "${candidates[@]}"; do
+        \\        [[ "$existing" == "$item" ]] && return 0
+        \\    done
+        \\    candidates+=("$item")
+        \\}
+        \\
+        \\conf_path_for() {
+        \\    local iface="$1"
+        \\    if [[ -f "$CONF_DIR/${iface}.conf" ]]; then
+        \\        printf '%s/%s.conf\n' "$CONF_DIR" "$iface"
+        \\    elif [[ -f "/etc/wireguard/${iface}.conf" ]]; then
+        \\        printf '/etc/wireguard/%s.conf\n' "$iface"
+        \\    else
+        \\        printf '%s/%s.conf\n' "$CONF_DIR" "$iface"
+        \\    fi
+        \\}
+        \\
+        \\quick_tool_for() {
+        \\    local iface="$1"
+        \\    if [[ "$iface" == wg* ]] && command -v wg-quick >/dev/null 2>&1; then
+        \\        printf 'wg-quick\n'
+        \\        return
+        \\    fi
+        \\    if command -v awg-quick >/dev/null 2>&1; then
+        \\        printf 'awg-quick\n'
+        \\        return
+        \\    fi
+        \\    if command -v wg-quick >/dev/null 2>&1; then
+        \\        printf 'wg-quick\n'
+        \\        return
+        \\    fi
+        \\    return 1
+        \\}
+        \\
+        \\show_tool_for() {
+        \\    local iface="$1"
+        \\    if [[ "$iface" == wg* ]] && command -v wg >/dev/null 2>&1; then
+        \\        printf 'wg\n'
+        \\        return
+        \\    fi
+        \\    if command -v awg >/dev/null 2>&1; then
+        \\        printf 'awg\n'
+        \\        return
+        \\    fi
+        \\    if command -v wg >/dev/null 2>&1; then
+        \\        printf 'wg\n'
+        \\        return
+        \\    fi
+        \\    return 1
+        \\}
+        \\
+        \\ensure_iface_up() {
+        \\    local iface="$1"
+        \\    ip link show dev "$iface" >/dev/null 2>&1 && return 0
+        \\    local quick conf
+        \\    quick="$(quick_tool_for "$iface")" || return 1
+        \\    conf="$(conf_path_for "$iface")"
+        \\    [[ -f "$conf" ]] || return 1
+        \\    "$quick" up "$conf" >/dev/null 2>&1
+        \\}
+        \\
+        \\policy_rule_exists() {
+        \\    local mark_hex
+        \\    mark_hex="$(printf '0x%x' "$MARK")"
+        \\    ip -4 rule show | awk -v mark="$MARK" -v mark_hex="$mark_hex" -v table="$TABLE" '
+        \\        (($0 ~ "fwmark " mark || $0 ~ "fwmark " mark_hex) && ($0 ~ "lookup " table || $0 ~ "table " table)) { found = 1 }
+        \\        END { exit found ? 0 : 1 }
+        \\    '
+        \\}
+        \\
+        \\ensure_policy_rule() {
+        \\    while ip -4 rule del priority "$RULE_PRIORITY" fwmark "$MARK" table "$TABLE" 2>/dev/null; do :; done
+        \\    while ip -4 rule del fwmark "$MARK" table "$TABLE" 2>/dev/null; do :; done
+        \\    ip -4 rule add fwmark "$MARK" table "$TABLE" priority "$RULE_PRIORITY" 2>/dev/null || true
+        \\    policy_rule_exists
+        \\}
+        \\
+        \\route_table_to_iface() {
+        \\    local iface="$1"
+        \\    ip -4 route flush table "$TABLE" 2>/dev/null || true
+        \\    ip -4 route replace default dev "$iface" table "$TABLE"
+        \\}
+        \\
+        \\policy_route_matches_iface() {
+        \\    local iface="$1" target="${2:-149.154.175.50}"
+        \\    ip -4 route get "$target" mark "$MARK" 2>/dev/null |
+        \\        awk -v iface="$iface" '
+        \\            { for (i = 1; i < NF; i++) if ($i == "dev" && $(i + 1) == iface) found = 1 }
+        \\            END { exit found ? 0 : 1 }
+        \\        '
+        \\}
+        \\
+        \\telegram_probe_iface() {
+        \\    local iface="$1"
+        \\    command -v curl >/dev/null 2>&1 || return 2
+        \\    curl --interface "$iface" -fsS --connect-timeout 3 --max-time 5 "$PROBE_URL" >/dev/null 2>&1
+        \\}
+        \\
+        \\probe_iface() {
+        \\    local iface="$1"
+        \\    reason=""
+        \\    ensure_iface_up "$iface" || { reason="failed to bring interface up"; return 1; }
+        \\    ip link show dev "$iface" >/dev/null 2>&1 || { reason="interface missing"; return 1; }
+        \\    local show_tool
+        \\    show_tool="$(show_tool_for "$iface")" || { reason="awg/wg show tool missing"; return 1; }
+        \\    "$show_tool" show "$iface" >/dev/null 2>&1 || { reason="tunnel show failed"; return 1; }
+        \\    route_table_to_iface "$iface" || { reason="failed to install policy route"; return 1; }
+        \\    policy_route_matches_iface "$iface" || { reason="policy route check failed"; return 1; }
+        \\    if telegram_probe_iface "$iface"; then
+        \\        reason="healthy"
+        \\        return 0
+        \\    fi
+        \\    # Usable (up + policy route installed) but can't reach Telegram through it.
+        \\    # Return 2 ("degraded-usable") so pool selection PREFERS a tunnel that can
+        \\    # actually reach Telegram, and only falls back to this one if none can.
+        \\    reason="up; Telegram probe failed"
+        \\    return 2
+        \\}
+        \\
+        \\state_value() {
+        \\    local key="$1"
+        \\    [[ -f "$STATE_FILE" ]] || return 0
+        \\    awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' "$STATE_FILE"
+        \\}
+        \\
+        \\write_state() {
+        \\    local active="$1" status="$2" reason="$3"
+        \\    local prev_active prev_last now last_switch
+        \\    prev_active="$(state_value active || true)"
+        \\    prev_last="$(state_value last_switch || true)"
+        \\    now="$(date -Is)"
+        \\    last_switch="${prev_last:-$now}"
+        \\    [[ "$active" != "$prev_active" ]] && last_switch="$now"
+        \\    {
+        \\        printf 'active=%s\n' "$active"
+        \\        printf 'status=%s\n' "$status"
+        \\        printf 'reason=%s\n' "$reason"
+        \\        printf 'pinned=%s\n' "$pinned"
+        \\        printf 'pool=%s\n' "${pool[*]}"
+        \\        printf 'last_switch=%s\n' "$last_switch"
+        \\        printf 'checked_at=%s\n' "$now"
+        \\    } > "$STATE_FILE"
+        \\}
+        \\
+        \\mapfile -t pool < <(
+        \\    raw_interfaces="$(read_tunnel_key interfaces || true)"
+        \\    if [[ -n "${raw_interfaces:-}" ]]; then
+        \\        parse_interfaces "$raw_interfaces"
+        \\    else
+        \\        legacy="$(read_tunnel_key interface || true)"
+        \\        printf '%s\n' "${legacy:-awg0}"
+        \\    fi
+        \\)
+        \\
+        \\previous="$(ip -4 route show table "$TABLE" default 2>/dev/null | awk '/default/ { for (i=1;i<=NF;i++) if ($i=="dev") { print $(i+1); exit } }' || true)"
+        \\pinned="$(read_tunnel_key pinned_interface || true)"
+        \\candidates=()
+        \\add_unique "$pinned"
+        \\# Sticky: after the pin, prefer the currently-active tunnel if it's still in the
+        \\# pool, so a healthy active tunnel isn't dropped for an earlier-listed one — that
+        \\# would flap (reset every connection) whenever the first pool entry is reachable.
+        \\for iface in "${pool[@]}"; do
+        \\    [[ "$iface" == "$previous" ]] && add_unique "$previous"
+        \\done
+        \\for iface in "${pool[@]}"; do
+        \\    add_unique "$iface"
+        \\done
+        \\
+        \\ensure_policy_rule || {
+        \\    write_state "" "degraded" "failed to install policy rule"
+        \\    echo "Failed to install tunnel policy rule: fwmark=$MARK table=$TABLE" >&2
+        \\    exit 1
+        \\}
+        \\
+        \\selected=""
+        \\selected_reason=""
+        \\selected_status="healthy"
+        \\fallback=""
+        \\fallback_reason=""
+        \\for iface in "${candidates[@]}"; do
+        \\    if probe_iface "$iface"; then rc=0; else rc=$?; fi
+        \\    if [[ "$rc" -eq 0 ]]; then
+        \\        selected="$iface"
+        \\        selected_reason="$reason"
+        \\        break
+        \\    elif [[ "$rc" -eq 2 && -z "$fallback" ]]; then
+        \\        # Up but can't reach Telegram — remember it as a last resort, but keep
+        \\        # looking for one that actually reaches Telegram. This is the pool
+        \\        # failover: a dead-but-up active tunnel is now skipped over.
+        \\        fallback="$iface"
+        \\        fallback_reason="$reason"
+        \\        log "tunnel $iface up but Telegram probe failed; trying others"
+        \\    else
+        \\        log "tunnel $iface unhealthy: $reason"
+        \\    fi
+        \\done
+        \\
+        \\if [[ -z "$selected" && -n "$fallback" ]]; then
+        \\    # No tunnel reached Telegram (the probe may be globally blocked/flaky) — fall
+        \\    # back to the first usable one so a single-tunnel deploy doesn't go dark.
+        \\    selected="$fallback"
+        \\    selected_reason="$fallback_reason (fallback)"
+        \\    selected_status="degraded"
+        \\    log "no Telegram-reachable tunnel; falling back to $selected"
+        \\fi
+        \\
+        \\if [[ -z "$selected" ]]; then
+        \\    write_state "" "degraded" "no usable tunnel"
+        \\    echo "No usable tunnel in pool: ${candidates[*]}" >&2
+        \\    exit 1
+        \\fi
+        \\
+        \\route_table_to_iface "$selected"
+        \\write_state "$selected" "$selected_status" "$selected_reason"
+        \\
+        \\if [[ "$previous" != "$selected" ]]; then
+        \\    log "selected tunnel $selected (previous: ${previous:-none})"
+        \\fi
+        \\echo "Tunnel routing ready: fwmark=$MARK -> table $TABLE via $selected"
+    );
+}
+fn stripAwgDnsLines(allocator: std.mem.Allocator, path: []const u8) !bool {
+    const content = try readFileAllocCwd(allocator, path, 1024 * 1024);
+    defer allocator.free(content);
+
+    var output: std.ArrayList(u8) = .empty;
+    defer output.deinit(allocator);
+
+    var removed_any = false;
+    var wrote_any = false;
+
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r' });
+
+        var skip = false;
+        if (trimmed.len > 0 and trimmed[0] != '#') {
+            if (std.mem.indexOfScalar(u8, trimmed, '=')) |eq_pos| {
+                const key = std.mem.trim(u8, trimmed[0..eq_pos], &[_]u8{ ' ', '\t' });
+                if (std.ascii.eqlIgnoreCase(key, "DNS")) {
+                    skip = true;
+                }
+            }
+        }
+
+        if (skip) {
+            removed_any = true;
+            continue;
+        }
+
+        if (wrote_any) try output.append(allocator, '\n');
+        try output.appendSlice(allocator, line);
+        wrote_any = true;
+    }
+
+    if (!removed_any) return false;
+
+    const sanitized = try output.toOwnedSlice(allocator);
+    defer allocator.free(sanitized);
+
+    try sys.writeFileMode(path, sanitized, 0o600);
+    return true;
+}
+fn stripAwgEmptyAssignments(allocator: std.mem.Allocator, path: []const u8) !bool {
+    const content = try readFileAllocCwd(allocator, path, 1024 * 1024);
+    defer allocator.free(content);
+
+    var output: std.ArrayList(u8) = .empty;
+    defer output.deinit(allocator);
+
+    var removed_any = false;
+    var wrote_any = false;
+
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r' });
+
+        var skip = false;
+        if (trimmed.len > 0 and trimmed[0] != '#' and trimmed[0] != ';') {
+            if (std.mem.indexOfScalar(u8, trimmed, '=')) |eq_pos| {
+                const key = std.mem.trim(u8, trimmed[0..eq_pos], &[_]u8{ ' ', '\t' });
+                const value = std.mem.trim(u8, trimmed[eq_pos + 1 ..], &[_]u8{ ' ', '\t' });
+                if (key.len > 0 and value.len == 0) {
+                    skip = true;
+                }
+            }
+        }
+
+        if (skip) {
+            removed_any = true;
+            continue;
+        }
+
+        if (wrote_any) try output.append(allocator, '\n');
+        try output.appendSlice(allocator, line);
+        wrote_any = true;
+    }
+
+    if (!removed_any) return false;
+
+    const sanitized = try output.toOwnedSlice(allocator);
+    defer allocator.free(sanitized);
+
+    try sys.writeFileMode(path, sanitized, 0o600);
+    return true;
+}
+fn ensureAwgTableOff(allocator: std.mem.Allocator, path: []const u8) !bool {
+    const content = try readFileAllocCwd(allocator, path, 1024 * 1024);
+    defer allocator.free(content);
+
+    var in_interface = false;
+    var has_interface = false;
+    var has_table = false;
+    var interface_header_idx: ?usize = null;
+
+    var idx: usize = 0;
+    var lines_scan = std.mem.splitScalar(u8, content, '\n');
+    while (lines_scan.next()) |line| : (idx += 1) {
+        const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r' });
+
+        if (trimmed.len >= 2 and trimmed[0] == '[' and trimmed[trimmed.len - 1] == ']') {
+            in_interface = std.ascii.eqlIgnoreCase(trimmed, "[Interface]");
+            if (in_interface) {
+                has_interface = true;
+                if (interface_header_idx == null) interface_header_idx = idx;
+            }
+            continue;
+        }
+
+        if (!in_interface) continue;
+        if (trimmed.len == 0 or trimmed[0] == '#' or trimmed[0] == ';') continue;
+
+        if (std.mem.indexOfScalar(u8, trimmed, '=')) |eq_pos| {
+            const key = std.mem.trim(u8, trimmed[0..eq_pos], &[_]u8{ ' ', '\t' });
+            if (std.ascii.eqlIgnoreCase(key, "Table")) {
+                has_table = true;
+                break;
+            }
+        }
+    }
+
+    if (!has_interface or has_table or interface_header_idx == null) return false;
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(allocator);
+
+    var out_idx: usize = 0;
+    var wrote_any = false;
+    var lines_write = std.mem.splitScalar(u8, content, '\n');
+    while (lines_write.next()) |line| : (out_idx += 1) {
+        if (wrote_any) try out.append(allocator, '\n');
+        try out.appendSlice(allocator, line);
+        wrote_any = true;
+
+        if (out_idx == interface_header_idx.?) {
+            try out.appendSlice(allocator, "\nTable = off");
+        }
+    }
+
+    const sanitized = try out.toOwnedSlice(allocator);
+    defer allocator.free(sanitized);
+
+    try sys.writeFileMode(path, sanitized, 0o600);
+    return true;
+}
+fn cleanupNetnsNginxListen(allocator: std.mem.Allocator) bool {
+    const content = readFileAllocCwd(allocator, NGINX_MASKING_CONF, 256 * 1024) catch return false;
+    defer allocator.free(content);
+
+    var output: std.ArrayList(u8) = .empty;
+    defer output.deinit(allocator);
+
+    var removed_any = false;
+    var wrote_any = false;
+
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r' });
+
+        // Match directives like: listen 10.200.200.1:8443 ssl;
+        if (std.mem.startsWith(u8, trimmed, "listen ") and
+            std.mem.indexOf(u8, trimmed, "10.200.200.") != null)
+        {
+            removed_any = true;
+            continue;
+        }
+
+        if (wrote_any) output.append(allocator, '\n') catch return false;
+        output.appendSlice(allocator, line) catch return false;
+        wrote_any = true;
+    }
+
+    if (!removed_any) return false;
+
+    const sanitized = output.toOwnedSlice(allocator) catch return false;
+    defer allocator.free(sanitized);
+
+    sys.writeFile(NGINX_MASKING_CONF, sanitized) catch return false;
+    return true;
+}
+const test_amnezia_vpn_link =
+    "vpn://AAABPXicLY9Ra8IwFIX_Srn4WGoSHZSCD6I-lDEX9Gm0IrG5jkKbliSdG6X_fTdWTiA53wn3JCNo4zhkwJOnIA5AEEiTpwhUnfGqNmgdZMUI6vEN2QiNcv5K0b0mC2MJ87mELCqhyI1He1cVXsrSbLW26Fy0iThLgsRyJYhLW_8oj-_4R1FPhtj-eCazkKf8Y3v6upKNo8X5sPs87l-eLuUi2tBGq5CINnTI4dbU1WvUcAutTdM9UOcyFM-9bMkoOBjdd7XxhPFXtX2DSdW12Xq9CjMhpve3fpg_wkXKZtR31gf2xlPBJpimy_QPWglhtw";
+test "tunnel pool - script renders failover (prefer reachable, fall back to usable)" {
+    const script = try renderTunnelPoolScript(std.testing.allocator);
+    defer std.testing.allocator.free(script);
+
+    try std.testing.expect(std.mem.indexOf(u8, script, "route_table_to_iface \"$selected\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "policy_route_matches_iface \"$iface\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "route show table \"$TABLE\" default 2>/dev/null") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "https://core.telegram.org/getProxyConfig") != null);
+    // probe_iface returns 2 (up but Telegram-unreachable) so the pool can skip a
+    // dead-but-up tunnel and fail over to a healthy one.
+    try std.testing.expect(std.mem.indexOf(u8, script, "return 2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "trying others") != null);
+    // ...but a single tunnel whose probe fails is still used (fallback), not dropped.
+    try std.testing.expect(std.mem.indexOf(u8, script, "falling back to $selected") != null);
+    // set -e safety: probe's non-zero exit is captured, not fatal.
+    try std.testing.expect(std.mem.indexOf(u8, script, "if probe_iface \"$iface\"; then rc=0; else rc=$?; fi") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "pinned_interface") != null);
+}
+
+test "tunnel pool timer repeats after oneshot service exits" {
+    const source = @embedFile("tunnel_wg.zig");
+    const needle = "OnUnitInactiveSec" ++ "=30s";
+    try std.testing.expect(std.mem.indexOf(u8, source, needle) != null);
+}
+
+test "tunnel - converts Amnezia vpn link to AWG config" {
+    const conf = try convertAmneziaVpnLink(std.testing.allocator, test_amnezia_vpn_link);
+    defer std.testing.allocator.free(conf);
+
+    try std.testing.expect(std.mem.indexOf(u8, conf, "[Interface]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, conf, "[Peer]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, conf, "DNS = 1.1.1.1, 8.8.8.8") != null);
+    try std.testing.expect(std.mem.indexOf(u8, conf, "MTU = 1280") != null);
+    try std.testing.expect(std.mem.indexOf(u8, conf, "ListenPort = 51820") != null);
+}
+test "tunnel - installs Amnezia vpn link source directly" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const dest_path = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}/awg0.conf", .{tmp.sub_path});
+
+    const kind = try installAwgConfigSource(std.testing.allocator, " \n" ++ test_amnezia_vpn_link ++ "\n", dest_path);
+    try std.testing.expectEqual(AwgConfigKind.amnezia_vpn_link, kind);
+
+    const installed = try std.Io.Dir.cwd().readFileAlloc(io(), dest_path, std.testing.allocator, .limited(4096));
+    defer std.testing.allocator.free(installed);
+
+    try std.testing.expect(std.mem.indexOf(u8, installed, "vpn://") == null);
+    try std.testing.expect(std.mem.indexOf(u8, installed, "[Interface]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, installed, "[Peer]") != null);
+}
+test "tunnel - strips empty AWG assignments" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const name = "awg0.conf";
+    try tmp.dir.writeFile(io(), .{
+        .sub_path = name,
+        .data =
+        \\[Interface]
+        \\PrivateKey = key
+        \\I2 =
+        \\I3 =
+        \\Jc = 6
+        \\
+        \\[Peer]
+        \\PublicKey = peer
+        \\
+        ,
+    });
+
+    var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}/{s}", .{ tmp.sub_path, name });
+
+    try std.testing.expect(try stripAwgEmptyAssignments(std.testing.allocator, path));
+
+    const sanitized = try tmp.dir.readFileAlloc(io(), name, std.testing.allocator, .limited(4096));
+    defer std.testing.allocator.free(sanitized);
+
+    try std.testing.expect(std.mem.indexOf(u8, sanitized, "I2") == null);
+    try std.testing.expect(std.mem.indexOf(u8, sanitized, "I3") == null);
+    try std.testing.expect(std.mem.indexOf(u8, sanitized, "Jc = 6") != null);
+}
+
+pub fn appendInterfaceIfMissing(allocator: std.mem.Allocator, values: []const []const u8, iface: []const u8) ![]const []const u8 {
+    var out: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (out.items) |value| allocator.free(value);
+        out.deinit(allocator);
+    }
+
+    for (values) |value| {
+        try out.append(allocator, try allocator.dupe(u8, value));
+    }
+    if (!containsInterface(values, iface)) {
+        try out.append(allocator, try allocator.dupe(u8, iface));
+    }
+    if (out.items.len == 0) {
+        out.deinit(allocator);
+        return &.{};
+    }
+    return try out.toOwnedSlice(allocator);
+}


### PR DESCRIPTION
Two things, bundled because they touch the same files.

## 1. Interactive share-link egress
The v1.2.0 egress provider was only reachable via the CLI (`mtbuddy setup egress <link>`); the interactive **Setup tunnel** flow still offered AmneziaWG only. Now it asks the upstream type first: *AmneziaWG config* (the existing flow) or *VPN share-link* (`vless:// vmess:// trojan:// ss://` → sing-box TUN tunnel; `wireguard://` → native WG tunnel), the latter routed to a new `runInteractive` that prompts for link(s) and runs the same dispatch as the CLI. (The install wizard and `config doctor` have no separate upstream-type selector — the tunnel chooser was the only Amnezia-only path.)

## 2. Split egress/tunnel into four modules (pure refactor)
`egress.zig` was a stale name — it began as the SOCKS bridge, then got pivoted to a sing-box TUN tunnel — and overlapped with `tunnel.zig` (both produce `type=tunnel`). Reorganized by responsibility, **no behavior change**:

| File | Responsibility | LOC |
|---|---|---|
| `sharelink.zig` | parse/transform any VPN share-link → struct; pure, std-only | 426 |
| `tunnel.zig` | tunnel orchestration: interactive setup, pool selection, status/delete | 638 (was 2145) |
| `tunnel_wg.zig` | the AmneziaWG/WireGuard kernel backend: bring up + manage the WG pool, failover script + units | 1491 |
| `tunnel_singbox.zig` | the sing-box TUN backend + the `setup egress` command (renamed egress.zig, minus parsers) | 491 |

Import graph is a DAG (`tunnel` & `tunnel_singbox` → `tunnel_wg`; `tunnel_singbox` & `tunnel_wg` → `sharelink`; `sharelink` → std only). Total LOC unchanged (≈3046, pure move). Tests moved with their code.

## Verified
`zig build test` (190 tests) + `x86_64/aarch64` ReleaseFast + `zig fmt` green; **installer-e2e** (install + tunnel-pool failover + uninstall, exercising the moved WG backend) and **`setup egress <vless-reality>`** (sbx0 up, exercising tunnel_singbox + sharelink) both pass.