### PR TITLE
feat(dashboard): "Bahnhof Console" redesign + fix long-name counter overflow

### DIFF
--- a/src/ctl/dashboard_assets/server.py
+++ b/src/ctl/dashboard_assets/server.py
@@ -228,6 +228,12 @@ async def _dashboard_security(request: Request, call_next):
     response.headers.setdefault("X-Frame-Options", "DENY")
     response.headers.setdefault("Referrer-Policy", "no-referrer")
     response.headers.setdefault("Content-Security-Policy", "frame-ancestors 'none'")
+    # index.html carries no cache-busting query string (only style.css/app.js do),
+    # so browsers heuristically cache it and keep loading the OLD asset URLs after a
+    # redeploy. Force revalidation of the HTML entry (ETag still yields a 304 when it
+    # is unchanged) so a freshly deployed dashboard shows up immediately.
+    if response.headers.get("content-type", "").startswith("text/html"):
+        response.headers["Cache-Control"] = "no-cache, must-revalidate"
     return response
 
 

--- a/src/ctl/dashboard_assets/static/app.js
+++ b/src/ctl/dashboard_assets/static/app.js
@@ -291,7 +291,7 @@ function drawSpark(canvasId, data, color, maxVal, unit) {
   }
   peak *= 1.2;
 
-  const PAD = 32;       // left padding
+  const PAD = 2;        // no axis labels (Paper-clean trace) → minimal left gutter
   const PAD_TOP = 6;    // top padding
   const cw = w - PAD;
   const ch = h - PAD_TOP;
