### PR TITLE
[codex] Add tunnel dependency installer smoke

### DIFF
--- a/src/ctl/main.zig
+++ b/src/ctl/main.zig
@@ -422,7 +422,8 @@ fn printHelp(lang: i18n.Lang) void {
     printCmd(&ui, "update", tr(lang, "Update to latest GitHub release", "Обновить до последнего GitHub релиза"));
     printCmd(&ui, "setup masking", tr(lang, "Setup local Nginx DPI masking", "Настроить локальную DPI-маскировку через Nginx"));
     printCmd(&ui, "setup nfqws", tr(lang, "Setup nfqws TCP desync (Zapret)", "Настроить nfqws TCP desync (Zapret)"));
-    printCmd(&ui, "setup tunnel [--iface awgN] <conf|vpn://>", tr(lang, "Setup AmneziaWG tunnel pool member", "Настроить участника пула туннелей AmneziaWG"));
+    printCmd(&ui, "setup tunnel [--deps-only] [--iface awgN] <conf|vpn://>", tr(lang, "Setup AmneziaWG tunnel pool member", "Настроить участника пула туннелей AmneziaWG"));
+    printCmd(&ui, "setup egress [--deps-only] <share-link...>", tr(lang, "Setup VPN share-link egress", "Настроить egress через VPN-ссылку"));
     printCmd(&ui, "setup dashboard", tr(lang, "Install web monitoring dashboard", "Установить веб-дашборд мониторинга"));
     printCmd(&ui, "setup recovery", tr(lang, "Install DPI auto-recovery", "Установить авто-восстановление DPI"));
     printCmd(&ui, "ipv6-hop", tr(lang, "IPv6 address rotation", "Ротация IPv6 адреса"));

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -49,13 +49,18 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
             continue;
         }
 
+        if (std.mem.eql(u8, arg, "--deps-only")) {
+            opts.deps_only = true;
+            continue;
+        }
+
         if (arg.len > 0 and arg[0] != '-') {
             opts.awg_source = arg;
         }
     }
 
