### PR TITLE
fix(proxy): max_connection_lifetime_sec — recycle long-lived relays to fix resume "updating" hang

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -237,6 +237,13 @@ pub const Config = struct {
     workers: u16 = 1,
     /// Pre-handshake idle timeout: wait for first client byte
     idle_timeout_sec: u32 = 120,
+    /// Max lifetime (seconds) of an established relay connection; 0 = unlimited. When set,
+    /// a relay older than this is recycled with a TCP RST so the client immediately makes a
+    /// fresh connection. Mobile clients that keep one TCP alive for hours accumulate a
+    /// collapsed congestion window (heavy retransmits/reordering); on resume they reuse that
+    /// degraded connection and the re-sync trickles ("updating" hangs). Recycling forces a
+    /// clean reconnect. Telegram resumes transparently across the brief drop. Try 1800-3600.
+    max_connection_lifetime_sec: u32 = 0,
     /// Per-connection random jitter (± percent, 0-100) applied to the effective idle
     /// timeout, so a constant timeout isn't itself a behavioral fingerprint. Computed
     /// once per slot. 0 disables jitter.
@@ -674,6 +681,8 @@ pub const Config = struct {
                     } else if (std.mem.eql(u8, key, "idle_timeout_sec")) {
                         const parsed = std.fmt.parseInt(u32, value, 10) catch cfg.idle_timeout_sec;
                         cfg.idle_timeout_sec = @max(@as(u32, 5), parsed);
+                    } else if (std.mem.eql(u8, key, "max_connection_lifetime_sec")) {
+                        cfg.max_connection_lifetime_sec = std.fmt.parseInt(u32, value, 10) catch cfg.max_connection_lifetime_sec;
                     } else if (std.mem.eql(u8, key, "handshake_timeout_sec")) {
                         const parsed = std.fmt.parseInt(u32, value, 10) catch cfg.handshake_timeout_sec;
                         cfg.handshake_timeout_sec = @max(@as(u32, 5), parsed);

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -4304,6 +4304,18 @@ const EventLoop = struct {
                     continue;
                 }
             } else if (slot.phase == .relaying or slot.phase == .mask_relaying) {
+                // Recycle a too-long-lived relay with a TCP RST so the client makes a fresh
+                // connection. A mobile TCP kept alive for hours collapses its congestion
+                // window; on resume the client reuses it and the re-sync trickles. The RST
+                // makes the client reconnect cleanly (Telegram resumes across the drop).
+                if (self.state.config.max_connection_lifetime_sec > 0 and
+                    now_ms - slot.created_at_ms > secondsToMs(self.state.config.max_connection_lifetime_sec))
+                {
+                    log.info("[{d}] recycling relay: lifetime cap {d}s reached (RST -> fresh reconnect)", .{ slot.conn_id, self.state.config.max_connection_lifetime_sec });
+                    setLingerReset(slot.client_fd);
+                    self.closeSlot(slot, "max connection lifetime");
+                    continue;
+                }
                 if (slot.phase == .mask_relaying and self.state.config.mask_relay_max_secs > 0 and
                     now_ms - slot.created_at_ms > secondsToMs(self.state.config.mask_relay_max_secs))
                 {


### PR DESCRIPTION
Fixes the long-standing iOS resume hang: when Telegram is backgrounded for hours (e.g. overnight) without being unloaded from memory, on resume it sits in **"updating"** until you switch proxies.

## Root cause
A mobile client keeps **one** TCP connection alive for hours. Over that lifetime the kernel congestion window collapses (heavy retransmits + reordering — observed on prod: an **8.5h** connection with `cwnd:10`, `bytes_retrans:18721`, `reord_seen:1188`, throughput trickling at ~20 B/s). On resume the client **reuses that degraded socket**, so the re-sync crawls and Telegram shows "updating" indefinitely. Switching proxies forces a fresh connection, which is why that "fixes" it.

## Fix
New opt-in config `max_connection_lifetime_sec` (default `0` = unlimited, byte-identical behavior when unset). When set, a relay older than the cap is recycled with a **TCP RST** (`SO_LINGER{0}`), so the client immediately opens a clean connection. Telegram resumes transparently across the brief drop.

## Validation (live prod, proxy.sleep3r.ru)
- Deployed with `cap=120s`; journal confirmed recycle firing: `recycling relay: lifetime cap 120s reached (RST -> fresh reconnect)`, client reconnected cleanly, `active` stable, `NRestarts=0`, no errors.
- Production value set to **1800s** (30 min): kills overnight zombies; active users reconnect every 30 min, which Telegram handles transparently. Tunable to 3600.

## Changes
- `config.zig`: `max_connection_lifetime_sec` field + parser.
- `proxy.zig`: recycle check in the relay sweep (`relaying`/`mask_relaying`) — RST + `closeSlot`.

21 insertions, no behavior change unless the option is set.