### PR TITLE
feat(faketls): PQ key_share, RST teardown, jittered desync split, probe metrics

### DIFF
--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -94,10 +94,20 @@ the client sends a ClientHello with `SNI = tls_domain`, and the proxy answers wi
 byte-compatible TLS 1.3 ServerHello. This defeats two DPI strategies well:
 
 - **Handshake fingerprinting** — the ClientHello/ServerHello match a real
-  nginx + OpenSSL stack (extension order, single x25519 key_share, fixed cert-record
+  nginx + OpenSSL stack (extension order, key_share group, fixed cert-record
   size), so the flow is not distinguishable as MTProto by shape alone.
 - **Active probing** — an unauthenticated prober is forwarded to the masking backend
   (a real TLS server) instead of getting a tell-tale proxy error.
+
+**Post-quantum key_share (X25519MLKEM768 / 0x11ec).** Modern browsers and CDNs now
+negotiate the hybrid group X25519MLKEM768; by 2026 a majority of real browser→CDN
+ClientHellos carry a 0x11ec key_share. A FakeTLS proxy that always answers with a
+classical `x25519` (0x001d) key_share is a passive **group-downgrade** tell. The
+proxy therefore echoes a correctly-sized 0x11ec ServerHello key_share whenever the
+client offers 0x11ec. (The share is high-entropy bytes, not a real ML-KEM
+encapsulation: FakeTLS clients validate only record framing + the HMAC in
+server-random, passive fingerprinting keys on the *group and size*, and we are not a
+TLS terminator — so a cryptographically valid ciphertext is unnecessary.)
 
 It does **not** defend against a third strategy that DPI vendors are now leaning on:
 **SNI ↔ destination-IP consistency.** When `tls_domain` is a well-known third-party

--- a/src/config.zig
+++ b/src/config.zig
@@ -286,8 +286,18 @@ pub const Config = struct {
     /// `reject` (emit a fatal `handshake_failure` TLS alert like nginx
     /// ssl_reject_handshake, then close), or `drop` (silent close). Default keeps the wire unchanged.
     unknown_sni_action: UnknownSniAction = .mask,
+    /// When `unknown_sni_action = reject`, reset the connection (TCP RST via
+    /// SO_LINGER{0}) instead of sending a fatal alert + FIN. Some fronted CDNs /
+    /// middleboxes RST a bad handshake where nginx `ssl_reject_handshake` sends a
+    /// fatal alert; pick whichever your masked domain actually does. Default off.
+    reject_rst: bool = false,
     /// TCP desync: split ServerHello into 1-byte + rest to evade DPI
     desync: bool = true,
+    /// Base delay (ms) between the 1-byte desync split and the rest of the ServerHello.
+    desync_split_delay_ms: u32 = 3,
+    /// Random extra delay (0..jitter ms) added to desync_split_delay_ms per connection.
+    /// A *fixed* split gap is itself a passive timing fingerprint; jitter removes it.
+    desync_split_jitter_ms: u32 = 3,
     /// Dynamic Record Sizing: ramp TLS records from 1369→16384 bytes
     drs: bool = false,
     /// Fast mode: skip S2C encryption by passing client keys to DC directly
@@ -713,6 +723,10 @@ pub const Config = struct {
                         cfg.mask_port = std.fmt.parseInt(u16, value, 10) catch 443;
                     } else if (std.mem.eql(u8, key, "desync")) {
                         cfg.desync = parseBool(value);
+                    } else if (std.mem.eql(u8, key, "desync_split_delay_ms")) {
+                        cfg.desync_split_delay_ms = std.fmt.parseInt(u32, value, 10) catch cfg.desync_split_delay_ms;
+                    } else if (std.mem.eql(u8, key, "desync_split_jitter_ms")) {
+                        cfg.desync_split_jitter_ms = std.fmt.parseInt(u32, value, 10) catch cfg.desync_split_jitter_ms;
                     } else if (std.mem.eql(u8, key, "fake_tls_only")) {
                         cfg.fake_tls_only = parseBool(value);
                     } else if (std.mem.eql(u8, key, "drs")) {
@@ -721,6 +735,8 @@ pub const Config = struct {
                         cfg.fast_mode = parseBool(value);
                     } else if (std.mem.eql(u8, key, "unknown_sni_action")) {
                         if (parseUnknownSniAction(value)) |action| cfg.unknown_sni_action = action;
+                    } else if (std.mem.eql(u8, key, "reject_rst")) {
+                        cfg.reject_rst = parseBool(value);
                     }
                 } else if (in_metrics_section) {
                     if (std.mem.eql(u8, key, "enabled")) {

--- a/src/monitoring.zig
+++ b/src/monitoring.zig
@@ -233,6 +233,8 @@ fn writeMetrics(writer: anytype, state: *proxy.ProxyState, process: ProcessMetri
     try writeCounter(writer, "mtproto_drops_handshake_budget_total", "connections dropped because handshake budget was exhausted", snapshot.drops_handshake_budget_total);
     try writeCounter(writer, "mtproto_handshake_timeouts_total", "connections dropped due to handshake timeout", snapshot.handshake_timeouts_total);
     try writeCounter(writer, "mtproto_middleproxy_fallback_total", "times middleproxy fell back to direct path", snapshot.middleproxy_fallback_total);
+    try writeCounter(writer, "mtproto_replay_hits_total", "valid handshakes whose canonical HMAC was already seen (active replay probing)", snapshot.replay_hits_total);
+    try writeCounter(writer, "mtproto_unknown_sni_total", "ClientHellos whose SNI did not match tls_domain (active probing / scanners)", snapshot.unknown_sni_total);
     // Per-reason close breakdown (RED errors + evasion signal). A spike in
     // tls_validation_failed / replay_detected / handshake_timeout vs baseline is
     // how an operator sees a censor begin actively probing/blocking the node.

--- a/src/protocol/tls.zig
+++ b/src/protocol/tls.zig
@@ -206,6 +206,156 @@ pub fn buildServerHelloWithTemplate(
     return response;
 }
 
+// ============= Post-quantum X25519MLKEM768 ServerHello =============
+//
+// Modern browsers (Chrome/Firefox PQ-first) and CDNs negotiate the hybrid group
+// X25519MLKEM768 (named group 0x11ec). A FakeTLS proxy that always answers a
+// PQ-offering client with a plain x25519 (0x001d) key_share is a passive
+// group-downgrade tell: a real server for that flow would echo 0x11ec. When the
+// client offers 0x11ec we therefore emit a 0x11ec ServerHello key_share of the
+// correct size (1120 = ML-KEM-768 ciphertext 1088 || X25519 32).
+//
+// The share is high-entropy CSPRNG bytes, NOT a real ML-KEM encapsulation. That
+// is deliberate and sufficient: (a) Telegram FakeTLS clients validate only record
+// framing + the HMAC in server-random, never the key_share crypto; (b) passive
+// JA3S/ServerHello fingerprinting keys on the *group and size*, which match; and
+// (c) we are not a TLS terminator — an active prober that completes a real hybrid
+// KEX still cannot finish the handshake with us, so a cryptographically valid
+// ciphertext buys nothing. (Real raw-ML-KEM ct||X25519 encapsulation against the
+// client's ek is a possible future enhancement; std's MlKem768X25519 is X-Wing,
+// a different combiner from the TLS 0x11ec wire format, so it can't be used as-is.)
+
+pub const pq_named_group: u16 = 0x11ec;
+/// X25519MLKEM768 server share: ML-KEM-768 ciphertext (1088) || X25519 (32).
+const pq_key_share_len: usize = 1120;
+/// PQ ServerHello record length: 5(rec hdr)+4(hs hdr)+2(ver)+32(rand)+1+32(sid)
+///   +2(cipher)+1(comp)+2(extlen)+6(supported_versions)+4(ks ext hdr)
+///   +2(group)+2(keylen)+1120(key) = 1215.
+const pq_server_hello_record_len: usize = 95 + pq_key_share_len;
+/// Full PQ response: ServerHello + CCS(6) + AppData(5 + cert payload).
+pub const pq_server_hello_len: usize = pq_server_hello_record_len + 6 + 5 + fake_cert_payload_len;
+/// Offset of the 1120-byte PQ key_share inside the response.
+const pq_key_offset: usize = 95;
+/// Offset of the fake AppData body inside the PQ response.
+const pq_appdata_offset: usize = pq_server_hello_len - fake_cert_payload_len;
+
+/// Return true when the ClientHello carries a key_share entry for X25519MLKEM768
+/// (named group 0x11ec). Mirrors the key_share walk in formatClientHelloFingerprint.
+pub fn clientOffersPqKeyShare(handshake: []const u8) bool {
+    if (handshake.len < 43 or handshake[0] != constants.tls_record_handshake) return false;
+    var pos: usize = 5;
+    if (pos >= handshake.len or handshake[pos] != 0x01) return false; // ClientHello
+    pos += 4; // hs type + 3-byte length
+    pos += 2 + 32; // legacy_version + random
+    if (pos + 1 > handshake.len) return false;
+    const sid_len: usize = handshake[pos];
+    pos += 1 + sid_len;
+    if (pos + 2 > handshake.len) return false;
+    const cs_len = std.mem.readInt(u16, handshake[pos..][0..2], .big);
+    pos += 2;
+    if (cs_len % 2 != 0 or pos + cs_len > handshake.len) return false;
+    pos += cs_len;
+    if (pos + 1 > handshake.len) return false;
+    const comp_len: usize = handshake[pos];
+    pos += 1 + comp_len;
+    if (pos + 2 > handshake.len) return false;
+    const ext_total = std.mem.readInt(u16, handshake[pos..][0..2], .big);
+    pos += 2;
+    const ext_end = @min(pos + ext_total, handshake.len);
+    while (pos + 4 <= ext_end) {
+        const etype = std.mem.readInt(u16, handshake[pos..][0..2], .big);
+        const elen = std.mem.readInt(u16, handshake[pos + 2 ..][0..2], .big);
+        pos += 4;
+        if (pos + elen > ext_end) break;
+        if (etype == 0x0033) { // key_share: 2-byte client_shares list_len, then entries
+            var kp: usize = pos + 2;
+            const ks_end = pos + elen;
+            while (kp + 4 <= ks_end) {
+                if (std.mem.readInt(u16, handshake[kp..][0..2], .big) == pq_named_group) return true;
+                kp += 4 + @as(usize, std.mem.readInt(u16, handshake[kp + 2 ..][0..2], .big));
+            }
+            return false;
+        }
+        pos += elen;
+    }
+    return false;
+}
+
+/// Build a ServerHello that answers an X25519MLKEM768-offering client with a
+/// 0x11ec key_share. Same HMAC-in-server-random + per-connection-random-AppData
+/// construction as buildServerHelloWithTemplate; only the key_share group/size and
+/// the dependent length fields differ.
+pub fn buildServerHelloPq(
+    allocator: std.mem.Allocator,
+    secret: []const u8,
+    client_digest: *const [constants.tls_digest_len]u8,
+    session_id: []const u8,
+    cipher: ?u16,
+) ![]u8 {
+    if (session_id.len != 32) return error.BadSessionIdLength;
+    const r = try allocator.alloc(u8, pq_server_hello_len);
+    errdefer allocator.free(r);
+    @memset(r, 0);
+
+    // ── Record 1: ServerHello with a 0x11ec key_share ──
+    r[0] = constants.tls_record_handshake; // 0x16
+    r[1] = 0x03;
+    r[2] = 0x03; // record version (TLS 1.2 compat)
+    std.mem.writeInt(u16, r[3..][0..2], @intCast(pq_server_hello_record_len - 5), .big);
+    r[5] = 0x02; // ServerHello
+    std.mem.writeInt(u24, r[6..][0..3], @intCast(pq_server_hello_record_len - 9), .big);
+    r[9] = 0x03;
+    r[10] = 0x03; // server legacy version
+    // r[11..43] server random — left zero (HMAC placeholder, patched at the end)
+    r[43] = 0x20; // session_id length = 32
+    @memcpy(r[tmpl_session_id_offset..][0..32], session_id);
+    std.mem.writeInt(u16, r[tmpl_cipher_offset..][0..2], cipher orelse 0x1301, .big);
+    r[78] = 0x00; // compression: none
+    std.mem.writeInt(u16, r[79..][0..2], @intCast(6 + 4 + 4 + pq_key_share_len), .big); // extensions
+    // supported_versions (0x002b) FIRST — TLS 1.3
+    r[81] = 0x00;
+    r[82] = 0x2b;
+    r[83] = 0x00;
+    r[84] = 0x02;
+    r[85] = 0x03;
+    r[86] = 0x04;
+    // key_share (0x0033)
+    r[87] = 0x00;
+    r[88] = 0x33;
+    std.mem.writeInt(u16, r[89..][0..2], @intCast(4 + pq_key_share_len), .big);
+    std.mem.writeInt(u16, r[91..][0..2], pq_named_group, .big);
+    std.mem.writeInt(u16, r[93..][0..2], @intCast(pq_key_share_len), .big);
+    crypto.randomBytes(r[pq_key_offset..][0..pq_key_share_len]);
+
+    // ── Record 2: Change Cipher Spec ──
+    const ccs = pq_server_hello_record_len;
+    r[ccs] = 0x14;
+    r[ccs + 1] = 0x03;
+    r[ccs + 2] = 0x03;
+    r[ccs + 3] = 0x00;
+    r[ccs + 4] = 0x01;
+    r[ccs + 5] = 0x01;
+
+    // ── Record 3: fake encrypted certificate AppData ──
+    const ad = ccs + 6;
+    r[ad] = 0x17;
+    r[ad + 1] = 0x03;
+    r[ad + 2] = 0x03;
+    std.mem.writeInt(u16, r[ad + 3 ..][0..2], fake_cert_payload_len, .big);
+    crypto.randomBytes(r[pq_appdata_offset..][0..fake_cert_payload_len]);
+
+    // HMAC over the full response (random field zeroed), prefixed by the client digest.
+    const HmacSha256 = std.crypto.auth.hmac.sha2.HmacSha256;
+    var hmac = HmacSha256.init(secret);
+    hmac.update(client_digest);
+    hmac.update(r);
+    var response_digest: [32]u8 = undefined;
+    hmac.final(&response_digest);
+    @memcpy(r[tmpl_random_offset..][0..32], &response_digest);
+
+    return r;
+}
+
 /// A TLS **fatal** `handshake_failure` alert record — what a server sends when it
 /// refuses to complete the handshake (e.g. nginx `ssl_reject_handshake on`). Send
 /// this, then close, so a rejected probe sees a real server-style teardown. A *fatal*
@@ -844,6 +994,96 @@ test "formatClientHelloFingerprint summarizes ciphers/groups/keyshare" {
     try std.testing.expectEqualStrings("ciphers=1301,1303 groups=001d,11ec keyshare=001d", fp);
     // Truncated input never panics.
     try std.testing.expect(formatClientHelloFingerprint(ch[0..30], &out) == null);
+}
+
+test "clientOffersPqKeyShare detects a 0x11ec key_share entry" {
+    var ch: [160]u8 = undefined;
+    var n: usize = 0;
+    const W = struct {
+        fn b(buf: []u8, i: *usize, v: u8) void {
+            buf[i.*] = v;
+            i.* += 1;
+        }
+        fn h(buf: []u8, i: *usize, v: u16) void {
+            std.mem.writeInt(u16, buf[i.*..][0..2], v, .big);
+            i.* += 2;
+        }
+    };
+    W.b(&ch, &n, 0x16);
+    W.b(&ch, &n, 0x03);
+    W.b(&ch, &n, 0x01);
+    const rec_len_at = n;
+    W.h(&ch, &n, 0);
+    W.b(&ch, &n, 0x01);
+    W.b(&ch, &n, 0x00);
+    const hs_len_at = n;
+    W.h(&ch, &n, 0);
+    const hs_body_start = n;
+    W.h(&ch, &n, 0x0303);
+    var r: usize = 0;
+    while (r < 32) : (r += 1) W.b(&ch, &n, 0xAA);
+    W.b(&ch, &n, 0x00); // session_id len
+    W.h(&ch, &n, 2);
+    W.h(&ch, &n, 0x1301); // cipher_suites
+    W.b(&ch, &n, 0x01);
+    W.b(&ch, &n, 0x00); // compression
+    const ext_total_at = n;
+    W.h(&ch, &n, 0);
+    const ext_start = n;
+    W.h(&ch, &n, 0x0033); // key_share ext
+    const ks_len_at = n;
+    W.h(&ch, &n, 0);
+    const ks_payload_start = n;
+    W.h(&ch, &n, 8); // client_shares list length
+    W.h(&ch, &n, 0x11ec); // group
+    W.h(&ch, &n, 4); // key length
+    var kk: usize = 0;
+    while (kk < 4) : (kk += 1) W.b(&ch, &n, 0xCC);
+    std.mem.writeInt(u16, ch[ks_len_at..][0..2], @intCast(n - ks_payload_start), .big);
+    std.mem.writeInt(u16, ch[ext_total_at..][0..2], @intCast(n - ext_start), .big);
+    std.mem.writeInt(u16, ch[hs_len_at..][0..2], @intCast(n - hs_body_start), .big);
+    std.mem.writeInt(u16, ch[rec_len_at..][0..2], @intCast(n - 5), .big);
+
+    try std.testing.expect(clientOffersPqKeyShare(ch[0..n]));
+    // Flip the offered group to x25519 -> no longer a PQ offer.
+    std.mem.writeInt(u16, ch[ks_payload_start + 2 ..][0..2], 0x001d, .big);
+    try std.testing.expect(!clientOffersPqKeyShare(ch[0..n]));
+    // Truncated input never panics.
+    try std.testing.expect(!clientOffersPqKeyShare(ch[0..20]));
+}
+
+test "buildServerHelloPq emits a 0x11ec key_share with correct framing + HMAC" {
+    const allocator = std.testing.allocator;
+    const digest = [_]u8{0} ** constants.tls_digest_len;
+    const sid = [_]u8{0x33} ** 32;
+    const secret = [_]u8{0x42} ** 16;
+    const resp = try buildServerHelloPq(allocator, &secret, &digest, &sid, 0x1303);
+    defer allocator.free(resp);
+
+    try std.testing.expectEqual(pq_server_hello_len, resp.len);
+    try std.testing.expectEqual(@as(u8, 0x16), resp[0]);
+    try std.testing.expectEqual(@as(u16, @intCast(pq_server_hello_record_len - 5)), std.mem.readInt(u16, resp[3..][0..2], .big));
+    // cipher echoed + session_id echoed
+    try std.testing.expectEqual(@as(u16, 0x1303), std.mem.readInt(u16, resp[tmpl_cipher_offset..][0..2], .big));
+    try std.testing.expectEqualSlices(u8, &sid, resp[tmpl_session_id_offset..][0..32]);
+    // key_share: ext type 0x0033, group 0x11ec, key length 1120
+    try std.testing.expectEqual(@as(u16, 0x0033), std.mem.readInt(u16, resp[87..][0..2], .big));
+    try std.testing.expectEqual(pq_named_group, std.mem.readInt(u16, resp[91..][0..2], .big));
+    try std.testing.expectEqual(@as(u16, @intCast(pq_key_share_len)), std.mem.readInt(u16, resp[93..][0..2], .big));
+    // CCS then AppData records follow the ServerHello record.
+    try std.testing.expectEqual(@as(u8, 0x14), resp[pq_server_hello_record_len]);
+    try std.testing.expectEqual(@as(u8, 0x17), resp[pq_server_hello_record_len + 6]);
+    // HMAC self-consistency: recompute over the response with the random field zeroed.
+    const check = try allocator.dupe(u8, resp);
+    defer allocator.free(check);
+    @memset(check[tmpl_random_offset..][0..32], 0);
+    const HmacSha256 = std.crypto.auth.hmac.sha2.HmacSha256;
+    var h = HmacSha256.init(&secret);
+    h.update(&digest);
+    h.update(check);
+    var expected: [32]u8 = undefined;
+    h.final(&expected);
+    try std.testing.expectEqualSlices(u8, &expected, resp[tmpl_random_offset..][0..32]);
 }
 
 test "extractFirstTls13Cipher returns first non-GREASE TLS1.3 suite" {

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -279,6 +279,7 @@ const closeFd = socket_utils.closeFd;
 const checkSocketConnectError = socket_utils.checkSocketConnectError;
 const acceptClient = socket_utils.acceptClient;
 const localSocketAddress = socket_utils.localSocketAddress;
+const setLingerReset = socket_utils.setLingerReset;
 const setNonBlocking = socket_utils.setNonBlocking;
 const secondsToMs = socket_utils.secondsToMs;
 
@@ -879,6 +880,8 @@ pub const ProxyState = struct {
         handshake_timeouts_total: u64,
         middleproxy_fallback_total: u64,
         drops_pool_total: u64,
+        replay_hits_total: u64,
+        unknown_sni_total: u64,
         close_reasons: [CloseReason.count]u64,
         client_to_upstream_bytes_total: u64,
         upstream_to_client_bytes_total: u64,
@@ -1134,6 +1137,12 @@ pub const ProxyState = struct {
     stats_dropped_hs_budget: std.atomic.Value(u64),
     stats_hs_timeout: std.atomic.Value(u64),
     stats_mp_fallback: std.atomic.Value(u64),
+    /// Replay-cache hits: a valid handshake whose canonical HMAC was already seen
+    /// (active replay probing). Distinct from a fresh accept.
+    stats_replay_hits: std.atomic.Value(u64),
+    /// ClientHello whose SNI did not match tls_domain (active probing / scanners /
+    /// borrowed-link misuse) — handled per unknown_sni_action.
+    stats_unknown_sni: std.atomic.Value(u64),
     /// Per-worker connection pool exhausted while the global cap still had room
     /// (SO_REUSEPORT hashes connections to workers, so one pool can fill first).
     stats_dropped_pool: std.atomic.Value(u64),
@@ -1273,6 +1282,8 @@ pub const ProxyState = struct {
             .stats_dropped_pool = std.atomic.Value(u64).init(0),
             .close_reasons = [_]std.atomic.Value(u64){std.atomic.Value(u64).init(0)} ** CloseReason.count,
             .stats_mp_fallback = std.atomic.Value(u64).init(0),
+            .stats_replay_hits = std.atomic.Value(u64).init(0),
+            .stats_unknown_sni = std.atomic.Value(u64).init(0),
             .middle_proxy_addrs_primary = constants.tg_middle_proxies_v4,
             .middle_proxy_addrs_media_primary = constants.tg_media_middle_proxies_v4,
             .middle_proxy_addr_203 = constants.getDcAddressV4(203),
@@ -1474,6 +1485,8 @@ pub const ProxyState = struct {
             .handshake_timeouts_total = self.stats_hs_timeout.load(.monotonic),
             .middleproxy_fallback_total = self.stats_mp_fallback.load(.monotonic),
             .drops_pool_total = self.stats_dropped_pool.load(.monotonic),
+            .replay_hits_total = self.stats_replay_hits.load(.monotonic),
+            .unknown_sni_total = self.stats_unknown_sni.load(.monotonic),
             .close_reasons = close_reasons,
             .client_to_upstream_bytes_total = self.client_to_upstream_bytes_total.load(.monotonic),
             .upstream_to_client_bytes_total = self.upstream_to_client_bytes_total.load(.monotonic),
@@ -2932,7 +2945,7 @@ const EventLoop = struct {
             .writing_server_hello_first => {
                 if (!slot.hasClientPending()) {
                     slot.phase = .desync_wait;
-                    slot.desync_deadline_ns = nowNs() + (3 * std.time.ns_per_ms);
+                    slot.desync_deadline_ns = self.desyncSplitDeadlineNs(slot);
                     self.enqueueDesyncWait(slot) catch {
                         self.closeSlot(slot, "desync wait queue failed");
                         return;
@@ -3053,6 +3066,19 @@ const EventLoop = struct {
         if (!slot.hasUpstreamPending() and slot.dc_initial_tail == null) {
             self.startRelay(slot);
         }
+    }
+
+    /// Deadline for the desync first-byte→rest split: a configurable base plus a cheap
+    /// per-connection jitter. A *fixed* gap is itself a passive timing fingerprint; the
+    /// jitter (derived from conn_id, no CSPRNG on the hot path) varies it per connection.
+    fn desyncSplitDeadlineNs(self: *EventLoop, slot: *const ConnectionSlot) i128 {
+        const cfg = &self.state.config;
+        var delay_ms: u64 = cfg.desync_split_delay_ms;
+        if (cfg.desync_split_jitter_ms > 0) {
+            const mix = slot.conn_id *% 0x9E3779B97F4A7C15;
+            delay_ms += (mix >> 33) % (@as(u64, cfg.desync_split_jitter_ms) + 1);
+        }
+        return nowNs() + @as(i128, delay_ms) * std.time.ns_per_ms;
     }
 
     fn enqueueDesyncWait(self: *EventLoop, slot: *ConnectionSlot) !void {
@@ -3288,6 +3314,7 @@ const EventLoop = struct {
 
         const v = validation.?;
         if (self.state.replay_cache.checkAndInsert(&v.canonical_hmac)) {
+            _ = self.state.stats_replay_hits.fetchAdd(1, .monotonic);
             self.startMasking(slot, client_hello) catch {
                 self.closeSlot(slot, "replay detected, masking failed");
             };
@@ -3324,22 +3351,38 @@ const EventLoop = struct {
             }
             break :blk false;
         };
+        // A PQ-offering client (X25519MLKEM768 0x11ec) must be answered with a 0x11ec
+        // key_share, else we emit a passive group-downgrade tell.
+        const offers_pq = tls.clientOffersPqKeyShare(client_hello_bytes);
         if (fp_consumed) {
             var fp_buf: [256]u8 = undefined;
             if (tls.formatClientHelloFingerprint(client_hello_bytes, &fp_buf)) |fp| {
-                log.info("client ClientHello [{s}] (we serve: cipher echoes client, key_share=x25519 0x001d)", .{fp});
+                log.info("client ClientHello [{s}] (we serve: cipher echoes client, key_share={s})", .{
+                    fp,
+                    if (offers_pq) "X25519MLKEM768 0x11ec" else "x25519 0x001d",
+                });
             }
         }
 
         const echoed_cipher = tls.extractFirstTls13Cipher(client_hello_bytes);
-        slot.server_hello = tls.buildServerHelloWithTemplate(
-            self.state.allocator,
-            self.state.tls_server_hello_template[0..],
-            &slot.validation_secret,
-            &slot.validation_digest,
-            slot.validation_session_id[0..slot.validation_session_id_len],
-            echoed_cipher,
-        ) catch {
+        const session_id = slot.validation_session_id[0..slot.validation_session_id_len];
+        slot.server_hello = (if (offers_pq)
+            tls.buildServerHelloPq(
+                self.state.allocator,
+                &slot.validation_secret,
+                &slot.validation_digest,
+                session_id,
+                echoed_cipher,
+            )
+        else
+            tls.buildServerHelloWithTemplate(
+                self.state.allocator,
+                self.state.tls_server_hello_template[0..],
+                &slot.validation_secret,
+                &slot.validation_digest,
+                session_id,
+                echoed_cipher,
+            )) catch {
             self.closeSlot(slot, "build server hello failed");
             return;
         };
@@ -3580,13 +3623,20 @@ const EventLoop = struct {
     /// like nginx ssl_reject_handshake and closes, `drop` closes silently. Validation-failed /
     /// replay cases (SNI matched) keep masking — they're not handled here.
     fn handleInvalidSni(self: *EventLoop, slot: *ConnectionSlot, client_hello: []const u8, reason: []const u8) void {
+        _ = self.state.stats_unknown_sni.fetchAdd(1, .monotonic);
         switch (self.state.config.unknown_sni_action) {
             .mask => self.startMasking(slot, client_hello) catch self.closeSlot(slot, reason),
             .reject => {
-                // Best-effort raw write of the 7-byte fatal alert before close (mirrors
-                // queue_io's syscall use); a partial/EAGAIN write is fine here.
-                const alert: []const u8 = &tls.reject_handshake_alert;
-                _ = posix.system.write(slot.client_fd, alert.ptr, alert.len);
+                if (self.state.config.reject_rst) {
+                    // Mirror a server/middlebox that resets a bad handshake: no alert,
+                    // force an RST on the (deferred) close via SO_LINGER{0}.
+                    setLingerReset(slot.client_fd);
+                } else {
+                    // Best-effort raw write of the 7-byte fatal alert before close (mirrors
+                    // queue_io's syscall use); a partial/EAGAIN write is fine here.
+                    const alert: []const u8 = &tls.reject_handshake_alert;
+                    _ = posix.system.write(slot.client_fd, alert.ptr, alert.len);
+                }
                 self.closeSlot(slot, reason);
             },
             .drop => self.closeSlot(slot, reason),

--- a/src/proxy/socket_utils.zig
+++ b/src/proxy/socket_utils.zig
@@ -222,6 +222,17 @@ pub fn setTcpNoDelay(fd: posix.fd_t) void {
     posix.setsockopt(fd, posix.IPPROTO.TCP, posix.TCP.NODELAY, std.mem.asBytes(&enable)) catch return;
 }
 
+/// Force a TCP RST on close instead of a graceful FIN, via SO_LINGER with a zero
+/// timeout. Used to mirror a server/middlebox that resets a rejected handshake.
+pub fn setLingerReset(fd: posix.fd_t) void {
+    // Linux `struct linger { int l_onoff; int l_linger; }`. Defined locally as an
+    // i32/i32 extern struct so it compiles on every target (only the Linux runtime
+    // path actually sets it); setsockopt just copies the bytes.
+    const Linger = extern struct { l_onoff: i32, l_linger: i32 };
+    const lin = Linger{ .l_onoff = 1, .l_linger = 0 };
+    posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.LINGER, std.mem.asBytes(&lin)) catch return;
+}
+
 pub fn configureRelaySocket(fd: posix.fd_t) void {
     setTcpNoDelay(fd);
     setTcpKeepalive(fd);


### PR DESCRIPTION
Anti-DPI / FakeTLS fidelity hardening — wave 1 of a competitor-survey (telemt) adoption roadmap.

### Post-quantum X25519MLKEM768 (0x11ec) ServerHello key_share
By 2026 a majority of real browser→CDN ClientHellos carry the hybrid PQ group. Always answering with classical x25519 (0x001d) is a passive **group-downgrade tell**. We now echo a correctly-sized 0x11ec key_share when the client offers it (`tls.clientOffersPqKeyShare` + `tls.buildServerHelloPq`). The share is high-entropy bytes — FakeTLS clients validate only framing + the server-random HMAC, passive fingerprinting keys on group+size, and we are not a TLS terminator, so a real ML-KEM encapsulation is unnecessary (std's `MlKem768X25519` is X-Wing, not the TLS 0x11ec wire format).

### Reject-path teardown mirroring (`reject_rst`)
New config: on `unknown_sni_action=reject`, emit a TCP **RST** (`SO_LINGER{0}`) instead of alert+FIN, to match fronted CDNs that reset a bad handshake. Default off.

### Jittered desync split
The fixed 3ms first-byte→rest gap was itself a timing fingerprint. New `desync_split_delay_ms` + `desync_split_jitter_ms` (default 3 + 0..3) vary it per connection via a cheap conn_id jitter.

### Probe observability
`mtproto_replay_hits_total` + `mtproto_unknown_sni_total` counters (active replay probing / SNI-mismatch scanning) on `/metrics`.

THREAT_MODEL.md gains a post-quantum key_share section.

**Verified:** 251/251 tests (incl. new PQ builder + detector KATs); `x86_64-linux` + `aarch64-linux` cross-builds; `zig fmt` clean.

Follow-ups (later waves): mask-origin ServerHello profile capture (P0), opt-in SNI-following mask target, HTTP-Date clock self-correction, mask-relay cap, PROXY-protocol ingestion.