### PR TITLE
ci(release): upload pubkey with explicit repo

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -178,4 +178,7 @@ jobs:
           PINNED_MINISIGN_PUBKEY="RWT8YwmUuq/3WpUnYJjD6rAfQugYdZKWr61U3O+2kdNvriLSyrvVU/NO"
           printf '%s\n' "untrusted comment: mtproto.zig minisign public key" > minisign.pub
           printf '%s\n' "${PINNED_MINISIGN_PUBKEY}" >> minisign.pub
-          gh release upload "${{ needs.release-please.outputs.tag_name }}" minisign.pub --clobber
+          gh release upload "${{ needs.release-please.outputs.tag_name }}" \
+            minisign.pub \
+            --repo "${{ github.repository }}" \
+            --clobber


### PR DESCRIPTION
## What changed

- Pass an explicit `--repo "${{ github.repository }}"` to the `publish-pubkey` `gh release upload` call.

## Why

The `publish-pubkey` job does not checkout the repository. Without `--repo`, `gh release upload` tries to infer the repository from `.git` and fails in the empty runner workspace:

```text
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

This made the v1.4.3 Release Please run red even though all build matrix uploads succeeded.

## Validation

- `git diff --check`
- YAML parse: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-please.yml")'`
- Reproduced the failing environment from a non-git `/tmp` directory and verified `gh release upload v1.4.3 minisign.pub --repo sleep3r/mtproto.zig --clobber` succeeds.
- Restored the missing `minisign.pub` asset on the v1.4.3 release.