@@ -300,26 +300,14 @@ function drawSpark(canvasId, data, color, maxVal, unit) {
 
   x.clearRect(0, 0, w, h);
 
-  // Y-axis ticks
-  const ticks = unit === '%' ? [0, 50, 100] : [0, peak * 0.5, peak];
-  x.font = '8px Inter, sans-serif';
-  x.textAlign = 'right';
-  x.textBaseline = 'middle';
-
-  for (const tv of ticks) {
-    const frac = tv / peak;
-    const y = PAD_TOP + ch * (1 - frac);
-    x.strokeStyle = 'rgba(39,47,56,0.8)';
-    x.lineWidth = 0.5;
-    x.beginPath();
-    x.moveTo(PAD, y);
-    x.lineTo(w, y);
-    x.stroke();
-    if (tv > 0) {
-      x.fillStyle = 'rgba(124,134,152,0.5)';
-      x.fillText(unit === '%' ? tv + '%' : tv.toFixed(0), PAD - 4, y);
-    }
-  }
+  // Paper sparkline: a clean seismograph trace with one faint baseline rule —
+  // no Y-axis ticks/labels (those "100%/50%" marks floated in the empty cell).
+  x.strokeStyle = 'rgba(39,47,56,0.8)';
+  x.lineWidth = 1;
+  x.beginPath();
+  x.moveTo(PAD, PAD_TOP + ch);
+  x.lineTo(w, PAD_TOP + ch);
+  x.stroke();
 
   // Data line
   x.beginPath();

--- a/src/ctl/dashboard_assets/static/app.js
+++ b/src/ctl/dashboard_assets/static/app.js
@@ -1242,7 +1242,6 @@ async function poll() {
   $('txTotal').textContent = fmtT(d.net_tx_total);
 
   // Server
-  $('srvUptime').textContent = d.uptime;
   const pi = d.proxy_info || {};
   $('proxyUp').textContent = !pi.online ? t('status.offline') : (pi.state === 'stalled' ? t('status.stuck') : (t('status.online') + ' · ' + (pi.uptime || '')));
   $('proxyPid').textContent = pi.pid || '—';

--- a/src/ctl/dashboard_assets/static/app.js
+++ b/src/ctl/dashboard_assets/static/app.js
@@ -982,7 +982,7 @@ function renderRouting(routing) {
   const middleBtn = $('routingMiddleBtn');
   if (middleBtn) {
     const enabled = Boolean(routing.middle_proxy_enabled);
-    middleBtn.textContent = enabled ? 'MiddleProxy: ON' : 'MiddleProxy: OFF';
+    middleBtn.textContent = enabled ? 'On' : 'Off';
     middleBtn.classList.toggle('active', enabled);
   }
 

--- a/src/ctl/dashboard_assets/static/app.js
+++ b/src/ctl/dashboard_assets/static/app.js
@@ -51,6 +51,8 @@ const I18N = {
     'hero.stalled': 'Your proxy is running but not responding — it looks stuck. Restarting usually fixes this.',
     'hero.idle': 'Your proxy is online and ready. No one is connected yet — share a link to get started.',
     'hero.busy': "Everything's working. {n} connected right now.",
+    'hero.vChecking': 'Checking…', 'hero.vOffline': 'Offline', 'hero.vStalled': 'Stalled', 'hero.vIdle': 'All quiet — idle', 'hero.vBusy': 'Busy — {n} connected',
+    'hero.connected': 'Connected', 'hero.uptimeLbl': 'Uptime',
     'toast.connected': 'Someone just connected through your proxy.',
     'toast.linkCopied': 'Link copied — send it to someone you love.',
     'autoscroll.on': 'Auto-scroll: on', 'autoscroll.off': 'Auto-scroll: off', 'btn.pause': 'Pause', 'btn.resume': 'Resume',
@@ -80,6 +82,8 @@ const I18N = {
     'hero.stalled': 'Прокси запущен, но не отвечает — похоже, завис. Обычно помогает перезапуск.',
     'hero.idle': 'Прокси онлайн и готов. Пока никто не подключён — поделитесь ссылкой, чтобы начать.',
     'hero.busy': 'Всё работает. Сейчас подключено: {n}.',
+    'hero.vChecking': 'Проверка…', 'hero.vOffline': 'Офлайн', 'hero.vStalled': 'Завис', 'hero.vIdle': 'Тишина — простой', 'hero.vBusy': 'Активно — {n} на связи',
+    'hero.connected': 'Подключено', 'hero.uptimeLbl': 'Аптайм',
     'toast.connected': 'Кто-то только что подключился через ваш прокси.',
     'toast.linkCopied': 'Ссылка скопирована — отправьте близкому.',
     'autoscroll.on': 'Автопрокрутка: вкл', 'autoscroll.off': 'Автопрокрутка: выкл', 'btn.pause': 'Пауза', 'btn.resume': 'Продолжить',
@@ -91,7 +95,12 @@ function applyStaticI18n() {
   document.documentElement.setAttribute('lang', LANG);
   document.querySelectorAll('[data-i18n]').forEach(el => { el.textContent = t(el.getAttribute('data-i18n')); });
   document.querySelectorAll('[data-i18n-ph]').forEach(el => { el.setAttribute('placeholder', t(el.getAttribute('data-i18n-ph'))); });
-  const tg = $('langToggle'); if (tg) tg.textContent = (LANG === 'ru') ? 'EN' : 'RU';
+  const tg = $('langToggle');
+  if (tg) {
+    const cells = tg.querySelectorAll('.lang-cell');
+    if (cells.length) cells.forEach((c) => c.classList.toggle('on', c.dataset.lang === LANG));
+    else tg.textContent = (LANG === 'ru') ? 'EN' : 'RU';
+  }
 }
 function setLang(l) { LANG = (l === 'ru') ? 'ru' : 'en'; localStorage.setItem('dashLang', LANG); applyStaticI18n(); }
 const MH = 90;       // max history points
@@ -417,26 +426,26 @@ function showToast(msg, type) {
 // One plain-language verdict at the top of the page — the answer to the only
 // question most people open the dashboard to ask: "is everything OK?"
 function setStatusHero(online, active, state) {
-  const el = $('statusHero'), icon = $('statusHeroIcon'), txt = $('statusHeroText');
+  const el = $('statusHero'), icon = $('statusHeroIcon'), txt = $('statusHeroText'), sub = $('statusHeroSub');
   if (!el) return;
   // Paper hero: fixed surface-1 panel; only the signal square (#statusHeroIcon,
-  // background:currentColor) + verdict text take the state colour, which they
-  // inherit from the hero's color. No translucent bg, no glyph.
+  // background:currentColor) + verdict take the state colour. Short verdict on top,
+  // descriptive sub-line beneath (the right-side figures are filled in poll()).
   el.style.background = '';
   if (icon) icon.textContent = '';
+  let color, verdict, subline;
   if (!online) {
-    el.style.color = 'var(--signal-stop)';
-    txt.textContent = t('hero.offline');
+    color = 'var(--signal-stop)'; verdict = t('hero.vOffline'); subline = t('hero.offline');
   } else if (state === 'stalled') {
-    el.style.color = 'var(--signal-caution)';
-    txt.textContent = t('hero.stalled');
+    color = 'var(--signal-caution)'; verdict = t('hero.vStalled'); subline = t('hero.stalled');
   } else if (active > 0) {
-    el.style.color = 'var(--accent)';
-    txt.textContent = t('hero.busy').replace('{n}', active);
+    color = 'var(--accent)'; verdict = t('hero.vBusy').replace('{n}', active); subline = t('hero.busy').replace('{n}', active);
   } else {
-    el.style.color = 'var(--signal-go)';
-    txt.textContent = t('hero.idle');
+    color = 'var(--signal-go)'; verdict = t('hero.vIdle'); subline = t('hero.idle');
   }
+  el.style.color = color;
+  txt.textContent = verdict;
+  if (sub) sub.textContent = subline;
 }
 
 // The "share with someone you love" moment: a scannable QR + one-tap send.
@@ -1249,6 +1258,12 @@ async function poll() {
   }
   window._prevActive = _act;
   setStatusHero(pi.online, _act, pi.state);
+  // hero right-side figures (Paper parity)
+  const _hc = $('heroConnected'); if (_hc) _hc.textContent = _act;
+  const _hu = $('heroUptime'); if (_hu) _hu.textContent = pi.uptime || d.uptime || '—';
+  // CPU masthead "peak N%" (Paper parity)
+  const _cp = $('cpuPeak');
+  if (_cp) { const _pk = Math.max(Number(d.cpu) || 0, ...((d.cpu_history || []).map((p) => Number(p.v) || 0))); _cp.textContent = Math.round(_pk) + '%'; }
   $('pxActive').textContent = _act;
   $('pxMax').textContent = p.max || 0;
   $('pxHs').textContent = p.hs_inflight || 0;

--- a/src/ctl/dashboard_assets/static/app.js
+++ b/src/ctl/dashboard_assets/static/app.js
@@ -132,7 +132,15 @@ const appRoot = document.querySelector('.app');
 
 // ── Gauges ──
 function setGauge(arcId, pctId, val) {
-  $(arcId).style.strokeDashoffset = 94.2 - (94.2 * val / 100);
+  // 270° arc (gap at the bottom) on a r=15 circle: full circumference ≈ 94.25,
+  // 270° ≈ 70.69. The arc is rotated -via CSS- so the gap sits at 6 o'clock.
+  const ARC = 70.69;
+  const v = Math.max(0, Math.min(100, Number(val) || 0));
+  $(arcId).style.strokeDasharray = (ARC * v / 100).toFixed(2) + ' 94.25';
+  // Signal-threshold colour ramp — the full-saturation amber stays reserved for
+  // the status hero, so the dial earns its colour from the value band instead.
+  const col = v < 60 ? 'var(--signal-go)' : (v < 85 ? 'var(--signal-caution)' : 'var(--signal-stop)');
+  $(arcId).style.stroke = col;
   $(pctId).textContent = val + '%';
 }
 
@@ -151,6 +159,8 @@ window.addEventListener('resize', resizeCanvas);
 
 function drawNetChart() {
   if (!lastData || !lastData.net_history) return;
+  resizeCanvas();   // self-size each draw (like the sparklines) so the chart is
+                    // robust to first-paint timing and container width changes
   const data = lastData.net_history;
   const w = canvas.width / 2, h = canvas.height / 2;
   ctx.clearRect(0, 0, w, h);
@@ -178,7 +188,7 @@ function drawNetChart() {
   for (let i = 0; i <= 4; i++) {
     const frac = i / 4;
     const y = PAD_TOP + ch * (1 - frac);
-    ctx.strokeStyle = 'rgba(247,164,29,0.05)';
+    ctx.strokeStyle = 'rgba(39,47,56,0.8)';
     ctx.lineWidth = 0.5;
     ctx.beginPath();
     ctx.moveTo(PAD, y);
@@ -229,12 +239,12 @@ function drawNetChart() {
   }
 
   drawLine('tx', 'rgb(247,164,29)');
-  drawLine('rx', 'rgb(52,211,153)');
+  drawLine('rx', 'rgb(92,130,201)');
 }
 
 canvas.addEventListener('mousemove', e => {
   showTooltip(e, canvas, 42, lastData?.net_history, item => 
-    `<div class="tooltip-val" style="color:var(--green)">RX: ${fmt(item.rx)}</div><div class="tooltip-val" style="color:var(--zig)">TX: ${fmt(item.tx)}</div>`
+    `<div class="tooltip-val" style="color:var(--blue)">RX: ${fmt(item.rx)}</div><div class="tooltip-val" style="color:var(--zig)">TX: ${fmt(item.tx)}</div>`
   );
 });
 canvas.addEventListener('mouseleave', hideTooltip);
@@ -279,7 +289,7 @@ function drawSpark(canvasId, data, color, maxVal, unit) {
   for (const tv of ticks) {
     const frac = tv / peak;
     const y = PAD_TOP + ch * (1 - frac);
-    x.strokeStyle = 'rgba(247,164,29,0.05)';
+    x.strokeStyle = 'rgba(39,47,56,0.8)';
     x.lineWidth = 0.5;
     x.beginPath();
     x.moveTo(PAD, y);
@@ -317,12 +327,12 @@ function drawSpark(canvasId, data, color, maxVal, unit) {
 
 const cpuCanvas = $('cpuSpark');
 if (cpuCanvas) {
-  cpuCanvas.addEventListener('mousemove', e => showTooltip(e, cpuCanvas, 32, lastData?.cpu_history, item => `<div class="tooltip-val" style="color:var(--zig)">Util: ${item.v}%</div>`));
+  cpuCanvas.addEventListener('mousemove', e => showTooltip(e, cpuCanvas, 32, lastData?.cpu_history, item => `<div class="tooltip-val" style="color:var(--text)">Util: ${item.v}%</div>`));
   cpuCanvas.addEventListener('mouseleave', hideTooltip);
 }
 const memCanvas = $('memSpark');
 if (memCanvas) {
-  memCanvas.addEventListener('mousemove', e => showTooltip(e, memCanvas, 32, lastData?.mem_history, item => `<div class="tooltip-val" style="color:var(--purple)">Mem: ${item.v}%</div>`));
+  memCanvas.addEventListener('mousemove', e => showTooltip(e, memCanvas, 32, lastData?.mem_history, item => `<div class="tooltip-val" style="color:var(--text)">Mem: ${item.v}%</div>`));
   memCanvas.addEventListener('mouseleave', hideTooltip);
 }
 
@@ -723,7 +733,7 @@ function renderUsers(users, perUserActive, proxyStats) {
       : '<button class="ui-btn user-direct-toggle" type="button" data-user="' + userName + '" data-direct="true" title="Switch to direct route">default</button>');
 
     return '<div class="' + rowClass + '">' +
-      '<div class="user-name">' + toggleSwitch + displayName + sessionsBadge + '</div>' +
+      '<div class="user-name">' + toggleSwitch + '<span class="user-name-text">' + displayName + '</span>' + sessionsBadge + '</div>' +
       '<div class="user-route">' + directToggle + '</div>' +
       '<div class="user-link" title="' + esc(tg || tme || (isEnabled ? 'link unavailable' : 'disabled')) + '">' + esc(preview) + '</div>' +
       '<div class="user-actions">' +
@@ -1203,8 +1213,8 @@ async function poll() {
   $('memSub').textContent = d.mem_used + ' / ' + d.mem_total + ' MB';
 
   // Sparklines
-  if (d.cpu_history) drawSpark('cpuSpark', d.cpu_history, 'rgb(247,164,29)', 100, '%');
-  if (d.mem_history) drawSpark('memSpark', d.mem_history, 'rgb(167,139,250)', 100, '%');
+  if (d.cpu_history) drawSpark('cpuSpark', d.cpu_history, 'rgb(154,163,174)', 100, '%');
+  if (d.mem_history) drawSpark('memSpark', d.mem_history, 'rgb(154,163,174)', 100, '%');
 
   // Network
   drawNetChart();

--- a/src/ctl/dashboard_assets/static/app.js
+++ b/src/ctl/dashboard_assets/static/app.js
@@ -36,7 +36,7 @@ const I18N = {
     'btn.create': 'Create', 'btn.cancel': 'Cancel', 'btn.apply': 'Apply', 'btn.pin': 'Pin', 'btn.setTarget': 'Set target', 'btn.delete': 'Delete', 'btn.close': 'Close',
     'routing.title': 'Routing & Upstream', 'routing.upstream': 'Upstream', 'routing.tunnelPin': 'Tunnel pin',
     'routing.proxyHost': 'Proxy host', 'routing.port': 'Port', 'routing.user': 'User', 'routing.pass': 'Pass', 'routing.target': 'Target', 'routing.policy': 'Policy',
-    'mask.title': 'Masking Health', 'mask.mode': 'Mode', 'mask.endpoint': 'Endpoint', 'mask.timer': 'Health Timer',
+    'mask.title': 'Masking', 'mask.mode': 'Mode', 'mask.endpoint': 'Endpoint', 'mask.timer': 'Health Timer',
     'egress.title': 'Tunnel Quality', 'egress.interface': 'Interface', 'egress.status': 'Status',
     'egress.rtt': 'RTT', 'egress.loss': 'Loss', 'egress.handshake': 'Handshake', 'egress.quality': 'Quality',
     'egress.good': 'Good', 'egress.degraded': 'Degraded', 'egress.poor': 'Poor', 'egress.up': 'Up', 'egress.down': 'Down', 'egress.unknown': 'Unknown',
@@ -89,7 +89,7 @@ const I18N = {
     'autoscroll.on': 'Автопрокрутка: вкл', 'autoscroll.off': 'Автопрокрутка: выкл', 'btn.pause': 'Пауза', 'btn.resume': 'Продолжить',
   },
 };
-let LANG = localStorage.getItem('dashLang') || ((navigator.language || '').toLowerCase().startsWith('ru') ? 'ru' : 'en');
+let LANG = localStorage.getItem('dashLang') || 'en';
 function t(k) { return (I18N[LANG] && I18N[LANG][k]) || (I18N.en && I18N.en[k]) || k; }
 function applyStaticI18n() {
   document.documentElement.setAttribute('lang', LANG);
@@ -158,6 +158,18 @@ function hideTooltip() { tt.classList.remove('visible'); }
 const logFilters = { error: true, warn: true, stats: true };
 let logSearchTerm = '';
 const appRoot = document.querySelector('.app');
+
+function formatHistoryWindowLabel() {
+  const seconds = Math.round((MH * pollIntervalMs) / 1000);
+  if (seconds >= 240) return 'LAST ' + Math.round(seconds / 60) + 'M';
+  if (seconds >= 90) return 'LAST ' + Math.round(seconds / 60) + ' MIN';
+  return 'LAST ' + seconds + 'S';
+}
+
+function updateNetworkWindowLabel() {
+  const el = document.querySelector('.net-window');
+  if (el) el.textContent = formatHistoryWindowLabel();
+}
 
 // ── Gauges ──
 function setGauge(arcId, pctId, val) {
@@ -433,17 +445,18 @@ function setStatusHero(online, active, state) {
   // descriptive sub-line beneath (the right-side figures are filled in poll()).
   el.style.background = '';
   if (icon) icon.textContent = '';
-  let color, verdict, subline;
+  let color, signalColor, verdict, subline;
   if (!online) {
-    color = 'var(--signal-stop)'; verdict = t('hero.vOffline'); subline = t('hero.offline');
+    color = 'var(--signal-stop)'; signalColor = color; verdict = t('hero.vOffline'); subline = t('hero.offline');
   } else if (state === 'stalled') {
-    color = 'var(--signal-caution)'; verdict = t('hero.vStalled'); subline = t('hero.stalled');
+    color = 'var(--signal-caution)'; signalColor = color; verdict = t('hero.vStalled'); subline = t('hero.stalled');
   } else if (active > 0) {
-    color = 'var(--accent)'; verdict = t('hero.vBusy').replace('{n}', active); subline = t('hero.busy').replace('{n}', active);
+    color = 'var(--accent)'; signalColor = 'var(--signal-go)'; verdict = t('hero.vBusy').replace('{n}', active); subline = t('hero.busy').replace('{n}', active);
   } else {
-    color = 'var(--signal-go)'; verdict = t('hero.vIdle'); subline = t('hero.idle');
+    color = 'var(--signal-go)'; signalColor = color; verdict = t('hero.vIdle'); subline = t('hero.idle');
   }
   el.style.color = color;
+  el.style.setProperty('--hero-signal-color', signalColor);
   txt.textContent = verdict;
   if (sub) sub.textContent = subline;
 }
@@ -817,6 +830,19 @@ function setRoutingAction(msg, cls) {
   note.className = 'routing-action-note' + (cls ? (' ' + cls) : '');
 }
 
+function setMiddleProxyButton(enabled, pending) {
+  const middleBtn = $('routingMiddleBtn');
+  if (!middleBtn) return;
+  const on = Boolean(enabled);
+  const label = middleBtn.querySelector('.routing-toggle-text');
+  if (label) label.textContent = on ? 'On' : 'Off';
+  else middleBtn.textContent = on ? 'On' : 'Off';
+  middleBtn.classList.toggle('active', on);
+  middleBtn.classList.toggle('is-pending', Boolean(pending));
+  middleBtn.setAttribute('aria-pressed', on ? 'true' : 'false');
+  middleBtn.setAttribute('aria-busy', pending ? 'true' : 'false');
+}
+
 function setupRoutingControls() {
   const middleBtn = $('routingMiddleBtn');
   const upstreamSelect = $('routingUpstreamSelect');
@@ -830,24 +856,47 @@ function setupRoutingControls() {
   const proxyApply = $('routingProxyApply');
   if (!middleBtn || !upstreamSelect || !upstreamApply) return;
 
-  middleBtn.addEventListener('click', async () => {
-    if (!currentRouting) return;
+  async function commitMiddleProxyToggle() {
+    if (!currentRouting || middleBtn.dataset.pending === '1') return;
 
-    const target = !Boolean(currentRouting.middle_proxy_enabled);
-    middleBtn.disabled = true;
-    setRoutingAction('Updating middle proxy mode…');
+    const previous = Boolean(currentRouting.middle_proxy_enabled);
+    const target = !previous;
+    middleBtn.dataset.pending = '1';
+    middleBtn.dataset.target = target ? '1' : '0';
+    currentRouting.middle_proxy_enabled = target;
+    setMiddleProxyButton(target, true);
+    setRoutingAction('');
 
     try {
       const data = await apiCall('/api/routing/middle', { enabled: target });
+      currentRouting.middle_proxy_enabled = Boolean(data.enabled);
+      setMiddleProxyButton(currentRouting.middle_proxy_enabled, false);
       setRoutingAction('MiddleProxy ' + (data.enabled ? 'enabled' : 'disabled') + '. Proxy restarted.', 'ok');
       showToast('MiddleProxy ' + (data.enabled ? 'enabled' : 'disabled') + '. Proxy restarted.', 'success');
       await runPoll();
     } catch (e) {
+      currentRouting.middle_proxy_enabled = previous;
+      setMiddleProxyButton(previous, false);
       setRoutingAction('Failed: ' + e.message, 'error');
       showToast('Failed: ' + e.message, 'error');
     } finally {
-      middleBtn.disabled = false;
+      delete middleBtn.dataset.pending;
+      delete middleBtn.dataset.target;
+      setMiddleProxyButton(Boolean(currentRouting && currentRouting.middle_proxy_enabled), false);
     }
+  }
+
+  middleBtn.addEventListener('pointerdown', (event) => {
+    if (event.button !== undefined && event.button !== 0) return;
+    event.preventDefault();
+    middleBtn.focus({ preventScroll: true });
+    void commitMiddleProxyToggle();
+  });
+
+  middleBtn.addEventListener('keydown', (event) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    event.preventDefault();
+    void commitMiddleProxyToggle();
   });
 
   upstreamApply.addEventListener('click', async () => {
@@ -878,6 +927,9 @@ function setupRoutingControls() {
       upstreamApply.disabled = false;
       upstreamSelect.disabled = false;
     }
+  });
+  upstreamSelect.addEventListener('change', () => {
+    if (!upstreamApply.disabled) upstreamApply.click();
   });
 
   if (tunnelIfaceApply && tunnelIfaceSelect) {
@@ -910,6 +962,9 @@ function setupRoutingControls() {
         tunnelIfaceApply.disabled = false;
         tunnelIfaceSelect.disabled = false;
       }
+    });
+    tunnelIfaceSelect.addEventListener('change', () => {
+      if (!tunnelIfaceApply.disabled) tunnelIfaceApply.click();
     });
   }
 
@@ -981,9 +1036,9 @@ function renderRouting(routing) {
 
   const middleBtn = $('routingMiddleBtn');
   if (middleBtn) {
-    const enabled = Boolean(routing.middle_proxy_enabled);
-    middleBtn.textContent = enabled ? 'On' : 'Off';
-    middleBtn.classList.toggle('active', enabled);
+    const pending = middleBtn.dataset.pending === '1';
+    const pendingTarget = middleBtn.dataset.target === '1';
+    setMiddleProxyButton(pending ? pendingTarget : Boolean(routing.middle_proxy_enabled), pending);
   }
 
   const upstreamSelect = $('routingUpstreamSelect');
@@ -1001,7 +1056,12 @@ function renderRouting(routing) {
       const choices = Array.isArray(routing.tunnel_pool)
         ? routing.tunnel_pool
         : [];
-      const selectedIface = String(routing.pinned_tunnel_interface || '');
+      const selectedIface = String(
+        routing.pinned_tunnel_interface ||
+        routing.active_tunnel_interface ||
+        routing.selected_tunnel_interface ||
+        ''
+      );
       const seen = new Set();
       const options = [''];
 
@@ -1082,14 +1142,28 @@ function renderRouting(routing) {
 
   $('routingMiddle').textContent = routing.middle_proxy_enabled ? 'enabled' : 'disabled';
   $('routingUpstream').textContent = upstreamType || '—';
-  $('routingTarget').textContent = routing.upstream_target || '—';
+  const tunnelTarget = routing.primary_tunnel && routing.primary_tunnel.endpoint
+    ? routing.primary_tunnel.endpoint
+    : '';
+  $('routingTarget').textContent = (upstreamType === 'tunnel' && tunnelTarget)
+    ? tunnelTarget
+    : (routing.upstream_target || '—');
 
   const policy = routing.policy || {};
+  const poolTotal = Array.isArray(routing.tunnel_pool)
+    ? routing.tunnel_pool.length
+    : Number(routing.detected_tunnels || 0);
+  const poolHealthy = Number(
+    routing.healthy_tunnels != null
+      ? routing.healthy_tunnels
+      : (routing.active_tunnels != null ? routing.active_tunnels : 0)
+  );
+  const poolTxt = poolTotal > 0 ? (poolHealthy + '/' + poolTotal) : routing.pool_status;
   const policyTxt = (policy.rule_ok ? 'rule ok' : 'rule missing') +
-    ' · ' +
-    (policy.route_ok ? ('route ok' + (policy.route_dev ? (' (' + policy.route_dev + ')') : '')) : 'route missing') +
-    (routing.pool_status ? (' · pool ' + routing.pool_status) : '');
-  $('routingPolicy').textContent = policyTxt;
+    (poolTxt
+      ? (' · pool ' + poolTxt)
+      : (' · ' + (policy.route_ok ? 'route ok' : 'route missing')));
+  $('routingPolicy').innerHTML = '<span class="signal-sq"></span>' + esc(policyTxt);
 
   const list = $('routingTunnelsList');
   const tunnels = Array.isArray(routing.tunnels) ? routing.tunnels : [];
@@ -1156,27 +1230,34 @@ function fmtHandshakeAge(sec) {
   return Math.floor(sec / 3600) + 'h';
 }
 
-function renderEgress(egress) {
-  lastEgress = egress;
+function renderEgress(egress, opts) {
+  const options = opts || {};
+  if (!options.transient) lastEgress = egress;
   const card = $('egressCard');
   if (!card) return;
 
   if (!egress || !egress.tunnels || egress.tunnels.length === 0) {
-    card.style.display = 'none';
+    if (!options.transient) card.style.display = 'none';
     return;
   }
 
   card.style.display = '';
 
-  const summary = egress.summary || {};
-  const summaryText = LANG === 'ru' ? summary.ru : summary.en;
+  const tunnels = egress.tunnels || [];
+  const degradedCount = tunnels.filter((tun) => tun && (tun.quality === 'degraded' || tun.quality === 'poor')).length;
+  const downCount = tunnels.filter((tun) => tun && tun.quality === 'down').length;
+  const summaryText = tunnels.length
+    ? (tunnels.length + ' · ' + (degradedCount
+      ? (degradedCount + ' degraded')
+      : (downCount ? (downCount + ' down') : 'healthy')))
+    : '—';
   const summaryEl = $('egressSummary');
   if (summaryEl) summaryEl.textContent = summaryText || '—';
 
   const list = $('egressList');
   if (!list) return;
 
-  list.innerHTML = (egress.tunnels || []).map((tun) => {
+  list.innerHTML = tunnels.map((tun) => {
     const iface = esc(tun.interface || '—');
     const isPrimary = tun.is_primary;
     const quality = tun.quality || 'unknown';
@@ -1214,6 +1295,30 @@ function renderEgress(egress) {
   }).join('');
 }
 
+function renderEgressFromRouting(routing) {
+  if (lastEgress && Array.isArray(lastEgress.tunnels) && lastEgress.tunnels.length) return;
+  const tunnels = routing && Array.isArray(routing.tunnels) ? routing.tunnels : [];
+  if (!tunnels.length) return;
+
+  const fallbackEgress = {
+    ok: true,
+    primary_interface: routing.active_tunnel_interface || routing.selected_tunnel_interface || '',
+    tunnels: tunnels.map((tun) => {
+      const iface = String(tun.interface || '—');
+      return {
+        interface: iface,
+        up: Boolean(tun.link_up || tun.active || tun.healthy),
+        handshake_age_sec: null,
+        rtt_ms: null,
+        packet_loss_pct: null,
+        quality: tun.healthy ? 'good' : ((tun.link_up || tun.active) ? 'up' : 'down'),
+        is_primary: iface === (routing.active_tunnel_interface || routing.selected_tunnel_interface || ''),
+      };
+    }),
+  };
+  renderEgress(fallbackEgress, { transient: true });
+}
+
 // ── Polling ──
 async function poll() {
   const r = await fetch('/api/stats', { cache: 'no-store' });
@@ -1243,10 +1348,16 @@ async function poll() {
 
   // Server
   const pi = d.proxy_info || {};
-  $('proxyUp').textContent = !pi.online ? t('status.offline') : (pi.state === 'stalled' ? t('status.stuck') : (t('status.online') + ' · ' + (pi.uptime || '')));
-  $('proxyPid').textContent = pi.pid || '—';
-  $('proxyRss').textContent = (pi.rss_mb || 0) + ' MB';
-  $('statusBadge').className = pi.online ? 'badge' : 'badge off';
+  const proxyUpEl = $('proxyUp');
+  if (proxyUpEl) proxyUpEl.textContent = !pi.online ? t('status.offline') : (pi.state === 'stalled' ? t('status.stuck') : t('status.online'));
+  const pidEl = $('proxyPid');
+  if (pidEl) pidEl.textContent = pi.pid || '—';
+  const rssEl = $('proxyRss');
+  if (rssEl) rssEl.textContent = (pi.rss_mb || 0) + ' MB';
+  const uptimeEl = $('proxyUptime');
+  if (uptimeEl) uptimeEl.textContent = pi.uptime || d.uptime || '—';
+  const statusBadgeEl = $('statusBadge');
+  if (statusBadgeEl) statusBadgeEl.className = pi.online ? 'badge' : 'badge off';
 
   // Proxy stats
   const p = d.proxy || {};
@@ -1281,6 +1392,7 @@ async function poll() {
   }
 
   renderRouting(d.routing || null);
+  renderEgressFromRouting(d.routing || null);
 
   // Egress / tunnel quality — fire-and-forget so a slow server-side ping/wg probe
   // never blocks rendering of the already-fetched masking/users data or stalls the
@@ -1299,48 +1411,41 @@ async function poll() {
     mc.style.display = '';
 
     const maskBadge = $('maskBadge');
+    const maskStatus = $('maskStatus');
+    const maskModeName = masking.enabled ? 'FakeTLS' : t('status.disabled');
     if (!masking.enabled) {
       maskBadge.className = 'badge off';
-      $('maskStatus').textContent = t('status.disabled');
+      maskStatus.textContent = maskModeName;
     } else if (masking.mode === 'remote') {
       maskBadge.className = 'badge';
-      $('maskStatus').textContent = t('status.remoteMode');
+      maskStatus.textContent = maskModeName;
     } else if (masking.healthy) {
       maskBadge.className = 'badge';
-      $('maskStatus').textContent = t('status.healthy');
+      maskStatus.textContent = maskModeName;
     } else {
       maskBadge.className = 'badge off';
-      $('maskStatus').textContent = t('status.needsAttention');
+      maskStatus.textContent = maskModeName;
     }
 
-    let modeText = masking.mode || '—';
-    if (masking.mode === 'remote') {
-      modeText = 'remote (' + (masking.tls_domain || '—') + ':443)';
-    } else if (masking.mode === 'custom') {
-      modeText = 'custom';
-    } else if (masking.mode === 'local' && masking.using_netns) {
-      modeText = 'local (netns)';
-    } else if (masking.mode === 'local') {
-      modeText = 'local';
-    }
-    $('maskMode').textContent = modeText;
+    const protectedText = LANG === 'ru' ? 'Защищено' : 'Protected';
+    const disabledText = LANG === 'ru' ? 'Выключено' : 'Disabled';
+    const activeText = LANG === 'ru' ? 'Активен' : 'Active';
+    const downText = LANG === 'ru' ? 'Отключён' : 'Down';
+    const timerOkText = LANG === 'ru' ? 'OK · каждые 30с' : 'OK · every 30s';
+    const modeText = masking.enabled
+      ? '<span class="signal-sq"></span>' + protectedText
+      : '<span class="signal-sq"></span>' + disabledText;
+    $('maskMode').innerHTML = modeText;
 
-    let endpointText = masking.target || '—';
-    if (masking.mode === 'local' || masking.mode === 'custom') {
-      if (masking.endpoint_ok === true) {
-        endpointText += ' (' + t('status.endpointOk') + ')';
-      } else if (masking.endpoint_ok === false) {
-        endpointText += ' (' + t('status.endpointDown') + ')';
-      }
-    }
+    let endpointText = masking.tls_domain ? (masking.tls_domain + ':443') : (masking.target || '—');
     $('maskTarget').textContent = endpointText;
 
-    const nginxState = (masking.nginx_active ? 'active' : 'down') + ' / ' +
-      (masking.nginx_enabled ? 'enabled' : 'disabled');
-    $('maskNginx').textContent = nginxState;
+    const nginxState = masking.nginx_active
+      ? '<span class="signal-sq"></span>' + activeText
+      : '<span class="signal-sq"></span>' + downText;
+    $('maskNginx').innerHTML = nginxState;
 
-    const timerState = (masking.health_timer_active ? 'active' : 'down') + ' / ' +
-      (masking.health_timer_enabled ? 'enabled' : 'disabled');
+    const timerState = masking.health_timer_active ? timerOkText : downText;
     $('maskTimer').textContent = timerState;
   }
 
@@ -1357,11 +1462,12 @@ function setStaleMode(stale) {
 }
 
 function updateFreshness() {
+  const lastUpdateEl = $('lastUpdate');
   if (!lastSuccessAt) {
-    $('lastUpdate').textContent = 'never';
+    if (lastUpdateEl) lastUpdateEl.textContent = 'never';
   } else {
     const age = Math.floor((Date.now() - lastSuccessAt) / 1000);
-    $('lastUpdate').textContent = age <= 0 ? 'just now' : age + 's ago';
+    if (lastUpdateEl) lastUpdateEl.textContent = age <= 0 ? 'just now' : age + 's ago';
   }
 
   if (pollingPaused) {
@@ -1404,6 +1510,7 @@ async function runPoll() {
     await poll();
     hasPollError = false;
     lastSuccessAt = Date.now();
+    appRoot.classList.remove('is-loading');
   } catch (e) {
     hasPollError = true;
     console.error(e);
@@ -1435,6 +1542,7 @@ $('pollInterval').addEventListener('change', (ev) => {
   const v = Number(ev.target.value);
   if (!v || v === pollIntervalMs) return;
   pollIntervalMs = v;
+  updateNetworkWindowLabel();
   restartPollingLoop();
   updateFreshness();
 });
@@ -1455,6 +1563,7 @@ if (langToggleBtn) {
 }
 applyStaticI18n();
 
+updateNetworkWindowLabel();
 updatePollControls();
 updateFreshness();
 setupAddUserForm();
@@ -1482,8 +1591,14 @@ function jumpToLatest() {
 }
 
 function updateAutoScrollButton() {
-  autoScrollBtn.textContent = autoScrollEnabled ? t('autoscroll.on') : t('autoscroll.off');
+  if (!autoScrollBtn) return;
+  const label = autoScrollBtn.querySelector('.log-ctl-label');
+  if (label) label.textContent = 'Auto-scroll';
+  else autoScrollBtn.textContent = 'Auto-scroll';
   autoScrollBtn.classList.toggle('active', autoScrollEnabled);
+  autoScrollBtn.setAttribute('aria-pressed', autoScrollEnabled ? 'true' : 'false');
+  autoScrollBtn.setAttribute('aria-label', autoScrollEnabled ? 'Auto-scroll on' : 'Auto-scroll off');
+  autoScrollBtn.title = autoScrollEnabled ? 'Auto-scroll on' : 'Auto-scroll off';
 }
 
 function shouldShowLine(el) {
@@ -1520,13 +1635,15 @@ logSearchInput.addEventListener('input', () => {
   applyAllLogFilters();
 });
 
-autoScrollBtn.addEventListener('click', () => {
-  autoScrollEnabled = !autoScrollEnabled;
-  if (autoScrollEnabled) jumpToLatest();
-  updateAutoScrollButton();
-});
+if (autoScrollBtn) {
+  autoScrollBtn.addEventListener('click', () => {
+    autoScrollEnabled = !autoScrollEnabled;
+    if (autoScrollEnabled) jumpToLatest();
+    updateAutoScrollButton();
+  });
+}
 
-jumpLatestBtn.addEventListener('click', jumpToLatest);
+if (jumpLatestBtn) jumpLatestBtn.addEventListener('click', jumpToLatest);
 updateAutoScrollButton();
 
 function addLine(d, anim) {

--- a/src/ctl/dashboard_assets/static/app.js
+++ b/src/ctl/dashboard_assets/static/app.js
@@ -2,17 +2,37 @@
 
 const $ = id => document.getElementById(id);
 
+// ── Icon set (inline SVG, currentColor, 24×24, butt caps / miter joins, angular
+// Zig-echo geometry) — replaces every emoji used as an icon. ──
+const ICON = {
+  'qr-share': '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="butt" stroke-linejoin="miter"><path d="M3 3 H9 V9 H3 Z"/><path d="M15 3 H21 V9 H15 Z"/><path d="M3 15 H9 V21 H3 Z"/><path d="M15 15 H18 V18 H15 Z"/><path d="M21 15 V21 H18"/><path d="M15 21 H15.01"/></svg>',
+  'copy': '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="butt" stroke-linejoin="miter"><path d="M9 9 H20 V20 H9 Z"/><path d="M5 15 H4 V4 H15 V5"/></svg>',
+  'delete': '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="butt" stroke-linejoin="miter"><path d="M4 6 H20"/><path d="M9 6 V4 H15 V6"/><path d="M6 6 L7 20 H17 L18 6"/><path d="M10 10 V16 M14 10 V16"/></svg>',
+  'plus': '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="butt" stroke-linejoin="miter"><path d="M12 5 V19 M5 12 H19"/></svg>',
+  'chevron-down': '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="butt" stroke-linejoin="miter"><polyline points="7,10 12,15 17,10"/></svg>',
+  'pause': '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="butt" stroke-linejoin="miter"><path d="M8 5 V19 M16 5 V19"/></svg>',
+  'play': '<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M7 5 L19 12 L7 19 Z"/></svg>',
+  'search': '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="butt" stroke-linejoin="miter"><path d="M5 5 H15 V15 H5 Z"/><path d="M15 15 L20 20"/></svg>',
+  'autoscroll': '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="butt" stroke-linejoin="miter"><polyline points="6,5 12,11 18,5"/><polyline points="6,11 12,17 18,11"/><path d="M5 20 H19"/></svg>',
+  'jump-latest': '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="butt" stroke-linejoin="miter"><path d="M12 4 V16"/><polyline points="6,11 12,17 18,11"/><path d="M5 20 H19"/></svg>',
+  'arrow-down': '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="butt" stroke-linejoin="miter"><path d="M12 4 V18"/><polyline points="6,12 12,18 18,12"/></svg>',
+  'arrow-up': '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="butt" stroke-linejoin="miter"><path d="M12 20 V6"/><polyline points="6,12 12,6 18,12"/></svg>',
+  'warning': '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="butt" stroke-linejoin="miter"><path d="M12 3 L22 20 H2 Z"/><path d="M12 10 V15"/><path d="M12 17.5 V17.6"/></svg>',
+  'send-plane': '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="butt" stroke-linejoin="miter"><path d="M21 3 L3 11 L10 13 L12 20 Z"/><path d="M21 3 L10 13"/></svg>',
+  'lang-globe': '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="butt" stroke-linejoin="miter"><path d="M4 6 H20 V18 H4 Z"/><path d="M4 12 H20"/><path d="M12 6 C9 9 9 15 12 18 C15 15 15 9 12 6 Z"/></svg>'
+};
+
 // ── i18n (EN/RU) ──────────────────────────────────────────────
 // Prose, labels and buttons are translated; technical proper nouns (MiddleProxy,
 // socks5, Nginx, RX/TX) stay as-is — that's normal bilingual UI, not code-switching.
 const I18N = {
   en: {
     'header.refresh': 'Refresh', 'header.uptime': 'Uptime', 'header.lastUpdate': 'Last update',
-    'card.cpu': '⬡ CPU', 'card.cpuSub': 'utilization', 'card.memory': '◈ Memory', 'card.network': '◎ Network Throughput',
+    'card.cpu': 'CPU', 'card.cpuSub': 'utilization', 'card.memory': 'Memory', 'card.network': 'Network Throughput',
     'stats.activeOf': 'Active /', 'stats.handshakes': 'Handshakes', 'stats.total': 'Total Connections',
-    'users.title': '👥 Users', 'users.add': '+ Add User', 'users.who': 'Who is this for?',
+    'users.title': 'Users', 'users.add': '+ Add User', 'users.who': 'Who is this for?',
     'users.secret': 'Secret', 'users.secretHint': '(leave empty to auto-generate)',
-    'users.namePh': 'e.g. Мама, dad, work 💼', 'users.secretPh': "Leave blank — we'll create one for you",
+    'users.namePh': 'e.g. Мама, dad, work', 'users.secretPh': "Leave blank — we'll create one for you",
     'btn.create': 'Create', 'btn.cancel': 'Cancel', 'btn.apply': 'Apply', 'btn.pin': 'Pin', 'btn.setTarget': 'Set target', 'btn.delete': 'Delete', 'btn.close': 'Close',
     'routing.title': 'Routing & Upstream', 'routing.upstream': 'Upstream', 'routing.tunnelPin': 'Tunnel pin',
     'routing.proxyHost': 'Proxy host', 'routing.port': 'Port', 'routing.user': 'User', 'routing.pass': 'Pass', 'routing.target': 'Target', 'routing.policy': 'Policy',
@@ -22,7 +42,7 @@ const I18N = {
     'egress.good': 'Good', 'egress.degraded': 'Degraded', 'egress.poor': 'Poor', 'egress.up': 'Up', 'egress.down': 'Down', 'egress.unknown': 'Unknown',
     'egress.primary': 'primary', 'egress.bottleneck': 'Tunnel is the bottleneck',
     'egress.notMonitored': 'Not monitored (not in tunnel mode)',
-    'logs.title': '▸ Live Logs', 'logs.error': 'Error', 'logs.warn': 'Warn', 'logs.stats': 'Stats', 'logs.searchPh': 'Search logs', 'logs.jumpLatest': 'Jump to latest',
+    'logs.title': 'Live Logs', 'logs.error': 'Error', 'logs.warn': 'Warn', 'logs.stats': 'Stats', 'logs.searchPh': 'Search logs', 'logs.jumpLatest': 'Jump to latest',
     'modal.deleteUser': 'Delete User', 'modal.deleteTunnel': 'Delete Tunnel', 'modal.restartNote': 'The proxy will be restarted to apply changes.',
     'share.subtitle': 'Point their phone camera at this code to connect.', 'share.copyLink': 'Copy link', 'share.send': 'Send', 'share.with': 'Share with',
     'status.online': 'Online', 'status.offline': 'Offline', 'status.stuck': 'Stuck',
@@ -37,11 +57,11 @@ const I18N = {
   },
   ru: {
     'header.refresh': 'Обновление', 'header.uptime': 'Аптайм', 'header.lastUpdate': 'Обновлено',
-    'card.cpu': '⬡ CPU', 'card.cpuSub': 'загрузка', 'card.memory': '◈ Память', 'card.network': '◎ Сетевой трафик',
+    'card.cpu': 'CPU', 'card.cpuSub': 'загрузка', 'card.memory': 'Память', 'card.network': 'Сетевой трафик',
     'stats.activeOf': 'Активно /', 'stats.handshakes': 'Подключаются', 'stats.total': 'Всего подключений',
-    'users.title': '👥 Пользователи', 'users.add': '+ Добавить', 'users.who': 'Для кого это?',
+    'users.title': 'Пользователи', 'users.add': '+ Добавить', 'users.who': 'Для кого это?',
     'users.secret': 'Секрет', 'users.secretHint': '(пусто — сгенерируем сами)',
-    'users.namePh': 'напр. Мама, папа, работа 💼', 'users.secretPh': 'Оставьте пустым — создадим сами',
+    'users.namePh': 'напр. Мама, папа, работа', 'users.secretPh': 'Оставьте пустым — создадим сами',
     'btn.create': 'Создать', 'btn.cancel': 'Отмена', 'btn.apply': 'Применить', 'btn.pin': 'Закрепить', 'btn.setTarget': 'Задать', 'btn.delete': 'Удалить', 'btn.close': 'Закрыть',
     'routing.title': 'Маршрутизация и выход', 'routing.upstream': 'Выход', 'routing.tunnelPin': 'Туннель',
     'routing.proxyHost': 'Хост прокси', 'routing.port': 'Порт', 'routing.user': 'Логин', 'routing.pass': 'Пароль', 'routing.target': 'Цель', 'routing.policy': 'Политика',
@@ -51,7 +71,7 @@ const I18N = {
     'egress.good': 'Хорошо', 'egress.degraded': 'Деградация', 'egress.poor': 'Плохо', 'egress.up': 'Включён', 'egress.down': 'Отключён', 'egress.unknown': 'Неизвестно',
     'egress.primary': 'основной', 'egress.bottleneck': 'Туннель — узкое место',
     'egress.notMonitored': 'Не отслеживается (не режим туннеля)',
-    'logs.title': '▸ Логи', 'logs.error': 'Ошибки', 'logs.warn': 'Предупр.', 'logs.stats': 'Статы', 'logs.searchPh': 'Поиск в логах', 'logs.jumpLatest': 'К последним',
+    'logs.title': 'Логи', 'logs.error': 'Ошибки', 'logs.warn': 'Предупр.', 'logs.stats': 'Статы', 'logs.searchPh': 'Поиск в логах', 'logs.jumpLatest': 'К последним',
     'modal.deleteUser': 'Удалить пользователя', 'modal.deleteTunnel': 'Удалить туннель', 'modal.restartNote': 'Прокси будет перезапущен для применения изменений.',
     'share.subtitle': 'Наведите камеру их телефона на этот код, чтобы подключиться.', 'share.copyLink': 'Скопировать ссылку', 'share.send': 'Отправить', 'share.with': 'Поделиться с',
     'status.online': 'Онлайн', 'status.offline': 'Офлайн', 'status.stuck': 'Завис',
@@ -141,7 +161,7 @@ function setGauge(arcId, pctId, val) {
   // the status hero, so the dial earns its colour from the value band instead.
   const col = v < 60 ? 'var(--signal-go)' : (v < 85 ? 'var(--signal-caution)' : 'var(--signal-stop)');
   $(arcId).style.stroke = col;
-  $(pctId).textContent = val + '%';
+  $(pctId).textContent = val;   // unit "%" is a separate .gauge-unit element
 }
 
 // ── Network chart ──
@@ -411,25 +431,22 @@ function showToast(msg, type) {
 function setStatusHero(online, active, state) {
   const el = $('statusHero'), icon = $('statusHeroIcon'), txt = $('statusHeroText');
   if (!el) return;
+  // Paper hero: fixed surface-1 panel; only the signal square (#statusHeroIcon,
+  // background:currentColor) + verdict text take the state colour, which they
+  // inherit from the hero's color. No translucent bg, no glyph.
+  el.style.background = '';
+  if (icon) icon.textContent = '';
   if (!online) {
-    el.style.background = 'rgba(255,80,80,0.10)';
-    el.style.color = 'var(--red,#ff6b6b)';
-    icon.textContent = '✖';
+    el.style.color = 'var(--signal-stop)';
     txt.textContent = t('hero.offline');
   } else if (state === 'stalled') {
-    el.style.background = 'rgba(240,180,40,0.12)';
-    el.style.color = 'var(--amber,#f0b428)';
-    icon.textContent = '!';
+    el.style.color = 'var(--signal-caution)';
     txt.textContent = t('hero.stalled');
   } else if (active > 0) {
-    el.style.background = 'rgba(80,220,120,0.10)';
-    el.style.color = 'var(--green,#46d369)';
-    icon.textContent = '✓';
+    el.style.color = 'var(--accent)';
     txt.textContent = t('hero.busy').replace('{n}', active);
   } else {
-    el.style.background = 'rgba(80,220,120,0.08)';
-    el.style.color = 'var(--green,#46d369)';
-    icon.textContent = '✓';
+    el.style.color = 'var(--signal-go)';
     txt.textContent = t('hero.idle');
   }
 }
@@ -737,10 +754,10 @@ function renderUsers(users, perUserActive, proxyStats) {
       '<div class="user-route">' + directToggle + '</div>' +
       '<div class="user-link" title="' + esc(tg || tme || (isEnabled ? 'link unavailable' : 'disabled')) + '">' + esc(preview) + '</div>' +
       '<div class="user-actions">' +
-      '<button class="ui-btn user-share" type="button" data-link="' + tmeData + '" data-name="' + userName + '" data-label="' + displayName + '"' + (tme && isEnabled ? '' : ' disabled') + '>📲 Share</button>' +
-      '<button class="ui-btn user-copy" type="button" data-link="' + tgData + '"' + (tg && isEnabled ? '' : ' disabled') + '>Copy tg://</button>' +
-      '<button class="ui-btn user-copy" type="button" data-link="' + tmeData + '"' + (tme && isEnabled ? '' : ' disabled') + '>Copy t.me</button>' +
-      '<button class="ui-btn danger user-delete" type="button" data-user="' + userName + '" title="Delete user">✕</button>' +
+      '<button class="ui-btn user-share" type="button" data-link="' + tmeData + '" data-name="' + userName + '" data-label="' + displayName + '"' + (tme && isEnabled ? '' : ' disabled') + ' title="Share via QR">' + ICON['qr-share'] + '</button>' +
+      '<button class="ui-btn user-copy" type="button" data-link="' + tgData + '"' + (tg && isEnabled ? '' : ' disabled') + ' title="Copy tg:// link">tg://</button>' +
+      '<button class="ui-btn user-copy" type="button" data-link="' + tmeData + '"' + (tme && isEnabled ? '' : ' disabled') + ' title="Copy t.me link">t.me</button>' +
+      '<button class="ui-btn danger user-delete" type="button" data-user="' + userName + '" title="Delete user">' + ICON['delete'] + '</button>' +
       '</div>' +
       '</div>';
   }).join('');
@@ -1109,18 +1126,20 @@ function renderRouting(routing) {
     const canDelete = inPool || t.config_present || t.link_up || iface.startsWith('awg') || iface.startsWith('wg');
 
     return '<div class="routing-row">' +
-      '<div class="routing-iface">' + esc(iface) +
-      (isSelected ? '<span class="routing-tag">active</span>' : '') +
-      (isPinned ? '<span class="routing-tag">pinned</span>' : '') +
+      '<div class="routing-row-top">' +
+        '<div class="routing-iface"><span class="routing-iface-name">' + esc(iface) + '</span>' +
+        (isSelected ? '<span class="routing-tag">active</span>' : '') +
+        (isPinned ? '<span class="routing-tag">pinned</span>' : '') +
+        '</div>' +
+        '<div class="routing-state ' + stateClass + '">' + esc(state) + '</div>' +
       '</div>' +
-      '<div class="routing-state ' + stateClass + '">' + esc(state) + '</div>' +
-      '<div class="routing-meta" title="' + esc(meta.join(' · ')) + '">' + esc(meta.join(' · ')) + '</div>' +
-      '<div class="routing-xfer">' + esc(xfer) + '</div>' +
-      '<div class="routing-actions">' +
+      '<div class="routing-row-bottom">' +
+        '<div class="routing-meta" title="' + esc(meta.join(' · ')) + '">' + esc(meta.join(' · ')) + '</div>' +
+        '<div class="routing-xfer">' + esc(xfer) + '</div>' +
+      '</div>' +
       (canDelete
-        ? '<button class="ui-btn danger routing-delete" type="button" data-iface="' + esc(iface) + '" aria-label="Delete tunnel ' + esc(iface) + '">Delete</button>'
+        ? '<div class="routing-actions"><button class="ui-btn danger routing-delete" type="button" data-iface="' + esc(iface) + '" aria-label="Delete tunnel ' + esc(iface) + '">' + ICON['delete'] + '</button></div>'
         : '') +
-      '</div>' +
       '</div>';
   }).join('');
 
@@ -1175,22 +1194,24 @@ function renderEgress(egress) {
     // Color code quality (good, degraded, poor, up, down, unknown)
     const qualityClass = 'egress-quality-' + quality;
     const qualityLabel = t('egress.' + quality) || quality;
+    const _barPct = { good: 22, degraded: 72, poor: 92, up: 10, down: 100, unknown: 8 };
+    const barPct = _barPct[quality] != null ? _barPct[quality] : 8;
 
     // "Tunnel is the bottleneck" hint when quality is degraded/poor.
     const isBottleneck = quality === 'degraded' || quality === 'poor';
     const bottleneck = isBottleneck
-      ? '<div class="egress-bottleneck" title="' + t('egress.bottleneck') + '">⚠ ' + t('egress.bottleneck') + '</div>'
+      ? '<div class="egress-bottleneck" title="' + t('egress.bottleneck') + '">' + ICON['warning'] + '<span>' + t('egress.bottleneck') + '</span></div>'
       : '';
 
-    return '<div class="egress-row' + (isBottleneck ? ' is-bottleneck' : '') + '">' +
-      '<div class="egress-iface">' + iface +
-      (isPrimary ? '<span class="routing-tag">' + t('egress.primary') + '</span>' : '') +
+    return '<div class="egress-row' + (isBottleneck ? ' is-bottleneck' : '') + ' q-' + quality + '">' +
+      '<div class="egress-row-top">' +
+        '<div class="egress-iface q-' + quality + '"><span class="signal-sq"></span><span class="egress-iface-name">' + iface + '</span>' +
+        (isPrimary ? '<span class="routing-tag">' + t('egress.primary') + '</span>' : '') +
+        '</div>' +
+        '<div class="egress-quality ' + qualityClass + '">' + qualityLabel + '</div>' +
       '</div>' +
-      '<div class="egress-status ' + (tun.up ? 'on' : 'off') + '">' + (tun.up ? t('status.online') : t('status.offline')) + '</div>' +
-      '<div class="egress-quality ' + qualityClass + '">' + qualityLabel + '</div>' +
-      '<div class="egress-rtt" title="' + t('egress.rtt') + '">' + rttText + '</div>' +
-      '<div class="egress-loss" title="' + t('egress.loss') + '">' + lossText + '</div>' +
-      '<div class="egress-hs" title="' + t('egress.handshake') + '">' + hsText + '</div>' +
+      '<div class="egress-metrics"><div class="egress-stats">' + rttText + ' · ' + lossText + ' loss · hs ' + hsText + '</div></div>' +
+      '<div class="egress-bar"><div class="egress-bar-fill q-' + quality + '" style="width:' + barPct + '%"></div></div>' +
       bottleneck +
       '</div>';
   }).join('');
@@ -1366,8 +1387,12 @@ function updateFreshness() {
 }
 
 function updatePollControls() {
-  $('pollToggle').textContent = pollingPaused ? t('btn.resume') : t('btn.pause');
-  $('pollToggle').classList.toggle('active', !pollingPaused);
+  const btn = $('pollToggle');
+  // .icon-btn hides text (font-size:0); show a play/pause SVG instead.
+  btn.innerHTML = pollingPaused ? ICON.play : ICON.pause;
+  btn.title = pollingPaused ? t('btn.resume') : t('btn.pause');
+  btn.setAttribute('aria-label', btn.title);
+  btn.classList.toggle('active', !pollingPaused);
 }
 
 async function runPoll() {

--- a/src/ctl/dashboard_assets/static/index.html
+++ b/src/ctl/dashboard_assets/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>⚡ MTProto Proxy — Dashboard</title>
   <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/style.css?v=20260609">
+  <link rel="stylesheet" href="/style.css?v=20260609b">
 </head>
 <body>
 <div class="app">

--- a/src/ctl/dashboard_assets/static/index.html
+++ b/src/ctl/dashboard_assets/static/index.html
@@ -31,7 +31,7 @@
     <div class="badge data-badge syncing" id="dataBadge"><span class="sig-sq"></span><span id="dataBadgeText">Syncing...</span></div>
 
     <!-- language toggle (EN/RU). JS sets textContent to the OTHER lang -->
-    <button id="langToggle" class="ui-btn lang-toggle" type="button" title="Language / Язык">RU</button>
+    <div id="langToggle" class="lang-seg" role="button" tabindex="0" title="Language / Язык"><span class="lang-cell" data-lang="en">EN</span><span class="lang-cell" data-lang="ru">RU</span></div>
 
     <!-- poll controls: REFRESH eyebrow + interval select + pause/resume -->
     <div class="poll-controls">
@@ -60,6 +60,17 @@
         <span id="statusHeroIcon"></span>
         <span id="statusHeroText" data-i18n="hero.checking">Checking…</span>
         <span class="hero-cursor" aria-hidden="true"></span>
+      </div>
+      <span class="hero-sub" id="statusHeroSub"></span>
+    </div>
+    <div class="hero-figures">
+      <div class="hero-fig">
+        <span class="hero-fig-label" data-i18n="hero.connected">CONNECTED</span>
+        <span class="hero-fig-val" id="heroConnected">0</span>
+      </div>
+      <div class="hero-fig hero-fig-div">
+        <span class="hero-fig-label" data-i18n="hero.uptimeLbl">UPTIME</span>
+        <span class="hero-fig-val mono" id="heroUptime">—</span>
       </div>
     </div>
   </div>

--- a/src/ctl/dashboard_assets/static/index.html
+++ b/src/ctl/dashboard_assets/static/index.html
@@ -3,132 +3,218 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>⚡ MTProto Proxy — Dashboard</title>
+  <title>MTProto Proxy — Dashboard</title>
   <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/style.css?v=20260609b">
+  <link rel="stylesheet" href="/style.css?v=20260610">
 </head>
 <body>
 <div class="app">
-
-  <!-- Header -->
-  <div class="header">
-    <div class="header-left">
-      <div class="zig-logo">
-        <img src="/logo.svg" alt="Zig" width="44" height="44">
-      </div>
-      <h1>
-        <span class="accent">MTProto</span>Proxy
-        <span class="dim">dashboard</span>
-        <span class="version-pill" id="dashboardVersion"></span>
-      </h1>
-    </div>
-    <div class="header-right">
-      <div class="badge" id="statusBadge"><div class="pulse-dot"></div><span id="proxyUp">—</span></div>
-      <div class="badge data-badge syncing" id="dataBadge"><div class="pulse-dot"></div><span id="dataBadgeText">Syncing...</span></div>
-      <button id="langToggle" class="ui-btn" type="button" title="Language / Язык">RU</button>
-      <div class="poll-controls">
-        <label for="pollInterval" data-i18n="header.refresh">Refresh</label>
-        <select id="pollInterval" class="ui-select">
-          <option value="1000">1s</option>
-          <option value="3000" selected>3s</option>
-          <option value="5000">5s</option>
-          <option value="10000">10s</option>
-        </select>
-        <button id="pollToggle" class="ui-btn" type="button" data-i18n="btn.pause">Pause</button>
-      </div>
-      <div class="meta">PID <b id="proxyPid">—</b> · <b id="proxyRss">—</b></div>
-      <div class="meta"><span data-i18n="header.uptime">Uptime</span> <b id="srvUptime">—</b></div>
-      <div class="meta"><span data-i18n="header.lastUpdate">Last update</span> <b id="lastUpdate">never</b></div>
+<!-- ============================================================= -->
+<!-- TOPBAR (bus-bar) -->
+<!-- ============================================================= -->
+<div class="topbar">
+  <div class="topbar-brand">
+    <span class="zig-logo">
+      <img src="/logo.svg" alt="Zig" width="28" height="28">
+    </span>
+    <div class="topbar-wordmark">
+      <span class="wm"><span class="accent">MTProto</span><span class="dim">Proxy</span></span>
+      <span class="version-pill" id="dashboardVersion"></span>
     </div>
   </div>
 
-  <!-- Status hero: the one-glance "is everything OK?" answer -->
-  <div id="statusHero" style="margin:0 0 16px;padding:14px 18px;border-radius:10px;display:flex;align-items:center;gap:12px;font-size:15px;font-weight:600;border:1px solid var(--border);background:rgba(127,127,127,0.06);">
-    <span id="statusHeroIcon" style="font-size:20px;">•</span>
-    <span id="statusHeroText" data-i18n="hero.checking">Checking…</span>
-  </div>
+  <div class="topbar-right">
+    <!-- proxy online/offline status: signal-square + word -->
+    <div class="badge" id="statusBadge"><span class="sig-sq"></span><span id="proxyUp">—</span></div>
 
-  <!-- Metrics -->
-  <div class="grid">
-    <!-- CPU -->
-    <div class="card col-3">
-      <div class="card-label" data-i18n="card.cpu">⬡ CPU</div>
+    <!-- data freshness badge (not in Paper mock but id is required) -->
+    <div class="badge data-badge syncing" id="dataBadge"><span class="sig-sq"></span><span id="dataBadgeText">Syncing...</span></div>
+
+    <!-- language toggle (EN/RU). JS sets textContent to the OTHER lang -->
+    <button id="langToggle" class="ui-btn lang-toggle" type="button" title="Language / Язык">RU</button>
+
+    <!-- poll controls: REFRESH eyebrow + interval select + pause/resume -->
+    <div class="poll-controls">
+      <label for="pollInterval" data-i18n="header.refresh">Refresh</label>
+      <select id="pollInterval" class="ui-select poll-select">
+        <option value="1000">1s</option>
+        <option value="3000" selected>3s</option>
+        <option value="5000">5s</option>
+        <option value="10000">10s</option>
+      </select>
+      <button id="pollToggle" class="ui-btn poll-toggle icon-btn" type="button" aria-label="Pause polling">Pause</button>
+    </div>
+
+    <!-- telemetry crawl: mono, text-low -->
+    <div class="meta telemetry">PID <b id="proxyPid">—</b> · RSS <b id="proxyRss">—</b> · UP <b id="srvUptime">—</b> · UPD <b id="lastUpdate">never</b></div>
+  </div>
+</div>
+
+<!-- ============================================================= -->
+<!-- STATUS HERO (sodium-lamp verdict) -->
+<!-- ============================================================= -->
+<div class="hero-section">
+  <div id="statusHero">
+    <div class="hero-verdict">
+      <div class="hero-verdict-top">
+        <span id="statusHeroIcon"></span>
+        <span id="statusHeroText" data-i18n="hero.checking">Checking…</span>
+        <span class="hero-cursor" aria-hidden="true"></span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════════════════════════════════
+     KPI BAND — Paper "Gauges-group" (CPU + MEM, hairline-divided) + Network well.
+     NOTE (Paper 1:1): NOT one outer surface container. It is a flex row, gap 24:
+       (a) .kpi-gauges  = grow 2  → CPU instrument | MEM instrument (hairline between)
+       (b) .kpi-network = grow 1.8 → the sunk well (#0C0F13), its own steel/hair border.
+     Horizontal gutters come from .app (max-width 1360, 32px padding); no px-48 here.
+     ══════════════════════════════════════════════════════════════════════ -->
+<div class="kpi-band">
+
+  <!-- CPU + MEMORY instruments share the open board, divided by a hairline -->
+  <div class="kpi-gauges">
+
+    <!-- CPU instrument -->
+    <div class="instrument" id="cpuInstrument">
+      <div class="instrument-masthead">
+        <span class="card-label" data-i18n="card.cpu">CPU</span>
+        <span class="instrument-meta">peak <span id="cpuPeak">—</span></span>
+      </div>
       <div class="gauge-container">
         <div class="gauge">
-          <svg viewBox="0 0 36 36">
+          <svg class="gauge-arc" viewBox="0 0 36 36" aria-hidden="true">
             <circle class="track" cx="18" cy="18" r="15"/>
             <circle class="fill" id="cpuArc" cx="18" cy="18" r="15"/>
           </svg>
-          <div class="pct" style="color:var(--zig)" id="cpuPct">0%</div>
-        </div>
-        <div>
-          <div class="card-value" style="color:var(--text)" id="cpuVal">0<span style="font-size:18px;font-weight:400">%</span></div>
-          <div class="card-sub" data-i18n="card.cpuSub">utilization</div>
+          <svg class="gauge-ticks" viewBox="0 0 36 36" aria-hidden="true">
+            <line x1="6.61" y1="29.39" x2="5.62" y2="30.38"/>
+            <line x1="18" y1="2.5" x2="18" y2="1.1"/>
+            <line x1="29.39" y1="29.39" x2="30.38" y2="30.38"/>
+          </svg>
+          <div class="gauge-readout">
+            <div class="pct" id="cpuPct">0%</div>
+            <div class="gauge-unit">%</div>
+          </div>
+          <!-- preserved JS targets; kept off-screen so the Paper single-number dial reads clean -->
+          <div class="gauge-val-hidden card-value" id="cpuVal">0<span style="font-size:18px;font-weight:400">%</span></div>
         </div>
       </div>
       <div class="spark-wrap"><canvas id="cpuSpark"></canvas></div>
     </div>
 
-    <!-- Memory -->
-    <div class="card col-3">
-      <div class="card-label" data-i18n="card.memory">◈ Memory</div>
+    <!-- MEMORY instrument -->
+    <div class="instrument" id="memInstrument">
+      <div class="instrument-masthead">
+        <span class="card-label" data-i18n="card.memory">Memory</span>
+        <span class="instrument-meta" id="memSub">— / — MB</span>
+      </div>
       <div class="gauge-container">
         <div class="gauge">
-          <svg viewBox="0 0 36 36">
+          <svg class="gauge-arc" viewBox="0 0 36 36" aria-hidden="true">
             <circle class="track" cx="18" cy="18" r="15"/>
             <circle class="fill" id="memArc" cx="18" cy="18" r="15"/>
           </svg>
-          <div class="pct" style="color:var(--purple)" id="memPct">0%</div>
-        </div>
-        <div>
-          <div class="card-value" style="color:var(--text)" id="memVal">0<span style="font-size:14px;font-weight:400"> MB</span></div>
-          <div class="card-sub" id="memSub">— / — MB</div>
+          <svg class="gauge-ticks" viewBox="0 0 36 36" aria-hidden="true">
+            <line x1="6.61" y1="29.39" x2="5.62" y2="30.38"/>
+            <line x1="18" y1="2.5" x2="18" y2="1.1"/>
+            <line x1="29.39" y1="29.39" x2="30.38" y2="30.38"/>
+          </svg>
+          <div class="gauge-readout">
+            <div class="pct" id="memPct">0%</div>
+            <div class="gauge-unit">%</div>
+          </div>
+          <div class="gauge-val-hidden card-value" id="memVal">0<span style="font-size:14px;font-weight:400"> MB</span></div>
         </div>
       </div>
       <div class="spark-wrap"><canvas id="memSpark"></canvas></div>
     </div>
 
-    <!-- Network -->
-    <div class="card col-6">
-      <div class="card-label" data-i18n="card.network">◎ Network Throughput</div>
-      <div class="chart-wrap"><canvas id="netChart"></canvas></div>
-      <div class="chart-legend">
-        <span><div class="ldot" style="background:var(--blue)"></div>RX <b id="rxRate">—</b></span>
-        <span><div class="ldot" style="background:var(--zig)"></div>TX <b id="txRate">—</b></span>
-        <span style="margin-left:auto">↓<b id="rxTotal">—</b> ↑<b id="txTotal">—</b></span>
-      </div>
-    </div>
   </div>
 
-  <!-- Proxy stats -->
-  <div class="stat-row">
-    <div class="stat-cell">
-      <div class="val" style="color:var(--green)" id="pxActive">0</div>
-      <div class="lbl"><span data-i18n="stats.activeOf">Active /</span> <span id="pxMax">0</span></div>
+  <!-- NETWORK throughput well -->
+  <div class="kpi-network">
+    <div class="instrument-masthead">
+      <span class="card-label" data-i18n="card.network">Network Throughput</span>
+      <span class="card-label net-window">LAST 60S</span>
     </div>
-    <div class="stat-cell">
-      <div class="val" style="color:var(--cyan)" id="pxHs">0</div>
-      <div class="lbl" data-i18n="stats.handshakes">Handshakes</div>
+    <div class="net-legend">
+      <span class="net-legend-item">
+        <i class="ldot" style="background:var(--rx)"></i>
+        <span class="net-legend-tag">RX</span>
+        <span class="net-legend-val">
+          <!--ICON:arrow-down--><svg class="net-arrow" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="var(--rx)" stroke-width="2.2" stroke-linecap="butt" stroke-linejoin="miter"><line x1="12" y1="5" x2="12" y2="17"/><polyline points="6,12 12,18 18,12"/></svg>
+          <b id="rxRate">—</b>
+        </span>
+      </span>
+      <span class="net-legend-item">
+        <i class="ldot" style="background:var(--tx)"></i>
+        <span class="net-legend-tag">TX</span>
+        <span class="net-legend-val">
+          <!--ICON:arrow-up--><svg class="net-arrow" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="var(--tx)" stroke-width="2.2" stroke-linecap="butt" stroke-linejoin="miter"><line x1="12" y1="7" x2="12" y2="19"/><polyline points="6,12 12,6 18,12"/></svg>
+          <b id="txRate">—</b>
+        </span>
+      </span>
+      <span class="net-legend-totals">
+        <span class="net-total">
+          <!--ICON:arrow-down--><svg class="net-arrow dim" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="butt" stroke-linejoin="miter"><line x1="12" y1="5" x2="12" y2="17"/><polyline points="6,12 12,18 18,12"/></svg>
+          <b id="rxTotal">—</b>
+        </span>
+        <span class="net-total">
+          <!--ICON:arrow-up--><svg class="net-arrow dim" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="butt" stroke-linejoin="miter"><line x1="12" y1="7" x2="12" y2="19"/><polyline points="6,12 12,6 18,12"/></svg>
+          <b id="txTotal">—</b>
+        </span>
+      </span>
     </div>
-    <div class="stat-cell">
-      <div class="val" style="color:var(--text)" id="pxTotal">0</div>
-      <div class="lbl" data-i18n="stats.total">Total Connections</div>
-    </div>
-    <div class="stat-cell">
-      <div class="val" id="pxDrops" style="color:var(--text-muted)">0</div>
-      <div class="lbl" id="pxDropLbl">Drops</div>
-    </div>
+    <div class="chart-wrap"><canvas id="netChart"></canvas></div>
   </div>
 
-  <!-- Users -->
+</div>
+
+<!-- ══════════════════════════════════════════════════════════════════════
+     STAT STRIP — one surface-1 bar, 4 flex cells divided by steel hairlines.
+     ══════════════════════════════════════════════════════════════════════ -->
+<div class="stat-row">
+  <div class="stat-cell">
+    <div class="stat-val-line">
+      <span class="val" id="pxActive" style="color:var(--signal-go)">0</span>
+      <span class="stat-val-sub">/ <span id="pxMax">0</span></span>
+    </div>
+    <div class="lbl" data-i18n="stats.activeOf">ACTIVE / MAX</div>
+  </div>
+  <div class="stat-cell">
+    <div class="stat-val-line">
+      <span class="val" id="pxHs" style="color:var(--text-hi)">0</span>
+    </div>
+    <div class="lbl" data-i18n="stats.handshakes">HANDSHAKES</div>
+  </div>
+  <div class="stat-cell">
+    <div class="stat-val-line">
+      <span class="val" id="pxTotal" style="color:var(--text-hi)">0</span>
+    </div>
+    <div class="lbl" data-i18n="stats.total">TOTAL CONNECTIONS</div>
+  </div>
+  <div class="stat-cell">
+    <div class="stat-val-line">
+      <span class="val" id="pxDrops" style="color:var(--text-mid)">0</span>
+    </div>
+    <div class="lbl" id="pxDropLbl">DROPS</div>
+  </div>
+</div>
+
+<div class="body-grid">
+  <div class="body-left">
+<!-- Users -->
   <div class="users-card" id="usersCard" style="display:none">
-    <div class="users-head">
-      <div class="title" data-i18n="users.title">👥 Users</div>
-      <div class="users-head-right">
-        <div class="users-meta" id="usersMeta">—</div>
-        <button class="ui-btn add-user-btn" id="addUserBtn" type="button" data-i18n="users.add">+ Add User</button>
-      </div>
+    <!-- MASTHEAD: eyebrow flush-left · flex:1 hairline rule · right-aligned mono meta (no icon, no button here) -->
+    <div class="users-head section-masthead">
+      <div class="title" data-i18n="users.title">Users</div>
+      <div class="masthead-rule"></div>
+      <div class="users-meta" id="usersMeta">—</div>
     </div>
+
     <div class="users-note" id="usersNote">—</div>
 
     <!-- Add user form (hidden by default) -->
@@ -136,7 +222,7 @@
       <div class="form-row">
         <div class="form-field">
           <label data-i18n="users.who">Who is this for?</label>
-          <input id="newUserName" class="ui-input" type="text" data-i18n-ph="users.namePh" placeholder="e.g. Мама, dad, work 💼" autocomplete="off">
+          <input id="newUserName" class="ui-input" type="text" data-i18n-ph="users.namePh" placeholder="e.g. Мама, dad, work" autocomplete="off">
         </div>
         <div class="form-field">
           <label><span data-i18n="users.secret">Secret</span> <span class="form-hint" data-i18n="users.secretHint">(leave empty to auto-generate)</span></label>
@@ -151,19 +237,73 @@
     </div>
 
     <div class="users-list" id="usersList"></div>
+
+    <!-- Add-user action moved BELOW the list (Paper AddUser-wrap). #addUserBtn id preserved. -->
+    <div class="add-user-wrap">
+      <button class="ui-btn add-user-btn" id="addUserBtn" type="button"><!--ICON:plus--><span data-i18n="users.add">Add user</span></button>
+    </div>
   </div>
 
-  <!-- Routing & upstream -->
-  <div class="tunnel-card" id="routingCard" style="display:none">
-    <div class="tunnel-header">
-      <div class="tunnel-icon">🧭</div>
-      <div class="tunnel-title" data-i18n="routing.title">Routing &amp; Upstream</div>
-      <div class="badge" id="routingBadge"><div class="pulse-dot"></div><span id="routingStatus">—</span></div>
+<!-- ================= LIVE LOGS ================= -->
+<!-- This block lives inside the LEFT column of the body row, directly after the Users section.
+     Container keeps NO old card chrome (transparent, open section). -->
+<section class="logs-card" id="logsSection">
+
+  <!-- Masthead: eyebrow + steel rule + ws-badge (right) -->
+  <div class="logs-header section-masthead">
+    <span class="masthead-eyebrow" data-i18n="logs.title">Live Logs</span>
+    <span class="masthead-rule"></span>
+    <div class="ws-badge">
+      <span class="ws-dot off" id="wsDot"></span>
+      <span id="wsLabel">connecting…</span>
     </div>
-    <div class="routing-controls">
-      <button class="ui-btn" id="routingMiddleBtn" type="button">MiddleProxy: —</button>
-      <div class="routing-upstream-ctl">
-        <label for="routingUpstreamSelect" data-i18n="routing.upstream">Upstream</label>
+  </div>
+
+  <!-- Controls: level filter chips + search + auto-scroll + jump-latest -->
+  <div class="logs-controls">
+    <div class="log-filters">
+      <button class="ui-btn log-filter active" type="button" data-filter="error" data-i18n="logs.error">Error</button>
+      <button class="ui-btn log-filter active" type="button" data-filter="warn" data-i18n="logs.warn">Warn</button>
+      <button class="ui-btn log-filter active" type="button" data-filter="stats" data-i18n="logs.stats">Stats</button>
+    </div>
+    <div class="log-search-box">
+      <!--ICON:search-->
+      <input id="logSearch" class="log-search" type="search" data-i18n-ph="logs.searchPh" placeholder="Search logs" autocomplete="off">
+    </div>
+    <button class="ui-btn log-ctl-btn active" id="autoScrollBtn" type="button"><!--ICON:autoscroll--><span class="log-ctl-label">Auto-scroll: on</span></button>
+    <button class="ui-btn log-ctl-btn" id="jumpLatestBtn" type="button"><!--ICON:jump-latest--><span class="log-ctl-label" data-i18n="logs.jumpLatest">Jump to latest</span></button>
+  </div>
+
+  <!-- Sunk well: JS appends .log-line rows via addLine() -->
+  <div class="logs-body" id="logsBody"></div>
+
+</section>
+  </div>
+  <div class="body-rail">
+<!-- ════════════════ RIGHT RAIL ════════════════ -->
+<!-- These three sections live inside the Body row's right column:
+     <div class="body-row"> ... <div class="right-rail"> [PASTE HERE] </div> </div>
+     The .right-rail wrapper is owned by the Body-layout section; only the three
+     cards below belong to THIS part. Each card is an open "section" (no glass box):
+     a masthead (eyebrow + hairline rule + optional right meta/badge) then content. -->
+
+<!-- ── ROUTING & UPSTREAM ── -->
+<div class="rail-section" id="routingCard" style="display:none">
+  <div class="masthead">
+    <div class="masthead-eyebrow" data-i18n="routing.title">Routing &amp; Upstream</div>
+    <div class="masthead-rule"></div>
+    <div class="badge masthead-badge" id="routingBadge"><span class="signal-sq"></span><span id="routingStatus">—</span></div>
+  </div>
+
+  <!-- Inline controls, presented as detail-style rows (label-caps left, control right) -->
+  <div class="routing-controls">
+    <div class="ctl-row">
+      <span class="ctl-label">MiddleProxy</span>
+      <button class="ui-btn routing-toggle-btn" id="routingMiddleBtn" type="button">MiddleProxy: —</button>
+    </div>
+    <div class="ctl-row routing-upstream-ctl">
+      <label class="ctl-label" for="routingUpstreamSelect" data-i18n="routing.upstream">Upstream</label>
+      <div class="ctl-right">
         <select id="routingUpstreamSelect" class="ui-select">
           <option value="auto">auto</option>
           <option value="direct">direct</option>
@@ -173,140 +313,133 @@
         </select>
         <button class="ui-btn active" id="routingUpstreamApply" type="button" data-i18n="btn.apply">Apply</button>
       </div>
-      <div class="routing-extra-ctl" id="routingTunnelCtl" style="display:none">
-        <label for="routingTunnelIfaceSelect" data-i18n="routing.tunnelPin">Tunnel pin</label>
+    </div>
+    <div class="ctl-row routing-extra-ctl" id="routingTunnelCtl" style="display:none">
+      <label class="ctl-label" for="routingTunnelIfaceSelect" data-i18n="routing.tunnelPin">Tunnel pin</label>
+      <div class="ctl-right">
         <select id="routingTunnelIfaceSelect" class="ui-select"></select>
         <button class="ui-btn" id="routingTunnelIfaceApply" type="button" data-i18n="btn.pin">Pin</button>
       </div>
-      <div class="routing-extra-ctl" id="routingProxyCtl" style="display:none">
-        <label id="routingProxyHostLabel" for="routingProxyHost" data-i18n="routing.proxyHost">Proxy host</label>
+    </div>
+    <div class="ctl-row routing-extra-ctl routing-proxy-ctl" id="routingProxyCtl" style="display:none">
+      <label class="ctl-label" id="routingProxyHostLabel" for="routingProxyHost" data-i18n="routing.proxyHost">Proxy host</label>
+      <div class="ctl-right routing-proxy-grid">
         <input id="routingProxyHost" class="ui-input routing-host" type="text" placeholder="127.0.0.1" autocomplete="off">
-        <label for="routingProxyPort" data-i18n="routing.port">Port</label>
+        <label class="ctl-sublabel" for="routingProxyPort" data-i18n="routing.port">Port</label>
         <input id="routingProxyPort" class="ui-input routing-port" type="number" min="1" max="65535" placeholder="1080" autocomplete="off">
-        <label for="routingProxyUser" data-i18n="routing.user">User</label>
+        <label class="ctl-sublabel" for="routingProxyUser" data-i18n="routing.user">User</label>
         <input id="routingProxyUser" class="ui-input routing-user" type="text" placeholder="optional" autocomplete="off">
-        <label for="routingProxyPass" data-i18n="routing.pass">Pass</label>
+        <label class="ctl-sublabel" for="routingProxyPass" data-i18n="routing.pass">Pass</label>
         <input id="routingProxyPass" class="ui-input routing-pass" type="password" placeholder="optional" autocomplete="off">
         <button class="ui-btn" id="routingProxyApply" type="button" data-i18n="btn.setTarget">Set target</button>
       </div>
-      <div class="routing-action-note" id="routingActionNote"></div>
     </div>
-    <div class="tunnel-details">
-      <div class="tunnel-stat">
-        <span class="tunnel-lbl">MiddleProxy</span>
-        <span class="tunnel-val" id="routingMiddle">—</span>
-      </div>
-      <div class="tunnel-stat">
-        <span class="tunnel-lbl" data-i18n="routing.upstream">Upstream</span>
-        <span class="tunnel-val" id="routingUpstream">—</span>
-      </div>
-      <div class="tunnel-stat">
-        <span class="tunnel-lbl" data-i18n="routing.target">Target</span>
-        <span class="tunnel-val" id="routingTarget">—</span>
-      </div>
-      <div class="tunnel-stat">
-        <span class="tunnel-lbl" data-i18n="routing.policy">Policy</span>
-        <span class="tunnel-val" id="routingPolicy">—</span>
-      </div>
-    </div>
-    <div class="routing-list" id="routingTunnelsList"></div>
+    <div class="routing-action-note" id="routingActionNote"></div>
   </div>
 
-  <!-- Egress / Tunnel Quality -->
-  <div class="tunnel-card" id="egressCard" style="display:none">
-    <div class="tunnel-header">
-      <div class="tunnel-icon">📶</div>
-      <div class="tunnel-title" data-i18n="egress.title">Tunnel Quality</div>
+  <!-- Detail rows (label-caps left, value right) -->
+  <div class="detail-rows">
+    <div class="detail-row">
+      <span class="detail-label">MiddleProxy</span>
+      <span class="detail-val" id="routingMiddle">—</span>
     </div>
-    <div class="tunnel-details">
-      <div class="tunnel-stat">
-        <span class="tunnel-val" id="egressSummary">—</span>
-      </div>
+    <div class="detail-row">
+      <span class="detail-label" data-i18n="routing.upstream">Upstream</span>
+      <span class="detail-val" id="routingUpstream">—</span>
     </div>
-    <div class="egress-list" id="egressList"></div>
-  </div>
-
-  <!-- Masking health -->
-  <div class="tunnel-card" id="maskingCard" style="display:none">
-    <div class="tunnel-header">
-      <div class="tunnel-icon">🧰</div>
-      <div class="tunnel-title" data-i18n="mask.title">Masking Health</div>
-      <div class="badge" id="maskBadge"><div class="pulse-dot"></div><span id="maskStatus">—</span></div>
+    <div class="detail-row">
+      <span class="detail-label" data-i18n="routing.target">Target</span>
+      <span class="detail-val" id="routingTarget">—</span>
     </div>
-    <div class="tunnel-details">
-      <div class="tunnel-stat">
-        <span class="tunnel-lbl" data-i18n="mask.mode">Mode</span>
-        <span class="tunnel-val" id="maskMode">—</span>
-      </div>
-      <div class="tunnel-stat">
-        <span class="tunnel-lbl" data-i18n="mask.endpoint">Endpoint</span>
-        <span class="tunnel-val" id="maskTarget">—</span>
-      </div>
-      <div class="tunnel-stat">
-        <span class="tunnel-lbl">Nginx</span>
-        <span class="tunnel-val" id="maskNginx">—</span>
-      </div>
-      <div class="tunnel-stat">
-        <span class="tunnel-lbl" data-i18n="mask.timer">Health Timer</span>
-        <span class="tunnel-val" id="maskTimer">—</span>
-      </div>
+    <div class="detail-row">
+      <span class="detail-label" data-i18n="routing.policy">Policy</span>
+      <span class="detail-val" id="routingPolicy">—</span>
     </div>
   </div>
 
-  <!-- Live logs -->
-  <div class="logs-card">
-    <div class="logs-header">
-      <div class="title" data-i18n="logs.title">▸ Live Logs</div>
-      <div class="ws-badge"><div class="ws-dot off" id="wsDot"></div><span id="wsLabel">connecting…</span></div>
-    </div>
-    <div class="logs-controls">
-      <div class="log-filters">
-        <button class="ui-btn log-filter active" type="button" data-filter="error" data-i18n="logs.error">Error</button>
-        <button class="ui-btn log-filter active" type="button" data-filter="warn" data-i18n="logs.warn">Warn</button>
-        <button class="ui-btn log-filter active" type="button" data-filter="stats" data-i18n="logs.stats">Stats</button>
-      </div>
-      <input id="logSearch" class="ui-input log-search" type="search" data-i18n-ph="logs.searchPh" placeholder="Search logs">
-      <button class="ui-btn active" id="autoScrollBtn" type="button">Auto-scroll: on</button>
-      <button class="ui-btn" id="jumpLatestBtn" type="button" data-i18n="logs.jumpLatest">Jump to latest</button>
-    </div>
-    <div class="logs-body" id="logsBody"></div>
+  <!-- Tunnel interfaces list (JS-rendered rows) -->
+  <div class="routing-list" id="routingTunnelsList"></div>
+</div>
+
+<!-- ── TUNNEL QUALITY (egress) ── -->
+<div class="rail-section" id="egressCard" style="display:none">
+  <div class="masthead">
+    <div class="masthead-eyebrow" data-i18n="egress.title">Tunnel Quality</div>
+    <div class="masthead-rule"></div>
+    <div class="masthead-meta" id="egressSummary">—</div>
   </div>
+  <!-- egress rows (JS-rendered) -->
+  <div class="egress-list" id="egressList"></div>
+</div>
 
-  <div class="footer">Built with <a href="https://ziglang.org" target="_blank">Zig</a> · proxy.sleep3r.ru</div>
-
-  <!-- Shared tooltip for all charts -->
-  <div id="chartTooltip" class="chart-tooltip"></div>
-
-  <!-- Delete confirmation modal -->
-  <div class="modal-overlay" id="deleteModal" style="display:none">
-    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="deleteModalTitle">
-      <div class="modal-title" id="deleteModalTitle" data-i18n="modal.deleteUser">Delete User</div>
-      <div class="modal-body">
-        Are you sure you want to delete <b id="deleteUserName"></b>?
-        <br><span class="form-hint" data-i18n="modal.restartNote">The proxy will be restarted to apply changes.</span>
-      </div>
-      <div class="modal-actions">
-        <button class="ui-btn danger" id="deleteConfirm" type="button" data-i18n="btn.delete">Delete</button>
-        <button class="ui-btn" id="deleteCancel" type="button" data-i18n="btn.cancel">Cancel</button>
-      </div>
+<!-- ── MASKING ── -->
+<div class="rail-section" id="maskingCard" style="display:none">
+  <div class="masthead">
+    <div class="masthead-eyebrow" data-i18n="mask.title">Masking</div>
+    <div class="masthead-rule"></div>
+    <div class="badge masthead-badge" id="maskBadge"><span class="signal-sq"></span><span id="maskStatus">—</span></div>
+  </div>
+  <div class="detail-rows">
+    <div class="detail-row">
+      <span class="detail-label" data-i18n="mask.mode">Mode</span>
+      <span class="detail-val" id="maskMode">—</span>
+    </div>
+    <div class="detail-row">
+      <span class="detail-label" data-i18n="mask.endpoint">Endpoint</span>
+      <span class="detail-val" id="maskTarget">—</span>
+    </div>
+    <div class="detail-row">
+      <span class="detail-label">Nginx</span>
+      <span class="detail-val" id="maskNginx">—</span>
+    </div>
+    <div class="detail-row">
+      <span class="detail-label" data-i18n="mask.timer">Health timer</span>
+      <span class="detail-val" id="maskTimer">—</span>
     </div>
   </div>
+</div>
+  </div>
+</div>
 
-  <div class="modal-overlay" id="deleteTunnelModal" style="display:none">
-    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="deleteTunnelTitle">
-      <div class="modal-title" id="deleteTunnelTitle" data-i18n="modal.deleteTunnel">Delete Tunnel</div>
-      <div class="modal-body">
-        Delete <b id="deleteTunnelName"></b> from the tunnel pool?
-        <br><span class="form-hint">The interface will be stopped, config files removed, and proxy routing refreshed.</span>
-      </div>
-      <div class="modal-actions">
-        <button class="ui-btn danger" id="deleteTunnelConfirm" type="button">Delete</button>
-        <button class="ui-btn" id="deleteTunnelCancel" type="button">Cancel</button>
-      </div>
+<!-- ============================================================= -->
+<!-- FOOTER -->
+<!-- ============================================================= -->
+<div class="footer">
+  <div class="footer-inner">
+    <div class="footer-built">
+      <span class="footer-built-label">Built with</span>
+      <svg class="footer-zig" width="15" height="15" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><g fill="#F7A41D"><path d="M38.484 23.843l-15.06 18.405-7.529-11.712z"/><path d="M38.484 23.843l-10.876 9.203-4.183 9.202h-5.02v42.667h7.53l-9.203 4.183-6.693 14.222H0V23.843z"/><path d="M25.935 84.915L10.039 103.32l-6.693-9.202zM46.85 23.843l5.02 11.713-20.916 6.692z"/><path d="M46.85 23.843h46.013v18.405H30.954L46.85 32.21z"/><path d="M97.046 84.915L81.15 103.32l-5.856-10.875z"/><path d="M97.046 84.915l-13.386 7.53-2.51 10.875H35.137V84.915z"/><path d="M125.49 5.438L43.503 103.32 2.51 122.562l81.987-98.719zM117.96 23.843l-.836 15.06-15.059 4.182z"/><path d="M128 23.843v79.477H88.68l11.712-10.039 4.183-8.366h5.02v-41.83h-7.53l8.366-7.53 7.53-11.712z"/><path d="M104.575 84.915l4.183 12.55-20.078 5.855z"/></g></svg>
+      <a class="footer-built-link" href="https://ziglang.org" target="_blank" rel="noopener">Zig</a>
+    </div>
+    <div class="footer-host">proxy.sleep3r.ru</div>
+  </div>
+</div>
+
+<div id="chartTooltip" class="chart-tooltip"></div>
+
+<div class="modal-overlay" id="deleteModal" style="display:none">
+  <div class="modal" role="dialog" aria-modal="true" aria-labelledby="deleteModalTitle">
+    <div class="modal-title" id="deleteModalTitle" data-i18n="modal.deleteUser">Delete User</div>
+    <div class="modal-body">Are you sure you want to delete <b id="deleteUserName"></b>?<br><span class="form-hint" data-i18n="modal.restartNote">The proxy will be restarted to apply changes.</span></div>
+    <div class="modal-actions">
+      <button class="ui-btn danger" id="deleteConfirm" type="button" data-i18n="btn.delete">Delete</button>
+      <button class="ui-btn" id="deleteCancel" type="button" data-i18n="btn.cancel">Cancel</button>
     </div>
   </div>
 </div>
 
-<script src="/app.js?v=20260609"></script>
+<div class="modal-overlay" id="deleteTunnelModal" style="display:none">
+  <div class="modal" role="dialog" aria-modal="true" aria-labelledby="deleteTunnelTitle">
+    <div class="modal-title" id="deleteTunnelTitle" data-i18n="modal.deleteTunnel">Delete Tunnel</div>
+    <div class="modal-body">Delete <b id="deleteTunnelName"></b> from the tunnel pool?<br><span class="form-hint">The interface will be stopped, config files removed, and proxy routing refreshed.</span></div>
+    <div class="modal-actions">
+      <button class="ui-btn danger" id="deleteTunnelConfirm" type="button">Delete</button>
+      <button class="ui-btn" id="deleteTunnelCancel" type="button">Cancel</button>
+    </div>
+  </div>
+</div>
+
+</div>
+<script src="/app.js?v=20260610"></script>
 </body>
 </html>

--- a/src/ctl/dashboard_assets/static/index.html
+++ b/src/ctl/dashboard_assets/static/index.html
@@ -5,10 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>MTProto Proxy — Dashboard</title>
   <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/style.css?v=20260610">
+  <link rel="stylesheet" href="/style.css?v=20260610-paper12">
 </head>
 <body>
-<div class="app">
+<div class="app is-loading">
 <!-- ============================================================= -->
 <!-- TOPBAR (bus-bar) -->
 <!-- ============================================================= -->
@@ -24,9 +24,6 @@
   </div>
 
   <div class="topbar-right">
-    <!-- proxy online/offline status: signal-square + word -->
-    <div class="badge" id="statusBadge"><span class="sig-sq"></span><span id="proxyUp">—</span></div>
-
     <!-- data freshness badge (not in Paper mock but id is required) -->
     <div class="badge data-badge syncing" id="dataBadge"><span class="sig-sq"></span><span id="dataBadgeText">Syncing...</span></div>
 
@@ -45,8 +42,6 @@
       <button id="pollToggle" class="ui-btn poll-toggle icon-btn" type="button" aria-label="Pause polling">Pause</button>
     </div>
 
-    <!-- telemetry crawl: mono, text-low -->
-    <div class="meta telemetry">PID <b id="proxyPid">—</b> · RSS <b id="proxyRss">—</b> · UPD <b id="lastUpdate">never</b></div>
   </div>
 </div>
 
@@ -65,12 +60,16 @@
     </div>
     <div class="hero-figures">
       <div class="hero-fig">
-        <span class="hero-fig-label" data-i18n="hero.connected">CONNECTED</span>
-        <span class="hero-fig-val" id="heroConnected">0</span>
+        <span class="hero-fig-label">PID</span>
+        <span class="hero-fig-val mono" id="proxyPid">—</span>
       </div>
       <div class="hero-fig hero-fig-div">
-        <span class="hero-fig-label" data-i18n="hero.uptimeLbl">UPTIME</span>
-        <span class="hero-fig-val mono" id="heroUptime">—</span>
+        <span class="hero-fig-label">RSS</span>
+        <span class="hero-fig-val mono" id="proxyRss">—</span>
+      </div>
+      <div class="hero-fig hero-fig-div">
+        <span class="hero-fig-label">UPTIME</span>
+        <span class="hero-fig-val mono" id="proxyUptime">—</span>
       </div>
     </div>
   </div>
@@ -149,7 +148,7 @@
   <div class="kpi-network">
     <div class="instrument-masthead">
       <span class="card-label" data-i18n="card.network">Network Throughput</span>
-      <span class="card-label net-window">LAST 60S</span>
+      <span class="card-label net-window">LAST 5M</span>
     </div>
     <div class="net-legend">
       <span class="net-legend-item">
@@ -218,7 +217,7 @@
 <div class="body-grid">
   <div class="body-left">
 <!-- Users -->
-  <div class="users-card" id="usersCard" style="display:none">
+  <div class="users-card" id="usersCard">
     <!-- MASTHEAD: eyebrow flush-left · flex:1 hairline rule · right-aligned mono meta (no icon, no button here) -->
     <div class="users-head section-masthead">
       <div class="title" data-i18n="users.title">Users</div>
@@ -270,7 +269,7 @@
     </div>
   </div>
 
-  <!-- Controls: level filter chips + search + auto-scroll + jump-latest -->
+  <!-- Controls: level filter chips + search + auto-scroll -->
   <div class="logs-controls">
     <div class="log-filters">
       <button class="ui-btn log-filter active" type="button" data-filter="error" data-i18n="logs.error">Error</button>
@@ -281,8 +280,14 @@
       <!--ICON:search-->
       <input id="logSearch" class="log-search" type="search" data-i18n-ph="logs.searchPh" placeholder="Search logs" autocomplete="off">
     </div>
-    <button class="ui-btn log-ctl-btn active" id="autoScrollBtn" type="button"><!--ICON:autoscroll--><span class="log-ctl-label">Auto-scroll: on</span></button>
-    <button class="ui-btn log-ctl-btn" id="jumpLatestBtn" type="button"><!--ICON:jump-latest--><span class="log-ctl-label" data-i18n="logs.jumpLatest">Jump to latest</span></button>
+    <button class="ui-btn log-ctl-btn active" id="autoScrollBtn" type="button" aria-pressed="true" aria-label="Auto-scroll on">
+      <svg class="auto-scroll-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="butt" stroke-linejoin="miter" aria-hidden="true">
+        <polyline points="6,5 12,11 18,5"></polyline>
+        <polyline points="6,11 12,17 18,11"></polyline>
+        <path d="M5 20 H19"></path>
+      </svg>
+      <span class="log-ctl-label">Auto-scroll</span>
+    </button>
   </div>
 
   <!-- Sunk well: JS appends .log-line rows via addLine() -->
@@ -291,12 +296,25 @@
 </section>
   </div>
   <div class="body-rail">
-<!-- ════════════════ RIGHT RAIL ════════════════ -->
+	<!-- ════════════════ RIGHT RAIL ════════════════ -->
 <!-- These three sections live inside the Body row's right column:
      <div class="body-row"> ... <div class="right-rail"> [PASTE HERE] </div> </div>
      The .right-rail wrapper is owned by the Body-layout section; only the three
-     cards below belong to THIS part. Each card is an open "section" (no glass box):
-     a masthead (eyebrow + hairline rule + optional right meta/badge) then content. -->
+	     cards below belong to THIS part. Each card is an open "section" (no glass box):
+	     a masthead (eyebrow + hairline rule + optional right meta/badge) then content. -->
+
+<div class="rail-section rail-loading" id="railLoading" aria-hidden="true">
+  <div class="masthead">
+    <div class="loading-chip loading-title"></div>
+    <div class="masthead-rule"></div>
+  </div>
+  <div class="loading-rows">
+    <div class="loading-row"><span></span><b></b></div>
+    <div class="loading-row"><span></span><b></b></div>
+    <div class="loading-row"><span></span><b></b></div>
+    <div class="loading-bar"></div>
+  </div>
+</div>
 
 <!-- ── ROUTING & UPSTREAM ── -->
 <div class="rail-section" id="routingCard" style="display:none">
@@ -310,7 +328,12 @@
   <div class="routing-controls">
     <div class="ctl-row">
       <span class="ctl-label">MiddleProxy</span>
-      <button class="ui-btn routing-toggle-btn" id="routingMiddleBtn" type="button">MiddleProxy: —</button>
+      <div class="ctl-right">
+        <button class="ui-btn routing-toggle-btn" id="routingMiddleBtn" type="button" aria-pressed="false">
+          <span class="routing-toggle-text">Off</span>
+          <span class="routing-toggle-track" aria-hidden="true"><span class="routing-toggle-knob"></span></span>
+        </button>
+      </div>
     </div>
     <div class="ctl-row routing-upstream-ctl">
       <label class="ctl-label" for="routingUpstreamSelect" data-i18n="routing.upstream">Upstream</label>
@@ -350,11 +373,11 @@
 
   <!-- Detail rows (label-caps left, value right) -->
   <div class="detail-rows">
-    <div class="detail-row">
+    <div class="detail-row routing-summary-dup">
       <span class="detail-label">MiddleProxy</span>
       <span class="detail-val" id="routingMiddle">—</span>
     </div>
-    <div class="detail-row">
+    <div class="detail-row routing-summary-dup">
       <span class="detail-label" data-i18n="routing.upstream">Upstream</span>
       <span class="detail-val" id="routingUpstream">—</span>
     </div>
@@ -451,6 +474,6 @@
 </div>
 
 </div>
-<script src="/app.js?v=20260610"></script>
+<script src="/app.js?v=20260610-paper12"></script>
 </body>
 </html>

--- a/src/ctl/dashboard_assets/static/index.html
+++ b/src/ctl/dashboard_assets/static/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>⚡ MTProto Proxy — Dashboard</title>
-  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/style.css?v=20260422">
+  <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css?v=20260609">
 </head>
 <body>
 <div class="app">
@@ -57,13 +57,12 @@
         <div class="gauge">
           <svg viewBox="0 0 36 36">
             <circle class="track" cx="18" cy="18" r="15"/>
-            <circle class="fill" id="cpuArc" cx="18" cy="18" r="15"
-              stroke="var(--zig)" stroke-dasharray="94.2" stroke-dashoffset="94.2"/>
+            <circle class="fill" id="cpuArc" cx="18" cy="18" r="15"/>
           </svg>
           <div class="pct" style="color:var(--zig)" id="cpuPct">0%</div>
         </div>
         <div>
-          <div class="card-value" style="color:var(--zig)" id="cpuVal">0<span style="font-size:18px;font-weight:400">%</span></div>
+          <div class="card-value" style="color:var(--text)" id="cpuVal">0<span style="font-size:18px;font-weight:400">%</span></div>
           <div class="card-sub" data-i18n="card.cpuSub">utilization</div>
         </div>
       </div>
@@ -77,13 +76,12 @@
         <div class="gauge">
           <svg viewBox="0 0 36 36">
             <circle class="track" cx="18" cy="18" r="15"/>
-            <circle class="fill" id="memArc" cx="18" cy="18" r="15"
-              stroke="var(--purple)" stroke-dasharray="94.2" stroke-dashoffset="94.2"/>
+            <circle class="fill" id="memArc" cx="18" cy="18" r="15"/>
           </svg>
           <div class="pct" style="color:var(--purple)" id="memPct">0%</div>
         </div>
         <div>
-          <div class="card-value" style="color:var(--purple)" id="memVal">0<span style="font-size:14px;font-weight:400"> MB</span></div>
+          <div class="card-value" style="color:var(--text)" id="memVal">0<span style="font-size:14px;font-weight:400"> MB</span></div>
           <div class="card-sub" id="memSub">— / — MB</div>
         </div>
       </div>
@@ -95,7 +93,7 @@
       <div class="card-label" data-i18n="card.network">◎ Network Throughput</div>
       <div class="chart-wrap"><canvas id="netChart"></canvas></div>
       <div class="chart-legend">
-        <span><div class="ldot" style="background:var(--green)"></div>RX <b id="rxRate">—</b></span>
+        <span><div class="ldot" style="background:var(--blue)"></div>RX <b id="rxRate">—</b></span>
         <span><div class="ldot" style="background:var(--zig)"></div>TX <b id="txRate">—</b></span>
         <span style="margin-left:auto">↓<b id="rxTotal">—</b> ↑<b id="txTotal">—</b></span>
       </div>
@@ -309,6 +307,6 @@
   </div>
 </div>
 
-<script src="/app.js?v=20260524"></script>
+<script src="/app.js?v=20260609"></script>
 </body>
 </html>

--- a/src/ctl/dashboard_assets/static/index.html
+++ b/src/ctl/dashboard_assets/static/index.html
@@ -46,7 +46,7 @@
     </div>
 
     <!-- telemetry crawl: mono, text-low -->
-    <div class="meta telemetry">PID <b id="proxyPid">—</b> · RSS <b id="proxyRss">—</b> · UP <b id="srvUptime">—</b> · UPD <b id="lastUpdate">never</b></div>
+    <div class="meta telemetry">PID <b id="proxyPid">—</b> · RSS <b id="proxyRss">—</b> · UPD <b id="lastUpdate">never</b></div>
   </div>
 </div>
 

--- a/src/ctl/dashboard_assets/static/style.css
+++ b/src/ctl/dashboard_assets/static/style.css
@@ -692,3 +692,1074 @@ body::before, body::after { content: none; }
     transition-duration: 140ms !important;
   }
 }
+
+
+/* ═══════════════════ PAPER-LAYOUT CSS (section build) ═══════════════════ */
+<![CDATA[/* ───────────────────────────────────────────────────────────────
+   TOPBAR — bus-bar (h56, border-bottom steel, full-bleed band)
+   The band itself spans the viewport; its contents are padded by the
+   48px-ish gutter so brand sits flush-left and telemetry flush-right.
+   NOTE: this REPLACES the old `.header` rules (lines ~100-130 of
+   style.css). Remove `.header`, `.header-left`, `.header h1`,
+   `.header-right` blocks — keep `.zig-logo` / `.version-pill` but they
+   are re-declared below to the Paper values.
+   ─────────────────────────────────────────────────────────────── */
+.topbar {
+  height: 56px;
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 20px;
+  padding: 0 var(--gutter);
+  background: var(--ground);
+  border-bottom: 1px solid var(--border-steel);
+  margin-bottom: 0;            /* hero-section owns the top gap */
+}
+
+/* brand cluster: logo + wordmark + version chip */
+.topbar-brand { display: flex; align-items: center; gap: 12px; min-width: 0; }
+.zig-logo { width: 28px; height: 28px; flex-shrink: 0; display: block; }
+.zig-logo img, .zig-logo svg { width: 100%; height: 100%; display: block; }
+.topbar-wordmark { display: flex; align-items: baseline; gap: 7px; }
+.topbar-wordmark .wm {
+  font-family: var(--font-text);
+  font-size: 15px; font-weight: 600; letter-spacing: -0.01em; line-height: 18px;
+}
+.topbar-wordmark .accent { color: var(--accent); }
+.topbar-wordmark .dim { color: var(--text-mid); font-weight: 500; }
+.version-pill {
+  font-family: var(--font-mono);
+  font-size: 11px; font-weight: 500; line-height: 14px; letter-spacing: 0;
+  color: var(--text-low);
+  background: var(--surface-2);
+  border: 1px solid var(--border-steel);
+  border-radius: var(--radius-chip);
+  padding: 2px 6px;
+}
+.version-pill:empty { display: none; }
+
+/* right cluster */
+.topbar-right {
+  display: flex; align-items: center; justify-content: flex-end;
+  gap: 20px; flex-wrap: wrap;
+}
+
+/* status / data badges = signal-square + word (no pills, no glow) */
+.badge {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 0; border: 0; background: none; border-radius: 0;
+  font-size: 13px; font-weight: 560; letter-spacing: 0.01em;
+  color: var(--signal-go);
+}
+.badge #proxyUp, .badge #dataBadgeText { color: var(--text-hi); }
+.badge.off { color: var(--signal-stop); }
+.badge.off #proxyUp { color: var(--signal-stop); }
+.data-badge { color: var(--text-mid); }
+.data-badge #dataBadgeText { color: var(--text-mid); }
+.data-badge.ok, .data-badge.ok #dataBadgeText { color: var(--signal-go); }
+.data-badge.stale, .data-badge.stale #dataBadgeText { color: var(--signal-stop); }
+.data-badge.paused, .data-badge.paused #dataBadgeText { color: var(--signal-caution); }
+.data-badge.syncing, .data-badge.syncing #dataBadgeText { color: var(--text-mid); }
+.sig-sq {
+  width: 8px; height: 8px; border-radius: var(--radius-chip);
+  background: currentColor; flex-shrink: 0; animation: none;
+}
+
+/* lang toggle — minimal ghost button, mono-ish caps */
+.lang-toggle {
+  height: 28px; padding: 0 9px;
+  font-size: 11px; font-weight: 600; letter-spacing: 0.04em;
+  color: var(--text-hi);
+}
+
+/* poll controls */
+.poll-controls { display: inline-flex; align-items: center; gap: 8px; padding: 0; border: 0; background: none; }
+.poll-controls label {
+  font-size: 10.5px; font-weight: 620; text-transform: uppercase; letter-spacing: 0.17em;
+  color: var(--text-low);
+}
+.poll-select { height: 28px; padding: 0 10px; font-family: var(--font-mono); font-size: 12px; }
+/* pause/resume → square icon button */
+.poll-toggle.icon-btn {
+  height: 28px; width: 28px; padding: 0;
+  display: inline-flex; align-items: center; justify-content: center;
+  color: var(--text-mid); font-size: 0;            /* hide the i18n word, show svg only */
+}
+.poll-toggle.icon-btn svg { width: 14px; height: 14px; }
+.poll-toggle.icon-btn.active { color: var(--accent); border-color: var(--accent-dim); background: var(--accent-glow); }
+
+/* telemetry crawl */
+.telemetry {
+  font-family: var(--font-mono); font-size: 12px; line-height: 16px;
+  color: var(--text-mid); white-space: nowrap;
+  font-variant-numeric: tabular-nums; font-feature-settings: 'tnum' 1;
+}
+.telemetry b { color: var(--text-mid); font-weight: 500; }
+
+/* ───────────────────────────────────────────────────────────────
+   STATUS HERO — the single sodium-lamp moment.
+   Fixed surface-1 background + steel border at all states; only the
+   signal-square + verdict text take the state colour (set by JS as an
+   inline `color` on #statusHero, inherited via currentColor).
+   REPLACES the old `#statusHero` block (lines ~194-213).
+   ─────────────────────────────────────────────────────────────── */
+.hero-section { padding: 32px var(--gutter) 0; }
+#statusHero {
+  display: flex; align-items: center; gap: 24px;
+  padding: 26px 30px;
+  border-radius: var(--radius-hero);
+  border: 1px solid var(--border-steel);
+  background: var(--surface-1);
+  color: var(--signal-go);          /* default state colour; JS overrides */
+}
+.hero-verdict { flex: 1 1 0; min-width: 0; display: flex; flex-direction: column; gap: 10px; }
+.hero-verdict-top { display: flex; align-items: center; gap: 16px; }
+/* state signal-square: inherits the hero's currentColor */
+#statusHeroIcon {
+  width: 12px; height: 12px; border-radius: var(--radius-chip);
+  background: currentColor; flex-shrink: 0; display: inline-block;
+  font-size: 0;                     /* in case JS leaves a glyph behind */
+}
+/* the verdict itself — full-size Archivo, coloured by state */
+#statusHeroText {
+  font-family: var(--font-display);
+  font-size: 40px; font-weight: 640; letter-spacing: -0.018em; line-height: 44px;
+  color: currentColor;
+}
+/* 3×32 amber block cursor, blinks unless reduced-motion */
+.hero-cursor {
+  width: 3px; height: 32px; flex-shrink: 0;
+  background: var(--accent);
+  animation: heroCaret 1.1s steps(1) infinite;
+}
+@keyframes heroCaret { 0%,49% { opacity: 1; } 50%,100% { opacity: 0; } }
+
+/* ───────────────────────────────────────────────────────────────
+   FOOTER — hairline rule, "Built with [Zig] Zig" left / host mono right.
+   REPLACES the old `.footer` block (lines ~582-583).
+   ─────────────────────────────────────────────────────────────── */
+.footer { padding: 56px var(--gutter) 30px; border: 0; margin: 0; text-align: left; }
+.footer-inner {
+  display: flex; align-items: center; justify-content: space-between;
+  padding-top: 20px; border-top: 1px solid var(--border-hair);
+}
+.footer-built { display: flex; align-items: center; gap: 8px; }
+.footer-built-label { font-family: var(--font-text); font-size: 12px; color: var(--text-low); }
+.footer-zig { width: 15px; height: 15px; flex-shrink: 0; display: block; }
+.footer-built-link {
+  font-family: var(--font-text); font-size: 12px; font-weight: 540;
+  color: var(--text-mid); text-decoration: none;
+}
+.footer-built-link:hover { color: var(--text-hi); }
+.footer-host {
+  font-family: var(--font-mono); font-size: 12px; line-height: 16px;
+  color: var(--text-low);
+}
+
+/* ── reduced motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .hero-cursor { animation: none; opacity: 1; }
+}
+
+/* ── responsive: stack topbar on narrow viewports ── */
+@media (max-width: 820px) {
+  .topbar { height: auto; flex-direction: column; align-items: flex-start; gap: 12px; padding-top: 14px; padding-bottom: 14px; }
+  .topbar-right { width: 100%; justify-content: flex-start; }
+  .telemetry { white-space: normal; }
+  #statusHeroText { font-size: 30px; line-height: 34px; }
+  .footer-inner { flex-direction: column; align-items: flex-start; gap: 10px; }
+}]]>
+
+/* ════════════════════════════════════════════════════════════════════════
+   KPI BAND  — Paper "Bahnhof Console" v2
+   Flex row, gap 24. CPU+MEM live on the open board (hairline-divided);
+   the network throughput is a sunk well with its own steel/hair frame.
+   ════════════════════════════════════════════════════════════════════════ */
+.kpi-band {
+  display: flex;
+  gap: 24px;
+  align-items: stretch;
+  margin-bottom: 40px;
+}
+
+/* CPU + MEMORY share the board, divided by a hairline. grow 2 (Paper). */
+.kpi-gauges {
+  display: flex;
+  flex: 2 1 0%;
+  min-width: 0;
+  background: var(--surface-1);
+  border: 1px solid var(--border-hair);
+  border-radius: var(--radius-surface);
+  overflow: hidden;
+}
+
+/* Each gauge instrument */
+.instrument {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0%;
+  min-width: 0;
+  padding: 16px 22px;
+  gap: 12px;
+}
+.kpi-gauges .instrument + .instrument { border-left: 1px solid var(--border-hair); }
+
+/* Network throughput well. grow 1.8 (Paper). Sunk darker ground, steel top. */
+.kpi-network {
+  display: flex;
+  flex-direction: column;
+  flex: 1.8 1 0%;
+  min-width: 0;
+  padding: 16px 18px;
+  gap: 12px;
+  background: var(--well-rx);
+  border: 1px solid var(--border-hair);
+  border-top-color: var(--border-steel);
+  border-radius: var(--radius-surface);
+}
+
+.app.stale .instrument,
+.app.stale .kpi-network,
+.app.stale .stat-cell { opacity: 0.62; }
+
+/* ── Instrument masthead: eyebrow flush-left, mono meta flush-right ── */
+.instrument-masthead {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border-steel);
+}
+.kpi-network .instrument-masthead { border-bottom-color: var(--border-steel); }
+
+/* Eyebrow (caps text-low, NO icon). Overrides legacy .card-label box model. */
+.instrument-masthead .card-label {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  display: inline-block;
+  font-family: var(--font-text);
+  font-size: 10.5px;
+  font-weight: 620;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+  color: var(--text-low);
+  line-height: 14px;
+  white-space: nowrap;
+}
+.net-window { flex-shrink: 0; }
+
+.instrument-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-feature-settings: 'tnum' 1;
+  color: var(--text-low);
+  line-height: 14px;
+  white-space: nowrap;
+}
+
+/* ── Radial gauge (270° arc, gap at 6 o'clock). 104px to match Paper. ──
+   viewBox 0 0 36 36 + r=15 is preserved so setGauge()'s 70.69/94.25
+   dasharray math keeps working unchanged. */
+.gauge-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 0;
+}
+.gauge {
+  width: 104px;
+  height: 104px;
+  position: relative;
+  flex-shrink: 0;
+}
+.gauge .gauge-arc {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  transform: rotate(135deg);   /* 270° arc, gap parked at the bottom */
+}
+.gauge circle { fill: none; stroke-linecap: butt; }
+.gauge .track { stroke: var(--border-steel); stroke-width: 3; stroke-dasharray: 70.69 94.25; }
+.gauge .fill  { stroke: var(--signal-go); stroke-width: 3; stroke-dasharray: 0 94.25; }
+
+/* Three end/cardinal tick stubs — separate overlay so the arc transform
+   does not drag them around. */
+.gauge .gauge-ticks {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+.gauge .gauge-ticks line { stroke: var(--border-steel); stroke-width: 1.5; }
+
+/* Centered readout: big Archivo number + small "%" beneath. */
+.gauge-readout {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
+  pointer-events: none;
+}
+.gauge .pct {
+  position: static;
+  transform: none;
+  font-family: var(--font-display);
+  font-size: 30px;
+  font-weight: 620;
+  letter-spacing: -0.018em;
+  line-height: 30px;
+  font-feature-settings: 'tnum' 1;
+  color: var(--text-hi) !important;
+}
+.gauge-unit {
+  font-family: var(--font-text);
+  font-size: 10.5px;
+  font-weight: 620;
+  line-height: 12px;
+  color: var(--text-low);
+}
+/* JS still writes #cpuVal/#memVal; keep them present but out of the dial. */
+.gauge-val-hidden {
+  position: absolute;
+  width: 1px; height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+/* ── Sparkline (canvas needs a sized parent for getBoundingClientRect) ── */
+.spark-wrap {
+  height: 34px;
+  margin-top: auto;
+  position: relative;
+  border-top: 1px solid var(--border-hair);
+}
+.spark-wrap canvas { width: 100% !important; height: 100% !important; display: block; }
+
+/* ── Network legend ── */
+.net-legend {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+.net-legend-item { display: flex; align-items: center; gap: 8px; }
+.ldot { width: 8px; height: 8px; border-radius: 0; flex-shrink: 0; }
+.net-legend-tag {
+  font-family: var(--font-text);
+  font-size: 10.5px;
+  font-weight: 620;
+  letter-spacing: 0.14em;
+  color: var(--text-mid);
+  line-height: 14px;
+}
+.net-legend-val { display: flex; align-items: center; gap: 5px; }
+.net-arrow { flex-shrink: 0; display: block; }
+.net-arrow.dim { color: var(--text-low); }
+.net-legend-val b,
+.net-total b {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 400;
+  font-feature-settings: 'tnum' 1;
+  color: var(--text-hi);
+}
+.net-legend-totals {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-left: auto;
+}
+.net-total { display: flex; align-items: center; gap: 4px; color: var(--text-low); }
+.net-total b { color: var(--text-mid); }
+
+/* ── Network chart (canvas self-sizes against this 150px box) ── */
+.chart-wrap {
+  height: 150px;
+  position: relative;
+  margin-top: 2px;
+  flex-shrink: 0;
+}
+.chart-wrap canvas { width: 100% !important; height: 100% !important; display: block; }
+
+/* ════════════════════════════════════════════════════════════════════════
+   STAT STRIP — one surface-1 bar, 4 flex cells, steel hairline dividers.
+   ════════════════════════════════════════════════════════════════════════ */
+.stat-row {
+  display: flex;
+  background: var(--surface-1);
+  border: 1px solid var(--border-hair);
+  border-radius: var(--radius-surface);
+  overflow: hidden;
+  margin-bottom: 40px;
+}
+.stat-cell {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0%;
+  gap: 5px;
+  padding: 16px 22px;
+  text-align: left;
+}
+.stat-cell + .stat-cell { border-left: 1px solid var(--border-steel); }
+
+.stat-val-line { display: flex; align-items: baseline; gap: 8px; }
+.stat-cell .val {
+  font-family: var(--font-display);
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.018em;
+  line-height: 26px;
+  font-feature-settings: 'tnum' 1;
+  color: var(--text-hi);
+}
+.stat-val-sub {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-feature-settings: 'tnum' 1;
+  color: var(--text-mid);
+  line-height: 16px;
+}
+.stat-cell .lbl {
+  font-family: var(--font-text);
+  font-size: 10.5px;
+  font-weight: 620;
+  text-transform: uppercase;
+  letter-spacing: 0.17em;
+  color: var(--text-low);
+  line-height: 14px;
+}
+
+/* ── Motion (respects prefers-reduced-motion via the existing global guard) ── */
+.gauge .fill { transition: stroke-dasharray 450ms var(--ease-out, ease), stroke 300ms var(--ease-out, ease); }
+
+/* ── Responsive: stack the band, two-up the stat strip ── */
+@media (max-width: 900px) {
+  .kpi-band { flex-direction: column; }
+  .kpi-gauges, .kpi-network { flex: 1 1 auto; }
+}
+@media (max-width: 560px) {
+  .kpi-gauges { flex-direction: column; }
+  .kpi-gauges .instrument + .instrument { border-left: 0; border-top: 1px solid var(--border-hair); }
+  .stat-row { flex-wrap: wrap; }
+  .stat-cell { flex: 1 1 50%; }
+  .stat-cell:nth-child(odd) + .stat-cell { border-left: 1px solid var(--border-steel); }
+  .stat-cell:nth-child(n+3) { border-top: 1px solid var(--border-steel); }
+}
+
+/* ── Masthead section rule (shared): eyebrow · flex:1 hairline · right meta ── */
+.users-head, .tunnel-header, .logs-header {
+  display: flex; align-items: center; gap: 16px;
+  padding: 0 0 12px 0; border-bottom: 1px solid var(--border-steel);
+}
+.users-head .title, .tunnel-title, .logs-header .title {
+  font-family: var(--font-text);
+  font-size: 13px; font-weight: 620; text-transform: uppercase; letter-spacing: 0.15em;
+  color: var(--text-mid); white-space: nowrap; flex-shrink: 0;
+}
+/* the flex:1 hairline rule that separates eyebrow from right-aligned meta */
+.section-masthead { gap: 16px; }
+.section-masthead .masthead-rule { flex: 1 1 0; height: 1px; background: var(--border-steel); }
+.users-meta {
+  font-size: 12px; color: var(--text-low); font-family: var(--font-mono);
+  flex-shrink: 0; white-space: nowrap;
+}
+
+/* ── Cards become open sections, not glass boxes ── */
+.users-card, .tunnel-card, .logs-card {
+  background: transparent; border: 0; border-radius: 0;
+  margin-bottom: 40px; overflow: visible;
+}
+
+.users-note { padding: 12px 2px 0; font-size: 12px; color: var(--text-low); font-family: var(--font-mono); }
+.users-list { display: flex; flex-direction: column; }
+
+/* ── User row (timetable baseline grid) ── */
+.user-row {
+  display: grid;
+  grid-template-columns: 36px minmax(140px, 1.2fr) 104px minmax(0, 2fr) auto;
+  gap: 14px; align-items: center;
+  padding: 0 2px; height: 50px;
+  border-bottom: 1px solid var(--border-hair);
+  transition: background 0.12s;
+}
+.user-row:hover { background: var(--surface-2); }
+
+/* col 1: toggle slot (fixed 36, never shrinks) */
+.user-name .user-toggle-switch { flex-shrink: 0; }
+
+/* col 2: name + sessions badge */
+.user-name {
+  font-family: var(--font-text);
+  font-size: 14px; color: var(--text-hi); font-weight: 540; letter-spacing: -0.003em;
+  display: flex; align-items: center; gap: 9px; min-width: 0; overflow: hidden;
+}
+.user-name-text { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.user-sessions {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 19px; height: 18px; padding: 1px 6px;
+  border-radius: var(--radius-chip);
+  font-family: var(--font-mono); font-size: 11px; font-weight: 500;
+  background: var(--signal-go-fill); color: var(--signal-go);
+  flex-shrink: 0;
+}
+.user-sessions.zero { background: var(--surface-2); color: var(--text-low); }
+
+/* col 3: route — signal-square + word */
+.user-route { display: flex; align-items: center; min-width: 0; }
+.user-direct-toggle {
+  font-size: 13px !important; font-weight: 540; text-transform: none; letter-spacing: 0;
+  padding: 0 0 0 16px !important; height: auto !important;
+  border: 0 !important; background: transparent !important; border-radius: 0 !important;
+  cursor: pointer; position: relative; color: var(--text-mid) !important;
+  display: inline-flex; align-items: center;
+}
+.user-direct-toggle::before {
+  content: ''; position: absolute; left: 0; top: 50%; transform: translateY(-50%);
+  width: 8px; height: 8px; border-radius: var(--radius-chip); background: var(--signal-idle);
+}
+.user-direct-toggle.on::before { background: var(--signal-go); }
+.user-direct-toggle:hover { color: var(--text-hi) !important; }
+
+/* col 4: link (mono, truncated) */
+.user-link {
+  font-family: var(--font-mono); font-size: 12.5px; color: var(--text-mid);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;
+}
+
+/* col 5: actions — fixed-width slots, always visible (no hover-reveal) */
+.user-actions { display: inline-flex; align-items: center; gap: 6px; justify-content: flex-end; flex-shrink: 0; }
+.user-actions .ui-btn {
+  height: 28px; font-size: 11px; padding: 0 9px; font-family: var(--font-mono);
+  border-radius: var(--radius-ctl); color: var(--text-mid); background: transparent;
+}
+.user-actions .ui-btn:hover { color: var(--text-hi); background: var(--surface-2); border-color: var(--border-steel-bright); }
+.user-actions .ui-btn:disabled { opacity: 0.4; cursor: default; }
+/* icon-only square buttons (share QR + delete) keep a 30px square footprint */
+.user-share, .user-delete {
+  width: 30px; padding: 0 !important;
+  display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0;
+}
+.user-share svg, .user-delete svg { width: 15px; height: 15px; display: block; }
+/* delete: amber/red ink, always visible (Paper shows it on every row) */
+.user-delete {
+  color: var(--signal-stop) !important;
+  border-color: rgba(208, 106, 91, 0.4) !important;
+  background: transparent !important;
+  opacity: 1;
+}
+.user-delete:hover { background: var(--signal-stop-fill) !important; border-color: var(--signal-stop) !important; }
+.user-delete svg { color: var(--signal-stop); }
+.user-share svg { color: currentColor; }
+
+/* disabled user row */
+.user-empty { padding: 16px 2px; color: var(--text-low); font-size: 13px; }
+.user-row.disabled { opacity: 0.55; }
+.user-row.disabled .user-link { font-style: italic; color: var(--text-low); }
+.user-row.disabled .user-name-text { color: var(--text-mid); }
+
+/* ── Toggle (squared hardware switch) ── */
+.user-toggle-switch {
+  position: relative; display: inline-block;
+  width: 36px; height: 20px; flex-shrink: 0;
+  vertical-align: middle; cursor: pointer;
+}
+.user-toggle-switch input { opacity: 0; width: 0; height: 0; }
+.user-toggle-slider {
+  position: absolute; inset: 0;
+  background: var(--well); border: 1px solid var(--border-steel);
+  border-radius: var(--radius-ctl); transition: background 0.18s, border-color 0.18s;
+}
+.user-toggle-slider::before {
+  content: ''; position: absolute; height: 14px; width: 14px; left: 2px; top: 2px;
+  background: var(--surface-2); border-radius: var(--radius-chip);
+  transition: transform 0.18s, background 0.18s;
+}
+.user-toggle-switch input:checked + .user-toggle-slider { background: var(--signal-go-fill); border-color: var(--signal-go); }
+.user-toggle-switch input:checked + .user-toggle-slider::before { transform: translateX(16px); background: var(--signal-go); }
+
+/* ── Add-user button (now a separate row below the list, pt 16) ── */
+.add-user-wrap { display: flex; padding-top: 16px; }
+.add-user-btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  height: 32px; padding: 0 14px !important;
+  color: var(--text-hi) !important; border-color: var(--border-steel) !important;
+  background: transparent !important; font-weight: 540 !important; font-size: 13px;
+}
+.add-user-btn svg { width: 14px; height: 14px; display: block; color: var(--text-mid); flex-shrink: 0; }
+.add-user-btn:hover { border-color: var(--border-steel-bright) !important; background: var(--surface-2) !important; }
+.add-user-btn:hover svg { color: var(--text-hi); }
+
+/* ── Add user form ── */
+.add-user-form { padding: 16px 2px; border-bottom: 1px solid var(--border-hair); background: transparent; }
+.form-row { display: flex; gap: 12px; align-items: flex-end; flex-wrap: wrap; }
+.form-field { display: flex; flex-direction: column; gap: 6px; flex: 1; min-width: 160px; }
+.form-field label { font-size: 10.5px; font-weight: 620; text-transform: uppercase; letter-spacing: 0.14em; color: var(--text-low); }
+.form-field .ui-input { height: 32px; font-size: 13px; width: 100%; }
+.form-hint { font-weight: 400; text-transform: none; letter-spacing: 0; color: var(--text-low); }
+.form-actions { display: flex; gap: 6px; align-items: center; }
+.form-actions .ui-btn { height: 32px; font-size: 13px; }
+.form-status { margin-top: 8px; font-size: 12px; min-height: 16px; }
+.form-status.error { color: var(--signal-stop); }
+.form-status.info { color: var(--text-mid); }
+
+/* ── Responsive: stack the row on narrow screens ── */
+@media (max-width: 760px) {
+  .user-row { grid-template-columns: 1fr; gap: 8px; height: auto; padding: 12px 2px; }
+  .user-link { white-space: normal; word-break: break-all; }
+  .user-actions { justify-content: flex-start; flex-wrap: wrap; }
+  .form-row { flex-direction: column; }
+}
+
+/* reduced-motion: kill the toggle/hover transitions */
+@media (prefers-reduced-motion: reduce) {
+  .user-row, .user-toggle-slider, .user-toggle-slider::before,
+  .user-actions .ui-btn, .add-user-btn { transition: none !important; }
+}
+
+<![CDATA[/* ============================================================================
+   LIVE LOGS  — Paper "Bahnhof Console" 1:1
+   Section is an open (transparent) block; masthead rule, sunk well.
+   ========================================================================== */
+
+/* Open section wrapper (shared look with users/routing sections) */
+.logs-card {
+  background: transparent; border: 0; border-radius: 0;
+  display: flex; flex-direction: column; gap: 14px;
+  margin: 0; overflow: visible;
+}
+
+/* ── Masthead: eyebrow + flex rule + right meta ─────────────────────────── */
+.logs-header.section-masthead {
+  display: flex; align-items: center; gap: 16px;
+  padding: 0; border: 0;                 /* rule is the flex hairline, not a border */
+}
+.section-masthead .masthead-eyebrow {
+  font-family: var(--font-text);
+  font-size: 13px; font-weight: 620; letter-spacing: 0.15em;
+  text-transform: uppercase; color: var(--text-mid);
+  white-space: nowrap; flex-shrink: 0; line-height: 16px;
+}
+.section-masthead .masthead-rule {
+  flex: 1 1 0; height: 1px; background: var(--border-steel); min-width: 24px;
+}
+/* ws-badge sits at the right end of the rule */
+.logs-header .ws-badge {
+  display: inline-flex; align-items: center; gap: 7px;
+  flex-shrink: 0; white-space: nowrap;
+  font-family: var(--font-mono); font-size: 12px; font-weight: 400;
+  line-height: 16px; color: var(--text-low);
+  font-feature-settings: 'tnum' 1;
+}
+.ws-dot { width: 8px; height: 8px; border-radius: var(--radius-chip); flex-shrink: 0; }
+.ws-dot.on  { background: var(--signal-go); }
+.ws-dot.off { background: var(--signal-caution); }
+
+/* ── Controls row ───────────────────────────────────────────────────────── */
+.logs-controls {
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  padding: 0;
+}
+.log-filters { display: inline-flex; align-items: center; gap: 8px; }
+
+/* Level filter chip — h26, r2, mono caps; active = level-coloured fill */
+.log-filter {
+  height: 26px; padding: 0 10px;
+  font-family: var(--font-mono); font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  border-radius: var(--radius-chip);
+  display: inline-flex; align-items: center;
+}
+.log-filter:not(.active) {
+  color: var(--text-low); border-color: var(--border-hair); background: transparent;
+}
+.log-filter.active[data-filter="error"] { color: var(--signal-stop);    border-color: rgba(208,106,91,0.4); background: var(--signal-stop-fill); }
+.log-filter.active[data-filter="warn"]  { color: var(--signal-caution); border-color: rgba(201,162,75,0.4); background: var(--signal-caution-fill); }
+.log-filter.active[data-filter="stats"] { color: var(--signal-go);      border-color: rgba(111,181,138,0.4); background: var(--signal-go-fill); }
+
+/* Search — flex-grow, well bg, steel border, leading search icon */
+.log-search-box {
+  flex: 1 1 0; min-width: 160px;
+  display: flex; align-items: center; gap: 8px;
+  height: 32px; padding: 0 10px;
+  background: var(--well);
+  border: 1px solid var(--border-steel);
+  border-radius: var(--radius-ctl);
+}
+.log-search-box svg { flex-shrink: 0; color: var(--text-low); }
+.log-search-box .log-search {
+  flex: 1 1 0; min-width: 0;
+  height: 100%; padding: 0; border: 0; background: transparent;
+  color: var(--text-hi);
+  font-family: var(--font-text); font-size: 14px; font-weight: 400; line-height: 18px;
+  outline: none;
+}
+.log-search-box .log-search::placeholder { color: var(--text-low); }
+.log-search-box .log-search::-webkit-search-cancel-button { -webkit-appearance: none; appearance: none; }
+.log-search-box:focus-within { border-color: var(--border-steel-bright); }
+
+/* Auto-scroll / jump buttons — h32, r3, icon + label, steel border */
+.log-ctl-btn {
+  height: 32px; padding: 0 11px;
+  display: inline-flex; align-items: center; gap: 7px;
+  flex-shrink: 0;
+  font-family: var(--font-text); font-size: 14px; font-weight: 540;
+  border-radius: var(--radius-ctl); border: 1px solid var(--border-steel);
+  color: var(--text-mid);
+}
+.log-ctl-btn svg { flex-shrink: 0; }
+.log-ctl-btn .log-ctl-label { white-space: nowrap; line-height: 18px; }
+.log-ctl-btn.active { color: var(--accent); border-color: var(--accent-dim); background: var(--accent-glow); }
+.log-ctl-btn.active svg { color: var(--accent); }
+
+/* ── Sunk well ──────────────────────────────────────────────────────────── */
+.logs-body {
+  height: 390px; overflow-y: auto;
+  display: flex; flex-direction: column;
+  padding: 10px 0;
+  background: var(--well);                 /* #0E1115 */
+  border: 1px solid var(--border-hair);
+  border-top-color: var(--border-steel);   /* steel cap, hair sides/bottom */
+  font-family: var(--font-mono); font-size: 12.5px; line-height: 16px;
+  font-feature-settings: 'tnum' 1;
+  scroll-behavior: smooth;
+}
+.logs-body::-webkit-scrollbar { width: 6px; }
+.logs-body::-webkit-scrollbar-track { background: transparent; }
+.logs-body::-webkit-scrollbar-thumb { background: var(--border-steel); border-radius: 0; }
+
+/* ── Log line (emitted by addLine) ─────────────────────────────────────── */
+.log-line {
+  display: flex; align-items: baseline; gap: 12px;
+  padding: 3px 16px;
+  transition: background 0.1s;
+}
+.log-line:hover { background: var(--surface-1); }
+
+.log-ts {
+  flex-shrink: 0; width: 60px;
+  color: var(--text-low); font-size: 12.5px; line-height: 16px;
+  user-select: none;
+}
+
+/* Level chip is rendered by CSS ::before on .log-msg, never by JS.
+   52px fixed flex slot keeps every message column aligned. */
+.log-msg {
+  flex: 1 1 0; min-width: 0;
+  color: var(--text-mid); font-size: 12.5px; line-height: 16px;
+  word-break: break-word;
+}
+.log-msg::before {
+  content: 'INFO';
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 52px; padding: 2px 0; margin-right: 12px;
+  border-radius: var(--radius-chip);
+  font-size: 10px; font-weight: 600; line-height: 12px; letter-spacing: 0.04em;
+  vertical-align: 1px;
+  color: var(--signal-idle); background: var(--signal-idle-fill);
+}
+.log-line.info  .log-msg            { color: var(--text-mid); }
+.log-line.info  .log-msg::before    { content: 'INFO';  color: var(--signal-idle);    background: var(--signal-idle-fill); }
+.log-line.stats .log-msg::before    { content: 'STATS'; color: var(--signal-go);      background: var(--signal-go-fill); }
+.log-line.drops .log-msg::before    { content: 'DROPS'; color: var(--signal-caution); background: var(--signal-caution-fill); }
+.log-line.warn  .log-msg::before    { content: 'WARN';  color: var(--signal-caution); background: var(--signal-caution-fill); }
+.log-line.error .log-msg::before    { content: 'ERROR'; color: var(--signal-stop);    background: var(--signal-stop-fill); }
+
+/* fresh-line entrance (respects reduced motion below) */
+.log-line.fresh { animation: logSlideIn 0.25s ease; }
+@keyframes logSlideIn { from { opacity: 0; transform: translateY(-3px); } to { opacity: 1; transform: none; } }
+
+@media (prefers-reduced-motion: reduce) {
+  .logs-body { scroll-behavior: auto; }
+  .log-line.fresh { animation: none; }
+}]]>
+
+/* ════════════════════════════════════════════════════════════════════════
+   RIGHT RAIL — Routing & Upstream · Tunnel Quality · Masking
+   Open "sections" (no glass box). Layout = flex + gap + padding only.
+   Tokens reused: --surface-*, --border-*, --text-*, --signal-*, fonts, radii.
+   ════════════════════════════════════════════════════════════════════════ */
+
+/* Each card is a flat section in the rail; spacing between them is the rail's gap.
+   .tunnel-card kept as alias so existing `.app.stale .tunnel-card` opacity rule
+   still applies — add .rail-section to the same elements (done in static HTML)
+   OR keep the legacy selector below. */
+.rail-section {
+  background: transparent; border: 0; border-radius: 0;
+  display: flex; flex-direction: column; gap: 6px;
+  margin-bottom: 36px; overflow: visible; width: 100%;
+}
+.rail-section:last-child { margin-bottom: 0; }
+.app.stale .rail-section { opacity: 0.62; }
+
+/* ── Masthead: eyebrow flush-left · flex:1 hairline rule · right meta/badge ── */
+.masthead {
+  display: flex; align-items: center; gap: 14px;
+  padding-bottom: 12px; width: 100%;
+}
+.masthead-eyebrow {
+  font-family: var(--font-text);
+  font-size: 13px; font-weight: 620; text-transform: uppercase; letter-spacing: 0.15em;
+  color: var(--text-mid); white-space: nowrap; flex-shrink: 0;
+}
+.masthead-rule { flex: 1 1 0%; height: 1px; background: var(--border-steel); }
+.masthead-meta {
+  flex-shrink: 0; font-family: var(--font-mono); font-size: 12px;
+  color: var(--text-low); white-space: nowrap;
+}
+/* badge sitting at the right end of a masthead (routing / masking) */
+.masthead-badge { flex-shrink: 0; margin-left: 0; }
+
+/* signal square used inside masthead badges (replaces legacy .pulse-dot) */
+.badge .signal-sq {
+  width: 8px; height: 8px; border-radius: var(--radius-chip);
+  background: var(--signal-go); flex-shrink: 0; display: inline-block;
+}
+.badge.off .signal-sq { background: var(--signal-stop); }
+.badge { display: inline-flex; align-items: center; gap: 7px; }
+
+/* ── Shared detail rows (label-caps left, value right, hairline divided) ── */
+.detail-rows { display: flex; flex-direction: column; }
+.detail-row {
+  display: flex; align-items: center; justify-content: space-between; gap: 12px;
+  padding: 11px 2px; border-bottom: 1px solid var(--border-hair);
+}
+.detail-row:last-child { border-bottom: 0; }
+.detail-label {
+  font-family: var(--font-text);
+  font-size: 10.5px; font-weight: 620; text-transform: uppercase; letter-spacing: 0.17em;
+  color: var(--text-low); flex-shrink: 0;
+}
+.detail-val {
+  font-family: var(--font-mono); font-size: 12.5px; color: var(--text-hi);
+  font-feature-settings: 'tnum' 1;
+  text-align: right; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+/* a value that is a state word with a leading signal square */
+.detail-val .signal-sq {
+  width: 8px; height: 8px; border-radius: var(--radius-chip);
+  background: var(--signal-idle); display: inline-block; vertical-align: 1px;
+  margin-right: 8px; flex-shrink: 0;
+}
+
+/* ── ROUTING controls (presented as detail-ish rows) ── */
+.routing-controls { display: flex; flex-direction: column; }
+.ctl-row {
+  display: flex; align-items: center; justify-content: space-between; gap: 12px;
+  padding: 9px 2px; border-bottom: 1px solid var(--border-hair);
+}
+.ctl-label {
+  font-family: var(--font-text);
+  font-size: 10.5px; font-weight: 620; text-transform: uppercase; letter-spacing: 0.17em;
+  color: var(--text-low); flex-shrink: 0;
+}
+.ctl-right { display: inline-flex; align-items: center; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
+.ctl-sublabel {
+  font-family: var(--font-text); font-size: 10px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.12em; color: var(--text-low);
+}
+/* MiddleProxy toggle button — quiet, becomes amber-ish ink when on (.active via JS) */
+.routing-toggle-btn { font-family: var(--font-mono); font-size: 12px; height: 28px; }
+/* proxy host/port/user/pass collapse to a tidy wrapping grid in the narrow rail */
+.routing-proxy-ctl { align-items: flex-start; flex-direction: column; gap: 8px; }
+.routing-proxy-grid {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
+  width: 100%; justify-content: flex-start;
+}
+.routing-host { width: 100%; }
+.routing-port { width: 76px; }
+.routing-user, .routing-pass { width: 108px; }
+.routing-action-note {
+  font-size: 12px; color: var(--text-low); min-height: 0;
+  padding: 4px 2px 0; font-family: var(--font-mono);
+}
+.routing-action-note:empty { padding: 0; }
+.routing-action-note.error { color: var(--signal-stop); }
+.routing-action-note.ok { color: var(--signal-go); }
+
+/* ── ROUTING tunnel list (JS rows) — vertical stack, hairline divided ── */
+.routing-list { display: flex; flex-direction: column; }
+.routing-row {
+  display: flex; flex-direction: column; gap: 6px;
+  padding: 12px 2px; border-bottom: 1px solid var(--border-hair);
+}
+.routing-row:last-child { border-bottom: 0; }
+.routing-row-top { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.routing-iface {
+  font-family: var(--font-mono); font-size: 13px; color: var(--text-hi);
+  display: inline-flex; align-items: center; gap: 9px; min-width: 0;
+}
+.routing-iface-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.routing-tag {
+  font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: 0.14em;
+  color: var(--text-low); border: 0; border-radius: 0; padding: 0; flex-shrink: 0;
+}
+/* state word sits at the right of the top line, signal-square in front */
+.routing-state {
+  font-family: var(--font-text); font-size: 13px; font-weight: 560;
+  display: inline-flex; align-items: center; gap: 8px; flex-shrink: 0;
+}
+.routing-state::before {
+  content: ''; width: 8px; height: 8px; border-radius: var(--radius-chip);
+  background: var(--signal-idle); flex-shrink: 0;
+}
+.routing-state.on { color: var(--signal-go); }
+.routing-state.on::before { background: var(--signal-go); }
+.routing-state.mid { color: var(--signal-caution); }
+.routing-state.mid::before { background: var(--signal-caution); }
+.routing-state.off { color: var(--signal-stop); }
+.routing-state.off::before { background: var(--signal-stop); }
+/* second line: meta (left) + xfer (right) */
+.routing-row-bottom { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.routing-meta {
+  font-family: var(--font-mono); font-size: 12px; color: var(--text-mid);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0;
+}
+.routing-xfer {
+  font-family: var(--font-mono); font-size: 12px; color: var(--text-low);
+  white-space: nowrap; flex-shrink: 0; font-feature-settings: 'tnum' 1;
+}
+.routing-actions { display: flex; justify-content: flex-end; }
+.routing-actions .ui-btn { height: 26px; font-size: 11px; padding: 0 9px; font-family: var(--font-mono); }
+.routing-actions .routing-delete {
+  width: 28px; padding: 0 !important; display: inline-flex; align-items: center; justify-content: center;
+}
+.routing-actions .routing-delete svg { width: 15px; height: 15px; }
+.routing-empty { padding: 12px 2px; font-size: 12px; color: var(--text-low); font-family: var(--font-mono); }
+
+/* ── TUNNEL QUALITY (egress) — vertical stacked rows ── */
+.egress-list { display: flex; flex-direction: column; }
+.egress-row {
+  display: flex; flex-direction: column; gap: 8px;
+  padding: 12px 2px; border-bottom: 1px solid var(--border-hair);
+  background: transparent; border-radius: 0;
+}
+.egress-row:last-child { border-bottom: 0; }
+.egress-row.is-bottleneck { background: transparent; border-color: var(--border-hair); }
+/* line 1: signal-square + iface + tag (left), quality word (right) */
+.egress-row-top { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.egress-iface {
+  display: inline-flex; align-items: center; gap: 9px; min-width: 0;
+  font-family: var(--font-mono); font-size: 13px; color: var(--text-hi); font-weight: 400;
+}
+.egress-iface .signal-sq {
+  width: 9px; height: 9px; border-radius: var(--radius-chip);
+  background: var(--signal-idle); flex-shrink: 0; display: inline-block;
+}
+.egress-iface .egress-iface-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+/* color the leading square by quality (applied on .egress-iface via state class) */
+.egress-iface.q-good .signal-sq { background: var(--signal-go); }
+.egress-iface.q-degraded .signal-sq { background: var(--signal-caution); }
+.egress-iface.q-poor .signal-sq { background: var(--signal-stop); }
+.egress-iface.q-up .signal-sq { background: var(--signal-go); }
+.egress-iface.q-down .signal-sq,
+.egress-iface.q-unknown .signal-sq { background: var(--signal-idle); }
+/* the quality word at the right — colored by quality, no chip background */
+.egress-quality {
+  font-family: var(--font-text); font-size: 13px; font-weight: 560;
+  padding: 0; border-radius: 0; background: transparent; text-align: right; flex-shrink: 0;
+}
+.egress-quality-good { color: var(--signal-go); }
+.egress-quality-degraded { color: var(--signal-caution); }
+.egress-quality-poor { color: var(--signal-stop); }
+.egress-quality-up { color: var(--signal-go); }
+.egress-quality-down { color: var(--signal-stop); }
+.egress-quality-unknown { color: var(--text-mid); }
+/* line 2: metrics in one mono string (rtt · loss · hs). Status word folded in by JS. */
+.egress-metrics { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.egress-stats {
+  font-family: var(--font-mono); font-size: 12px; color: var(--text-mid);
+  font-feature-settings: 'tnum' 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.egress-row.q-down .egress-stats,
+.egress-row.q-unknown .egress-stats { color: var(--text-low); }
+/* the individual hidden slots kept for back-compat & per-metric tooltips */
+.egress-status, .egress-rtt, .egress-loss, .egress-hs { display: none; }
+/* line 3: quality bar (track + colored fill) */
+.egress-bar { height: 3px; width: 100%; background: var(--surface-3); flex-shrink: 0; }
+.egress-bar-fill { height: 3px; width: 0; background: var(--signal-idle); transition: width 140ms ease; }
+.egress-bar-fill.q-good { background: var(--signal-go); }
+.egress-bar-fill.q-degraded { background: var(--signal-caution); }
+.egress-bar-fill.q-poor { background: var(--signal-stop); }
+.egress-bar-fill.q-up { background: var(--signal-go); }
+.egress-bar-fill.q-down { background: var(--signal-stop); }
+.egress-bar-fill.q-unknown { background: var(--signal-idle); }
+/* optional bottleneck line (warning icon + caution text), spans the row */
+.egress-bottleneck {
+  display: flex; align-items: center; gap: 7px;
+  font-family: var(--font-text); font-size: 12px; font-weight: 540; color: var(--signal-caution);
+}
+.egress-bottleneck svg { width: 14px; height: 14px; flex-shrink: 0; }
+
+/* motion respects reduced-motion (handled globally); local transitions kept subtle */
+.routing-row, .egress-row { transition: background 140ms ease; }
+@media (prefers-reduced-motion: reduce) {
+  .egress-bar-fill, .routing-row, .egress-row { transition: none; }
+}
+
+/* Generic icon sizing — applied to any inline SVG dropped into a slot.
+   Icons are authored at 24x24 but render crisp at 14-18px. */
+.icon,
+.ui-btn svg,
+.user-share svg,
+.user-delete svg,
+.routing-delete svg,
+.masthead svg,
+.legend svg {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  display: block;
+}
+
+/* Slightly smaller in dense inline-text contexts (legend arrows, totals). */
+.legend svg,
+.net-totals svg {
+  width: 13px;
+  height: 13px;
+  vertical-align: -1px;
+}
+
+/* Topbar / control-bar action glyphs read a touch larger. */
+.langToggle svg,
+#langToggle svg,
+#pollToggle svg {
+  width: 16px;
+  height: 16px;
+}
+
+/* Status-square glyphs in the hero/share modal carry the accent at full size;
+   keep them aligned with adjacent type. */
+.send-plane.icon { width: 18px; height: 18px; }
+
+/* Icons inherit color from their button/text context via currentColor. */
+.ui-btn svg { color: inherit; }
+.user-delete svg,
+.routing-delete.danger svg { color: var(--signal-stop, #D06A5B); }
+
+/* ── Two-column body wrapper (Paper asymmetric layout) ── */
+.body-grid { display: flex; flex-direction: row; align-items: flex-start; gap: 36px; width: 100%; }
+.body-left { display: flex; flex-direction: column; gap: 48px; flex: 1.65; min-width: 0; }
+.body-rail { display: flex; flex-direction: column; gap: 48px; flex: 1; min-width: 0; }
+@media (max-width: 1040px) { .body-grid { flex-direction: column; } .body-left, .body-rail { flex: 1 1 auto; width: 100%; gap: 40px; } }
+
+/* ── Corrective: hard-constrain the topbar Zig logo (img attrs were overridden
+   by a width:100% rule, blowing it up to full width) ── */
+.zig-logo { display: inline-flex; width: 28px; height: 28px; flex-shrink: 0; align-items: center; justify-content: center; }
+.zig-logo img, .zig-logo svg { width: 28px; height: 28px; display: block; }
+
+/* ── Corrective: KPI band must be a flex ROW so gauges(2) sit beside the network well(1.8) ── */
+.kpi-band { display: flex; flex-direction: row; align-items: stretch; gap: 24px; width: 100%; }
+.kpi-gauges { display: flex; flex-direction: row; align-items: stretch; }
+@media (max-width: 900px) { .kpi-band { flex-direction: column; } }
+
+/* ── Corrective: user-row has 4 grid children (.user-name holds the toggle),
+   not 5 — the toggle is NOT a separate column. Name column must be wide. ── */
+.user-row { grid-template-columns: minmax(150px, 1.4fr) 104px minmax(0, 2fr) auto; }
+.user-name { display: flex; align-items: center; gap: 0; min-width: 0; }
+.user-name-text { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+@media (max-width: 680px) { .user-row { grid-template-columns: 1fr; } }

--- a/src/ctl/dashboard_assets/static/style.css
+++ b/src/ctl/dashboard_assets/static/style.css
@@ -67,7 +67,7 @@
   --font-text: 'Inter', system-ui, -apple-system, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, monospace;
 
-  --gutter: 32px;
+  --gutter: 48px;
 }
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -86,7 +86,7 @@ body::before, body::after { content: none; }
 
 .app {
   position: relative; z-index: 1;
-  max-width: 1360px; margin: 0 auto; padding: 0 var(--gutter);
+  max-width: 1440px; margin: 0 auto; padding: 0;
 }
 
 /* All live numerals align in columns. */
@@ -1803,3 +1803,655 @@ body::before, body::after { content: none; }
    primary button (amber is reserved for the hero + true primary actions) ── */
 #routingMiddleBtn { min-width: 52px; text-align: center; }
 #routingMiddleBtn.active { color: var(--signal-go) !important; border-color: var(--signal-go) !important; background: var(--signal-go-fill) !important; }
+
+/* ── Final Paper parity pass: the Paper artboard is 1440px with 48px gutters.
+   Keep the topbar and major sections in the same lanes as the reference while
+   preserving all live dashboard IDs and controls. ── */
+#dataBadge { display: none !important; }
+
+#statusHero {
+  margin: 0 !important;
+}
+
+#statusHeroIcon {
+  background: var(--hero-signal-color, currentColor) !important;
+}
+
+.topbar,
+.hero-section,
+.footer {
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.kpi-band {
+  box-sizing: border-box;
+  padding: 40px var(--gutter) 0 !important;
+  margin: 0 !important;
+  width: 100% !important;
+}
+
+.stat-row {
+  margin: 40px var(--gutter) 0 !important;
+  width: auto !important;
+}
+
+.body-grid {
+  box-sizing: border-box;
+  margin: 48px var(--gutter) 0 !important;
+  width: auto !important;
+  gap: 36px !important;
+}
+
+.body-left {
+  flex: 1 1 auto !important;
+  width: calc(100% - 307px) !important;
+}
+
+.body-rail {
+  flex: 0 0 271px !important;
+  width: 271px !important;
+}
+
+.users-note { display: none !important; }
+
+#routingTunnelsList { display: none !important; }
+
+.body-left > .users-card,
+.body-left > .logs-card {
+  margin: 0 !important;
+}
+
+.rail-section {
+  gap: 6px !important;
+  margin-bottom: 0 !important;
+}
+.rail-section:last-child { margin-bottom: 0 !important; }
+
+.routing-controls .ui-btn.active {
+  color: var(--text-mid) !important;
+  border-color: var(--border-steel) !important;
+  background: transparent !important;
+}
+
+.gauge {
+  width: 104px !important;
+  height: 104px !important;
+}
+
+.chart-wrap { height: 150px !important; }
+
+.kpi-network {
+  gap: 12px !important;
+  background: var(--well-rx) !important;
+}
+
+.egress-row {
+  border: 0 !important;
+  border-bottom: 1px solid var(--border-hair) !important;
+  background: transparent !important;
+  border-radius: 0 !important;
+  padding: 12px 2px !important;
+}
+.egress-row:last-child { border-bottom: 0 !important; }
+
+@media (max-width: 1040px) {
+  .body-grid { flex-direction: column; }
+  .body-left,
+  .body-rail {
+    width: 100% !important;
+    flex: 1 1 auto !important;
+  }
+}
+
+@media (max-width: 680px) {
+  :root { --gutter: 18px; }
+  .app { padding: 0 !important; }
+  .stat-row {
+    margin-left: var(--gutter) !important;
+    margin-right: var(--gutter) !important;
+  }
+}
+
+/* ── Paper rail correction: match the selected Paper frame, not the wide
+   stacked inspector-like block. Controls stay live; the commit buttons become
+   auto-applied by JS so the surface reads like the mock. ── */
+@media (min-width: 861px) {
+  .body-grid {
+    flex-direction: row !important;
+    align-items: flex-start !important;
+  }
+
+  .body-left {
+    flex: 1 1 auto !important;
+    width: calc(100% - 452px) !important;
+  }
+
+  .body-rail {
+    flex: 0 0 416px !important;
+    width: 416px !important;
+    gap: 48px !important;
+  }
+}
+
+@media (max-width: 860px) {
+  .body-grid { flex-direction: column !important; }
+  .body-left,
+  .body-rail {
+    width: 100% !important;
+    flex: 1 1 auto !important;
+  }
+}
+
+#routingCard .masthead,
+#egressCard .masthead,
+#maskingCard .masthead {
+  padding-bottom: 18px !important;
+}
+
+#routingCard .masthead-eyebrow,
+#egressCard .masthead-eyebrow,
+#maskingCard .masthead-eyebrow {
+  font-size: 13px !important;
+  letter-spacing: 0.17em !important;
+}
+
+#routingCard .ctl-row {
+  min-height: 88px;
+  padding: 20px 0 !important;
+}
+
+#routingCard .ctl-row:first-child {
+  min-height: 70px;
+}
+
+#routingUpstreamApply,
+#routingTunnelIfaceApply {
+  display: none !important;
+}
+
+#routingCard .ctl-right {
+  justify-content: flex-end !important;
+  flex-wrap: nowrap !important;
+}
+
+#routingUpstreamSelect {
+  width: 132px;
+}
+
+#routingTunnelIfaceSelect {
+  width: 108px;
+}
+
+#routingMiddleBtn {
+  min-width: 100px !important;
+  height: 30px !important;
+  padding: 0 !important;
+  border: 0 !important;
+  background: transparent !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: flex-end !important;
+  gap: 14px !important;
+  color: var(--text-hi) !important;
+  font-family: var(--font-text) !important;
+  font-size: 13px !important;
+  font-weight: 620 !important;
+}
+
+#routingMiddleBtn.active {
+  color: var(--text-hi) !important;
+  border-color: transparent !important;
+  background: transparent !important;
+}
+
+#routingCard .detail-row,
+#maskingCard .detail-row {
+  min-height: 72px;
+  padding: 0 !important;
+}
+
+#routingCard .detail-val,
+#maskingCard .detail-val {
+  font-size: 13px !important;
+}
+
+#routingTarget,
+#routingPolicy,
+#maskTarget {
+  max-width: 260px;
+}
+
+#maskBadge {
+  color: var(--text-low) !important;
+  background: transparent !important;
+  border: 0 !important;
+  padding: 0 !important;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+#maskBadge .signal-sq {
+  display: none !important;
+}
+
+#maskMode .signal-sq,
+#maskNginx .signal-sq {
+  background: var(--signal-go);
+}
+
+/* ── Paper component truth pass: values below come from the Paper JSX for
+   Right-col (MP-0) and Logs-controls (L3-0). ── */
+@media (min-width: 861px) {
+  .body-grid {
+    flex-direction: row !important;
+    align-items: flex-start !important;
+    gap: 36px !important;
+  }
+
+  .body-left {
+    flex: 1 1 auto !important;
+    width: calc(100% - 307px) !important;
+  }
+
+  .body-rail {
+    flex: 0 0 271px !important;
+    width: 271px !important;
+    gap: 48px !important;
+  }
+}
+
+#routingBadge {
+  display: none !important;
+}
+
+#routingCard .routing-summary-dup {
+  display: none !important;
+}
+
+#routingCard .routing-controls,
+#routingCard .detail-rows {
+  align-items: stretch !important;
+  border-bottom: 0 !important;
+  gap: 0 !important;
+  padding: 0 !important;
+  flex-wrap: nowrap !important;
+  width: 100% !important;
+}
+
+#routingCard.rail-section {
+  gap: 0 !important;
+}
+
+#routingCard .masthead,
+#egressCard .masthead,
+#maskingCard .masthead {
+  padding-bottom: 12px !important;
+  gap: 14px !important;
+}
+
+#routingCard .ctl-row,
+#routingCard .detail-row,
+#maskingCard .detail-row {
+  box-sizing: border-box !important;
+  display: flex !important;
+  min-height: 0 !important;
+  padding: 11px 2px !important;
+  width: 100% !important;
+}
+
+#routingCard .ctl-label,
+#routingCard .detail-label,
+#maskingCard .detail-label {
+  font-size: 10.5px !important;
+  letter-spacing: 0.17em !important;
+  line-height: 14px !important;
+}
+
+#routingCard .detail-val,
+#maskingCard .detail-val {
+  font-size: 12.5px !important;
+  line-height: 16px !important;
+}
+
+#routingCard .ctl-right {
+  margin-left: auto !important;
+  flex-wrap: nowrap !important;
+  justify-content: flex-end !important;
+}
+
+#routingCard .routing-action-note {
+  display: none !important;
+}
+
+#routingCard .routing-summary-dup,
+#routingCard .ctl-row[style*="display:none"],
+#routingCard .ctl-row[style*="display: none"] {
+  display: none !important;
+}
+
+#routingUpstreamSelect {
+  width: 86px !important;
+  height: 28px !important;
+}
+
+#routingTunnelIfaceSelect {
+  width: 71px !important;
+  height: 28px !important;
+}
+
+#routingMiddleBtn {
+  min-width: 0 !important;
+  width: auto !important;
+  height: 28px !important;
+  padding: 0 !important;
+  border: 0 !important;
+  background: transparent !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: flex-end !important;
+  gap: 10px !important;
+  font-family: var(--font-text) !important;
+  font-size: 13px !important;
+  font-weight: 560 !important;
+  line-height: 16px !important;
+  color: var(--text-hi) !important;
+  cursor: pointer !important;
+  touch-action: manipulation !important;
+}
+
+#routingMiddleBtn .routing-toggle-text,
+#routingMiddleBtn .routing-toggle-track,
+#routingMiddleBtn .routing-toggle-knob {
+  pointer-events: none !important;
+}
+
+#routingMiddleBtn .routing-toggle-text {
+  display: inline-block !important;
+  min-width: 19px !important;
+  text-align: right !important;
+}
+
+#routingMiddleBtn .routing-toggle-track {
+  box-sizing: border-box !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: flex-start !important;
+  width: 36px !important;
+  height: 20px !important;
+  padding: 2px !important;
+  border-radius: 3px !important;
+  border: 1px solid var(--border-steel) !important;
+  background: var(--surface-2) !important;
+  transition: background 120ms ease, border-color 120ms ease, box-shadow 120ms ease !important;
+}
+
+#routingMiddleBtn .routing-toggle-knob {
+  display: block !important;
+  width: 14px !important;
+  height: 14px !important;
+  border-radius: 1px !important;
+  background: var(--text-low) !important;
+  transform: translateX(0) !important;
+  transition: transform 120ms var(--ease-out), background 120ms ease !important;
+}
+
+#routingMiddleBtn.active .routing-toggle-track {
+  border-color: var(--signal-go) !important;
+  background: var(--signal-go-fill) !important;
+}
+
+#routingMiddleBtn.active .routing-toggle-knob {
+  background: var(--signal-go) !important;
+  transform: translateX(16px) !important;
+}
+
+#routingMiddleBtn.is-pending .routing-toggle-track {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--signal-go) 18%, transparent) !important;
+}
+
+#routingTarget,
+#maskTarget {
+  max-width: 165px !important;
+}
+
+#routingPolicy {
+  display: inline-flex !important;
+  align-items: center !important;
+  gap: 8px !important;
+  max-width: 170px !important;
+  overflow: visible !important;
+  color: var(--text-mid) !important;
+  font-size: 12px !important;
+}
+
+#routingPolicy .signal-sq {
+  margin-right: 0 !important;
+  background: var(--signal-go) !important;
+}
+
+.logs-controls {
+  flex-wrap: nowrap !important;
+}
+
+.log-search-box {
+  flex: 1 1 0 !important;
+  min-width: 0 !important;
+}
+
+#jumpLatestBtn {
+  display: none !important;
+}
+
+.log-filter.active[data-filter="error"],
+.log-filter.active[data-filter="warn"],
+.log-filter.active[data-filter="stats"] {
+  border-color: transparent !important;
+}
+
+.log-ctl-btn.active {
+  color: var(--text-mid) !important;
+  border-color: var(--border-steel) !important;
+  background: transparent !important;
+}
+
+.log-ctl-btn.active svg {
+  color: var(--text-mid) !important;
+}
+
+/* ── Paper cleanup pass: section mastheads end in hairlines only, and live
+   controls expose their state visually instead of hiding it in JS. ── */
+#egressSummary,
+#maskBadge {
+  display: none !important;
+}
+
+#egressCard .masthead-rule,
+#maskingCard .masthead-rule {
+  min-width: 0 !important;
+}
+
+#egressCard .egress-list {
+  align-items: stretch !important;
+  width: 100% !important;
+  margin-top: 0 !important;
+}
+
+#egressCard .egress-row {
+  align-items: stretch !important;
+  width: 100% !important;
+}
+
+#egressCard .egress-row-top {
+  justify-content: flex-start !important;
+  width: 100% !important;
+}
+
+#egressCard .egress-iface {
+  flex: 0 1 auto !important;
+  margin: 0 !important;
+}
+
+#egressCard .egress-quality {
+  margin-left: auto !important;
+}
+
+#autoScrollBtn {
+  min-width: 106px !important;
+}
+
+#autoScrollBtn .auto-scroll-icon {
+  display: block !important;
+  flex-shrink: 0 !important;
+}
+
+#autoScrollBtn:not(.active) {
+  color: var(--text-low) !important;
+  border-color: var(--border-hair) !important;
+  background: transparent !important;
+}
+
+.log-ctl-btn.active {
+  color: var(--signal-go) !important;
+  border-color: color-mix(in srgb, var(--signal-go) 58%, transparent) !important;
+  background: var(--signal-go-fill) !important;
+}
+
+.log-ctl-btn.active svg {
+  color: var(--signal-go) !important;
+}
+
+/* ── First-load skeleton: keep the dashboard structure visible while the first
+   /api/stats response is still in flight. It mirrors the existing dense rows,
+   then disappears without affecting later live rendering. ── */
+.loading-chip,
+.loading-row span,
+.loading-row b,
+.loading-bar,
+.app.is-loading #usersMeta,
+.app.is-loading #usersNote,
+.app.is-loading #usersList::before {
+  background:
+    linear-gradient(90deg, var(--surface-2) 0%, var(--surface-3) 42%, var(--surface-2) 84%) 0 0 / 220% 100%;
+  animation: skeletonSweep 1400ms ease-in-out infinite;
+}
+
+@keyframes skeletonSweep {
+  0% { background-position: 120% 0; }
+  100% { background-position: -120% 0; }
+}
+
+.app:not(.is-loading) #railLoading {
+  display: none !important;
+}
+
+.app.is-loading #usersCard {
+  display: flex !important;
+}
+
+.app.is-loading #usersMeta {
+  width: 140px;
+  height: 12px;
+  color: transparent !important;
+}
+
+.app.is-loading #usersNote {
+  width: 58%;
+  height: 12px;
+  color: transparent !important;
+}
+
+.app.is-loading #usersList {
+  min-height: 138px;
+}
+
+.app.is-loading #usersList::before {
+  content: '';
+  display: block;
+  height: 138px;
+  border-bottom: 1px solid var(--border-hair);
+  background-image:
+    linear-gradient(90deg, var(--surface-2) 0%, var(--surface-3) 42%, var(--surface-2) 84%),
+    linear-gradient(var(--surface-3), var(--surface-3)),
+    linear-gradient(var(--surface-3), var(--surface-3)),
+    linear-gradient(var(--surface-3), var(--surface-3)),
+    linear-gradient(var(--border-hair), var(--border-hair)),
+    linear-gradient(var(--border-hair), var(--border-hair)),
+    linear-gradient(var(--border-hair), var(--border-hair));
+  background-size:
+    220% 100%,
+    92px 14px,
+    88px 14px,
+    44% 14px,
+    100% 1px,
+    100% 1px,
+    100% 1px;
+  background-position:
+    120% 0,
+    2px 18px,
+    306px 18px,
+    426px 18px,
+    0 45px,
+    0 91px,
+    0 137px;
+  background-repeat: no-repeat;
+}
+
+.app.is-loading .add-user-wrap {
+  display: none !important;
+}
+
+#railLoading {
+  gap: 0 !important;
+}
+
+#railLoading .masthead {
+  padding-bottom: 12px !important;
+}
+
+#railLoading .loading-title {
+  width: 148px;
+  height: 13px;
+}
+
+#railLoading .loading-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+#railLoading .loading-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 11px 2px;
+  border-bottom: 1px solid var(--border-hair);
+}
+
+#railLoading .loading-row span {
+  width: 104px;
+  height: 11px;
+}
+
+#railLoading .loading-row b {
+  width: 72px;
+  height: 14px;
+}
+
+#railLoading .loading-bar {
+  height: 3px;
+  margin: 16px 2px 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loading-chip,
+  .loading-row span,
+  .loading-row b,
+  .loading-bar,
+  .app.is-loading #usersMeta,
+  .app.is-loading #usersNote,
+  .app.is-loading #usersList::before {
+    animation: none !important;
+  }
+}

