### PR TITLE
fix(middleproxy): detect NAT IP through the egress so socks/tunnel + ad-tag work out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ type = "auto"            # auto | direct | tunnel | socks5 | http
 port = 443
 # public_ip = "proxy.example.com"   # Inbound IP/domain used in client links
 # public_port = 443                 # Link port when behind HAProxy/Nginx
-# middle_proxy_nat_ip = "203.0.113.10"   # Outbound IPv4 seen by Telegram MiddleProxy
+# middle_proxy_nat_ip = "203.0.113.10"   # Override outbound IPv4 seen by Telegram MiddleProxy (auto-detected through the egress otherwise)
 max_connections = 512
 # workers = 1            # SO_REUSEPORT epoll workers: 1 = single-threaded (default); 0 = one per CPU; N spreads load across cores
 idle_timeout_sec = 120
@@ -427,7 +427,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[server] bind_address` | — | Specific IP to bind the listen socket (default: all interfaces) |
 | `[server] public_ip` | auto | Inbound IP/domain shown in client links. Required with VPN tunnel; set IPv4 explicitly if clients fail on IPv6 links |
 | `[server] public_port` | `[server].port` | Port shown in client links; useful when HAProxy/Nginx exposes a different public port |
-| `[server] middle_proxy_nat_ip` | auto | Outbound IPv4 used in MiddleProxy key derivation; auto-detected independently from `public_ip`, set explicitly when DC traffic exits through a VPN/NAT IP |
+| `[server] middle_proxy_nat_ip` | auto | Outbound IPv4 used in MiddleProxy key derivation; auto-detected **through the configured egress** (direct → host IP, socks5/http → proxy exit IP, tunnel → tunnel exit IP), so SOCKS/tunnel + ad-tag work out of the box. Set explicitly only to override when auto-detection can't see the real egress |
 | `[server] backlog` | `4096` | TCP listen queue depth |
 | `[server] max_connections` | `512` | Concurrent connection cap, auto-clamped by RAM and `RLIMIT_NOFILE` |
 | `[server] workers` | `1` | SO_REUSEPORT epoll worker threads. `1` = single-threaded; `0` = one per CPU; `N` spreads relay/crypto load across cores. SIGHUP config reload requires a restart when `>1` |
@@ -585,7 +585,7 @@ docker run --rm \
   ghcr.io/sleep3r/mtproto.zig:latest
 ```
 
-MiddleProxy media/promo traffic is sensitive to the outbound source IP:port used in its encrypted handshake. For Docker deployments that need MiddleProxy, prefer host networking (`--network host`) or a native `mtbuddy` install. `[server].public_ip` is only the inbound address shown to clients; if outbound DC traffic exits through a VPN/NAT IP, set `[server].middle_proxy_nat_ip` to that egress IPv4. Bridge or remote NAT that rewrites source ports can still break MiddleProxy handshakes.
+MiddleProxy media/promo traffic is sensitive to the outbound source IP:port used in its encrypted handshake. The egress IPv4 is **auto-detected through the configured upstream** — direct probes the host, `socks5`/`http` probes through the proxy (so it learns the SOCKS exit IP), and `tunnel` probes through the tunnel interface — so SOCKS/tunnel egress + ad-tag work without manual setup. For Docker deployments that need MiddleProxy, prefer host networking (`--network host`) or a native `mtbuddy` install. `[server].public_ip` is only the inbound address shown to clients; set `[server].middle_proxy_nat_ip` only to override when auto-detection can't see the real egress. Bridge or remote NAT that rewrites source ports can still break MiddleProxy handshakes.
 
 Build locally:
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -356,7 +356,7 @@ type = "auto"            # auto | direct | tunnel | socks5 | http
 port = 443
 # public_ip = "proxy.example.com"   # входящий IP/domain для клиентских ссылок
 # public_port = 443                 # порт в ссылках при HAProxy/Nginx
