### PR TITLE
fix(dashboard): stop phantom tunnel card flashing in non-tunnel modes

### DIFF
--- a/src/ctl/dashboard_assets/static/app.js
+++ b/src/ctl/dashboard_assets/static/app.js
@@ -1296,6 +1296,12 @@ function renderEgress(egress, opts) {
 }
 
 function renderEgressFromRouting(routing) {
+  // Only surface tunnel/egress UI when egress actually goes through a tunnel. In
+  // direct/socks5/http modes _routing_status still reports a placeholder awg0 probe
+  // (the default interface, shown "down"), which otherwise flashed an orange tunnel
+  // card on every poll until the async /api/egress (which knows the mode isn't tunnel)
+  // cleared it again.
+  if (!routing || String(routing.upstream_type || '').toLowerCase() !== 'tunnel') return;
   if (lastEgress && Array.isArray(lastEgress.tunnels) && lastEgress.tunnels.length) return;
   const tunnels = routing && Array.isArray(routing.tunnels) ? routing.tunnels : [];
   if (!tunnels.length) return;

--- a/src/ctl/dashboard_assets/static/index.html
+++ b/src/ctl/dashboard_assets/static/index.html
@@ -474,6 +474,6 @@
 </div>
 
 </div>
-<script src="/app.js?v=20260610-paper12"></script>
+<script src="/app.js?v=20260610-paper13"></script>
 </body>
 </html>


### PR DESCRIPTION
### Symptom
On a **direct-egress** deploy (no tunnel) the dashboard intermittently flashes an **orange "tunnel down" egress card** above the masking card, which then disappears on the next poll — looking like a tunnel is trying to do something.

### Cause
`_routing_status` (`/api/stats`) reports a **placeholder tunnel for the default `awg0` interface** (probed → `link_up:false`, `"interface down"`) regardless of upstream mode. `renderEgressFromRouting()` renders that placeholder as an egress card on every `/api/stats` poll, and the async `/api/egress` fetch — which correctly knows the mode isn't `tunnel` (`"Tunnel monitoring not active"`, `tunnels:[]`) — clears it a moment later. The result is a per-poll orange flicker.

### Fix
Guard `renderEgressFromRouting()` to only surface tunnel/egress UI when `routing.upstream_type === 'tunnel'`. Bumps the `app.js?v=` cache-bust so browsers fetch the updated script.

Pure dashboard frontend change; no proxy/runtime behavior affected. Verified on a live direct-egress prod (the orange flash is gone after refresh).