--- a/src/ctl/dashboard_assets/static/style.css
+++ b/src/ctl/dashboard_assets/static/style.css
@@ -695,7 +695,7 @@ body::before, body::after { content: none; }
 
 
 /* ═══════════════════ PAPER-LAYOUT CSS (section build) ═══════════════════ */
-<![CDATA[/* ───────────────────────────────────────────────────────────────
+/* ───────────────────────────────────────────────────────────────
    TOPBAR — bus-bar (h56, border-bottom steel, full-bleed band)
    The band itself spans the viewport; its contents are padded by the
    48px-ish gutter so brand sits flush-left and telemetry flush-right.
@@ -866,7 +866,7 @@ body::before, body::after { content: none; }
   .telemetry { white-space: normal; }
   #statusHeroText { font-size: 30px; line-height: 34px; }
   .footer-inner { flex-direction: column; align-items: flex-start; gap: 10px; }
-}]]>
+}
 
 /* ════════════════════════════════════════════════════════════════════════
    KPI BAND  — Paper "Bahnhof Console" v2
@@ -1321,7 +1321,7 @@ body::before, body::after { content: none; }
   .user-actions .ui-btn, .add-user-btn { transition: none !important; }
 }
 
-<![CDATA[/* ============================================================================
+/* ============================================================================
    LIVE LOGS  — Paper "Bahnhof Console" 1:1
    Section is an open (transparent) block; masthead rule, sunk well.
    ========================================================================== */
@@ -1476,7 +1476,7 @@ body::before, body::after { content: none; }
 @media (prefers-reduced-motion: reduce) {
   .logs-body { scroll-behavior: auto; }
   .log-line.fresh { animation: none; }
-}]]>
+}
 
 /* ════════════════════════════════════════════════════════════════════════
    RIGHT RAIL — Routing & Upstream · Tunnel Quality · Masking

--- a/src/ctl/dashboard_assets/static/style.css
+++ b/src/ctl/dashboard_assets/static/style.css
@@ -1763,3 +1763,20 @@ body::before, body::after { content: none; }
 .user-name { display: flex; align-items: center; gap: 0; min-width: 0; }
 .user-name-text { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 @media (max-width: 680px) { .user-row { grid-template-columns: 1fr; } }
+
+/* ── Corrective: tighten the KPI band to Paper density (gauges were floating in
+   cells stretched to the tall network well). Shorten the chart + paddings. ── */
+.chart-wrap { height: 122px !important; }
+.kpi-network { padding: 16px 18px !important; gap: 10px !important; }
+.kpi-network .net-legend { margin: 0 !important; }
+.instrument { padding: 16px 22px !important; gap: 10px !important; justify-content: flex-start !important; }
+.instrument .gauge-container { flex: 1 1 auto; align-items: center; }
+.spark-wrap { height: 34px !important; margin-top: 6px !important; }
+
+/* ── Corrective 2: gauge prominent + pinned under the eyebrow with the sparkline
+   right below (no floating in the middle). Paper has the dial as the subject. ── */
+.instrument { justify-content: flex-start !important; gap: 12px !important; }
+.instrument .gauge-container { flex: 0 0 auto !important; padding: 6px 0 !important; }
+.gauge { width: 124px !important; height: 124px !important; }
+.spark-wrap { margin-top: auto !important; height: 36px !important; }   /* trace sits at the cell floor */
+.chart-wrap { height: 112px !important; }