-# middle_proxy_nat_ip = "203.0.113.10"   # исходящий IPv4, который видит Telegram MiddleProxy
+# middle_proxy_nat_ip = "203.0.113.10"   # переопределить исходящий IPv4 для Telegram MiddleProxy (иначе авто-детект через egress)
 max_connections = 512
 # workers = 1            # SO_REUSEPORT epoll-воркеры: 1 = однопоточно (дефолт); 0 = по числу CPU; N распределяет нагрузку по ядрам
 idle_timeout_sec = 120
@@ -399,7 +399,7 @@ alice = true
 | `[server] port` | `443` | TCP listen port |
 | `[server] public_ip` | auto | Входящий IP/domain для клиентских ссылок |
 | `[server] public_port` | `[server].port` | Порт для клиентских ссылок, если публичный порт отличается от listen-port |
-| `[server] middle_proxy_nat_ip` | auto | Исходящий IPv4 для MiddleProxy key derivation; auto-detect не использует `public_ip`, задайте явно при VPN/NAT egress |
+| `[server] middle_proxy_nat_ip` | auto | Исходящий IPv4 для MiddleProxy key derivation; авто-детект **через настроенный egress** (direct → IP хоста, socks5/http → exit-IP прокси, tunnel → exit-IP туннеля), поэтому SOCKS/туннель + ad-tag работают из коробки. Задавайте явно только для переопределения, если авто-детект не видит реальный egress |
 | `[server] max_connections` | `512` | Лимит одновременных соединений |
 | `[server] workers` | `1` | SO_REUSEPORT epoll-воркеры: `1` = однопоточно; `0` = по числу CPU; `N` распределяет нагрузку relay/crypto по ядрам. При `>1` перезагрузка конфига по SIGHUP требует рестарта |
 | `[server] middleproxy_buffer_kb` | `1024` | Буфер MiddleProxy на соединение |