-    if (opts.awg_source.len == 0) {
-        ui.fail("Usage: mtbuddy setup tunnel [--iface awgN] <conf-path-or-vpn-link>");
+    if (!opts.deps_only and opts.awg_source.len == 0) {
+        ui.fail("Usage: mtbuddy setup tunnel [--deps-only] [--iface awgN] <conf-path-or-vpn-link>");
         return;
     }
 

--- a/src/ctl/tunnel_singbox.zig
+++ b/src/ctl/tunnel_singbox.zig
@@ -193,11 +193,22 @@ fn dispatchLinks(ui: *Tui, allocator: std.mem.Allocator, link_list: []const []co
 pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) !void {
     var links: std.ArrayListUnmanaged([]const u8) = .empty;
     defer links.deinit(allocator);
+    var deps_only = false;
     while (args.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--deps-only")) {
+            deps_only = true;
+            continue;
+        }
         if (arg.len > 0 and arg[0] != '-') links.append(allocator, arg) catch {};
     }
+    if (deps_only) {
+        ui.step("Checking sing-box dependency...");
+        if (!ensureSingboxInstalled(ui, allocator)) return;
+        ui.ok("sing-box dependency available");
+        return;
+    }
     if (links.items.len == 0) {
-        ui.fail("Usage: mtbuddy setup egress <share-link> [<share-link>...]");
+        ui.fail("Usage: mtbuddy setup egress [--deps-only] <share-link> [<share-link>...]");
         ui.hint("vless:// vmess:// trojan:// ss://  ->  sing-box TUN tunnel (upstream.type=tunnel)");
         ui.hint("wireguard://                       ->  native kernel WG tunnel");
         return;
@@ -290,14 +301,7 @@ fn setupSingboxTunnel(ui: *Tui, allocator: std.mem.Allocator, link_texts: []cons
         _ = sys.exec(allocator, &.{ "systemctl", "daemon-reload" }) catch {};
     }
 
-    if (!sys.commandExists("sing-box") and !sys.fileExists(SB_BIN)) {
-        ui.step("Installing sing-box...");
-        if (!installSingbox(allocator)) {
-            ui.fail("Failed to install sing-box (download/extract). Check network and retry.");
-            return;
-        }
-        ui.ok("sing-box installed");
-    }
+    if (!ensureSingboxInstalled(ui, allocator)) return;
     const sb_bin: []const u8 = if (sys.fileExists(SB_BIN)) SB_BIN else "sing-box";
 
     const cfg = genSingboxConfig(a, parsed) catch {
@@ -386,6 +390,18 @@ fn wireUpstreamTunnel(allocator: std.mem.Allocator, link_texts: []const []const 
     try arr.append(allocator, ']');
     try doc.set("upstream.xray", "links", arr.items);
     try doc.save(CONFIG_PATH);
+}
+
+fn ensureSingboxInstalled(ui: *Tui, allocator: std.mem.Allocator) bool {
+    if (sys.commandExists("sing-box") or sys.fileExists(SB_BIN)) return true;
+
+    ui.step("Installing sing-box...");
+    if (!installSingbox(allocator)) {
+        ui.fail("Failed to install sing-box (download/extract). Check network and retry.");
+        return false;
+    }
+    ui.ok("sing-box installed");
+    return true;
 }
 
 /// Download + install the static sing-box binary for this arch. The release asset name

--- a/src/ctl/tunnel_wg.zig
+++ b/src/ctl/tunnel_wg.zig
@@ -47,6 +47,26 @@ fn readFileAllocCwd(allocator: std.mem.Allocator, path: []const u8, limit: usize
 pub const TunnelOpts = struct {
     awg_source: []const u8 = "",
     iface: []const u8 = "",
+    deps_only: bool = false,
+};
+
+const AwgRepositorySetup = enum {
+    ubuntu_add_apt_repository,
+    debian_launchpad_focal_source,
+};
+
+const ubuntu_awg_repo_prereqs = [_][]const u8{
+    "ca-certificates",
+    "curl",
+    "gnupg2",
+    "software-properties-common",
+    "python3-launchpadlib",
+};
+
+const debian_awg_repo_prereqs = [_][]const u8{
+    "ca-certificates",
+    "curl",
+    "gnupg2",
 };
 
 /// Set up a tunnel directly from a WireGuard/AmneziaWG `.conf` path — same flow as
@@ -59,6 +79,13 @@ pub fn setupFromConf(ui: *Tui, allocator: std.mem.Allocator, conf_path: []const 
 pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
     if (!sys.isRoot()) {
         ui.fail(i18n.get(ui.lang, .error_not_root));
+        return;
+    }
+
+    if (opts.deps_only) {
+        ui.step("Checking AmneziaWG dependencies...");
+        if (!ensureAmneziaWgInstalled(ui, allocator)) return;
+        ui.ok("AmneziaWG dependencies available");
         return;
     }
 
@@ -632,19 +659,30 @@ fn ensureAmneziaWgInstalled(ui: *Tui, allocator: std.mem.Allocator) bool {
         "Failed to refresh apt package index",
     )) return false;
 
-    if (!runCommandChecked(
-        ui,
-        allocator,
-        &.{ "apt-get", "-o", "DPkg::Lock::Timeout=600", "install", "-y", "software-properties-common" },
-        "Failed to install software-properties-common",
-    )) return false;
+    const os_release = readFileAllocAbsolute(allocator, "/etc/os-release", 16 * 1024) catch null;
+    defer if (os_release) |content| allocator.free(content);
+    const repo_setup = awgRepositorySetupForOsRelease(os_release orelse "");
 
-    if (!runCommandChecked(
-        ui,
-        allocator,
-        &.{ "add-apt-repository", "-y", "ppa:amnezia/ppa" },
-        "Failed to add Amnezia PPA",
-    )) return false;
+    if (!installAwgRepositoryPrerequisites(ui, allocator, repo_setup)) return false;
+
+    switch (repo_setup) {
+        .ubuntu_add_apt_repository => {
+            if (!runCommandChecked(
+                ui,
+                allocator,
+                &.{ "add-apt-repository", "-y", "ppa:amnezia/ppa" },
+                "Failed to add Amnezia PPA",
+            )) return false;
+        },
+        .debian_launchpad_focal_source => {
+            if (!runCommandChecked(
+                ui,
+                allocator,
+                &.{ "sh", "-c", debianAmneziaRepositorySetupScript() },
+                "Failed to configure Amnezia PPA for Debian",
+            )) return false;
+        },
+    }
 
     if (!runCommandChecked(
         ui,
@@ -667,6 +705,71 @@ fn ensureAmneziaWgInstalled(ui: *Tui, allocator: std.mem.Allocator) bool {
     }
 
     return true;
+}
+fn installAwgRepositoryPrerequisites(ui: *Tui, allocator: std.mem.Allocator, repo_setup: AwgRepositorySetup) bool {
+    var argv: std.ArrayList([]const u8) = .empty;
+    defer argv.deinit(allocator);
+
+    for ([_][]const u8{ "apt-get", "-o", "DPkg::Lock::Timeout=600", "install", "-y", "--no-install-recommends" }) |arg| {
+        argv.append(allocator, arg) catch return false;
+    }
+    for (awgRepositoryPrerequisitePackages(repo_setup)) |package| {
+        argv.append(allocator, package) catch return false;
+    }
+
+    return runCommandChecked(ui, allocator, argv.items, "Failed to install AmneziaWG repository prerequisites");
+}
+fn awgRepositoryPrerequisitePackages(repo_setup: AwgRepositorySetup) []const []const u8 {
+    return switch (repo_setup) {
+        .ubuntu_add_apt_repository => &ubuntu_awg_repo_prereqs,
+        .debian_launchpad_focal_source => &debian_awg_repo_prereqs,
+    };
+}
+fn awgRepositorySetupForOsRelease(os_release: []const u8) AwgRepositorySetup {
+    const id = osReleaseValue(os_release, "ID") orelse "";
+    if (std.ascii.eqlIgnoreCase(id, "debian")) return .debian_launchpad_focal_source;
+    return .ubuntu_add_apt_repository;
+}
+fn osReleaseValue(content: []const u8, key: []const u8) ?[]const u8 {
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r' });
+        if (trimmed.len <= key.len or trimmed[key.len] != '=') continue;
+        if (!std.mem.eql(u8, trimmed[0..key.len], key)) continue;
+
+        var value = std.mem.trim(u8, trimmed[key.len + 1 ..], &[_]u8{ ' ', '\t', '\r' });
+        if (value.len >= 2 and value[0] == '"' and value[value.len - 1] == '"') {
+            value = value[1 .. value.len - 1];
+        }
+        return value;
+    }
+    return null;
+}
+fn debianAmneziaRepositorySetupScript() []const u8 {
+    return
+    \\set -eu
+    \\install -d -m 0755 /usr/share/keyrings /etc/apt/sources.list.d
+    \\tmp="$(mktemp)"
+    \\trap 'rm -f "$tmp"' EXIT
+    \\curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x75C9DD72C799870E310542E24166F2C257290828" -o "$tmp"
+    \\gpg --batch --yes --dearmor -o /usr/share/keyrings/amnezia-ppa.gpg "$tmp"
+    \\cat >/etc/apt/sources.list.d/amnezia-ppa.list <<'AMNEZIA_PPA'
+    \\deb [signed-by=/usr/share/keyrings/amnezia-ppa.gpg] https://ppa.launchpadcontent.net/amnezia/ppa/ubuntu focal main
+    \\deb-src [signed-by=/usr/share/keyrings/amnezia-ppa.gpg] https://ppa.launchpadcontent.net/amnezia/ppa/ubuntu focal main
+    \\AMNEZIA_PPA
+    ;
+}
+fn readFileAllocAbsolute(allocator: std.mem.Allocator, path: []const u8, limit: usize) ![]u8 {
+    var file = try std.Io.Dir.openFileAbsolute(io(), path, .{});
+    defer file.close(io());
+    var reader = file.reader(io(), &.{});
+    return try reader.interface.allocRemaining(allocator, .limited(limit));
+}
+fn containsString(values: []const []const u8, needle: []const u8) bool {
+    for (values) |value| {
+        if (std.mem.eql(u8, value, needle)) return true;
+    }
+    return false;
 }
 fn runCommandChecked(
     ui: *Tui,
@@ -1415,6 +1518,47 @@ test "tunnel pool timer repeats after oneshot service exits" {
     const source = @embedFile("tunnel_wg.zig");
     const needle = "OnUnitInactiveSec" ++ "=30s";
     try std.testing.expect(std.mem.indexOf(u8, source, needle) != null);
+}
+
+test "tunnel deps - Debian uses explicit Amnezia Launchpad focal source" {
+    const os_release =
+        \\PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
+        \\NAME="Debian GNU/Linux"
+        \\ID=debian
+        \\VERSION_ID="12"
+        \\VERSION_CODENAME=bookworm
+    ;
+
+    try std.testing.expectEqual(AwgRepositorySetup.debian_launchpad_focal_source, awgRepositorySetupForOsRelease(os_release));
+
+    const script = debianAmneziaRepositorySetupScript();
+    try std.testing.expect(std.mem.indexOf(u8, script, "ppa.launchpadcontent.net/amnezia/ppa/ubuntu focal main") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "signed-by=/usr/share/keyrings/amnezia-ppa.gpg") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "0x75C9DD72C799870E310542E24166F2C257290828") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "add-apt-repository") == null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "pipefail") == null);
+
+    const prereqs = awgRepositoryPrerequisitePackages(.debian_launchpad_focal_source);
+    try std.testing.expect(containsString(prereqs, "curl"));
+    try std.testing.expect(containsString(prereqs, "gnupg2"));
+    try std.testing.expect(!containsString(prereqs, "software-properties-common"));
+    try std.testing.expect(!containsString(prereqs, "python3-launchpadlib"));
+}
+
+test "tunnel deps - Ubuntu keeps add-apt-repository PPA path" {
+    const os_release =
+        \\PRETTY_NAME="Ubuntu 24.04.2 LTS"
+        \\NAME="Ubuntu"
+        \\ID=ubuntu
+        \\VERSION_ID="24.04"
+        \\VERSION_CODENAME=noble
+    ;
+
+    try std.testing.expectEqual(AwgRepositorySetup.ubuntu_add_apt_repository, awgRepositorySetupForOsRelease(os_release));
+
+    const prereqs = awgRepositoryPrerequisitePackages(.ubuntu_add_apt_repository);
+    try std.testing.expect(containsString(prereqs, "software-properties-common"));
+    try std.testing.expect(containsString(prereqs, "python3-launchpadlib"));
 }
 
 test "tunnel - converts Amnezia vpn link to AWG config" {

--- a/test/README.md
+++ b/test/README.md
@@ -7,6 +7,7 @@ This folder contains practical tools to validate **capacity**, **stability**, an
 - `capacity_connections_probe.py` — concurrent connection sweeps with RSS tracking.
 - `connection_stability_check.py` — churn + idle-pool stability harness (leak/regression detector).
 - `e2e/run.py` — process-level integration harness (`make e2e` / `zig build e2e`).
+- `installer-e2e/run.sh` — distro-matrix installer smoke, including tunnel dependency installers.
 
 ## E2E Harness
 
@@ -226,6 +227,7 @@ coverage:
   answer steady-state encrypted frames. The key derivation itself is now covered by
   known-answer tests in `src/protocol/middleproxy.zig`.
 - **Share-link / sing-box egress** (`installer-e2e/run.sh`): the WG/AmneziaWG tunnel pool
-  is covered, but the sing-box TUN egress (`mtbuddy setup egress 'vless://…'`) is not — it
-  needs a stub `sing-box` that creates a dummy TUN interface. Link parsing + config JSON
-  generation are covered by unit tests in `src/ctl/`.
+  and sing-box dependency installer are covered, but the full sing-box TUN egress
+  (`mtbuddy setup egress 'vless://…'`) is not — it needs a stub `sing-box` that creates a
+  dummy TUN interface. Link parsing + config JSON generation are covered by unit tests in
+  `src/ctl/`.

--- a/test/installer-e2e/run.sh
+++ b/test/installer-e2e/run.sh
@@ -7,6 +7,7 @@ LOG_DIR="${MTPROTO_INSTALLER_E2E_LOG_DIR:-$ROOT/test/installer-e2e/logs}"
 IMAGES="${MTPROTO_INSTALLER_E2E_IMAGES:-debian:11 debian:12 ubuntu:20.04 ubuntu:22.04 ubuntu:24.04}"
 VERSION="${MTPROTO_INSTALLER_E2E_VERSION:-latest}"
 PORT="${MTPROTO_INSTALLER_E2E_PORT:-443}"
+VERIFY_TUNNEL_DEPS="${MTPROTO_INSTALLER_E2E_TUNNEL_DEPS:-1}"
 # Default to the shipped installer default (rutube.ru), not the domain the installer
 # now warns against (wb.ru). The verify curl is domain-agnostic (-k + --resolve forces
 # the local nginx on 127.0.0.1:8443 regardless of SNI/Host), so this stays green.
@@ -426,6 +427,27 @@ verify_update_preserves_config() {
   '
 }
 
+verify_tunnel_dependency_installers() {
+  local container="$1"
+
+  run_script_in_container "$container" <<'CONTAINER_SCRIPT'
+set -Eeuo pipefail
+
+mtbuddy setup tunnel --deps-only
+command -v awg >/dev/null
+command -v awg-quick >/dev/null
+
+mtbuddy setup egress --deps-only
+if command -v sing-box >/dev/null; then
+  singbox="$(command -v sing-box)"
+else
+  singbox="/usr/local/bin/sing-box"
+fi
+test -x "$singbox"
+"$singbox" version | grep -F "sing-box" >/dev/null
+CONTAINER_SCRIPT
+}
+
 run_case() {
   local base_image="$1"
   local safe
@@ -488,6 +510,12 @@ run_case() {
   run_in_container "$container" mtbuddy setup nfqws 2>&1 | tee "$LOG_DIR/$safe.nfqws-rerun.log"
   verify_install "$container" 2>&1 | tee "$LOG_DIR/$safe.verify-after-nfqws-rerun.log"
   echo "::endgroup::"
+
+  if [[ "$VERIFY_TUNNEL_DEPS" != "0" ]]; then
+    echo "::group::Install tunnel dependency set ($base_image)"
+    verify_tunnel_dependency_installers "$container" 2>&1 | tee "$LOG_DIR/$safe.tunnel-deps.log"
+    echo "::endgroup::"
+  fi
 
   echo "::group::Update preserves config.toml + keeps service active ($base_image)"
   verify_update_preserves_config "$container" 2>&1 | tee "$LOG_DIR/$safe.update.log"


### PR DESCRIPTION
## What changed

- Add Debian-specific AmneziaWG repository setup for `mtbuddy setup tunnel`, using the upstream-documented Launchpad `focal` source with a signed keyring instead of Ubuntu-only `add-apt-repository ppa:amnezia/ppa`.
- Add `--deps-only` smoke paths for `setup tunnel` and `setup egress` so CI can verify real tunnel dependency installers without trying to bring up kernel/TUN interfaces in Docker.
- Extend installer E2E to run the tunnel dependency smoke before replacing AWG tools with fakes for routing/failover tests.
- Update test docs for the new installer coverage.

## Why

Issue #329 reports Debian failing before tunnel setup because the Ubuntu PPA helper path is not portable there. The existing installer E2E matrix covered tunnel routing with fake AWG tools, but it did not verify that the real AWG/sing-box dependencies could be installed on each distro leg.

## Validation

- `zig build test`
- `bash -n test/installer-e2e/run.sh`
- Debian 12 Docker smoke: local Linux `mtbuddy`, `setup tunnel --deps-only`, `setup egress --deps-only`
- Ubuntu 24.04 Docker smoke: local Linux `mtbuddy`, `setup tunnel --deps-only`, `setup egress --deps-only`