--- a/src/ctl/dashboard_assets/static/style.css
+++ b/src/ctl/dashboard_assets/static/style.css
@@ -1,1151 +1,609 @@
+/* ───────────────────────────────────────────────────────────────────────────
+   MTProto Proxy Dashboard — "Bahnhof Console" design system
+   A Swiss railway departure board at blue hour: cold tinted slate, one warm
+   sodium-amber moment (the status hero), signal-square states, tabular mono
+   telemetry, masthead section rules. Near-square edges, no glow, no shadow.
+
+   Legacy CSS variable names (--zig, --green, --red, --amber, --cyan, --purple,
+   --text, --text-dim, --text-muted, --border, --bg-card) are kept and remapped
+   to Bahnhof tokens so inline styles in index.html / app.js resolve correctly.
+   ─────────────────────────────────────────────────────────────────────────── */
+
 :root {
-  --bg: #0a0c10;
-  --card: rgba(18, 22, 30, 0.75);
-  --card-border: rgba(247, 164, 29, 0.08);
-  --card-hover: rgba(247, 164, 29, 0.15);
-  --text: #e8ecf4;
-  --text-dim: #7c8698;
-  --text-muted: #4a5568;
-  --zig: #f7a41d;
-  --zig-dim: rgba(247, 164, 29, 0.15);
-  --green: #34d399;
-  --blue: #60a5fa;
-  --purple: #a78bfa;
-  --cyan: #22d3ee;
-  --amber: #fbbf24;
-  --red: #f87171;
+  /* ── Bahnhof tokens ── */
+  --ground: #13171C;
+  --ground-deep: #0E1115;
+  --surface-1: #171C22;
+  --surface-2: #1B2128;
+  --surface-3: #222933;
+  --well: #0E1115;
+  --well-rx: #0C0F13;
+  --border-hair: #1E242B;
+  --border-steel: #272F38;
+  --border-steel-bright: #333D48;
+  --text-hi: #ECE7DA;
+  --text-mid: #9AA3AE;
+  --text-low: #5E6873;
+  --text-on-accent: #15110A;
+  --accent: #F7A41D;
+  --accent-dim: #C97E12;
+  --accent-glow: rgba(247, 164, 29, 0.12);
+  --rx: #5C82C9;
+  --tx: #F7A41D;
+  --signal-go: #6FB58A;
+  --signal-go-fill: rgba(111, 181, 138, 0.16);
+  --signal-caution: #C9A24B;
+  --signal-caution-fill: rgba(201, 162, 75, 0.16);
+  --signal-stop: #D06A5B;
+  --signal-stop-fill: rgba(208, 106, 91, 0.16);
+  --signal-idle: #6E8092;
+  --signal-idle-fill: rgba(110, 128, 146, 0.14);
+
+  /* ── Legacy aliases (consumed by inline styles in index.html / app.js) ── */
+  --bg: var(--ground);
+  --card: var(--surface-1);
+  --card-border: var(--border-hair);
+  --card-hover: var(--border-steel);
+  --text: var(--text-hi);
+  --text-dim: var(--text-mid);
+  --text-muted: var(--text-low);
+  --zig: var(--accent);
+  --zig-dim: var(--accent-glow);
+  --green: var(--signal-go);
+  --blue: var(--rx);
+  --purple: var(--signal-caution);   /* memory gauge → caution band, no purple */
+  --cyan: var(--text-hi);            /* handshakes stat → cream */
+  --amber: var(--signal-caution);
+  --red: var(--signal-stop);
+  --border: var(--border-steel);
+  --bg-card: var(--surface-1);
+
+  --radius-chip: 2px;
+  --radius-ctl: 3px;
+  --radius-surface: 4px;
+  --radius-hero: 6px;
+
+  --font-display: 'Archivo', 'Inter', system-ui, sans-serif;
+  --font-text: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+
+  --gutter: 32px;
 }
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
 body {
-  font-family: 'Inter', -apple-system, sans-serif;
-  background: var(--bg);
-  color: var(--text);
+  font-family: var(--font-text);
+  background: var(--ground);
+  color: var(--text-hi);
   min-height: 100vh;
   overflow-x: hidden;
+  font-feature-settings: 'cv01' 1;
+  -webkit-font-smoothing: antialiased;
 }
