### PR TITLE
fix(dashboard): show the real masking-endpoint port + add "setup dashboard --remove"

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ sudo mtbuddy setup recovery
 
 # Install web monitoring dashboard
 sudo mtbuddy setup dashboard
+# Remove just the dashboard (leaves the proxy running)
+sudo mtbuddy setup dashboard --remove
 
 # VPN tunnel (for servers where Telegram DCs are blocked)
 sudo mtbuddy setup tunnel /path/to/awg0.conf

--- a/README.ru.md
+++ b/README.ru.md
@@ -215,6 +215,8 @@ sudo mtbuddy setup recovery
 
 # Установить web dashboard
 sudo mtbuddy setup dashboard
+# Удалить только дашборд (прокси продолжит работать)
+sudo mtbuddy setup dashboard --remove
 
 # VPN tunnel pool
 sudo mtbuddy setup tunnel /path/to/awg0.conf

--- a/src/ctl/dashboard.zig
+++ b/src/ctl/dashboard.zig
@@ -68,12 +68,46 @@ fn dashboardPipInstallArgv() []const []const u8 {
 /// Run in CLI mode.
 pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) !void {
     var opts = DashboardOpts{};
+    var do_remove = false;
     while (args.next()) |arg| {
         if (std.mem.eql(u8, arg, "--quiet")) {
             opts.quiet = true;
+        } else if (std.mem.eql(u8, arg, "--remove") or std.mem.eql(u8, arg, "--uninstall")) {
+            do_remove = true;
         }
     }
+    if (do_remove) return removeDashboard(ui);
     try execute(ui, allocator, opts);
+}
+
+fn tr(lang: i18n.Lang, en: []const u8, ru: []const u8) []const u8 {
+    return if (lang == .ru) ru else en;
+}
+
+/// Stop and remove only the dashboard (`proxy-monitor`), leaving the proxy itself untouched.
+/// `mtbuddy uninstall` removes everything; this is the targeted counterpart to
+/// `mtbuddy setup dashboard`.
+fn removeDashboard(ui: *Tui) void {
+    if (!sys.isRoot()) {
+        ui.fail(i18n.get(ui.lang, .error_not_root));
+        return;
+    }
+    ui.section(tr(ui.lang, "Remove monitoring dashboard", "Удаление дашборда мониторинга"));
+
+    if (!sys.fileExists(SERVICE_FILE) and !sys.isServiceActive(SERVICE_NAME)) {
+        ui.info(tr(ui.lang, "Dashboard is not installed — nothing to remove.", "Дашборд не установлен — удалять нечего."));
+        return;
+    }
+
+    ui.step(tr(ui.lang, "Stopping and disabling " ++ SERVICE_NAME ++ "...", "Останавливаю и отключаю " ++ SERVICE_NAME ++ "..."));
+    _ = sys.execForward(&.{ "systemctl", "disable", "--now", SERVICE_NAME }) catch {};
+
+    ui.step(tr(ui.lang, "Removing service unit and dashboard files...", "Удаляю unit и файлы дашборда..."));
+    _ = sys.execForward(&.{ "rm", "-f", SERVICE_FILE }) catch {};
+    _ = sys.execForward(&.{ "systemctl", "daemon-reload" }) catch {};
+    _ = sys.execForward(&.{ "rm", "-rf", INSTALL_DIR }) catch {};
+
+    ui.ok(tr(ui.lang, "Dashboard removed. The proxy itself is untouched.", "Дашборд удалён. Сам прокси не затронут."));
 }
 
 /// Run in interactive mode.

--- a/src/ctl/dashboard_assets/server.py
+++ b/src/ctl/dashboard_assets/server.py
@@ -1467,6 +1467,11 @@ def _masking_status() -> dict:
     mask_enabled = bool(censorship["mask"])
     mask_target = str(censorship.get("mask_target") or "").strip()
     mask_port = int(censorship["mask_port"])
+    # Client-facing port for the FakeTLS endpoint shown in the UI: public_port if set
+    # (e.g. behind a load balancer), else the proxy's listen port. NOT mask_port (that's
+    # the internal masking backend), and never a hardcoded 443.
+    _proxy_cfg = _load_proxy_runtime_config()
+    client_port = int(_proxy_cfg.get("public_port") or 0) or int(_proxy_cfg.get("port") or 443)
     tls_domain = censorship["tls_domain"]
 
     using_netns_target = False
@@ -1505,6 +1510,7 @@ def _masking_status() -> dict:
         "mask_port": mask_port,
         "mask_target": mask_target,
         "tls_domain": tls_domain,
+        "port": client_port,
         "target": f"{target_host}:{mask_port}" if mode != "disabled" else "-",
         "using_netns": using_netns_target,
         "endpoint_ok": endpoint_ok,

--- a/src/ctl/dashboard_assets/static/app.js
+++ b/src/ctl/dashboard_assets/static/app.js
@@ -1443,7 +1443,7 @@ async function poll() {
       : '<span class="signal-sq"></span>' + disabledText;
     $('maskMode').innerHTML = modeText;
 
-    let endpointText = masking.tls_domain ? (masking.tls_domain + ':443') : (masking.target || '—');
+    let endpointText = masking.tls_domain ? (masking.tls_domain + ':' + (masking.port || 443)) : (masking.target || '—');
     $('maskTarget').textContent = endpointText;
 
     const nginxState = masking.nginx_active

--- a/src/ctl/dashboard_assets/static/index.html
+++ b/src/ctl/dashboard_assets/static/index.html
@@ -474,6 +474,6 @@
 </div>
 
 </div>
-<script src="/app.js?v=20260610-paper13"></script>
+<script src="/app.js?v=20260611-paper14"></script>
 </body>
 </html>


### PR DESCRIPTION
Closes two reported dashboard issues.

### #342 — Masking "Endpoint" shows the wrong port
The card hardcoded `:443` (`app.js`: `tls_domain + ':443'`), so a proxy on a non-443 port (reporter: `port = 7443`) showed `kgn.test.net:443`. `mask_port` (8443) is the internal nginx backend and is unrelated to this field; the 443 came from nothing in the config.
**Fix:** `server.py` reports the client-facing port (`public_port` if set, else the listen `port`) in the masking status; `app.js` renders `tls_domain:<port>`. Display-only — the proxy/masking themselves were always correct.

### #343 — No way to remove just the dashboard
Only full `mtbuddy uninstall` existed (tears down the whole proxy).
**Fix:** added `mtbuddy setup dashboard --remove` (alias `--uninstall`): stops + disables `proxy-monitor`, removes the systemd unit and `/opt/mtproto-proxy/monitor`, leaves the proxy running. Documented in README / README.ru.

**Verified:** 249/249 tests; `server.py` + `app.js` validated; `zig fmt` clean.