@@ -528,7 +528,7 @@ docker run --rm \
   ghcr.io/sleep3r/mtproto.zig:latest
 ```
 
-MiddleProxy для медиа/промо чувствителен к исходному source IP:port, который попадает в encrypted handshake. Для Docker-деплоя с MiddleProxy лучше использовать host networking (`--network host`) или нативный `mtbuddy install`. `[server].public_ip` теперь только входящий адрес для клиентов; если DC-трафик выходит через VPN/NAT IP, задайте `[server].middle_proxy_nat_ip` этим egress IPv4. Bridge или удаленный NAT, переписывающий source port, всё равно может ломать MiddleProxy handshake.
+MiddleProxy для медиа/промо чувствителен к исходному source IP:port, который попадает в encrypted handshake. Исходящий IPv4 **авто-детектится через настроенный upstream** — direct зондирует хост, `socks5`/`http` зондирует через прокси (узнаёт exit-IP SOCKS), `tunnel` — через интерфейс туннеля, — поэтому SOCKS/туннель + ad-tag работают без ручной настройки. Для Docker-деплоя с MiddleProxy лучше использовать host networking (`--network host`) или нативный `mtbuddy install`. `[server].public_ip` — только входящий адрес для клиентов; задавайте `[server].middle_proxy_nat_ip` лишь для переопределения, если авто-детект не видит реальный egress. Bridge или удаленный NAT, переписывающий source port, всё равно может ломать MiddleProxy handshake.
 
 Локальная сборка:
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -37,10 +37,11 @@ port = 443
 # public_port = 443
 
 # IPv4 address Telegram MiddleProxy sees for outbound DC connections.
-# Set this when DC traffic exits through a VPN/NAT IP that differs from
-# public_ip or when auto-detection cannot see the real egress. Docker bridge
-# or remote VPN NAT that rewrites source ports can still break MiddleProxy;
-# prefer native/host-network deployments there.
+# Auto-detected through the SAME egress DC traffic uses: direct -> the host IP,
+# socks5/http -> the proxy's exit IP, tunnel -> the tunnel's exit IP. So SOCKS/
+# tunnel egress + ad-tag now work out of the box without setting this. Only set
+# it to override (e.g. Docker bridge / remote NAT that rewrites source ports and
+# breaks auto-detection — there, prefer native/host-network deployments).
 # middle_proxy_nat_ip = "203.0.113.10"
 
 # 32 hex-char promotion tag from @MTProxybot (enables sponsored channels).

--- a/src/proxy/middle_proxy_nat.zig
+++ b/src/proxy/middle_proxy_nat.zig
@@ -9,7 +9,7 @@ pub fn detectIpv4(
     allocator: std.mem.Allocator,
     cfg: *const Config,
     comptime detect_awg: fn (std.mem.Allocator) ?[4]u8,
-    comptime detect_public: fn (std.mem.Allocator) ?[4]u8,
+    comptime detect_public: fn (std.mem.Allocator, *const Config) ?[4]u8,
 ) ?[4]u8 {
     if (cfg.middle_proxy_nat_ip) |configured_nat_ip| {
         if (network_detect.parseIpv4Literal(configured_nat_ip)) |parsed_ip| {
@@ -17,26 +17,29 @@ pub fn detectIpv4(
             log.info("Using server.middle_proxy_nat_ip for middle-proxy NAT translation: {s}", .{network_detect.formatIpv4Bytes(parsed_ip, &ip_buf)});
             return parsed_ip;
         }
-        log.info("server.middle_proxy_nat_ip='{s}' is not an IPv4 literal; falling back to AWG/public detection", .{configured_nat_ip});
+        log.info("server.middle_proxy_nat_ip='{s}' is not an IPv4 literal; falling back to egress detection", .{configured_nat_ip});
     }
 
-    // The AWG/WireGuard endpoint IP equals the middle-proxy egress IP ONLY when DC traffic
-    // is actually routed through that tunnel (upstream_mode = tunnel). On a host where a WG
-    // config exists but egress is direct, the endpoint IP is the VPN server's, while
-    // Telegram sees the host's own IP — using it would fail every handshake. So only trust
-    // the AWG endpoint in tunnel mode; otherwise go straight to the public-egress probe.
+    // PRIMARY: probe the public IP THROUGH the configured egress (socks5/http/tunnel/direct),
+    // so the detected IP is exactly what Telegram's MiddleProxy sees — making socks/tunnel +
+    // ad-tag work out of the box without a hand-set middle_proxy_nat_ip. (detect_public is
+    // egress-aware; in direct/auto it's a plain probe, under socks5/http it goes through the
+    // proxy, under tunnel it goes through the tunnel interface.)
+    if (detect_public(allocator, cfg)) |ip| {
+        var ip_buf: [16]u8 = undefined;
+        log.info("Detected egress public IPv4 for middle-proxy NAT translation: {s} (upstream={s})", .{ network_detect.formatIpv4Bytes(ip, &ip_buf), @tagName(cfg.upstream_mode) });
+        return ip;
+    }
+
+    // FALLBACK (tunnel only): if the through-tunnel probe couldn't reach an echo service,
+    // fall back to the WireGuard endpoint IP from the tunnel config. Only valid in tunnel
+    // mode — in other modes the endpoint IP has no relation to the egress IP.
     if (cfg.upstream_mode == .tunnel) {
         if (detect_awg(allocator)) |awg_ip| {
             var awg_ip_buf: [16]u8 = undefined;
-            log.info("Using AWG endpoint IPv4 for middle-proxy NAT translation: {s}", .{network_detect.formatIpv4Bytes(awg_ip, &awg_ip_buf)});
+            log.info("Egress probe failed; using AWG endpoint IPv4 for middle-proxy NAT translation: {s}", .{network_detect.formatIpv4Bytes(awg_ip, &awg_ip_buf)});
             return awg_ip;
         }
-    }
-
-    if (detect_public(allocator)) |ip| {
-        var ip_buf: [16]u8 = undefined;
-        log.info("Detected public IPv4 for middle-proxy NAT translation: {s}", .{network_detect.formatIpv4Bytes(ip, &ip_buf)});
-        return ip;
     }
 
     return null;
@@ -55,7 +58,7 @@ test "middle-proxy NAT detection does not derive from public_ip" {
             return null;
         }
 
-        fn publicEgress(_: std.mem.Allocator) ?[4]u8 {
+        fn publicEgress(_: std.mem.Allocator, _: *const Config) ?[4]u8 {
             return .{ 203, 0, 113, 9 };
         }
     };
@@ -75,7 +78,7 @@ test "middle-proxy NAT detection prefers explicit override" {
             return .{ 203, 0, 113, 9 };
         }
 
-        fn publicEgress(_: std.mem.Allocator) ?[4]u8 {
+        fn publicEgress(_: std.mem.Allocator, _: *const Config) ?[4]u8 {
             return .{ 198, 51, 100, 20 };
         }
     };
@@ -89,13 +92,15 @@ test "middle-proxy NAT detection prefers explicit override" {
     try std.testing.expectEqual([4]u8{ 192, 0, 2, 7 }, got);
 }
 
-test "middle-proxy NAT detection prefers AWG endpoint before public egress probe in tunnel mode" {
+test "middle-proxy NAT detection prefers the egress probe over the AWG endpoint in tunnel mode" {
+    // The egress probe returns the IP Telegram actually sees through the tunnel; the AWG
+    // endpoint IP is only a fallback. When the probe succeeds it must win.
     const Callbacks = struct {
         fn awgEgress(_: std.mem.Allocator) ?[4]u8 {
             return .{ 203, 0, 113, 9 };
         }
 
-        fn publicEgress(_: std.mem.Allocator) ?[4]u8 {
+        fn publicEgress(_: std.mem.Allocator, _: *const Config) ?[4]u8 {
             return .{ 198, 51, 100, 20 };
         }
     };
@@ -106,6 +111,27 @@ test "middle-proxy NAT detection prefers AWG endpoint before public egress probe
     cfg.upstream_mode = .tunnel;
 
     const got = detectIpv4(std.testing.allocator, &cfg, Callbacks.awgEgress, Callbacks.publicEgress).?;
+    try std.testing.expectEqual([4]u8{ 198, 51, 100, 20 }, got);
+}
+
+test "middle-proxy NAT detection falls back to AWG endpoint in tunnel mode when the egress probe fails" {
+    const Callbacks = struct {
+        fn awgEgress(_: std.mem.Allocator) ?[4]u8 {
+            return .{ 203, 0, 113, 9 };
+        }
+
+        // No echo service reachable through the tunnel at startup.
+        fn noPublic(_: std.mem.Allocator, _: *const Config) ?[4]u8 {
+            return null;
+        }
+    };
+
+    var cfg = emptyConfig();
+    defer cfg.users.deinit();
+    defer cfg.direct_users.deinit();
+    cfg.upstream_mode = .tunnel;
+
+    const got = detectIpv4(std.testing.allocator, &cfg, Callbacks.awgEgress, Callbacks.noPublic).?;
     try std.testing.expectEqual([4]u8{ 203, 0, 113, 9 }, got);
 }
 
@@ -113,12 +139,13 @@ test "middle-proxy NAT detection ignores AWG endpoint when egress is not tunnell
     const Callbacks = struct {
         fn awgEgress(_: std.mem.Allocator) ?[4]u8 {
             // A WG config exists on the host, but egress is direct — its endpoint IP must
-            // NOT be used (it would mismatch the IP Telegram observes).
+            // NOT be used (it would mismatch the IP Telegram observes), and a failed direct
+            // probe must not silently consult it.
             return .{ 203, 0, 113, 9 };
         }
 
-        fn publicEgress(_: std.mem.Allocator) ?[4]u8 {
-            return .{ 198, 51, 100, 20 };
+        fn noPublic(_: std.mem.Allocator, _: *const Config) ?[4]u8 {
+            return null;
         }
     };
 
@@ -127,6 +154,5 @@ test "middle-proxy NAT detection ignores AWG endpoint when egress is not tunnell
     defer cfg.direct_users.deinit();
     cfg.upstream_mode = .auto;
 
-    const got = detectIpv4(std.testing.allocator, &cfg, Callbacks.awgEgress, Callbacks.publicEgress).?;
-    try std.testing.expectEqual([4]u8{ 198, 51, 100, 20 }, got);
+    try std.testing.expectEqual(@as(?[4]u8, null), detectIpv4(std.testing.allocator, &cfg, Callbacks.awgEgress, Callbacks.noPublic));
 }

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -323,8 +323,46 @@ const isIpv6 = net_helpers.isIpv6;
 const addressEql = net_helpers.addressEql;
 const getAddressList = net_helpers.getAddressList;
 
-fn detectPublicIpv4(allocator: std.mem.Allocator) ?[4]u8 {
-    return network_detect.detectPublicIpv4(allocator, fetchUrlBytes);
+/// Fetch a public-IP echo service through the SAME egress middle-proxy traffic uses, so
+/// the IP we feed into the MP key derivation matches what Telegram's MiddleProxy observes.
+/// A plain direct probe returns the HOST's IP even when egress is socks5/http/tunnel — the
+/// long-standing "socks + ad-tag doesn't work out of the box, you must set
+/// middle_proxy_nat_ip by hand" trap. Routing the probe through the upstream removes it.
+fn fetchPublicIpProbe(allocator: std.mem.Allocator, cfg: *const Config, url: []const u8) ![]u8 {
+    switch (cfg.upstream_mode) {
+        .socks5, .http => {
+            const host = cfg.upstream_proxy_host orelse return error.InvalidProxyUpstreamConfig;
+            if (cfg.upstream_proxy_port == 0) return error.InvalidProxyUpstreamConfig;
+            return http_fetch.fetchUrlBytesViaProxy(allocator, url, .{
+                .kind = if (cfg.upstream_mode == .socks5) .socks5 else .http_connect,
+                .host = host,
+                .port = cfg.upstream_proxy_port,
+                .username = cfg.upstream_proxy_username,
+                .password = cfg.upstream_proxy_password,
+            });
+        },
+        .tunnel => {
+            const iface = cfg.tunnelCandidateAt(0) orelse cfg.upstream_tunnel_interface orelse "awg0";
+            return fetchUrlBytesViaInterface(allocator, url, iface);
+        },
+        .auto, .direct => return fetchUrlBytes(allocator, url),
+    }
+}
+
+/// Detect the public IPv4 as seen from the configured egress (see fetchPublicIpProbe).
+fn detectPublicIpv4ViaEgress(allocator: std.mem.Allocator, cfg: *const Config) ?[4]u8 {
+    const services = [_][]const u8{
+        "https://api.ipify.org",
+        "https://ifconfig.me",
+        "https://ipv4.icanhazip.com",
+    };
+    for (services) |url| {
+        const bytes = fetchPublicIpProbe(allocator, cfg, url) catch continue;
+        defer allocator.free(bytes);
+        const trimmed = std.mem.trim(u8, bytes, &[_]u8{ ' ', '\t', '\r', '\n' });
+        if (network_detect.parseIpv4Literal(trimmed)) |ip| return ip;
+    }
+    return null;
 }
 
 fn runSmallCommand(allocator: std.mem.Allocator, argv: []const []const u8) ?[]u8 {
@@ -1190,9 +1228,19 @@ pub const ProxyState = struct {
         @memcpy(default_middle_proxy_secret[0..middleproxy.proxy_secret.len], middleproxy.proxy_secret[0..]);
 
         const detected_nat_ip4 = if (cfg.datacenter_override == null)
-            middle_proxy_nat.detectIpv4(allocator, &cfg, detectAwgEndpointIpv4, detectPublicIpv4)
+            middle_proxy_nat.detectIpv4(allocator, &cfg, detectAwgEndpointIpv4, detectPublicIpv4ViaEgress)
         else
             null;
+
+        // The ad-tag and non-Premium media both require a working MiddleProxy handshake,
+        // which needs the egress public IP. If MiddleProxy is wanted but we couldn't learn
+        // that IP, say so loudly — otherwise the proxy silently falls back to direct DC
+        // (no ad-tag) and operators never notice.
+        if (detected_nat_ip4 == null and (cfg.use_middle_proxy or cfg.force_media_middle_proxy or cfg.tag != null)) {
+            log.warn("MiddleProxy/ad-tag is enabled but the egress public IP could not be detected; " ++
+                "the ad-tag (and non-Premium media via ME) may not work. Set [server].middle_proxy_nat_ip " ++
+                "to the IP Telegram sees for this server's egress (the SOCKS/tunnel exit IP when egress isn't direct).", .{});
+        }
 
         const owned_config_path = try allocator.dupe(u8, config_path);
         errdefer allocator.free(owned_config_path);
@@ -2465,6 +2513,13 @@ const EventLoop = struct {
             log.info("  drops: cap+={d} sat+={d} rate+={d} flood_guard+={d} hs_budget+={d} hs_timeout+={d} mp_fallback+={d} pool+={d}", .{
                 d_cap, d_sat, d_rate, d_flood, d_hs, d_hst, d_mpf, d_pool,
             });
+        }
+
+        // A run of MiddleProxy->direct fallbacks means the ad-tag (and non-Premium media via
+        // ME) is silently NOT applied for those connections. Surface it instead of letting it
+        // pass unnoticed — the usual cause is a wrong/undetected egress NAT IP.
+        if (d_mpf > 0 and (self.state.config.use_middle_proxy or self.state.config.tag != null)) {
+            log.warn("ad-tag likely inactive: {d} middle-proxy handshake(s) fell back to direct this interval — those connections carry no ad-tag/ME media. Check egress reachability and [server].middle_proxy_nat_ip.", .{d_mpf});
         }
 
         var top_entries: [5]HandshakeFloodGuard.TopEntry = undefined;


### PR DESCRIPTION
### Problem (reported)
> чтобы работал сокс и тег нужно дополнительно добавлять middle proxy IP, и клиенты обычно про это не знают, и с коробки оно не работает

For `socks5`/`http`/`tunnel` egress, the ad-tag (which requires MiddleProxy) didn't work out of the box — the operator had to manually set `[server].middle_proxy_nat_ip`, and the failure was silent.

### Root cause
The MiddleProxy connection and the `getProxyConfig`/`getProxySecret` asset fetch both exit through the configured upstream, but `middle_proxy_nat_ip` auto-detection probed the host's public IP **directly** (ipify over the default route). Under socks5/http/tunnel the source IP Telegram's MiddleProxy observes is the **upstream exit IP**, not the host IP — so the AES key derivation (which folds in that IP) never matched → every `RPC_HANDSHAKE` failed → silent fallback to direct DC (no ad-tag).

### Fix
Route the NAT-IP probe through the **same egress** MiddleProxy traffic uses:

| upstream | NAT-IP probe |
|---|---|
| `socks5` / `http` | via the configured proxy → learns the SOCKS/HTTP exit IP |
| `tunnel` | via the tunnel interface → real tunnel exit IP (WG endpoint IP is now only a fallback) |
| `direct` / `auto` | direct probe (unchanged) |

→ socks/tunnel + ad-tag now work without setting `middle_proxy_nat_ip`.

### Don't fail silently (UX)
- **Startup**: warns if MiddleProxy/ad-tag is enabled but no egress IP could be detected, naming the exact knob.
- **Runtime**: periodic stats warn when MiddleProxy handshakes fall back to direct, noting those connections carry no ad-tag and to check egress / `middle_proxy_nat_ip`.

### Docs & tests
`config.toml.example`, `README.md`, `README.ru.md` updated. New unit tests cover the egress-first priority and the tunnel fallback. **247/247 tests pass**; `x86_64-linux` + `aarch64-linux` cross-builds green; `zig fmt` clean.