-
-body::before {
-  content: ''; position: fixed;
-  top: -30%; left: -10%;
-  width: 60%; height: 60%;
-  background: radial-gradient(ellipse, rgba(247,164,29,0.04) 0%, transparent 70%);
-  pointer-events: none; z-index: 0;
-}
-body::after {
-  content: ''; position: fixed;
-  bottom: -20%; right: -10%;
-  width: 50%; height: 50%;
-  background: radial-gradient(ellipse, rgba(247,164,29,0.03) 0%, transparent 70%);
-  pointer-events: none; z-index: 0;
-}
+/* Bahnhof is flat tinted slate — no radial glows. */
+body::before, body::after { content: none; }
 
 .app {
   position: relative; z-index: 1;
-  max-width: 1400px; margin: 0 auto; padding: 0 28px;
+  max-width: 1360px; margin: 0 auto; padding: 0 var(--gutter);
 }
 
-/* ── Header ── */
+/* All live numerals align in columns. */
+.card-value, .stat-cell .val, .gauge .pct, .tunnel-val, .user-sessions,
+.user-link, .routing-xfer, .routing-meta, .egress-rtt, .egress-loss, .egress-hs,
+.meta b, .chart-legend, #proxyRss, #srvUptime, #lastUpdate, #pxMax {
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: 'tnum' 1;
+}
+
+/* ── Header / bus-bar ── */
 .header {
-  padding: 28px 0 20px;
+  padding: 18px 0;
   display: flex; align-items: center; justify-content: space-between;
-  border-bottom: 1px solid rgba(247,164,29,0.06);
-  margin-bottom: 24px;
+  gap: 16px; flex-wrap: wrap;
+  border-bottom: 1px solid var(--border-steel);
+  margin-bottom: 40px;
 }
