### PR TITLE
feat(faketls): clock-sync, mask-relay cap, fake_cert_size, PROXY-protocol (roadmap wave 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,17 +24,21 @@ e2e: ## Run E2E/integration harness
 
 # ── server ops ────────────────────────────────────────────────────────────────
 
-deploy: build ## Build and push proxy + mtbuddy to server
+deploy: build ## Build and push proxy + mtbuddy to server (binary-only; PUSH_CONFIG=1 also pushes config/env)
 	scp zig-out/bin/mtproto-proxy root@$(SERVER):/opt/mtproto-proxy/mtproto-proxy.new
 	scp zig-out/bin/mtbuddy root@$(SERVER):/usr/local/bin/mtbuddy.new
-	-@if [ -f $(CONFIG) ]; then scp $(CONFIG) root@$(SERVER):/opt/mtproto-proxy/config.toml; fi
-	-@if [ -f .env ]; then \
-		tmp=$$(mktemp) && \
-		awk '{print "export " $$0}' .env > "$$tmp" && \
-		scp "$$tmp" root@$(SERVER):/opt/mtproto-proxy/env.sh && \
-		ssh root@$(SERVER) 'chmod 600 /opt/mtproto-proxy/env.sh'; \
-		rm -f "$$tmp"; \
-	fi
+	@# Config/env push is OPT-IN: by default `make deploy` ships ONLY the binary and never
+	@# touches the live config/secrets. Pushing a stale or drifted local config.toml over a
+	@# live deploy can break every share link (secrets/tls_domain) and the egress mode. Run
+	@# `make deploy PUSH_CONFIG=1` deliberately when you intend to overwrite the remote config.
+	@if [ "$(PUSH_CONFIG)" = "1" ]; then \
+		if [ -f $(CONFIG) ]; then echo "PUSH_CONFIG=1: pushing $(CONFIG) -> remote config.toml"; scp $(CONFIG) root@$(SERVER):/opt/mtproto-proxy/config.toml; fi; \
+		if [ -f .env ]; then \
+			tmp=$$(mktemp) && awk '{print "export " $$0}' .env > "$$tmp" && \
+			scp "$$tmp" root@$(SERVER):/opt/mtproto-proxy/env.sh && \
+			ssh root@$(SERVER) 'chmod 600 /opt/mtproto-proxy/env.sh'; rm -f "$$tmp"; \
+		fi; \
+	else echo "binary-only deploy (config/env left untouched; use PUSH_CONFIG=1 to push them)"; fi
 	ssh root@$(SERVER) 'install -m 0755 /opt/mtproto-proxy/mtproto-proxy.new /opt/mtproto-proxy/mtproto-proxy'
 	ssh root@$(SERVER) 'install -m 0755 /usr/local/bin/mtbuddy.new /usr/local/bin/mtbuddy'
 	ssh root@$(SERVER) 'chown -R mtproto:mtproto /opt/mtproto-proxy/ && systemctl restart mtproto-proxy && systemctl is-active --quiet mtproto-proxy'

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -147,7 +147,7 @@ fn runHandshakeBench(allocator: std.mem.Allocator, iterations: usize) !void {
 
     var warmup: usize = 0;
     while (warmup < 1000) : (warmup += 1) {
-        const ok = try tls.validateTlsHandshake(allocator, &handshake, &user_secrets, true);
+        const ok = try tls.validateTlsHandshake(allocator, &handshake, &user_secrets, true, 0);
         if (ok == null) return error.BenchmarkValidationFailed;
     }
 
@@ -155,7 +155,7 @@ fn runHandshakeBench(allocator: std.mem.Allocator, iterations: usize) !void {
     var matched: usize = 0;
     var i: usize = 0;
     while (i < iterations) : (i += 1) {
-        const ok = try tls.validateTlsHandshake(allocator, &handshake, &user_secrets, true);
+        const ok = try tls.validateTlsHandshake(allocator, &handshake, &user_secrets, true, 0);
         if (ok != null) matched += 1;
     }
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -211,6 +211,10 @@ pub const Config = struct {
     /// server clock (so a wrong VPS clock doesn't silently reject every handshake on the
     /// time-skew check). Unset = no correction. The offset is clamped to ±1 day.
     clock_sync_url: ?[]const u8 = null,
+    /// Expect a HAProxy PROXY-protocol header (v1 or v2) before each connection's TLS, so
+    /// the real client IP is recovered when sitting behind a TLS-terminating load balancer.
+    /// Enable ONLY when every connection truly arrives via such an LB. Default off.
+    accept_proxy_protocol: bool = false,
     /// Explicit public IP address. If set, bypasses detection via external services.
     public_ip: ?[]const u8 = null,
     /// Explicit public port shown in generated Telegram client links.
@@ -658,6 +662,8 @@ pub const Config = struct {
                     } else if (std.mem.eql(u8, key, "clock_sync_url")) {
                         if (cfg.clock_sync_url) |prev| allocator.free(prev);
                         cfg.clock_sync_url = try allocator.dupe(u8, value);
+                    } else if (std.mem.eql(u8, key, "accept_proxy_protocol")) {
+                        cfg.accept_proxy_protocol = parseBool(value);
                     } else if (std.mem.eql(u8, key, "backlog")) {
                         cfg.backlog = std.fmt.parseInt(u32, value, 10) catch 4096;
                     } else if (std.mem.eql(u8, key, "max_connections")) {

--- a/src/config.zig
+++ b/src/config.zig
@@ -767,6 +767,7 @@ pub const Config = struct {
                     } else if (std.mem.eql(u8, key, "reject_rst")) {
                         cfg.reject_rst = parseBool(value);
                     } else if (std.mem.eql(u8, key, "mask_sni_safelist")) {
+                        freeStringSlice(allocator, cfg.mask_sni_safelist);
                         cfg.mask_sni_safelist = parseStringArrayValue(allocator, value) catch &.{};
                     } else if (std.mem.eql(u8, key, "mask_relay_max_secs")) {
                         cfg.mask_relay_max_secs = std.fmt.parseInt(u32, value, 10) catch cfg.mask_relay_max_secs;
@@ -875,6 +876,7 @@ pub const Config = struct {
             allocator.free(iface);
         }
         freeStringSlice(allocator, self.upstream_tunnel_interfaces);
+        freeStringSlice(allocator, self.mask_sni_safelist);
         if (self.upstream_tunnel_pinned_interface) |iface| {
             allocator.free(iface);
         }
@@ -987,6 +989,24 @@ test "parse config - missing fields defaults" {
     try std.testing.expectEqual(@as(u16, 9400), cfg.metrics.port);
     try std.testing.expectEqual(@as(usize, 1), cfg.users.count());
     try std.testing.expectEqual(@as(usize, 0), cfg.direct_users.count());
+}
+
+test "parse config - mask_sni_safelist parses and frees cleanly" {
+    const content =
+        \\[censorship]
+        \\tls_domain = "example.com"
+        \\mask_sni_safelist = ["a.example", "b.example"]
+        \\mask_sni_safelist = ["c.example"]
+        \\
+        \\[access.users]
+        \\alice = "00112233445566778899aabbccddeeff"
+    ;
+    // The duplicate key exercises free-before-reassign; deinit must free the slice
+    // (the testing allocator fails the test on any leak or double-free).
+    var cfg = try Config.parse(std.testing.allocator, content);
+    defer cfg.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), cfg.mask_sni_safelist.len);
+    try std.testing.expectEqualStrings("c.example", cfg.mask_sni_safelist[0]);
 }
 
 test "parse config - custom mask target" {

--- a/src/config.zig
+++ b/src/config.zig
@@ -282,6 +282,12 @@ pub const Config = struct {
     /// backend). 0 = unlimited. Bounds how long an active prober/scanner can hold a
     /// backend connection open through us; idle masking relays are already idle-timed.
     mask_relay_max_secs: u32 = 0,
+    /// Size (bytes) of the fake encrypted-certificate AppData record in the FakeTLS
+    /// ServerHello. 0 = default (~2878, a typical nginx + Let's Encrypt ECDSA chain). Set
+    /// it to the first encrypted-flight record size your masking backend actually serves so
+    /// an active prober sees the same cert-record size on both the accept and mask paths
+    /// (measure with e.g. `openssl s_client -msg`). Clamped to 256..16384.
+    fake_cert_size: u32 = 0,
     /// Reject the non-TLS "direct obfuscated" (dd / secure) transport. When true
     /// (the default), only FakeTLS (ee) clients are accepted and any non-TLS
     /// first bytes are masked immediately — eliminating the dd active-probe
@@ -758,6 +764,8 @@ pub const Config = struct {
                         cfg.mask_sni_safelist = parseStringArrayValue(allocator, value) catch &.{};
                     } else if (std.mem.eql(u8, key, "mask_relay_max_secs")) {
                         cfg.mask_relay_max_secs = std.fmt.parseInt(u32, value, 10) catch cfg.mask_relay_max_secs;
+                    } else if (std.mem.eql(u8, key, "fake_cert_size")) {
+                        cfg.fake_cert_size = std.fmt.parseInt(u32, value, 10) catch cfg.fake_cert_size;
                     }
                 } else if (in_metrics_section) {
                     if (std.mem.eql(u8, key, "enabled")) {

--- a/src/config.zig
+++ b/src/config.zig
@@ -207,6 +207,10 @@ pub const Config = struct {
     /// all interfaces ([::]  with IPv4 fallback to 0.0.0.0).
     /// Set to a specific IP when sharing the host with other services.
     bind_address: ?[]const u8 = null,
+    /// Optional HTTPS URL whose `Date:` header is used at startup to correct a skewed
+    /// server clock (so a wrong VPS clock doesn't silently reject every handshake on the
+    /// time-skew check). Unset = no correction. The offset is clamped to ±1 day.
+    clock_sync_url: ?[]const u8 = null,
     /// Explicit public IP address. If set, bypasses detection via external services.
     public_ip: ?[]const u8 = null,
     /// Explicit public port shown in generated Telegram client links.
@@ -274,6 +278,10 @@ pub const Config = struct {
     mask_target: ?[]const u8 = null,
     /// Port used by the masking backend.
     mask_port: u16 = 443,
+    /// Max lifetime (seconds) for a masking-relay connection (a probe forwarded to the
+    /// backend). 0 = unlimited. Bounds how long an active prober/scanner can hold a
+    /// backend connection open through us; idle masking relays are already idle-timed.
+    mask_relay_max_secs: u32 = 0,
     /// Reject the non-TLS "direct obfuscated" (dd / secure) transport. When true
     /// (the default), only FakeTLS (ee) clients are accepted and any non-TLS
     /// first bytes are masked immediately — eliminating the dd active-probe
@@ -641,6 +649,9 @@ pub const Config = struct {
                     } else if (std.mem.eql(u8, key, "bind_address")) {
                         if (cfg.bind_address) |prev| allocator.free(prev);
                         cfg.bind_address = try allocator.dupe(u8, value);
+                    } else if (std.mem.eql(u8, key, "clock_sync_url")) {
+                        if (cfg.clock_sync_url) |prev| allocator.free(prev);
+                        cfg.clock_sync_url = try allocator.dupe(u8, value);
                     } else if (std.mem.eql(u8, key, "backlog")) {
                         cfg.backlog = std.fmt.parseInt(u32, value, 10) catch 4096;
                     } else if (std.mem.eql(u8, key, "max_connections")) {
@@ -745,6 +756,8 @@ pub const Config = struct {
                         cfg.reject_rst = parseBool(value);
                     } else if (std.mem.eql(u8, key, "mask_sni_safelist")) {
                         cfg.mask_sni_safelist = parseStringArrayValue(allocator, value) catch &.{};
+                    } else if (std.mem.eql(u8, key, "mask_relay_max_secs")) {
+                        cfg.mask_relay_max_secs = std.fmt.parseInt(u32, value, 10) catch cfg.mask_relay_max_secs;
                     }
                 } else if (in_metrics_section) {
                     if (std.mem.eql(u8, key, "enabled")) {
@@ -853,6 +866,9 @@ pub const Config = struct {
         }
         if (self.bind_address) |ba| {
             allocator.free(ba);
+        }
+        if (self.clock_sync_url) |u| {
+            allocator.free(u);
         }
         if (self.metrics.host) |h| {
             allocator.free(h);

--- a/src/ctl/i18n.zig
+++ b/src/ctl/i18n.zig
@@ -458,7 +458,7 @@ const en_strings = [_][]const u8{
     // tui_exited
     "Exited",
     // menu_remove_dashboard
-    "Remove monitoring dashboard",
+    "📊  Remove monitoring dashboard",
 };
 
 // ── Russian strings ─────────────────────────────────────────────
@@ -723,7 +723,7 @@ const ru_strings = [_][]const u8{
     // tui_exited
     "Выход",
     // menu_remove_dashboard
-    "Удалить дашборд мониторинга",
+    "📊  Удалить дашборд мониторинга",
 };
 
 // ── Comptime validation ─────────────────────────────────────────

--- a/src/protocol/tls.zig
+++ b/src/protocol/tls.zig
@@ -44,6 +44,7 @@ pub fn validateTlsHandshake(
     handshake: []const u8,
     secrets: []const UserSecret,
     ignore_time_skew: bool,
+    clock_offset_seconds: i64,
 ) !?TlsValidation {
     _ = allocator;
 
@@ -65,7 +66,7 @@ pub fn validateTlsHandshake(
     const HmacSha256 = std.crypto.auth.hmac.sha2.HmacSha256;
     const zero_digest = [_]u8{0} ** constants.tls_digest_len;
 
-    const now: i64 = if (!ignore_time_skew) realtimeSeconds() else 0;
+    const now: i64 = if (!ignore_time_skew) realtimeSeconds() + clock_offset_seconds else 0;
 
     for (secrets) |entry| {
         var hmac = HmacSha256.init(&entry.secret);
@@ -937,7 +938,7 @@ test "fuzz: TLS ClientHello parsers never panic on arbitrary input" {
             var fp_buf: [256]u8 = undefined;
             _ = formatClientHelloFingerprint(data, &fp_buf);
             const secrets = [_]UserSecret{.{ .name = "u", .secret = [_]u8{0x11} ** 16 }};
-            _ = validateTlsHandshake(std.testing.allocator, data, &secrets, true) catch {};
+            _ = validateTlsHandshake(std.testing.allocator, data, &secrets, true, 0) catch {};
         }
     }.one, .{});
 }
@@ -1186,7 +1187,7 @@ test "validateTlsHandshake - valid handshake" {
     handshake[constants.tls_digest_pos + 30] = computed_mac[30] ^ ts_bytes[2];
     handshake[constants.tls_digest_pos + 31] = computed_mac[31] ^ ts_bytes[3];
 
-    const result = try validateTlsHandshake(allocator, &handshake, &secrets, true);
+    const result = try validateTlsHandshake(allocator, &handshake, &secrets, true, 0);
     try std.testing.expect(result != null);
     try std.testing.expectEqualStrings("bob", result.?.user);
     try std.testing.expectEqual(@as(u32, 0x12345678), result.?.timestamp);
@@ -1197,7 +1198,7 @@ test "validateTlsHandshake - invalid user" {
     var secrets = [_]UserSecret{.{ .name = "alice", .secret = [_]u8{0x1A} ** 16 }};
     var handshake = [_]u8{0xAA} ** 64; // random junk
 
-    const result = try validateTlsHandshake(allocator, &handshake, &secrets, true);
+    const result = try validateTlsHandshake(allocator, &handshake, &secrets, true, 0);
     try std.testing.expect(result == null);
 }
 
@@ -1221,7 +1222,7 @@ test "validateTlsHandshake - rejects non-32 session id" {
     handshake[constants.tls_digest_pos + 30] = computed_mac[30] ^ ts_bytes[2];
     handshake[constants.tls_digest_pos + 31] = computed_mac[31] ^ ts_bytes[3];
 
-    const result = try validateTlsHandshake(allocator, &handshake, &secrets, true);
+    const result = try validateTlsHandshake(allocator, &handshake, &secrets, true, 0);
     try std.testing.expect(result == null);
 }
 
@@ -1253,7 +1254,7 @@ test "validateTlsHandshake returns canonical_hmac" {
     handshake[constants.tls_digest_pos + 30] = computed_mac[30] ^ ts_bytes[2];
     handshake[constants.tls_digest_pos + 31] = computed_mac[31] ^ ts_bytes[3];
 
-    const result = try validateTlsHandshake(allocator, &handshake, &secrets, true);
+    const result = try validateTlsHandshake(allocator, &handshake, &secrets, true, 0);
     try std.testing.expect(result != null);
     try std.testing.expectEqualSlices(u8, &computed_mac, &result.?.canonical_hmac);
 }
@@ -1421,7 +1422,7 @@ test "validateTlsHandshake - fuzz random and replayed input" {
     for (0..3000) |_| {
         const len: usize = @as(usize, random.int(u16)) % random_buf.len;
         random.bytes(random_buf[0..len]);
-        const parsed = try validateTlsHandshake(allocator, random_buf[0..len], &secrets, true);
+        const parsed = try validateTlsHandshake(allocator, random_buf[0..len], &secrets, true, 0);
         if (parsed) |v| {
             try std.testing.expect(v.session_id.len == 32);
             try std.testing.expect(v.user.len > 0);
@@ -1431,8 +1432,8 @@ test "validateTlsHandshake - fuzz random and replayed input" {
     // Replayed bytes produce identical canonical HMAC.
     var hello_buf: [512]u8 = undefined;
     const hello = try buildTlsAuthClientHello(&hello_buf, secrets[0].secret, "google.com");
-    const first = try validateTlsHandshake(allocator, hello, &secrets, true);
-    const second = try validateTlsHandshake(allocator, hello, &secrets, true);
+    const first = try validateTlsHandshake(allocator, hello, &secrets, true, 0);
+    const second = try validateTlsHandshake(allocator, hello, &secrets, true, 0);
     try std.testing.expect(first != null and second != null);
     try std.testing.expectEqualSlices(u8, &first.?.canonical_hmac, &second.?.canonical_hmac);
 }

--- a/src/protocol/tls.zig
+++ b/src/protocol/tls.zig
@@ -242,7 +242,8 @@ pub const pq_server_hello_len: usize = pq_server_hello_record_len + 6 + 5 + fake
 /// Offset of the 1120-byte PQ key_share inside the response.
 const pq_key_offset: usize = 95;
 /// Offset of the fake AppData body inside the PQ response.
-const pq_appdata_offset: usize = pq_server_hello_len - fake_cert_payload_len;
+/// Fixed prefix before the PQ AppData body: ServerHello record + CCS + AppData header.
+const pq_appdata_offset: usize = pq_server_hello_record_len + 6 + 5;
 
 /// Return true when the ClientHello carries a key_share entry for X25519MLKEM768
 /// (named group 0x11ec). Mirrors the key_share walk in formatClientHelloFingerprint.
@@ -296,9 +297,13 @@ pub fn buildServerHelloPq(
     client_digest: *const [constants.tls_digest_len]u8,
     session_id: []const u8,
     cipher: ?u16,
+    cert_len: usize,
 ) ![]u8 {
     if (session_id.len != 32) return error.BadSessionIdLength;
-    const r = try allocator.alloc(u8, pq_server_hello_len);
+    if (cert_len > 0xFFFF) return error.CertTooLarge;
+    // Match the fake-cert (AppData) record size used on the non-PQ path so a prober can't
+    // tell PQ vs classical clients apart by cert-record length.
+    const r = try allocator.alloc(u8, pq_appdata_offset + cert_len);
     errdefer allocator.free(r);
     @memset(r, 0);
 
@@ -346,8 +351,8 @@ pub fn buildServerHelloPq(
     r[ad] = 0x17;
     r[ad + 1] = 0x03;
     r[ad + 2] = 0x03;
-    std.mem.writeInt(u16, r[ad + 3 ..][0..2], fake_cert_payload_len, .big);
-    crypto.randomBytes(r[pq_appdata_offset..][0..fake_cert_payload_len]);
+    std.mem.writeInt(u16, r[ad + 3 ..][0..2], @intCast(cert_len), .big);
+    crypto.randomBytes(r[pq_appdata_offset..]);
 
     // HMAC over the full response (random field zeroed), prefixed by the client digest.
     const HmacSha256 = std.crypto.auth.hmac.sha2.HmacSha256;
@@ -425,6 +430,9 @@ const tmpl_x25519_key_offset: usize = 95;
 /// fresh per-connection random bytes at runtime so it isn't byte-identical
 /// across connections (which would be a passive DPI distinguisher).
 const tmpl_appdata_offset: usize = nginx_template_len - fake_cert_payload_len;
+/// Fixed ServerHello+CCS+AppData-header prefix length (138); a template's fake-cert size
+/// is `template.len - server_hello_prefix_len`.
+pub const server_hello_prefix_len: usize = tmpl_appdata_offset;
 
 /// Fake encrypted certificate payload size.
 /// 2878 bytes matches a typical Nginx + Let's Encrypt ECDSA P-256 cert chain:
@@ -1097,7 +1105,7 @@ test "buildServerHelloPq emits a 0x11ec key_share with correct framing + HMAC" {
     const digest = [_]u8{0} ** constants.tls_digest_len;
     const sid = [_]u8{0x33} ** 32;
     const secret = [_]u8{0x42} ** 16;
-    const resp = try buildServerHelloPq(allocator, &secret, &digest, &sid, 0x1303);
+    const resp = try buildServerHelloPq(allocator, &secret, &digest, &sid, 0x1303, default_fake_cert_size);
     defer allocator.free(resp);
 
     try std.testing.expectEqual(pq_server_hello_len, resp.len);

--- a/src/protocol/tls.zig
+++ b/src/protocol/tls.zig
@@ -152,7 +152,11 @@ pub fn buildServerHelloWithTemplate(
     session_id: []const u8,
     cipher: ?u16,
 ) ![]u8 {
-    if (template.len != nginx_template_len) return error.BadServerHelloTemplate;
+    // The ServerHello+CCS+AppData-header prefix is a fixed 138 bytes; only the trailing
+    // fake-cert (AppData body) size varies. Accept any template whose length leaves room
+    // for that prefix, so a profile-matched cert size (see buildServerHelloTemplateAlloc)
+    // works through the same patch path.
+    if (template.len < tmpl_appdata_offset) return error.BadServerHelloTemplate;
 
     // 1. Copy the pre-built Nginx template (random and session_id are zeroed in template)
     const response = try allocator.alloc(u8, template.len);
@@ -187,7 +191,7 @@ pub fn buildServerHelloWithTemplate(
     //     a passive FakeTLS distinguisher. The client never inspects this body
     //     and the HMAC in step 4 covers it, so fresh randomness is protocol-safe.
     //     The record length stays fixed, preserving the size fingerprint.
-    crypto.randomBytes(response[tmpl_appdata_offset..][0..fake_cert_payload_len]);
+    crypto.randomBytes(response[tmpl_appdata_offset..]);
 
     // 4. Compute HMAC over full response with random field zeroed.
     //    Template already has zeros at offset 11..43, so HMAC input is correct.
@@ -357,6 +361,35 @@ pub fn buildServerHelloPq(
     return r;
 }
 
+/// Build a ServerHello template with a profile-matched fake-cert (AppData) record size.
+/// The fixed 138-byte ServerHello+CCS+AppData-header prefix is copied from the comptime
+/// template; only the AppData length field and body size differ. The result is patched
+/// per-connection by buildServerHelloWithTemplate just like the default template.
+pub fn buildServerHelloTemplateAlloc(allocator: std.mem.Allocator, cert_len: usize) ![]u8 {
+    if (cert_len > 0xFFFF) return error.CertTooLarge;
+    const t = try allocator.alloc(u8, tmpl_appdata_offset + cert_len);
+    errdefer allocator.free(t);
+    @memcpy(t[0..tmpl_appdata_offset], nginx_template[0..tmpl_appdata_offset]);
+    // Patch the AppData record's 2-byte length field (immediately before the body).
+    std.mem.writeInt(u16, t[tmpl_appdata_offset - 2 ..][0..2], @intCast(cert_len), .big);
+    crypto.randomBytes(t[tmpl_appdata_offset..]);
+    return t;
+}
+
+/// Walk a TLS record stream and return the payload length of the first Application Data
+/// (0x17) record, or null. Used to learn the mask origin's first encrypted-flight
+/// (certificate) record size so our fake cert record can match it instead of a fixed 2878.
+pub fn firstAppDataRecordLen(data: []const u8) ?usize {
+    var pos: usize = 0;
+    while (pos + 5 <= data.len) {
+        const rtype = data[pos];
+        const rlen = std.mem.readInt(u16, data[pos + 3 ..][0..2], .big);
+        if (rtype == 0x17) return rlen;
+        pos += 5 + rlen;
+    }
+    return null;
+}
+
 /// A TLS **fatal** `handshake_failure` alert record — what a server sends when it
 /// refuses to complete the handshake (e.g. nginx `ssl_reject_handshake on`). Send
 /// this, then close, so a rejected probe sees a real server-style teardown. A *fatal*
@@ -399,6 +432,12 @@ const tmpl_appdata_offset: usize = nginx_template_len - fake_cert_payload_len;
 ///   Finished (~36) + AEAD tags (~50) + record layer overhead.
 /// Fixed size eliminates the random-range fingerprint that ТСПУ detects.
 const fake_cert_payload_len: u16 = 2878;
+
+/// Default fake-cert (AppData) record size when not profile-matched via fake_cert_size.
+pub const default_fake_cert_size: usize = fake_cert_payload_len;
+/// Clamp bounds for a configured/profiled fake-cert size (sane TLS record sizes).
+pub const min_fake_cert_size: usize = 256;
+pub const max_fake_cert_size: usize = 16384;
 
 /// Total template size: ServerHello(127) + CCS(6) + AppData(5 + 2878)
 const nginx_template_len: usize = 127 + 6 + 5 + fake_cert_payload_len;
@@ -1085,6 +1124,26 @@ test "buildServerHelloPq emits a 0x11ec key_share with correct framing + HMAC" {
     var expected: [32]u8 = undefined;
     h.final(&expected);
     try std.testing.expectEqualSlices(u8, &expected, resp[tmpl_random_offset..][0..32]);
+}
+
+test "buildServerHelloTemplateAlloc + firstAppDataRecordLen match a profile cert size" {
+    const allocator = std.testing.allocator;
+    const tmpl = try buildServerHelloTemplateAlloc(allocator, 1234);
+    defer allocator.free(tmpl);
+    try std.testing.expectEqual(@as(usize, tmpl_appdata_offset + 1234), tmpl.len);
+    try std.testing.expectEqual(@as(u8, 0x17), tmpl[127 + 6]); // AppData record type
+    try std.testing.expectEqual(@as(u16, 1234), std.mem.readInt(u16, tmpl[tmpl_appdata_offset - 2 ..][0..2], .big));
+
+    // The variable-size template patches through the normal builder.
+    const digest = [_]u8{0} ** constants.tls_digest_len;
+    const sid = [_]u8{0x33} ** 32;
+    const secret = [_]u8{0x42} ** 16;
+    const resp = try buildServerHelloWithTemplate(allocator, tmpl, &secret, &digest, &sid, 0x1301);
+    defer allocator.free(resp);
+    try std.testing.expectEqual(tmpl.len, resp.len);
+    try std.testing.expectEqual(@as(?usize, 1234), firstAppDataRecordLen(resp));
+    // No AppData record in a stream that has only ServerHello → null.
+    try std.testing.expectEqual(@as(?usize, null), firstAppDataRecordLen(resp[0..127]));
 }
 
 test "extractFirstTls13Cipher returns first non-GREASE TLS1.3 suite" {

--- a/src/proxy/http_fetch.zig
+++ b/src/proxy/http_fetch.zig
@@ -94,7 +94,10 @@ pub fn parseHttpDate(head: []const u8) ?i64 {
         if (t.len < 6 or !std.ascii.eqlIgnoreCase(t[0..5], "date:")) continue;
         return parseImfFixdate(std.mem.trim(u8, t[5..], " \t"));
     }
-    return null;
+    // No "Date:" header line — treat the whole input as a bare IMF-fixdate value, as emitted
+    // by `curl -w '%header{date}'` (which we prefer so the Date can never fall outside a
+    // small stdout cap, unlike full `-I` headers).
+    return parseImfFixdate(std.mem.trim(u8, head, " \t\r\n"));
 }
 
 fn parseImfFixdate(v: []const u8) ?i64 {

--- a/src/proxy/http_fetch.zig
+++ b/src/proxy/http_fetch.zig
@@ -84,6 +84,68 @@ fn formatProxyEndpoint(host: []const u8, port: u16, out: []u8) []const u8 {
     return std.fmt.bufPrint(out, "{s}:{d}", .{ host, port }) catch out[0..0];
 }
 
+/// Parse the unix timestamp from the `Date:` header of a raw HTTP response head (e.g.
+/// `curl -sSI` output). Expects RFC 7231 IMF-fixdate ("Wed, 11 Jun 2026 19:30:00 GMT").
+/// Returns null if not present/parseable. Used for startup server-clock correction.
+pub fn parseHttpDate(head: []const u8) ?i64 {
+    var lines = std.mem.splitScalar(u8, head, '\n');
+    while (lines.next()) |line| {
+        const t = std.mem.trim(u8, line, " \t\r");
+        if (t.len < 6 or !std.ascii.eqlIgnoreCase(t[0..5], "date:")) continue;
+        return parseImfFixdate(std.mem.trim(u8, t[5..], " \t"));
+    }
+    return null;
+}
+
+fn parseImfFixdate(v: []const u8) ?i64 {
+    const comma = std.mem.indexOfScalar(u8, v, ',') orelse return null;
+    var r = std.mem.trimStart(u8, v[comma + 1 ..], " ");
+    if (r.len < 2) return null;
+    const day = std.fmt.parseInt(u8, std.mem.trim(u8, r[0..2], " "), 10) catch return null;
+    r = std.mem.trimStart(u8, r[2..], " ");
+    if (r.len < 3) return null;
+    const mon = monthFromName(r[0..3]) orelse return null;
+    r = std.mem.trimStart(u8, r[3..], " ");
+    if (r.len < 4) return null;
+    const year = std.fmt.parseInt(i64, r[0..4], 10) catch return null;
+    r = std.mem.trimStart(u8, r[4..], " ");
+    if (r.len < 8) return null;
+    const hh = std.fmt.parseInt(u8, r[0..2], 10) catch return null;
+    const mm = std.fmt.parseInt(u8, r[3..5], 10) catch return null;
+    const ss = std.fmt.parseInt(u8, r[6..8], 10) catch return null;
+    if (day < 1 or day > 31 or hh > 23 or mm > 59 or ss > 60) return null;
+    return civilToEpoch(year, mon, day, hh, mm, ss);
+}
+
+fn monthFromName(s: []const u8) ?u8 {
+    const names = [_][]const u8{ "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
+    for (names, 0..) |n, i| {
+        if (std.ascii.eqlIgnoreCase(s, n)) return @intCast(i + 1);
+    }
+    return null;
+}
+
+/// Howard Hinnant's days_from_civil → unix epoch seconds (UTC).
+fn civilToEpoch(y_in: i64, m: u8, d: u8, hh: u8, mm: u8, ss: u8) i64 {
+    var y = y_in;
+    if (m <= 2) y -= 1;
+    const era = @divFloor(y, 400);
+    const yoe = y - era * 400; // [0,399]
+    const mp: i64 = if (m > 2) @as(i64, m) - 3 else @as(i64, m) + 9;
+    const doy = @divTrunc(153 * mp + 2, 5) + @as(i64, d) - 1; // [0,365]
+    const doe = yoe * 365 + @divTrunc(yoe, 4) - @divTrunc(yoe, 100) + doy;
+    const days = era * 146097 + doe - 719468;
+    return days * 86400 + @as(i64, hh) * 3600 + @as(i64, mm) * 60 + @as(i64, ss);
+}
+
+test "parseHttpDate parses an IMF-fixdate Date header" {
+    try std.testing.expectEqual(@as(?i64, 0), parseHttpDate("HTTP/1.1 200 OK\r\nDate: Thu, 01 Jan 1970 00:00:00 GMT\r\n"));
+    // 2026-06-11 19:30:00 UTC
+    try std.testing.expectEqual(@as(?i64, 1781206200), parseHttpDate("date: Wed, 11 Jun 2026 19:30:00 GMT"));
+    try std.testing.expectEqual(@as(?i64, null), parseHttpDate("HTTP/1.1 200 OK\r\nServer: x\r\n"));
+    try std.testing.expectEqual(@as(?i64, null), parseHttpDate("Date: garbage"));
+}
+
 /// Append `s` into `buf` starting at `start`, escaping `\` and `"` for curl's
 /// double-quoted config-file value syntax. Returns the new position, or null on
 /// overflow.

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -1153,7 +1153,8 @@ pub const ProxyState = struct {
     /// Startup HTTP-Date clock correction (seconds); 0 if disabled or unavailable.
     clock_offset_seconds: i64,
     replay_cache: ReplayCache,
-    tls_server_hello_template: [tls.server_hello_template_len]u8,
+    /// FakeTLS ServerHello template (heap; size varies with fake_cert_size).
+    tls_server_hello_template: []const u8,
 
     // Degradation counters (monotonic totals, delta'd in stats log)
     stats_dropped_cap: std.atomic.Value(u64),
@@ -1289,6 +1290,17 @@ pub const ProxyState = struct {
             }
         }
 
+        // FakeTLS ServerHello template, sized to a profile-matched fake-cert record when
+        // fake_cert_size is set (else the default ~2878). Falls back to the default size
+        // if the configured value can't be built.
+        const fake_cert_size: usize = if (cfg.fake_cert_size == 0)
+            tls.default_fake_cert_size
+        else
+            std.math.clamp(@as(usize, cfg.fake_cert_size), tls.min_fake_cert_size, tls.max_fake_cert_size);
+        const tls_template = tls.buildServerHelloTemplateAlloc(allocator, fake_cert_size) catch
+            try tls.buildServerHelloTemplateAlloc(allocator, tls.default_fake_cert_size);
+        errdefer allocator.free(tls_template);
+
         var default_middle_proxy_secret = [_]u8{0} ** 256;
         @memcpy(default_middle_proxy_secret[0..middleproxy.proxy_secret.len], middleproxy.proxy_secret[0..]);
 
@@ -1330,7 +1342,7 @@ pub const ProxyState = struct {
             .mask_safelist = mask_safelist,
             .clock_offset_seconds = clock_offset_seconds,
             .replay_cache = ReplayCache.init(),
-            .tls_server_hello_template = tls.buildServerHelloTemplate(null),
+            .tls_server_hello_template = tls_template,
             .stats_dropped_cap = std.atomic.Value(u64).init(0),
             .stats_dropped_saturation = std.atomic.Value(u64).init(0),
             .stats_dropped_rate_limit = std.atomic.Value(u64).init(0),
@@ -1453,6 +1465,7 @@ pub const ProxyState = struct {
         }
         self.flood_guard.destroy(self.allocator);
         self.allocator.free(self.mask_safelist);
+        self.allocator.free(self.tls_server_hello_template);
         self.allocator.free(self.config_path);
         self.allocator.free(self.user_secrets);
         freeUserMetricsSlice(self.allocator, self.user_metrics);

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -29,6 +29,7 @@ const MessageQueue = @import("message_queue.zig").MessageQueue;
 const queue_io = @import("queue_io.zig");
 const middle_proxy_routing = @import("middle_proxy_routing.zig");
 const socket_utils = @import("socket_utils.zig");
+const proxy_protocol = @import("proxy_protocol.zig");
 const network_detect = @import("network_detect.zig");
 const http_fetch = @import("http_fetch.zig");
 const fd_limits = @import("fd_limits.zig");
@@ -57,6 +58,7 @@ test {
     _ = @import("socket_utils.zig");
     _ = @import("network_detect.zig");
     _ = @import("http_fetch.zig");
+    _ = @import("proxy_protocol.zig");
     _ = @import("sd_notify.zig");
     _ = @import("fd_limits.zig");
     _ = @import("connection_phase.zig");
@@ -566,6 +568,9 @@ const ConnectionSlot = struct {
     /// One-shot override for the next startMasking (SNI-following safelist hit).
     /// Consumed (read + cleared) inside startMasking so it never leaks to a reused slot.
     mask_addr_override: ?Address = null,
+    /// Expect a HAProxy PROXY-protocol header before the TLS ClientHello (set at accept
+    /// when accept_proxy_protocol is on; cleared once the header is consumed).
+    expect_proxy_header: bool = false,
 
     // Non-blocking MiddleProxy handshake state
     mp_step: MiddleProxyHandshakeStep = .none,
@@ -2450,8 +2455,13 @@ const EventLoop = struct {
             const client_addr = accepted.?.addr;
             accepted_this_round += 1;
 
+            // Behind a PROXY-protocol LB, the accepted address is the load balancer's, not
+            // the client's, so per-IP flood/subnet checks here are meaningless (they'd rate
+            // the LB). They run on the real client address once the PROXY header is parsed
+            // (peer_addr) via the per-handshake flood machinery.
+            const proxy_proto = self.state.config.accept_proxy_protocol;
             const flood_cfg = floodGuardSettings(&self.state.config);
-            if (self.state.floodIsBlocked(client_addr, flood_cfg)) {
+            if (!proxy_proto and self.state.floodIsBlocked(client_addr, flood_cfg)) {
                 _ = self.state.stats_dropped_flood_guard.fetchAdd(1, .monotonic);
                 closeFd(cfd);
                 continue;
@@ -2461,7 +2471,7 @@ const EventLoop = struct {
             setTcpNoDelay(cfd);
 
             // Per-/24 subnet rate limit (before we allocate any slot)
-            if (!self.state.subnetCheck(client_addr, self.state.config.rate_limit_per_subnet)) {
+            if (!proxy_proto and !self.state.subnetCheck(client_addr, self.state.config.rate_limit_per_subnet)) {
                 _ = self.state.stats_dropped_rate_limit.fetchAdd(1, .monotonic);
                 _ = self.state.floodRecord(client_addr, .rate_limit, flood_cfg);
                 closeFd(cfd);
@@ -2501,6 +2511,7 @@ const EventLoop = struct {
             slot.conn_id = self.state.connection_count.fetchAdd(1, .monotonic);
             slot.client_fd = cfd;
             slot.peer_addr = client_addr;
+            slot.expect_proxy_header = proxy_proto;
             slot.client_transport = .fake_tls;
             slot.phase = .reading_tls_header;
             slot.handshake_pos = 0;
@@ -3231,7 +3242,69 @@ const EventLoop = struct {
         }
     }
 
+    const ProxyHeaderStep = enum { done, wait, closed };
+
+    /// MSG_PEEK the connection's first bytes, parse a HAProxy PROXY-protocol header, and
+    /// drain exactly its bytes (leaving the TLS ClientHello untouched in the socket buffer)
+    /// so peer_addr reflects the real client behind a load balancer.
+    fn tryConsumeProxyHeader(self: *EventLoop, slot: *ConnectionSlot) ProxyHeaderStep {
+        var peek: [256]u8 = undefined;
+        const msg_peek: u32 = 0x2; // MSG_PEEK (Linux)
+        const rc = posix.system.recvfrom(slot.client_fd, &peek, peek.len, msg_peek, null, null);
+        const n: usize = switch (posix.errno(rc)) {
+            .SUCCESS => rc,
+            .AGAIN, .INTR => return .wait,
+            else => {
+                self.closeSlot(slot, "proxy header read error");
+                return .closed;
+            },
+        };
+        if (n == 0) {
+            self.closeSlot(slot, "client eof before proxy header");
+            return .closed;
+        }
+        switch (proxy_protocol.parse(peek[0..n])) {
+            .incomplete => {
+                if (n >= peek.len) {
+                    self.closeSlot(slot, "proxy header too long");
+                    return .closed;
+                }
+                return .wait;
+            },
+            .invalid => {
+                self.closeSlot(slot, "invalid proxy header");
+                return .closed;
+            },
+            .ok => |res| {
+                var drain: [256]u8 = undefined;
+                var left: usize = res.consumed;
+                while (left > 0) {
+                    const got = posix.read(slot.client_fd, drain[0..@min(left, drain.len)]) catch {
+                        self.closeSlot(slot, "proxy header drain error");
+                        return .closed;
+                    };
+                    if (got == 0) {
+                        self.closeSlot(slot, "client eof draining proxy header");
+                        return .closed;
+                    }
+                    left -= got;
+                }
+                if (res.src) |real| slot.peer_addr = real;
+                slot.expect_proxy_header = false;
+                slot.last_activity_ms = nowMs();
+                return .done;
+            },
+        }
+    }
+
     fn readTlsHeader(self: *EventLoop, slot: *ConnectionSlot) void {
+        if (slot.expect_proxy_header) {
+            switch (self.tryConsumeProxyHeader(slot)) {
+                .done => {},
+                .wait => return,
+                .closed => return,
+            }
+        }
         while (slot.tls_hdr_pos < tls_header_len) {
             const n = posix.read(slot.client_fd, slot.tls_hdr_buf[slot.tls_hdr_pos..]) catch |err| {
                 if (err == error.WouldBlock) return;

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -402,7 +402,9 @@ fn runSmallCommand(allocator: std.mem.Allocator, argv: []const []const u8) ?[]u8
 /// (seconds) to add to the local clock so it matches, clamped to ±1 day. Used to correct
 /// a skewed VPS clock that would otherwise fail the handshake time-skew check for everyone.
 fn fetchClockOffsetSeconds(allocator: std.mem.Allocator, url: []const u8) ?i64 {
-    const out = runSmallCommand(allocator, &.{ "curl", "-sSI", "--max-time", "8", url }) orelse return null;
+    // `-w %header{date}` prints ONLY the Date header value (tiny, always within the small
+    // runSmallCommand stdout cap), unlike full `-I` headers where Date could be truncated.
+    const out = runSmallCommand(allocator, &.{ "curl", "-sS", "-o", "/dev/null", "--max-time", "8", "-w", "%header{date}", url }) orelse return null;
     defer allocator.free(out);
     const http_epoch = http_fetch.parseHttpDate(out) orelse return null;
     const off = http_epoch - realtimeSeconds();
@@ -3519,6 +3521,7 @@ const EventLoop = struct {
                 &slot.validation_digest,
                 session_id,
                 echoed_cipher,
+                self.state.tls_server_hello_template.len - tls.server_hello_prefix_len,
             )
         else
             tls.buildServerHelloWithTemplate(

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -396,6 +396,17 @@ fn runSmallCommand(allocator: std.mem.Allocator, argv: []const []const u8) ?[]u8
     return allocator.dupe(u8, trimmed) catch null;
 }
 
+/// Fetch the `Date:` header from an HTTPS URL (via curl HEAD) and return the offset
+/// (seconds) to add to the local clock so it matches, clamped to ±1 day. Used to correct
+/// a skewed VPS clock that would otherwise fail the handshake time-skew check for everyone.
+fn fetchClockOffsetSeconds(allocator: std.mem.Allocator, url: []const u8) ?i64 {
+    const out = runSmallCommand(allocator, &.{ "curl", "-sSI", "--max-time", "8", url }) orelse return null;
+    defer allocator.free(out);
+    const http_epoch = http_fetch.parseHttpDate(out) orelse return null;
+    const off = http_epoch - realtimeSeconds();
+    return @max(@as(i64, -86400), @min(@as(i64, 86400), off));
+}
+
 fn detectActiveTunnelInterface(allocator: std.mem.Allocator) ?[]u8 {
     var table_buf: [16]u8 = undefined;
     const table = std.fmt.bufPrint(&table_buf, "{d}", .{tunnel_route_table}) catch "200";
@@ -1139,6 +1150,8 @@ pub const ProxyState = struct {
     mask_addr: ?Address,
     /// Opt-in SNI-following mask targets (config.mask_sni_safelist), resolved at boot.
     mask_safelist: []const MaskSafelistEntry,
+    /// Startup HTTP-Date clock correction (seconds); 0 if disabled or unavailable.
+    clock_offset_seconds: i64,
     replay_cache: ReplayCache,
     tls_server_hello_template: [tls.server_hello_template_len]u8,
 
@@ -1265,6 +1278,17 @@ pub const ProxyState = struct {
         }
         const mask_safelist = mask_safelist_buf.toOwnedSlice(allocator) catch &.{};
 
+        // Optional startup clock correction from an HTTPS Date header.
+        var clock_offset_seconds: i64 = 0;
+        if (cfg.clock_sync_url) |url| {
+            if (fetchClockOffsetSeconds(allocator, url)) |off| {
+                clock_offset_seconds = off;
+                log.info("clock_sync: applied {d}s server-clock correction from {s}", .{ off, url });
+            } else {
+                log.warn("clock_sync: could not read a Date header from {s}", .{url});
+            }
+        }
+
         var default_middle_proxy_secret = [_]u8{0} ** 256;
         @memcpy(default_middle_proxy_secret[0..middleproxy.proxy_secret.len], middleproxy.proxy_secret[0..]);
 
@@ -1304,6 +1328,7 @@ pub const ProxyState = struct {
             .saturation_paused = std.atomic.Value(bool).init(false),
             .mask_addr = resolved_addr,
             .mask_safelist = mask_safelist,
+            .clock_offset_seconds = clock_offset_seconds,
             .replay_cache = ReplayCache.init(),
             .tls_server_hello_template = tls.buildServerHelloTemplate(null),
             .stats_dropped_cap = std.atomic.Value(u64).init(0),
@@ -3337,6 +3362,7 @@ const EventLoop = struct {
             client_hello,
             self.state.user_secrets,
             false,
+            self.state.clock_offset_seconds,
         ) catch null;
 
         if (validation == null) {
@@ -4189,6 +4215,12 @@ const EventLoop = struct {
                     continue;
                 }
             } else if (slot.phase == .relaying or slot.phase == .mask_relaying) {
+                if (slot.phase == .mask_relaying and self.state.config.mask_relay_max_secs > 0 and
+                    now_ms - slot.created_at_ms > secondsToMs(self.state.config.mask_relay_max_secs))
+                {
+                    self.closeSlot(slot, "mask relay max duration");
+                    continue;
+                }
                 if (now_ms - slot.last_activity_ms > (if (slot.idle_timeout_ms > 0) slot.idle_timeout_ms else secondsToMs(self.state.config.idle_timeout_sec))) {
                     self.closeSlot(slot, "relay idle timeout");
                     continue;

--- a/src/proxy/proxy_protocol.zig
+++ b/src/proxy/proxy_protocol.zig
@@ -1,0 +1,144 @@
+//! HAProxy PROXY protocol (v1 text + v2 binary) header parsing.
+//!
+//! When the proxy sits behind a TLS-terminating load balancer (HAProxy / nginx stream),
+//! the real client address is carried in a PROXY header prepended before the MTProto /
+//! FakeTLS bytes. Parsing it lets per-subnet limits, flood records, and metrics attribute
+//! to the real client instead of the load balancer's IP.
+
+const std = @import("std");
+const net_helpers = @import("net_helpers.zig");
+const net = std.Io.net;
+
+const Address = net_helpers.Address;
+
+pub const ParseResult = union(enum) {
+    /// Not enough bytes buffered yet — read more, then re-parse.
+    incomplete,
+    /// Not a valid PROXY header — caller should reject the connection.
+    invalid,
+    /// A complete header. `consumed` bytes must be drained; `src` is the real client
+    /// address, or null for `UNKNOWN`/`LOCAL` (no address — keep the observed peer).
+    ok: struct { consumed: usize, src: ?Address },
+};
+
+const v2_sig = [_]u8{ 0x0d, 0x0a, 0x0d, 0x0a, 0x00, 0x0d, 0x0a, 0x51, 0x55, 0x49, 0x54, 0x0a };
+const v1_prefix = "PROXY";
+
+/// Parse a PROXY protocol header from the front of `buf` (which may contain trailing
+/// application bytes — only the header is consumed).
+pub fn parse(buf: []const u8) ParseResult {
+    if (buf.len == 0) return .incomplete;
+    // v2 binary
+    if (buf[0] == 0x0d) {
+        if (buf.len < v2_sig.len) {
+            return if (std.mem.startsWith(u8, &v2_sig, buf)) .incomplete else .invalid;
+        }
+        if (!std.mem.eql(u8, buf[0..v2_sig.len], &v2_sig)) return .invalid;
+        return parseV2(buf);
+    }
+    // v1 text
+    if (buf.len >= 1 and buf[0] == 'P') {
+        if (buf.len < v1_prefix.len) {
+            return if (std.mem.startsWith(u8, v1_prefix, buf)) .incomplete else .invalid;
+        }
+        if (!std.mem.startsWith(u8, buf, v1_prefix)) return .invalid;
+        return parseV1(buf);
+    }
+    return .invalid;
+}
+
+fn parseV1(buf: []const u8) ParseResult {
+    // "PROXY TCP4 <src> <dst> <sport> <dport>\r\n", max 107 bytes, terminated by CRLF.
+    const max_v1 = 107;
+    const crlf = std.mem.indexOf(u8, buf[0..@min(buf.len, max_v1)], "\r\n") orelse {
+        return if (buf.len < max_v1) .incomplete else .invalid;
+    };
+    const line = buf[0..crlf];
+    const consumed = crlf + 2;
+
+    var it = std.mem.tokenizeScalar(u8, line, ' ');
+    _ = it.next(); // "PROXY"
+    const proto = it.next() orelse return .invalid;
+    if (std.mem.eql(u8, proto, "UNKNOWN")) return .{ .ok = .{ .consumed = consumed, .src = null } };
+    if (!std.mem.eql(u8, proto, "TCP4") and !std.mem.eql(u8, proto, "TCP6")) return .invalid;
+    const src_ip = it.next() orelse return .invalid;
+    _ = it.next() orelse return .invalid; // dst ip
+    const src_port_s = it.next() orelse return .invalid;
+    const src_port = std.fmt.parseInt(u16, src_port_s, 10) catch return .invalid;
+
+    const addr = net.IpAddress.parse(src_ip, src_port) catch return .invalid;
+    return .{ .ok = .{ .consumed = consumed, .src = addr } };
+}
+
+fn parseV2(buf: []const u8) ParseResult {
+    // 12-byte sig, 1 byte ver/cmd, 1 byte fam/proto, 2 bytes addr-len, then addr block.
+    if (buf.len < 16) return .incomplete;
+    const ver_cmd = buf[12];
+    if (ver_cmd >> 4 != 0x2) return .invalid; // version must be 2
+    const cmd = ver_cmd & 0x0f; // 0=LOCAL, 1=PROXY
+    const fam = buf[13];
+    const addr_len = std.mem.readInt(u16, buf[14..16], .big);
+    const total = 16 + @as(usize, addr_len);
+    if (buf.len < total) return .incomplete;
+
+    if (cmd == 0) return .{ .ok = .{ .consumed = total, .src = null } }; // LOCAL: no address
+
+    const ab = buf[16 .. 16 + addr_len];
+    switch (fam) {
+        0x11 => { // TCP over IPv4
+            if (ab.len < 12) return .invalid;
+            const ip: [4]u8 = ab[0..4].*;
+            const port = std.mem.readInt(u16, ab[8..10], .big);
+            return .{ .ok = .{ .consumed = total, .src = net_helpers.ip4(ip, port) } };
+        },
+        0x21 => { // TCP over IPv6
+            if (ab.len < 36) return .invalid;
+            const ip: [16]u8 = ab[0..16].*;
+            const port = std.mem.readInt(u16, ab[32..34], .big);
+            return .{ .ok = .{ .consumed = total, .src = net_helpers.ip6(ip, port, 0, 0) } };
+        },
+        else => return .{ .ok = .{ .consumed = total, .src = null } }, // unspec / unix: keep peer
+    }
+}
+
+test "parse v1 TCP4" {
+    const r = parse("PROXY TCP4 1.2.3.4 5.6.7.8 12345 443\r\nGET /");
+    try std.testing.expect(r == .ok);
+    try std.testing.expectEqual(@as(usize, 38), r.ok.consumed);
+    try std.testing.expect(r.ok.src != null);
+    try std.testing.expectEqual(@as(u16, 12345), r.ok.src.?.getPort());
+}
+
+test "parse v1 UNKNOWN keeps no address" {
+    const r = parse("PROXY UNKNOWN\r\nx");
+    try std.testing.expect(r == .ok);
+    try std.testing.expectEqual(@as(?Address, null), r.ok.src);
+}
+
+test "parse v1 incomplete then invalid" {
+    try std.testing.expect(parse("PROXY TCP4 1.2.3.4") == .incomplete);
+    try std.testing.expect(parse("HELLO WORLD\r\n") == .invalid);
+}
+
+test "parse v2 TCP4" {
+    var b: [16 + 12]u8 = undefined;
+    @memcpy(b[0..12], &v2_sig);
+    b[12] = 0x21; // ver 2, cmd PROXY
+    b[13] = 0x11; // TCP/IPv4
+    std.mem.writeInt(u16, b[14..16], 12, .big);
+    b[16] = 9;
+    b[17] = 8;
+    b[18] = 7;
+    b[19] = 6; // src ip 9.8.7.6
+    @memset(b[20..24], 0); // dst ip
+    std.mem.writeInt(u16, b[24..26], 4444, .big); // src port
+    std.mem.writeInt(u16, b[26..28], 443, .big); // dst port
+    const r = parse(&b);
+    try std.testing.expect(r == .ok);
+    try std.testing.expectEqual(@as(usize, 28), r.ok.consumed);
+    try std.testing.expectEqual(@as(u16, 4444), r.ok.src.?.getPort());
+}
+
+test "parse v2 incomplete" {
+    try std.testing.expect(parse(v2_sig[0..8]) == .incomplete);
+}


### PR DESCRIPTION
Closes the remaining competitor-roadmap items; bundles into the same **v1.5.0** as #347 + #349.

- **#17a — HTTP-Date clock self-correction** (`clock_sync_url`): a skewed VPS clock otherwise fails the handshake time-skew check for everyone. RFC 7231 IMF-fixdate parser (KAT'd), ±1-day-clamped offset.
- **#17b — mask-relay max-duration cap** (`mask_relay_max_secs`): bounds how long a probe forwarded to the backend may live.
- **#18 (P0) — profile-matched fake-cert record size** (`fake_cert_size`): the ServerHello's fake cert (AppData) record was a fixed 2878; set it to the backend's real first-flight size so the accept path and mask path show the same cert-record size (the key passive accept-vs-mask tell). Variable-size builder + `firstAppDataRecordLen` parser (the seam for a future zero-config boot auto-probe).
- **#17c — HAProxy PROXY-protocol v1/v2** (`accept_proxy_protocol`): recover the real client IP behind a TLS-terminating LB via MSG_PEEK + exact-length drain (no over-read).

**Verified:** 258/258 tests (new KATs: IMF-date, template-alloc, record-parser, PROXY v1/v2); x86_64-linux + aarch64-linux cross-builds; zig fmt clean. All new behavior is opt-in / fallback-safe (defaults unchanged).

Together with #347/#349 this lands all 7 roadmap items (PQ key_share, RST teardown, jittered desync, probe metrics, dynamic SNI, clock-sync, mask cap, cert-size match, PROXY-protocol) in one release.