### PR TITLE
fix(dashboard): offer "Remove dashboard" in the interactive menu when installed

### DIFF
--- a/src/ctl/dashboard.zig
+++ b/src/ctl/dashboard.zig
@@ -84,6 +84,20 @@ fn tr(lang: i18n.Lang, en: []const u8, ru: []const u8) []const u8 {
     return if (lang == .ru) ru else en;
 }
 
+/// Interactive entry (main menu): confirm, then remove the dashboard. Shown in place of
+/// "Setup dashboard" once the dashboard is installed.
+pub fn removeInteractive(ui: *Tui) void {
+    const confirmed = ui.confirm(
+        tr(ui.lang, "Remove the dashboard? The proxy keeps running.", "Удалить дашборд? Прокси продолжит работать."),
+        false,
+    ) catch return;
+    if (!confirmed) {
+        ui.info(i18n.get(ui.lang, .aborting));
+        return;
+    }
+    removeDashboard(ui);
+}
+
 /// Stop and remove only the dashboard (`proxy-monitor`), leaving the proxy itself untouched.
 /// `mtbuddy uninstall` removes everything; this is the targeted counterpart to
 /// `mtbuddy setup dashboard`.

--- a/src/ctl/i18n.zig
+++ b/src/ctl/i18n.zig
@@ -184,6 +184,7 @@ pub const S = enum(u16) {
     tui_nav_hint_menu,
     tui_nav_hint_checkbox,
     tui_exited,
+    menu_remove_dashboard,
 };
 
 /// Get a localized string by key.
@@ -456,6 +457,8 @@ const en_strings = [_][]const u8{
     "↑↓ navigate  Space toggle  Enter confirm",
     // tui_exited
     "Exited",
+    // menu_remove_dashboard
+    "Remove monitoring dashboard",
 };
 
 // ── Russian strings ─────────────────────────────────────────────
@@ -719,6 +722,8 @@ const ru_strings = [_][]const u8{
     "↑↓ выбор  Space отметить  Enter подтвердить",
     // tui_exited
     "Выход",
+    // menu_remove_dashboard
+    "Удалить дашборд мониторинга",
 };
 
 // ── Comptime validation ─────────────────────────────────────────

--- a/src/ctl/main.zig
+++ b/src/ctl/main.zig
@@ -195,6 +195,7 @@ const Action = enum {
     tunnel,
     recovery,
     dashboard,
+    remove_dashboard,
     ipv6hop,
     status,
     restart,
@@ -231,6 +232,10 @@ fn interactiveMain(ui: *Tui, allocator: std.mem.Allocator) !void {
             if (!has_dashboard) {
                 try items.append(allocator, i18n.get(ui.lang, .menu_setup_dashboard));
                 try actions.append(allocator, .dashboard);
+            } else {
+                // Dashboard is installed: offer to remove it instead of installing again.
+                try items.append(allocator, i18n.get(ui.lang, .menu_remove_dashboard));
+                try actions.append(allocator, .remove_dashboard);
             }
             if (!has_recovery) {
                 try items.append(allocator, i18n.get(ui.lang, .menu_setup_recovery));
@@ -258,6 +263,7 @@ fn interactiveMain(ui: *Tui, allocator: std.mem.Allocator) !void {
             .masking => try masking.runInteractive(ui, allocator),
             .tunnel => try tunnelOrEgressInteractive(ui, allocator),
             .dashboard => try dashboard.runInteractive(ui, allocator),
+            .remove_dashboard => dashboard.removeInteractive(ui),
             .recovery => try recovery.runInteractive(ui, allocator),
             .ipv6hop => try ipv6hop.runInteractive(ui, allocator),
             .status => showStatus(ui, allocator),


### PR DESCRIPTION
Follow-up to #344. The CLI got `setup dashboard --remove`, but the interactive `mtbuddy` menu had no removal entry — it showed "Setup dashboard" only when not installed, and nothing once installed.

Now the menu mirrors state: **not installed → "Setup dashboard"**, **installed → "Remove monitoring dashboard"** (confirms, then removes `proxy-monitor` + `/opt/mtproto-proxy/monitor`, proxy untouched).

Adds the `menu_remove_dashboard` i18n key (EN/RU, appended at the end of the positional arrays — alignment verified: 122/122/122) + `dashboard.removeInteractive`. 249/249 tests, `zig fmt` clean.