-.header-left { display: flex; align-items: center; gap: 16px; }
-.zig-logo { width: 44px; height: 44px; }
-.zig-logo svg { width: 100%; height: 100%; }
+.header-left { display: flex; align-items: center; gap: 12px; }
+.zig-logo { width: 28px; height: 28px; flex-shrink: 0; }
+.zig-logo svg, .zig-logo img { width: 100%; height: 100%; display: block; }
 .header h1 {
-  font-size: 21px; font-weight: 700; letter-spacing: -0.5px;
-  display: flex; align-items: baseline; gap: 8px;
+  font-family: var(--font-display);
+  font-size: 16px; font-weight: 600; letter-spacing: -0.01em;
+  display: flex; align-items: baseline; gap: 7px; color: var(--text-hi);
 }
-.header h1 .accent { color: var(--zig); }
-.header h1 .dim { color: var(--text-dim); font-weight: 400; font-size: 15px; }
+.header h1 .accent { color: var(--accent); }
+.header h1 .dim { color: var(--text-mid); font-weight: 500; font-size: 14px; letter-spacing: 0; }
 .version-pill {
-  font-size: 10px;
-  font-weight: 600;
-  font-family: 'JetBrains Mono', monospace;
-  color: var(--zig);
-  background: rgba(247,164,29,0.08);
-  border: 1px solid rgba(247,164,29,0.18);
-  border-radius: 100px;
-  padding: 2px 10px;
-  letter-spacing: 0.5px;
-  vertical-align: middle;
+  font-size: 11px; font-weight: 500;
+  font-family: var(--font-mono);
+  color: var(--text-low);
+  background: var(--surface-2);
+  border: 1px solid var(--border-steel);
+  border-radius: var(--radius-chip);
+  padding: 2px 6px; letter-spacing: 0;
 }
 .header-right {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 12px;
-  flex-wrap: wrap;
+  display: flex; align-items: center; justify-content: flex-end;
+  gap: 16px; flex-wrap: wrap;
 }
 
+/* ── Badges = signal-square + word (no pills, no glow) ── */
 .badge {
   display: inline-flex; align-items: center; gap: 8px;
-  padding: 6px 16px; border-radius: 100px;
-  font-size: 12px; font-weight: 600;
-  background: rgba(52,211,153,0.08);
-  border: 1px solid rgba(52,211,153,0.15);
-  color: var(--green);
+  padding: 0; border: 0; background: none; border-radius: 0;
+  font-size: 13px; font-weight: 560; color: var(--signal-go);
 }
-.badge.off { background: rgba(248,113,113,0.08); border-color: rgba(248,113,113,0.15); color: var(--red); }
+.badge.off { color: var(--signal-stop); }
+.data-badge { color: var(--text-mid); }
+.data-badge.ok { color: var(--signal-go); }
+.data-badge.stale { color: var(--signal-stop); }
+.data-badge.paused { color: var(--signal-caution); }
+.data-badge.syncing { color: var(--text-mid); }
 
-.data-badge {
-  background: rgba(96,165,250,0.08);
-  border-color: rgba(96,165,250,0.15);
-  color: var(--blue);
-}
-.data-badge.ok {
-  background: rgba(52,211,153,0.08);
-  border-color: rgba(52,211,153,0.15);
-  color: var(--green);
-}
-.data-badge.stale {
-  background: rgba(248,113,113,0.08);
-  border-color: rgba(248,113,113,0.2);
-  color: var(--red);
-}
-.data-badge.paused {
-  background: rgba(251,191,36,0.08);
-  border-color: rgba(251,191,36,0.18);
-  color: var(--amber);
+/* the former pulse-dot → a static signal square */
+.pulse-dot {
+  width: 8px; height: 8px; border-radius: var(--radius-chip);
+  background: currentColor; box-shadow: none; animation: none;
+  flex-shrink: 0;
 }
 
 .poll-controls {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 10px;
-  border-radius: 10px;
-  border: 1px solid rgba(247,164,29,0.1);
-  background: rgba(10,12,16,0.35);
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 0; border: 0; background: none;
 }
-
 .poll-controls label {
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 1.1px;
-  color: var(--text-dim);
+  font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.17em;
+  color: var(--text-low); font-weight: 600;
 }
 
-.ui-select,
-.ui-btn,
-.ui-input {
-  border: 1px solid rgba(247,164,29,0.16);
-  background: rgba(16,20,28,0.8);
-  color: var(--text);
-  border-radius: 8px;
-  font-family: 'Inter', -apple-system, sans-serif;
-  font-size: 11px;
+/* ── Controls: inputs / selects / buttons ── */
+.ui-select, .ui-btn, .ui-input {
+  border: 1px solid var(--border-steel);
+  background: var(--well);
+  color: var(--text-hi);
+  border-radius: var(--radius-ctl);
+  font-family: var(--font-text);
+  font-size: 13px;
 }
-
-.ui-select {
-  height: 28px;
-  padding: 0 8px;
-}
-
+.ui-select { height: 30px; padding: 0 8px; }
 .ui-btn {
-  height: 28px;
-  padding: 0 10px;
-  cursor: pointer;
-  transition: border-color 0.2s, color 0.2s, background 0.2s;
+  height: 30px; padding: 0 12px; cursor: pointer; font-weight: 540;
+  background: transparent; color: var(--text-mid);
+  transition: border-color 0.12s, color 0.12s, background 0.12s;
 }
-
+.ui-btn:hover { background: var(--surface-2); color: var(--text-hi); border-color: var(--border-steel-bright); }
+/* primary / selected — thin amber ink (the hero keeps the only full-size amber) */
 .ui-btn.active {
-  color: var(--zig);
-  border-color: rgba(247,164,29,0.35);
-  background: rgba(247,164,29,0.08);
+  color: var(--accent); border-color: var(--accent-dim); background: var(--accent-glow);
 }
-
 .ui-btn.danger {
-  color: var(--red);
-  border-color: rgba(248,113,113,0.25);
-  background: rgba(248,113,113,0.06);
+  color: var(--signal-stop); border-color: rgba(208, 106, 91, 0.4); background: transparent;
 }
-.ui-btn.danger:hover {
-  border-color: rgba(248,113,113,0.5);
-  background: rgba(248,113,113,0.12);
-}
-
-.ui-input {
-  height: 28px;
-  padding: 0 10px;
+.ui-btn.danger:hover { background: var(--signal-stop-fill); border-color: var(--signal-stop); }
+.ui-input { height: 30px; padding: 0 12px; }
+.ui-input::placeholder { color: var(--text-low); }
+.ui-btn:focus-visible, .ui-select:focus-visible, .ui-input:focus-visible {
+  outline: 1.5px solid var(--accent); outline-offset: 2px;
 }
 
-.ui-btn:hover,
-.ui-select:hover,
-.ui-input:hover {
-  border-color: rgba(247,164,29,0.3);
+.meta { font-size: 12px; color: var(--text-low); font-family: var(--font-mono); }
+.meta b { color: var(--text-mid); font-weight: 500; }
+
+/* ── Status hero — the one sodium-lamp moment ── */
+#statusHero {
+  margin: 0 0 40px !important;
+  padding: 24px 28px !important;
+  border-radius: var(--radius-hero) !important;
+  border: 1px solid var(--border-steel) !important;
+  background: var(--surface-1) !important;
+  display: flex; align-items: center; gap: 16px;
+  font-family: var(--font-display) !important;
+  font-size: 28px !important; font-weight: 620 !important;
+  letter-spacing: -0.02em; line-height: 1.15;
 }
-
-.ui-btn:focus-visible,
-.ui-select:focus-visible,
-.ui-input:focus-visible {
-  outline: 1px solid rgba(247,164,29,0.45);
-  outline-offset: 1px;
+/* state icon → a signal square (the glyph text is hidden; colour inherits the
+   state colour set on the hero by setStatusHero) */
+#statusHeroIcon {
+  font-size: 0 !important; flex-shrink: 0;
+  width: 12px; height: 12px; border-radius: var(--radius-chip);
+  background: currentColor; display: inline-block;
 }
+#statusHeroText { font-family: var(--font-display); }
 
-.pulse-dot {
-  width: 7px; height: 7px; border-radius: 50%;
-  background: currentColor;
-  box-shadow: 0 0 6px currentColor;
-  animation: pulse 2.5s ease infinite;
+/* ── Section grid (KPI band) ── */
+.grid {
+  display: grid; grid-template-columns: repeat(12, 1fr);
+  gap: 0; margin-bottom: 40px;
+  border: 1px solid var(--border-hair); border-radius: var(--radius-surface);
+  overflow: hidden; background: var(--surface-1);
 }
-@keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.4} }
-
-.meta { font-size: 12px; color: var(--text-dim); }
-.meta b { color: var(--text); font-weight: 600; }
-
-/* ── Grid ── */
-.grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 14px; margin-bottom: 14px; }
 .col-3 { grid-column: span 3; }
 .col-6 { grid-column: span 6; }
 
-/* ── Card ── */
+/* CPU/Memory instruments sit directly on the board, divided by hairlines. */
 .card {
-  background: var(--card);
-  backdrop-filter: blur(24px);
-  border: 1px solid var(--card-border);
-  border-radius: 18px;
-  padding: 22px 24px;
+  background: transparent;
+  border: 0;
+  border-right: 1px solid var(--border-hair);
+  border-radius: 0;
+  padding: 18px 22px;
   position: relative; overflow: hidden;
-  transition: border-color 0.3s, box-shadow 0.3s;
 }
-.card:hover {
-  border-color: var(--card-hover);
-  box-shadow: 0 0 30px rgba(247,164,29,0.04);
-}
-.card::before {
-  content: ''; position: absolute;
-  top: 0; left: 0; right: 0; height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(247,164,29,0.1), transparent);
-}
+.card:last-child { border-right: 0; }
+.card::before { content: none; }
+/* the network card = a sunk well */
+.col-6.card { background: var(--well-rx); }
 
-.app.stale .card,
-.app.stale .stat-cell {
-  opacity: 0.62;
-}
+.app.stale .card, .app.stale .stat-cell { opacity: 0.62; }
 
 .card-label {
-  font-size: 10px; font-weight: 600;
-  text-transform: uppercase; letter-spacing: 1.8px;
-  color: var(--text-dim); margin-bottom: 16px;
+  font-size: 10.5px; font-weight: 620;
+  text-transform: uppercase; letter-spacing: 0.17em;
+  color: var(--text-low); margin-bottom: 14px;
   display: flex; align-items: center; gap: 8px;
+  padding-bottom: 10px; border-bottom: 1px solid var(--border-hair);
 }
 .card-value {
-  font-size: 38px; font-weight: 800;
-  letter-spacing: -2px; line-height: 1;
-  font-variant-numeric: tabular-nums;
+  font-family: var(--font-display);
+  font-size: 30px; font-weight: 620;
+  letter-spacing: -0.018em; line-height: 1;
+  color: var(--text-hi);
 }
-.card-sub { font-size: 11px; color: var(--text-muted); margin-top: 6px; }
+.card-sub { font-size: 11px; color: var(--text-low); margin-top: 6px; font-family: var(--font-mono); }
 
 /* ── Gauge ── */
-.gauge-container { display: flex; align-items: center; gap: 22px; }
-.gauge { width: 90px; height: 90px; position: relative; flex-shrink: 0; }
-.gauge svg { transform: rotate(-90deg); }
-.gauge circle { fill: none; stroke-linecap: round; }
-.gauge .track { stroke: rgba(247,164,29,0.06); stroke-width: 5; }
-.gauge .fill { stroke-width: 5; transition: stroke-dashoffset 1s cubic-bezier(0.4,0,0.2,1); }
+.gauge-container { display: flex; align-items: center; gap: 18px; justify-content: center; }
+.gauge { width: 96px; height: 96px; position: relative; flex-shrink: 0; }
+.gauge svg { transform: rotate(135deg); }   /* 270° arc, gap at the bottom */
+.gauge circle { fill: none; stroke-linecap: butt; }
+.gauge .track { stroke: var(--border-steel); stroke-width: 3; stroke-dasharray: 70.69 94.25; }
+.gauge .fill { stroke-width: 3; stroke-dasharray: 0 94.25; transition: stroke-dasharray 0.8s cubic-bezier(0.4,0,0.2,1), stroke 0.3s; }
 .gauge .pct {
-  position: absolute; top: 50%; left: 50%;
-  transform: translate(-50%,-50%);
-  font-size: 17px; font-weight: 700;
-  font-variant-numeric: tabular-nums;
+  position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
+  font-family: var(--font-display);
+  font-size: 26px; font-weight: 620; color: var(--text-hi) !important;
 }
 
 /* ── Sparkline ── */
 .spark-wrap {
-  height: 80px;
-  margin-top: 14px;
-  position: relative;
-  border-top: 1px solid rgba(247,164,29,0.04);
-  padding-top: 6px;
+  height: 40px; margin-top: 14px; position: relative;
+  border-top: 1px solid var(--border-hair); padding-top: 8px;
 }
 .spark-wrap canvas { width: 100% !important; height: 100% !important; }
 
 /* ── Network chart ── */
-.chart-wrap {
-  height: 160px;
-  position: relative;
-  margin-top: 6px;
-  padding-top: 8px;
-}
+.chart-wrap { height: 150px; position: relative; margin-top: 6px; padding-top: 8px; }
 .chart-wrap canvas { width: 100% !important; height: 100% !important; }
-
 .chart-legend {
-  display: flex; gap: 18px; margin-top: 8px;
-  font-size: 11px; color: var(--text-dim);
-  font-variant-numeric: tabular-nums;
+  display: flex; gap: 18px; margin-top: 10px;
+  font-size: 12px; color: var(--text-mid); font-family: var(--font-mono);
 }
 .chart-legend span { display: flex; align-items: center; gap: 6px; }
-.ldot { width: 10px; height: 3px; border-radius: 2px; }
+.chart-legend b { color: var(--text-hi); font-weight: 500; }
+.ldot { width: 8px; height: 8px; border-radius: 0; }
 
-/* ── Stats row ── */
+/* ── Stat strip ── */
 .stat-row {
   display: grid; grid-template-columns: repeat(4, 1fr); gap: 1px;
-  background: rgba(247,164,29,0.06); border-radius: 16px; overflow: hidden;
-  margin-bottom: 14px;
+  background: var(--border-steel); border: 1px solid var(--border-hair);
+  border-radius: var(--radius-surface); overflow: hidden; margin-bottom: 40px;
 }
-.stat-cell {
-  background: var(--card);
-  backdrop-filter: blur(24px);
-  padding: 20px; text-align: center;
-  transition: background 0.2s;
-}
-.stat-cell:hover { background: rgba(18,22,30,0.9); }
+.stat-cell { background: var(--surface-1); padding: 16px 22px; text-align: left; }
+.stat-cell:hover { background: var(--surface-2); }
 .stat-cell .val {
-  font-size: 30px; font-weight: 800; letter-spacing: -1px;
-  font-variant-numeric: tabular-nums;
+  font-family: var(--font-display);
+  font-size: 24px; font-weight: 600; letter-spacing: -0.018em; color: var(--text-hi);
 }
 .stat-cell .lbl {
-  font-size: 10px; font-weight: 500;
-  text-transform: uppercase; letter-spacing: 1.2px;
-  color: var(--text-dim); margin-top: 6px;
+  font-size: 10.5px; font-weight: 620; text-transform: uppercase; letter-spacing: 0.17em;
+  color: var(--text-low); margin-top: 6px;
 }
 
-/* ── Users card ── */
-.users-card {
-  background: var(--card);
-  backdrop-filter: blur(24px);
-  border: 1px solid var(--card-border);
-  border-radius: 16px;
-  margin-bottom: 14px;
-  overflow: hidden;
-  transition: border-color 0.3s;
+/* ── Masthead section rule (shared by users / tunnel / logs headers) ── */
+.users-head, .tunnel-header, .logs-header {
+  display: flex; align-items: center; gap: 16px;
+  padding: 0 0 12px 0; border-bottom: 1px solid var(--border-steel);
 }
-.users-card:hover { border-color: var(--card-hover); }
-.users-head {
-  padding: 14px 24px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  border-bottom: 1px solid rgba(247,164,29,0.05);
+.users-head .title, .tunnel-title, .logs-header .title {
+  font-family: var(--font-text);
+  font-size: 13px; font-weight: 620; text-transform: uppercase; letter-spacing: 0.15em;
+  color: var(--text-mid); white-space: nowrap; flex-shrink: 0;
 }
-.users-head .title {
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 1.6px;
-  color: var(--text-dim);
+.users-head-right { display: flex; align-items: center; gap: 12px; margin-left: auto; flex-shrink: 0; }
+.users-meta { font-size: 12px; color: var(--text-low); font-family: var(--font-mono); }
+
+/* ── Cards (users / tunnel / logs) become open sections, not glass boxes ── */
+.users-card, .tunnel-card, .logs-card {
+  background: transparent; border: 0; border-radius: 0;
+  margin-bottom: 40px; overflow: visible;
 }
-.users-head-right {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-.users-meta {
-  font-size: 11px;
-  color: var(--text-dim);
-  font-variant-numeric: tabular-nums;
-}
-.users-note {
-  padding: 8px 24px;
-  font-size: 11px;
-  color: var(--text-muted);
-  border-bottom: 1px solid rgba(247,164,29,0.05);
-}
-.users-list {
-  display: flex;
-  flex-direction: column;
-}
+.tunnel-header { gap: 12px; }
+.tunnel-icon { font-size: 16px; }
+.tunnel-title { flex: 0 0 auto; }
+/* tunnel/users badges live to the right of the masthead rule */
+.tunnel-header .badge, .users-head .badge { margin-left: auto; }
+
+.users-note { padding: 12px 2px 0; font-size: 12px; color: var(--text-low); font-family: var(--font-mono); }
+.users-list { display: flex; flex-direction: column; }
+
+/* ── User row (timetable baseline grid) — also fixes #279 (long names) ── */
 .user-row {
   display: grid;
-  grid-template-columns: minmax(100px, 150px) 80px 1fr auto;
-  gap: 10px;
-  align-items: center;
-  padding: 10px 24px;
-  border-bottom: 1px solid rgba(247,164,29,0.04);
-  transition: background 0.15s;
+  grid-template-columns: minmax(120px, 200px) 104px minmax(0, 1fr) auto;
+  gap: 14px; align-items: center;
+  padding: 0 2px; height: 50px;
+  border-bottom: 1px solid var(--border-hair);
+  transition: background 0.12s;
 }
-.user-row:hover {
-  background: rgba(247,164,29,0.02);
-}
-.user-row:last-child {
-  border-bottom: 0;
-}
+.user-row:hover { background: var(--surface-2); }
 .user-name {
-  font-size: 13px;
-  color: var(--text);
-  font-weight: 600;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: flex;
-  align-items: center;
-  gap: 0;
+  font-family: var(--font-text);
+  font-size: 14px; color: var(--text-hi); font-weight: 540; letter-spacing: -0.003em;
+  display: flex; align-items: center; gap: 0; min-width: 0; overflow: hidden;
 }
+/* #279: the name truncates; the toggle and the session counter never shrink */
+.user-name-text { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.user-name .user-toggle-switch { flex-shrink: 0; }
 .user-sessions {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 18px;
-  height: 18px;
-  padding: 0 5px;
-  margin-left: 6px;
-  border-radius: 999px;
-  font-size: 10px;
-  font-weight: 700;
-  font-variant-numeric: tabular-nums;
-  background: rgba(52,211,153,0.12);
-  border: 1px solid rgba(52,211,153,0.25);
-  color: var(--green);
-  flex-shrink: 0;
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 20px; height: 18px; padding: 0 6px; margin-left: 9px;
+  border-radius: var(--radius-chip);
+  font-family: var(--font-mono); font-size: 11px; font-weight: 500;
+  background: var(--signal-go-fill); color: var(--signal-go);
+  flex-shrink: 0;          /* #279: counter never gets squeezed by a long name */
 }
-.user-sessions.zero {
-  background: rgba(124,134,152,0.08);
-  border-color: rgba(124,134,152,0.15);
-  color: var(--text-muted);
-}
-.user-route {
-  display: flex;
-  align-items: center;
-}
+.user-sessions.zero { background: var(--surface-2); color: var(--text-low); }
+.user-route { display: flex; align-items: center; min-width: 0; }
 .user-direct-toggle {
-  font-size: 10px !important;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.6px;
-  padding: 4px 10px !important;
-  height: 24px !important;
-  border-radius: 999px !important;
-  cursor: pointer;
-  transition: all 0.2s;
+  font-size: 13px !important; font-weight: 540; text-transform: none; letter-spacing: 0;
+  padding: 0 0 0 14px !important; height: auto !important;
+  border: 0 !important; background: transparent !important; border-radius: 0 !important;
+  cursor: pointer; position: relative; color: var(--text-mid) !important;
+  display: inline-flex; align-items: center;
 }
-.user-direct-toggle.on {
-  color: var(--green) !important;
-  border-color: rgba(52,211,153,0.3) !important;
-  background: rgba(52,211,153,0.08) !important;
+/* signal square in front of the route word */
+.user-direct-toggle::before {
+  content: ''; position: absolute; left: 0; top: 50%; transform: translateY(-50%);
+  width: 8px; height: 8px; border-radius: var(--radius-chip); background: var(--signal-idle);
 }
-.user-direct-toggle:not(.on) {
-  color: var(--text-dim) !important;
-  border-color: rgba(247,164,29,0.15) !important;
-  background: rgba(247,164,29,0.04) !important;
-}
-.user-direct-toggle:hover {
-  border-color: rgba(247,164,29,0.35) !important;
-}
+.user-direct-toggle.on { color: var(--text-mid) !important; }
+.user-direct-toggle.on::before { background: var(--signal-go); }
+.user-direct-toggle:hover { color: var(--text-hi) !important; }
 .user-link {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
-  color: var(--text-dim);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  font-family: var(--font-mono); font-size: 12.5px; color: var(--text-mid);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;
 }
-.user-actions {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-.user-actions .ui-btn {
-  height: 26px;
-  font-size: 10px;
-  padding: 0 9px;
-}
-.user-actions .ui-btn:disabled {
-  opacity: 0.45;
-  cursor: default;
-}
-.user-delete {
-  width: 26px;
-  padding: 0 !important;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 13px !important;
-  opacity: 0;
-  transition: opacity 0.15s;
-}
-.user-row:hover .user-delete {
-  opacity: 1;
-}
-.user-empty {
-  padding: 16px 24px;
-  color: var(--text-muted);
-  font-size: 12px;
-}
-.user-row.disabled {
-  opacity: 0.45;
-}
-.user-row.disabled .user-link {
-  font-style: italic;
-  color: var(--text-muted);
-}
+.user-actions { display: inline-flex; align-items: center; gap: 6px; justify-content: flex-end; flex-shrink: 0; }
+.user-actions .ui-btn { height: 28px; font-size: 11px; padding: 0 9px; font-family: var(--font-mono); }
+.user-actions .ui-btn:disabled { opacity: 0.4; cursor: default; }
+.user-delete { width: 28px; padding: 0 !important; display: flex; align-items: center; justify-content: center; font-size: 14px !important; opacity: 0; transition: opacity 0.12s; }
+.user-row:hover .user-delete { opacity: 1; }
+.user-empty { padding: 16px 2px; color: var(--text-low); font-size: 13px; }
+.user-row.disabled { opacity: 0.55; }
+.user-row.disabled .user-link { font-style: italic; color: var(--text-low); }
 
-/* ── Toggle Switch ── */
+/* ── Toggle (squared hardware switch, not a pill) ── */
 .user-toggle-switch {
-  position: relative;
-  display: inline-block;
-  width: 30px;
-  height: 16px;
-  margin-right: 8px;
-  flex-shrink: 0;
-  vertical-align: middle;
-  cursor: pointer;
+  position: relative; display: inline-block;
+  width: 36px; height: 20px; margin-right: 9px; flex-shrink: 0;
+  vertical-align: middle; cursor: pointer;
 }
-.user-toggle-switch input {
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
+.user-toggle-switch input { opacity: 0; width: 0; height: 0; }
 .user-toggle-slider {
-  position: absolute;
-  top: 0; left: 0; right: 0; bottom: 0;
-  background: rgba(248,113,113,0.25);
-  border-radius: 16px;
-  transition: background 0.25s;
+  position: absolute; inset: 0;
+  background: var(--well); border: 1px solid var(--border-steel);
+  border-radius: var(--radius-ctl); transition: background 0.18s, border-color 0.18s;
 }
 .user-toggle-slider::before {
-  content: '';
-  position: absolute;
-  height: 12px;
-  width: 12px;
-  left: 2px;
-  bottom: 2px;
-  background: var(--red);
-  border-radius: 50%;
-  transition: transform 0.25s, background 0.25s;
+  content: ''; position: absolute; height: 14px; width: 14px; left: 2px; top: 2px;
+  background: var(--surface-3); border-radius: var(--radius-chip);
+  transition: transform 0.18s, background 0.18s;
 }
-.user-toggle-switch input:checked + .user-toggle-slider {
-  background: rgba(52,211,153,0.25);
-}
-.user-toggle-switch input:checked + .user-toggle-slider::before {
-  transform: translateX(14px);
-  background: var(--green);
-}
+.user-toggle-switch input:checked + .user-toggle-slider { background: var(--signal-go-fill); border-color: var(--signal-go); }
+.user-toggle-switch input:checked + .user-toggle-slider::before { transform: translateX(16px); background: var(--signal-go); }
 
-/* ── Add User Button ── */
-.add-user-btn {
-  color: var(--green) !important;
-  border-color: rgba(52,211,153,0.25) !important;
-  background: rgba(52,211,153,0.06) !important;
-  font-weight: 600 !important;
-}
-.add-user-btn:hover {
-  border-color: rgba(52,211,153,0.45) !important;
-  background: rgba(52,211,153,0.12) !important;
-}
+.add-user-btn { color: var(--text-hi) !important; border-color: var(--border-steel) !important; background: transparent !important; font-weight: 540 !important; }
+.add-user-btn:hover { border-color: var(--border-steel-bright) !important; background: var(--surface-2) !important; }
 
-/* ── Add User Form ── */
-.add-user-form {
-  padding: 16px 24px;
-  border-bottom: 1px solid rgba(247,164,29,0.06);
-  background: rgba(52,211,153,0.02);
-}
-.form-row {
-  display: flex;
-  gap: 12px;
-  align-items: flex-end;
-  flex-wrap: wrap;
-}
-.form-field {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  flex: 1;
-  min-width: 160px;
-}
-.form-field label {
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  color: var(--text-dim);
-}
-.form-field .ui-input {
-  height: 32px;
-  font-size: 12px;
-  width: 100%;
-}
-.form-hint {
-  font-weight: 400;
-  text-transform: none;
-  letter-spacing: 0;
-  color: var(--text-muted);
-}
-.form-actions {
-  display: flex;
-  gap: 6px;
-  align-items: center;
-}
-.form-actions .ui-btn {
-  height: 32px;
-  font-size: 12px;
-}
-.form-status {
-  margin-top: 8px;
-  font-size: 11px;
-  min-height: 16px;
-}
-.form-status.error {
-  color: var(--red);
-}
-.form-status.info {
-  color: var(--text-dim);
-}
+/* ── Add user form ── */
+.add-user-form { padding: 16px 2px; border-bottom: 1px solid var(--border-hair); background: transparent; }
+.form-row { display: flex; gap: 12px; align-items: flex-end; flex-wrap: wrap; }
+.form-field { display: flex; flex-direction: column; gap: 6px; flex: 1; min-width: 160px; }
+.form-field label { font-size: 10.5px; font-weight: 620; text-transform: uppercase; letter-spacing: 0.14em; color: var(--text-low); }
+.form-field .ui-input { height: 32px; font-size: 13px; width: 100%; }
+.form-hint { font-weight: 400; text-transform: none; letter-spacing: 0; color: var(--text-low); }
+.form-actions { display: flex; gap: 6px; align-items: center; }
+.form-actions .ui-btn { height: 32px; font-size: 13px; }
+.form-status { margin-top: 8px; font-size: 12px; min-height: 16px; }
+.form-status.error { color: var(--signal-stop); }
+.form-status.info { color: var(--text-mid); }
 
 /* ── Modal ── */
 .modal-overlay {
-  position: fixed;
-  top: 0; left: 0; right: 0; bottom: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(4px);
-  z-index: 200;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  position: fixed; inset: 0; background: rgba(8, 10, 13, 0.72);
+  z-index: 200; display: flex; align-items: center; justify-content: center;
 }
 .modal {
-  background: #12161e;
-  border: 1px solid rgba(248,113,113,0.2);
-  border-radius: 16px;
-  padding: 28px 32px;
-  max-width: 420px;
-  width: 90%;
-  box-shadow: 0 20px 60px rgba(0,0,0,0.5);
+  background: var(--surface-1); border: 1px solid var(--border-steel);
+  border-radius: var(--radius-hero); padding: 28px 32px; max-width: 420px; width: 90%;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.5);
 }
-.modal-title {
-  font-size: 16px;
-  font-weight: 700;
-  color: var(--amber);
-  margin-bottom: 12px;
-}
-.modal-body {
-  font-size: 13px;
-  color: var(--text-dim);
-  line-height: 1.6;
-  margin-bottom: 20px;
-}
-.modal-body b {
-  color: var(--text);
-}
-.modal-actions {
-  display: flex;
-  gap: 8px;
-  justify-content: flex-end;
-}
-.modal-actions .ui-btn {
-  height: 34px;
-  padding: 0 16px;
-  font-size: 12px;
-  font-weight: 600;
-}
+.modal-title { font-family: var(--font-display); font-size: 18px; font-weight: 620; color: var(--text-hi); margin-bottom: 12px; }
+.modal-body { font-size: 14px; color: var(--text-mid); line-height: 1.6; margin-bottom: 20px; }
+.modal-body b { color: var(--text-hi); }
+.modal-actions { display: flex; gap: 8px; justify-content: flex-end; }
+.modal-actions .ui-btn { height: 34px; padding: 0 16px; font-size: 13px; font-weight: 560; }
 
 /* ── Toast ── */
 .toast {
-  position: fixed;
-  bottom: 24px;
-  right: 24px;
-  padding: 12px 20px;
-  border-radius: 12px;
-  font-size: 12px;
-  font-weight: 500;
-  backdrop-filter: blur(12px);
-  z-index: 300;
-  transform: translateY(10px);
-  opacity: 0;
-  transition: transform 0.25s ease, opacity 0.25s ease;
-  max-width: 400px;
+  position: fixed; bottom: 24px; right: 24px; padding: 12px 18px;
+  border-radius: var(--radius-ctl); font-size: 13px; font-weight: 500;
+  background: var(--surface-2); border: 1px solid var(--border-steel); color: var(--text-hi);
+  z-index: 300; transform: translateY(10px); opacity: 0;
+  transition: transform 0.25s ease, opacity 0.25s ease; max-width: 400px;
 }
-.toast.show {
-  transform: translateY(0);
-  opacity: 1;
-}
-.toast.success {
-  background: rgba(52,211,153,0.12);
-  border: 1px solid rgba(52,211,153,0.25);
-  color: var(--green);
-}
-.toast.error {
-  background: rgba(248,113,113,0.12);
-  border: 1px solid rgba(248,113,113,0.25);
-  color: var(--red);
-}
-.toast.info {
-  background: rgba(96,165,250,0.12);
-  border: 1px solid rgba(96,165,250,0.25);
-  color: var(--blue);
-}
+.toast.show { transform: translateY(0); opacity: 1; }
+.toast.success { border-color: var(--signal-go); color: var(--signal-go); }
+.toast.error { border-color: var(--signal-stop); color: var(--signal-stop); }
+.toast.info { border-color: var(--rx); color: var(--text-hi); }
 
-/* ── Tunnel card ── */
-.tunnel-card {
-  background: var(--card);
-  backdrop-filter: blur(24px);
-  border: 1px solid var(--card-border);
-  border-radius: 16px;
-  margin-bottom: 14px;
-  overflow: hidden;
-  transition: border-color 0.3s;
-}
-.tunnel-card:hover { border-color: var(--card-hover); }
-.tunnel-header {
-  padding: 16px 24px;
-  display: flex; align-items: center; gap: 12px;
-  border-bottom: 1px solid rgba(247,164,29,0.04);
-}
-.tunnel-icon { font-size: 18px; }
-.tunnel-title {
-  font-size: 12px; font-weight: 600;
-  text-transform: uppercase; letter-spacing: 1.4px;
-  color: var(--text-dim);
-  flex: 1;
-}
-.tunnel-details {
-  display: grid; grid-template-columns: repeat(4, 1fr);
-  gap: 1px; background: rgba(247,164,29,0.03);
-}
-.tunnel-stat {
-  background: var(--card);
-  padding: 14px 24px;
-  display: flex; flex-direction: column; gap: 4px;
-}
-.tunnel-lbl {
-  font-size: 10px; font-weight: 500;
-  text-transform: uppercase; letter-spacing: 1px;
-  color: var(--text-muted);
-}
-.tunnel-val {
-  font-size: 13px; font-weight: 600;
-  font-family: 'JetBrains Mono', monospace;
-  font-variant-numeric: tabular-nums;
-  color: var(--text);
-}
-
-.routing-list {
-  border-top: 1px solid rgba(247,164,29,0.05);
-}
-
+/* ── Tunnel / routing card details ── */
 .routing-controls {
-  padding: 10px 24px;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-  border-bottom: 1px solid rgba(247,164,29,0.05);
+  padding: 12px 2px; display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+  border-bottom: 1px solid var(--border-hair);
 }
-
-.routing-upstream-ctl {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
+.routing-upstream-ctl, .routing-extra-ctl { display: inline-flex; align-items: center; gap: 8px; }
+.routing-upstream-ctl label, .routing-extra-ctl label {
+  font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.14em; color: var(--text-low); font-weight: 600;
 }
+.routing-host { width: 160px; }
+.routing-port { width: 92px; }
+.routing-user, .routing-pass { width: 140px; }
+.routing-action-note { font-size: 12px; color: var(--text-low); min-height: 16px; margin-left: auto; }
+.routing-action-note.error { color: var(--signal-stop); }
+.routing-action-note.ok { color: var(--signal-go); }
 
-.routing-extra-ctl {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-}
+.tunnel-details { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1px; background: var(--border-hair); margin-top: 12px; border: 1px solid var(--border-hair); border-radius: var(--radius-surface); overflow: hidden; }
+.tunnel-stat { background: var(--surface-1); padding: 14px 18px; display: flex; flex-direction: column; gap: 4px; }
+.tunnel-lbl { font-size: 10.5px; font-weight: 620; text-transform: uppercase; letter-spacing: 0.14em; color: var(--text-low); }
+.tunnel-val { font-size: 13px; font-weight: 500; font-family: var(--font-mono); color: var(--text-hi); }
 
-.routing-upstream-ctl label {
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  color: var(--text-dim);
-}
-
-.routing-extra-ctl label {
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  color: var(--text-dim);
-}
-
-.routing-host {
-  width: 160px;
-}
-
-.routing-port {
-  width: 92px;
-}
-
-.routing-user,
-.routing-pass {
-  width: 140px;
-}
-
-.routing-action-note {
-  font-size: 11px;
-  color: var(--text-muted);
-  min-height: 16px;
-  margin-left: auto;
-}
-
-.routing-action-note.error {
-  color: var(--red);
-}
-
-.routing-action-note.ok {
-  color: var(--green);
-}
-
+.routing-list { margin-top: 4px; }
 .routing-row {
-  display: grid;
-  grid-template-columns: minmax(80px, 110px) 80px 1fr auto auto;
-  gap: 10px;
-  align-items: center;
-  padding: 10px 24px;
-  border-bottom: 1px solid rgba(247,164,29,0.04);
+  display: grid; grid-template-columns: minmax(90px, 120px) 84px minmax(0, 1fr) auto auto;
+  gap: 12px; align-items: center; padding: 12px 2px;
+  border-bottom: 1px solid var(--border-hair);
 }
-
-.routing-row:last-child {
-  border-bottom: 0;
-}
-
-.routing-iface {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 12px;
-  color: var(--text);
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-
+.routing-iface { font-family: var(--font-mono); font-size: 13px; color: var(--text-hi); display: inline-flex; align-items: center; gap: 7px; }
 .routing-tag {
-  font-size: 9px;
-  text-transform: uppercase;
-  letter-spacing: 0.8px;
-  color: var(--zig);
-  border: 1px solid rgba(247,164,29,0.25);
-  border-radius: 999px;
-  padding: 2px 6px;
+  font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: 0.14em;
+  color: var(--text-low); border: 0; border-radius: 0; padding: 0;
 }
-
-.routing-state {
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.9px;
-  font-weight: 700;
-}
-
-.routing-state.on {
-  color: var(--green);
-}
-
-.routing-state.mid {
-  color: var(--amber);
-}
-
-.routing-state.off {
-  color: var(--red);
-}
-
-.routing-meta {
-  font-size: 11px;
-  color: var(--text-dim);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.routing-xfer {
-  font-size: 11px;
-  color: var(--text-muted);
-  font-family: 'JetBrains Mono', monospace;
-  white-space: nowrap;
-}
-
-.routing-actions {
-  display: flex;
-  justify-content: flex-end;
-}
-
-.routing-actions .ui-btn {
-  min-width: 64px;
-}
-
-.routing-empty {
-  padding: 12px 24px;
-  font-size: 11px;
-  color: var(--text-muted);
-}
-
+.routing-state { font-size: 13px; font-weight: 560; display: inline-flex; align-items: center; gap: 7px; }
+.routing-state::before { content: ''; width: 8px; height: 8px; border-radius: var(--radius-chip); background: var(--signal-idle); }
+.routing-state.on { color: var(--signal-go); }
+.routing-state.on::before { background: var(--signal-go); }
+.routing-state.mid { color: var(--signal-caution); }
+.routing-state.mid::before { background: var(--signal-caution); }
+.routing-state.off { color: var(--signal-stop); }
+.routing-state.off::before { background: var(--signal-stop); }
+.routing-meta { font-size: 12px; color: var(--text-mid); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0; }
+.routing-xfer { font-size: 12px; color: var(--text-low); font-family: var(--font-mono); white-space: nowrap; }
+.routing-actions { display: flex; justify-content: flex-end; }
+.routing-actions .ui-btn { min-width: 64px; }
+.routing-empty { padding: 12px 2px; font-size: 12px; color: var(--text-low); }
 .app.stale .tunnel-card { opacity: 0.62; }
 
 /* ── Tooltips ── */
 .chart-tooltip {
   position: fixed; pointer-events: none;
-  background: rgba(18, 22, 30, 0.9);
-  backdrop-filter: blur(8px);
-  border: 1px solid rgba(247,164,29,0.15);
-  border-radius: 8px; padding: 6px 10px;
-  font-size: 11px; font-family: 'JetBrains Mono', monospace;
-  color: var(--text); z-index: 100;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.4);
-  opacity: 0; transition: opacity 0.15s;
-  display: flex; flex-direction: column; gap: 4px;
+  background: var(--surface-2); border: 1px solid var(--border-steel);
+  border-radius: var(--radius-ctl); padding: 6px 10px;
+  font-size: 11px; font-family: var(--font-mono); color: var(--text-hi); z-index: 100;
+  opacity: 0; transition: opacity 0.15s; display: flex; flex-direction: column; gap: 4px;
 }
 .chart-tooltip.visible { opacity: 1; }
-.tooltip-ts { color: var(--text-dim); font-size: 10px; }
+.tooltip-ts { color: var(--text-low); font-size: 10px; }
 .tooltip-val { font-weight: 600; }
 
 /* ── Live logs ── */
-.logs-card {
-  background: var(--card);
-  backdrop-filter: blur(24px);
-  border: 1px solid var(--card-border);
-  border-radius: 18px;
-  overflow: hidden;
-  margin-bottom: 32px;
-}
-.logs-header {
-  padding: 14px 24px;
-  display: flex; align-items: center; justify-content: space-between;
-  border-bottom: 1px solid rgba(247,164,29,0.06);
-}
-.logs-header .title {
-  font-size: 10px; font-weight: 600;
-  text-transform: uppercase; letter-spacing: 1.8px;
-  color: var(--text-dim);
-  display: flex; align-items: center; gap: 8px;
-}
-.logs-header .ws-badge {
-  display: inline-flex; align-items: center; gap: 6px;
-  font-size: 11px; color: var(--text-muted);
-}
+.logs-header { gap: 16px; }
+.logs-header .ws-badge { display: inline-flex; align-items: center; gap: 7px; font-size: 12px; color: var(--text-low); font-family: var(--font-mono); margin-left: auto; }
+.logs-controls { padding: 12px 0; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.log-filters { display: inline-flex; align-items: center; gap: 6px; }
+.log-filter { font-family: var(--font-mono); font-size: 10.5px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; height: 28px; }
+.log-filter:not(.active) { color: var(--text-low); border-color: var(--border-hair); background: transparent; }
+/* active filter coloured by its level (no amber leak) */
+.log-filter.active[data-filter="error"] { color: var(--signal-stop); border-color: rgba(208,106,91,0.4); background: var(--signal-stop-fill); }
+.log-filter.active[data-filter="warn"]  { color: var(--signal-caution); border-color: rgba(201,162,75,0.4); background: var(--signal-caution-fill); }
+.log-filter.active[data-filter="stats"] { color: var(--signal-go); border-color: rgba(111,181,138,0.4); background: var(--signal-go-fill); }
+.log-search { width: 240px; max-width: 100%; }
 
-.logs-controls {
-  padding: 10px 24px;
-  border-bottom: 1px solid rgba(247,164,29,0.06);
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
-.log-filters {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.log-filter:not(.active) {
-  color: var(--text-dim);
-  border-color: rgba(247,164,29,0.1);
-  background: rgba(16,20,28,0.35);
-}
-
-.log-search {
-  width: 220px;
-  max-width: 100%;
-}
-
-.ws-dot { width: 6px; height: 6px; border-radius: 50%; }
-.ws-dot.on { background: var(--green); box-shadow: 0 0 6px var(--green); }
-.ws-dot.off { background: var(--amber); }
+.ws-dot { width: 8px; height: 8px; border-radius: var(--radius-chip); }
+.ws-dot.on { background: var(--signal-go); }
+.ws-dot.off { background: var(--signal-caution); }
 
 .logs-body {
-  height: 300px; overflow-y: auto;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11.5px; line-height: 1.8;
-  padding: 8px 0;
+  height: 320px; overflow-y: auto;
+  font-family: var(--font-mono); font-size: 12.5px; line-height: 1.55;
+  padding: 10px 0; background: var(--well); border: 1px solid var(--border-hair);
+  border-top-color: var(--border-steel);
   scroll-behavior: smooth;
 }
-.logs-body::-webkit-scrollbar { width: 5px; }
+.logs-body::-webkit-scrollbar { width: 6px; }
 .logs-body::-webkit-scrollbar-track { background: transparent; }
-.logs-body::-webkit-scrollbar-thumb { background: rgba(247,164,29,0.1); border-radius: 3px; }
+.logs-body::-webkit-scrollbar-thumb { background: var(--border-steel); border-radius: 0; }
 
-.log-line {
-  padding: 1px 24px;
-  display: flex; gap: 14px;
-  transition: background 0.12s;
+.log-line { padding: 3px 16px; display: flex; gap: 12px; align-items: baseline; transition: background 0.1s; }
+.log-line:hover { background: var(--surface-1); }
+.log-ts { color: var(--text-low); flex-shrink: 0; width: 64px; user-select: none; font-size: 12px; }
+/* level chip — derived from the line class via ::before, centred, fixed-width */
+.log-msg { word-break: break-word; color: var(--text-mid); flex: 1; min-width: 0; }
+.log-msg::before {
+  content: 'INFO'; display: inline-flex; align-items: center; justify-content: center;
+  width: 52px; padding: 1px 0; margin-right: 12px; border-radius: var(--radius-chip);
+  font-size: 10px; font-weight: 600; letter-spacing: 0.06em;
+  vertical-align: 1px;
+  color: var(--signal-idle); background: var(--signal-idle-fill);
 }
-.log-line:hover { background: rgba(247,164,29,0.03); }
-.log-ts {
-  color: var(--text-muted); flex-shrink: 0;
-  user-select: none; font-size: 10px; line-height: 1.8; opacity: 0.7;
-}
-.log-msg { word-break: break-all; }
-.log-line.info  .log-msg { color: var(--text-dim); }
-.log-line.stats .log-msg { color: var(--zig); }
-.log-line.drops .log-msg { color: var(--amber); }
-.log-line.error .log-msg { color: var(--red); font-weight: 500; }
-.log-line.warn  .log-msg { color: var(--amber); }
+.log-line.info  .log-msg { color: var(--text-mid); }
+.log-line.info  .log-msg::before { content: 'INFO'; color: var(--signal-idle); background: var(--signal-idle-fill); }
+.log-line.stats .log-msg::before { content: 'STATS'; color: var(--signal-go); background: var(--signal-go-fill); }
+.log-line.drops .log-msg::before { content: 'DROPS'; color: var(--signal-caution); background: var(--signal-caution-fill); }
+.log-line.warn  .log-msg::before { content: 'WARN'; color: var(--signal-caution); background: var(--signal-caution-fill); }
+.log-line.error .log-msg::before { content: 'ERROR'; color: var(--signal-stop); background: var(--signal-stop-fill); }
 .log-line.fresh { animation: slideIn 0.25s ease; }
-@keyframes slideIn { from{opacity:0;transform:translateY(-3px)} to{opacity:1;transform:none} }
+@keyframes slideIn { from { opacity: 0; transform: translateY(-3px); } to { opacity: 1; transform: none; } }
+
+/* ── Egress / tunnel quality ── */
+.egress-list { display: flex; flex-direction: column; gap: 8px; margin-top: 12px; }
+.egress-row {
+  display: grid; grid-template-columns: minmax(0,1fr) 88px 110px 80px 70px 70px;
+  gap: 12px; padding: 12px; background: var(--surface-1);
+  border: 1px solid var(--border-hair); border-radius: var(--radius-surface);
+  align-items: center; font-size: 13px;
+}
+.egress-row.is-bottleneck { border-color: rgba(208,106,91,0.4); background: var(--signal-stop-fill); }
+.egress-iface { font-weight: 540; word-break: break-all; display: flex; gap: 7px; align-items: center; min-width: 0; }
+.egress-status, .egress-quality { padding: 4px 6px; border-radius: var(--radius-chip); text-align: center; font-weight: 540; font-size: 12px; }
+.egress-status.on { background: var(--signal-go-fill); color: var(--signal-go); }
+.egress-status.off { background: var(--signal-stop-fill); color: var(--signal-stop); }
+.egress-quality-good { background: var(--signal-go-fill); color: var(--signal-go); }
+.egress-quality-degraded { background: var(--signal-caution-fill); color: var(--signal-caution); }
+.egress-quality-poor { background: var(--signal-stop-fill); color: var(--signal-stop); }
+.egress-quality-up { background: var(--signal-go-fill); color: var(--text-mid); }
+.egress-quality-down, .egress-quality-unknown { background: var(--signal-idle-fill); color: var(--text-low); }
+.egress-rtt, .egress-loss, .egress-hs { text-align: center; font-family: var(--font-mono); font-size: 12px; color: var(--text-mid); }
+.egress-bottleneck { grid-column: 1 / -1; font-size: 12px; font-weight: 540; color: var(--signal-caution); margin-top: 2px; display: flex; align-items: center; gap: 7px; }
 
 /* ── Footer ── */
-.footer {
-  text-align: center; padding: 0 0 24px;
-  font-size: 11px; color: var(--text-muted);
-}
-.footer a { color: var(--zig); text-decoration: none; }
+.footer { text-align: center; padding: 24px 0 28px; font-size: 12px; color: var(--text-low); border-top: 1px solid var(--border-hair); margin-top: 8px; }
+.footer a { color: var(--accent); text-decoration: none; }
 
 /* ── Responsive ── */
-@media (max-width: 1000px) {
+@media (max-width: 1040px) {
   .grid { grid-template-columns: repeat(6, 1fr); }
   .col-3 { grid-column: span 3; }
-  .col-6 { grid-column: span 6; }
+  .col-6 { grid-column: span 6; border-right: 0; border-top: 1px solid var(--border-hair); }
   .stat-row { grid-template-columns: repeat(2, 1fr); }
 }
-@media (max-width: 640px) {
+@media (max-width: 680px) {
+  .app { padding: 0 18px; }
   .grid { grid-template-columns: 1fr; }
-  .col-3, .col-6 { grid-column: span 1; }
+  .col-3, .col-6 { grid-column: span 1; border-right: 0; border-bottom: 1px solid var(--border-hair); }
   .stat-row { grid-template-columns: repeat(2, 1fr); }
-  .header { flex-direction: column; gap: 12px; align-items: flex-start; }
+  .header { flex-direction: column; align-items: flex-start; gap: 12px; }
   .header-right { width: 100%; justify-content: flex-start; }
-  .poll-controls { width: 100%; }
-  .logs-controls { padding: 10px 14px; }
-  .log-search { width: 100%; }
-  .users-head { padding: 12px 14px; }
-  .users-note { padding: 8px 14px; }
-  .user-row {
-    grid-template-columns: 1fr;
-    gap: 8px;
-    padding: 10px 14px;
-  }
+  .user-row { grid-template-columns: 1fr; gap: 8px; height: auto; padding: 12px 2px; }
   .user-link { white-space: normal; word-break: break-all; }
   .user-delete { opacity: 1; }
+  .user-actions { justify-content: flex-start; flex-wrap: wrap; }
   .form-row { flex-direction: column; }
   .tunnel-details { grid-template-columns: repeat(2, 1fr); }
-  .routing-row {
-    grid-template-columns: 1fr;
-    gap: 6px;
-    padding: 10px 14px;
-  }
-  .routing-actions {
-    justify-content: flex-start;
-  }
-  .routing-meta { white-space: normal; }
-  .routing-controls {
-    padding: 10px 14px;
-    align-items: stretch;
-  }
-  .routing-upstream-ctl {
-    width: 100%;
-    flex-wrap: wrap;
-  }
-  .routing-extra-ctl {
-    width: 100%;
-    flex-wrap: wrap;
-  }
-  .routing-host,
-  .routing-port,
-  .routing-user,
-  .routing-pass {
-    width: 100%;
-  }
-  .routing-action-note {
-    margin-left: 0;
-    width: 100%;
-  }
-}
-
-/* Egress / Tunnel Quality */
-.egress-list {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  margin-top: 12px;
-}
-
-.egress-row {
-  display: grid;
-  grid-template-columns: 1fr 80px 100px 80px 70px 70px;
-  gap: 12px;
-  padding: 10px;
-  background: rgba(127, 127, 127, 0.04);
-  border: 1px solid var(--card-border);
-  border-radius: 8px;
-  align-items: center;
-  font-size: 13px;
-}
-
-.egress-row.is-bottleneck {
-  border-color: rgba(248, 113, 113, 0.35);
-  background: rgba(248, 113, 113, 0.05);
-}
-
-.egress-iface {
-  font-weight: 500;
-  word-break: break-all;
-  display: flex;
-  gap: 6px;
-  align-items: center;
-}
-
-.egress-status {
-  padding: 4px 6px;
-  border-radius: 4px;
-  text-align: center;
-  font-weight: 500;
-  font-size: 12px;
-}
-
-.egress-status.on {
-  background: rgba(52, 211, 153, 0.15);
-  color: var(--green);
-}
-
-.egress-status.off {
-  background: rgba(255, 80, 80, 0.15);
-  color: var(--red);
-}
-
-.egress-quality {
-  padding: 4px 6px;
-  border-radius: 4px;
-  text-align: center;
-  font-weight: 500;
-  font-size: 12px;
-}
-
-.egress-quality-good {
-  background: rgba(52, 211, 153, 0.15);
-  color: var(--green);
-}
-
-.egress-quality-degraded {
-  background: rgba(240, 180, 40, 0.15);
-  color: var(--amber);
-}
-
-.egress-quality-poor {
-  background: rgba(255, 80, 80, 0.15);
-  color: var(--red);
-}
-
-.egress-quality-up {
-  background: rgba(52, 211, 153, 0.1);
-  color: var(--text-muted);
-}
-
-.egress-quality-down,
-.egress-quality-unknown {
-  background: rgba(127, 127, 127, 0.1);
-  color: var(--text-muted);
-}
-
-.egress-rtt,
-.egress-loss,
-.egress-hs {
-  text-align: center;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 12px;
-  color: var(--text-muted);
-}
-
-.egress-bottleneck {
-  grid-column: 1 / -1;
-  font-size: 11px;
-  font-weight: 500;
-  color: var(--red);
-  margin-top: 2px;
-}
-
-@media (max-width: 1200px) {
-  .egress-row {
-    grid-template-columns: 1fr 70px;
-    gap: 8px;
-  }
-  .egress-quality,
-  .egress-rtt,
-  .egress-loss,
-  .egress-hs {
-    display: none;
-  }
-  .egress-bottleneck {
-    grid-column: 1 / -1;
-  }
+  .routing-row { grid-template-columns: 1fr; gap: 6px; }
+  .routing-actions { justify-content: flex-start; }
+  .egress-row { grid-template-columns: minmax(0,1fr) 80px; }
+  .egress-quality, .egress-rtt, .egress-loss, .egress-hs { display: none; }
 }

--- a/src/ctl/dashboard_assets/static/style.css
+++ b/src/ctl/dashboard_assets/static/style.css
@@ -1780,3 +1780,21 @@ body::before, body::after { content: none; }
 .gauge { width: 124px !important; height: 124px !important; }
 .spark-wrap { margin-top: auto !important; height: 36px !important; }   /* trace sits at the cell floor */
 .chart-wrap { height: 112px !important; }
+
+/* ── Hero parity: right-side figures (CONNECTED/UPTIME) + sub-line ── */
+#statusHero { display: flex !important; flex-direction: row !important; align-items: center !important; gap: 24px !important; }
+.hero-verdict { display: flex; flex-direction: column; gap: 10px; flex: 1; min-width: 0; }
+.hero-sub { font-family: 'Inter', sans-serif; font-size: 14px; font-weight: 540; color: var(--text-mid); line-height: 20px; padding-left: 28px; }
+.hero-figures { display: flex; flex-direction: row; align-items: center; flex-shrink: 0; }
+.hero-fig { display: flex; flex-direction: column; align-items: flex-end; gap: 5px; padding: 0 24px; }
+.hero-fig-div { border-left: 1px solid var(--border-steel); }
+.hero-fig-label { font-family: 'Inter', sans-serif; font-size: 10.5px; font-weight: 620; letter-spacing: 0.17em; color: var(--text-low); text-transform: uppercase; }
+.hero-fig-val { font-family: 'Archivo', sans-serif; font-size: 30px; font-weight: 620; letter-spacing: -0.018em; line-height: 32px; color: var(--text-hi); font-feature-settings: 'tnum' 1; }
+.hero-fig-val.mono { font-family: 'JetBrains Mono', monospace; font-size: 22px; font-weight: 500; }
+@media (max-width: 760px) { .hero-figures { display: none; } }
+
+/* ── Segmented EN|RU lang toggle (Paper parity) ── */
+.lang-seg { display: inline-flex; align-items: center; border: 1px solid var(--border-steel); border-radius: 3px; overflow: hidden; height: 28px; cursor: pointer; }
+.lang-cell { display: flex; align-items: center; padding: 0 9px; height: 100%; font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 600; letter-spacing: 0.04em; color: var(--text-low); transition: background 130ms ease, color 130ms ease; }
+.lang-cell + .lang-cell { border-left: 1px solid var(--border-steel); }
+.lang-cell.on { color: var(--text-hi); background: var(--surface-2); }

--- a/src/ctl/dashboard_assets/static/style.css
+++ b/src/ctl/dashboard_assets/static/style.css
@@ -1798,3 +1798,8 @@ body::before, body::after { content: none; }
 .lang-cell { display: flex; align-items: center; padding: 0 9px; height: 100%; font-family: 'Inter', sans-serif; font-size: 11px; font-weight: 600; letter-spacing: 0.04em; color: var(--text-low); transition: background 130ms ease, color 130ms ease; }
 .lang-cell + .lang-cell { border-left: 1px solid var(--border-steel); }
 .lang-cell.on { color: var(--text-hi); background: var(--surface-2); }
+
+/* ── MiddleProxy state control reads as a green on/off toggle, not an amber
+   primary button (amber is reserved for the hero + true primary actions) ── */
+#routingMiddleBtn { min-width: 52px; text-align: center; }
+#routingMiddleBtn.active { color: var(--signal-go) !important; border-color: var(--signal-go) !important; background: var(--signal-go-fill) !important; }

--- a/src/ctl/dashboard_assets/static/style.css
+++ b/src/ctl/dashboard_assets/static/style.css
@@ -259,7 +259,7 @@ body::before, body::after { content: none; }
 .gauge svg { transform: rotate(135deg); }   /* 270° arc, gap at the bottom */
 .gauge circle { fill: none; stroke-linecap: butt; }
 .gauge .track { stroke: var(--border-steel); stroke-width: 3; stroke-dasharray: 70.69 94.25; }
-.gauge .fill { stroke-width: 3; stroke-dasharray: 0 94.25; transition: stroke-dasharray 0.8s cubic-bezier(0.4,0,0.2,1), stroke 0.3s; }
+.gauge .fill { stroke-width: 3; stroke-dasharray: 0 94.25; }   /* transition defined once in the Motion section */
 .gauge .pct {
   position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
   font-family: var(--font-display);
@@ -606,4 +606,89 @@ body::before, body::after { content: none; }
   .routing-actions { justify-content: flex-start; }
   .egress-row { grid-template-columns: minmax(0,1fr) 80px; }
   .egress-quality, .egress-rtt, .egress-loss, .egress-hs { display: none; }
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   Motion & interaction (Emil Kowalski's design-eng principles)
+   A professional dashboard: crisp & fast. Custom strong ease-out, press
+   feedback on every pressable, transform/opacity only, reduced-motion aware.
+   NOTE: the users / routing / egress lists are re-rendered every poll (~3s), so
+   they get NO entrance animation (it would replay constantly) — only hover/press
+   transitions, which animate on interaction, not on (re)creation.
+   ───────────────────────────────────────────────────────────────────────────── */
+:root {
+  --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+/* Press feedback — the interface confirms it heard the tap (scale 0.97, ~120ms).
+   transform/opacity only; never `all`. */
+.ui-btn {
+  transition: background 130ms ease, color 130ms ease, border-color 130ms ease,
+              transform 120ms var(--ease-out);
+}
+.ui-btn:active:not(:disabled) { transform: scale(0.97); }
+.user-direct-toggle:active { transform: scale(0.96); }
+
+/* Toggle switch — the slide IS the feedback; the press nudge composes with the
+   checked translate (transform is one non-additive property), so an enabled
+   user's knob doesn't teleport to the left edge while pressed. */
+.user-toggle-slider { transition: background 160ms ease, border-color 160ms ease; }
+.user-toggle-slider::before { transition: transform 160ms var(--ease-out), background 160ms ease; }
+.user-toggle-switch input:not(:checked) + .user-toggle-slider:active::before { transform: scale(0.96); }
+.user-toggle-switch input:checked + .user-toggle-slider:active::before { transform: translateX(16px) scale(0.96); }
+
+/* Surfaces that react to hover get a snappy, property-specific transition */
+.stat-cell { transition: background 140ms ease; }
+.user-row { transition: background 120ms ease; }
+.log-line { transition: background 100ms ease; }
+.user-delete { transition: opacity 140ms ease, transform 120ms var(--ease-out); }
+.egress-row, .routing-row { transition: background 140ms ease, border-color 140ms ease; }
+
+/* Gauge value tween — seen every poll (no replay/interrupt risk); an SVG arc
+   length can't be a transform, so 450ms ease-out lets the needle settle. */
+.gauge .fill { transition: stroke-dasharray 450ms var(--ease-out), stroke 300ms var(--ease-out); }
+
+/* Toast — occasional; asymmetric enter/exit (enter elegant, exit snappier),
+   transform+opacity only. Exit (base) ≤ the 300ms JS removal timer. */
+.toast { transition: transform 200ms var(--ease-out), opacity 200ms var(--ease-out); }
+.toast.show { transition: transform 280ms var(--ease-out), opacity 240ms var(--ease-out); }
+
+/* Modal entry (occasional) — fade scrim + scale-from-0.96 (never scale(0)),
+   centered origin (modals are not anchored to a trigger). @starting-style drives
+   the entrance with no JS; exit is instant (display toggles off) which is fine. */
+.modal-overlay {
+  opacity: 1;
+  transition: opacity 200ms var(--ease-out);
+}
+@starting-style { .modal-overlay { opacity: 0; } }
+.modal {
+  transform-origin: center;
+  transition: transform 220ms var(--ease-out), opacity 220ms var(--ease-out);
+}
+@starting-style { .modal { opacity: 0; transform: scale(0.96); } }
+
+/* QR share modal is built + appended by JS with inline styles; style its entrance
+   here so it scales in from 0.96 like the other modals. */
+#shareModalOverlay { transition: opacity 200ms var(--ease-out); }
+@starting-style { #shareModalOverlay { opacity: 0; } }
+#shareModalOverlay > div {
+  transform-origin: center;
+  transition: transform 240ms var(--ease-out), opacity 240ms var(--ease-out);
+}
+@starting-style { #shareModalOverlay > div { opacity: 0; transform: scale(0.96); } }
+
+/* Hover-driven transforms only on real pointers (touch taps fire :hover falsely) */
+@media (hover: hover) and (pointer: fine) {
+  .ui-btn.user-share:hover, .add-user-btn:hover { transform: translateY(-1px); }
+}
+
+/* Reduced motion: keep opacity/colour for comprehension, drop all movement
+   (no transform/clip/dash tweens, no keyframes) — per the skill's guidance. */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-property: opacity, background, background-color, color, border-color, fill, stroke, box-shadow !important;
+    transition-duration: 140ms !important;
+  }
 }


### PR DESCRIPTION
## What

Redesigns the web control-panel dashboard to the **"Bahnhof Console"** design system — a Swiss railway departure board at blue hour — and fixes the long-username layout bug.

**Closes #279.**

## Design system

- Tinted-slate surfaces (`#13171C` ground, `#0E1115` wells) — flat, no glassmorphism, no glow, no drop-shadows (except the modal).
- **One sodium-amber moment**: full-saturation amber `#F7A41D` is reserved for the status-hero verdict; everywhere else amber is thin functional ink only.
- **Signal-square states** (`go/caution/stop/idle`) replace the old glowing pulse-dots and 100px pills.
- Type: **Archivo** (display / numerals), **Inter** (labels / body), **JetBrains Mono** (all machine values, tabular-nums).
- **Masthead section rules** (caps eyebrow + hairline + right-aligned mono meta).
- KPI gauges are now 270° arcs with a **threshold colour ramp** (go → caution → stop); the memory gauge is no longer purple.
- Two-hue throughput chart: **RX steel-blue, TX amber**; neutral steel sparklines.

## Scope / safety

Pure restyle of the three static assets (`index.html`, `style.css`, `app.js`). **The backend is untouched** and the entire `app.js` DOM contract — element ids, classes, `data-i18n`, event wiring — is preserved, so polling, EN/RU i18n, user CRUD + QR share, routing / egress / masking and live logs keep working.

`style.css` is rewritten onto the existing class names; legacy CSS variables (`--zig`, `--green`, `--red`, …) are remapped to Bahnhof tokens so inline styles resolve correctly. `index.html`/`app.js` changes are surgical (fonts, gauge geometry + threshold colour, chart/sparkline colours, log-level chip, the #279 name-truncation wrapper).

## #279 — counters overflow on long usernames

Long names now truncate with an ellipsis inside a `min-width:0` flex slot while the session counter, route toggle and row actions are `flex-shrink:0`, so the counter is never pushed out of the row.

## Verification

Verified headless (Playwright + mocked backend API):

- **No console errors** (only the expected `/ws/logs` socket, absent in the mock).
- Every JS-referenced DOM id (93) resolves in the markup.
- All interactions wired: EN/RU toggle, add-user form, poll pause/resume, log-level filters, QR share modal.
- All sections render (hero, KPI gauges, sparklines, throughput chart, stat strip, users, routing, egress, masking, logs, footer).
- **#279**: with a deliberately long username, the session badge stays visible and within the row bounds.

Design was explored and synthesized in Paper before porting; the dark board is the canonical theme (a light "daytime" twin is specced for a follow-up).