### PR TITLE
docs: document max_connection_lifetime_sec

### DIFF
--- a/README.fa.md
+++ b/README.fa.md
@@ -375,6 +375,7 @@ port = 443
 max_connections = 512
 # workers = 1            # SO_REUSEPORT epoll workers: 1 = single-threaded (default); 0 = one per CPU; N spreads load across cores
 idle_timeout_sec = 120
+# max_connection_lifetime_sec = 0   # Recycle a relay older than N sec (TCP RST) so mobile clients reconnect cleanly after a long background — fixes the "updating" hang on resume. 0 = unlimited; try 1800-3600
 handshake_timeout_sec = 15
 graceful_shutdown_timeout_sec = 15
 log_level = "info"        # debug | info | warn | err
@@ -431,6 +432,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[server] workers` | `1` | نخ‌های کارگرِ epoll با SO_REUSEPORT. `1` = تک‌نخی؛ `0` = یکی به ازای هر CPU؛ `N` بار رله/رمزنگاری را روی هسته‌ها پخش می‌کند. وقتی `>1` باشد، بارگذاری مجدد پیکربندی با SIGHUP نیازمند ری‌استارت است |
 | `[server] idle_timeout_sec` | `120` | مهلت بی‌کاریِ اتصال |
 | `[server] idle_timeout_jitter_pct` | `15` | لرزش ±٪ به ازای هر اتصال روی مهلت بی‌کاری تا یک مقدار ثابت به اثر انگشت تبدیل نشود (`0` غیرفعال می‌کند) |
+| `[server] max_connection_lifetime_sec` | `0` | بازیافت یک ریلهٔ برقرارشدهٔ قدیمی‌تر از N ثانیه با یک TCP RST، تا کلاینت تمیز دوباره وصل شود. هنگ «در حال به‌روزرسانی» موبایل پس از بازگشت از پس‌زمینهٔ طولانی را برطرف می‌کند (یک TCP طولانی‌عمر پنجرهٔ ازدحام را فرومی‌ریزد و همگام‌سازی کند می‌شود). `0` = نامحدود؛ `1800`–`3600` را امتحان کنید |
 | `[server] handshake_timeout_sec` | `15` | مهلت تکمیل هندشیک |
 | `[server] graceful_shutdown_timeout_sec` | `15` | مهلت تخلیه‌ی SIGTERM پیش از بستن اجباری |
 | `[server] middleproxy_buffer_kb` | `1024` | بافر ME برای هر اتصال (KiB). کمتر از 1024 ممکن است در ترافیک رسانه‌ای باعث سرریز شود |

--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ port = 443
 max_connections = 512
 # workers = 1            # SO_REUSEPORT epoll workers: 1 = single-threaded (default); 0 = one per CPU; N spreads load across cores
 idle_timeout_sec = 120
+# max_connection_lifetime_sec = 0   # Recycle a relay older than N sec (TCP RST) so mobile clients reconnect cleanly after a long background — fixes the "updating" hang on resume. 0 = unlimited; try 1800-3600
 handshake_timeout_sec = 15
 graceful_shutdown_timeout_sec = 15
 log_level = "info"        # debug | info | warn | err
@@ -435,6 +436,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[server] workers` | `1` | SO_REUSEPORT epoll worker threads. `1` = single-threaded; `0` = one per CPU; `N` spreads relay/crypto load across cores. SIGHUP config reload requires a restart when `>1` |
 | `[server] idle_timeout_sec` | `120` | Connection idle timeout |
 | `[server] idle_timeout_jitter_pct` | `15` | Per-connection ±% jitter on the idle timeout so a constant value isn't a fingerprint (`0` disables) |
+| `[server] max_connection_lifetime_sec` | `0` | Recycle an established relay older than N seconds with a TCP RST, forcing a clean client reconnect. Fixes the mobile "updating" hang on resume after a long background (a long-lived mobile TCP collapses its congestion window and the re-sync trickles). `0` = unlimited; try `1800`–`3600` |
 | `[server] handshake_timeout_sec` | `15` | Handshake completion timeout |
 | `[server] graceful_shutdown_timeout_sec` | `15` | SIGTERM drain timeout before force-close |
 | `[server] middleproxy_buffer_kb` | `2048` | ME per-connection buffer (KiB). Must hold one max RPC frame; below 1024 truncates 1 MiB media parts |

--- a/README.ru.md
+++ b/README.ru.md
@@ -362,6 +362,7 @@ port = 443
 max_connections = 512
 # workers = 1            # SO_REUSEPORT epoll-воркеры: 1 = однопоточно (дефолт); 0 = по числу CPU; N распределяет нагрузку по ядрам
 idle_timeout_sec = 120
+# max_connection_lifetime_sec = 0   # Пересоздавать релей старше N сек (TCP RST), чтобы мобильный клиент чисто реконнектился после долгого фона — фиксит зависание в «обновлении». 0 = без лимита; пробуйте 1800-3600
 handshake_timeout_sec = 15
 graceful_shutdown_timeout_sec = 15
 log_level = "info"
@@ -412,6 +413,7 @@ alice = true
 | `[server] handshake_flood_guard_window_sec` | `30` | Окно подсчёта для `handshake_flood_guard_threshold` |
 | `[server] handshake_flood_guard_block_sec` | `120` | Длительность временного deny для шумного IP |
 | `[server] idle_timeout_jitter_pct` | `15` | Джиттер ±% на idle-таймаут соединения, чтобы константа не была сигнатурой (`0` — выключить) |
+| `[server] max_connection_lifetime_sec` | `0` | Пересоздавать установленный релей старше N секунд через TCP RST, заставляя клиента чисто переподключиться. Фиксит зависание мобильного клиента в «обновлении» при возврате после долгого фона (долгоживущий TCP схлопывает congestion window, ресинк еле ползёт). `0` = без лимита; пробуйте `1800`–`3600` |
 | `[censorship] tls_domain` | `"google.com"` | Домен для TLS-маскировки |
 | `[censorship] mask` | `true` | Forward invalid clients на `tls_domain` |
 | `[censorship] unknown_sni_action` | `"mask"` | ClientHello с чужим SNI: `mask` (forward), `reject` (фатальный TLS-alert, как отклоняющий сервер) или `drop` |

--- a/README.vi.md
+++ b/README.vi.md
@@ -376,6 +376,7 @@ port = 443
 max_connections = 512
 # workers = 1            # SO_REUSEPORT epoll workers: 1 = single-threaded (default); 0 = one per CPU; N spreads load across cores
 idle_timeout_sec = 120
+# max_connection_lifetime_sec = 0   # Recycle a relay older than N sec (TCP RST) so mobile clients reconnect cleanly after a long background — fixes the "updating" hang on resume. 0 = unlimited; try 1800-3600
 handshake_timeout_sec = 15
 graceful_shutdown_timeout_sec = 15
 log_level = "info"        # debug | info | warn | err
@@ -432,6 +433,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[server] workers` | `1` | Số luồng worker epoll SO_REUSEPORT. `1` = đơn luồng; `0` = một luồng mỗi CPU; `N` phân tán tải chuyển tiếp/mã hóa qua các nhân. Việc nạp lại cấu hình bằng SIGHUP cần khởi động lại khi `>1` |
 | `[server] idle_timeout_sec` | `120` | Thời gian chờ kết nối nhàn rỗi |
 | `[server] idle_timeout_jitter_pct` | `15` | Jitter ±% trên mỗi kết nối cho thời gian chờ nhàn rỗi để một giá trị cố định không trở thành dấu vân tay (`0` để tắt) |
+| `[server] max_connection_lifetime_sec` | `0` | Tái tạo một relay đã thiết lập cũ hơn N giây bằng một TCP RST, buộc client kết nối lại sạch sẽ. Sửa lỗi treo "đang cập nhật" trên di động khi khôi phục sau thời gian dài chạy nền (một TCP sống lâu làm sụp đổ cửa sổ tắc nghẽn và việc đồng bộ lại nhỏ giọt). `0` = không giới hạn; thử `1800`–`3600` |
 | `[server] handshake_timeout_sec` | `15` | Thời gian chờ hoàn tất bắt tay |
 | `[server] graceful_shutdown_timeout_sec` | `15` | Thời gian chờ rút cạn khi SIGTERM trước khi buộc đóng |
 | `[server] middleproxy_buffer_kb` | `1024` | Bộ đệm ME cho mỗi kết nối (KiB). Dưới 1024 có thể gây tràn với lưu lượng media |

--- a/README.zh.md
+++ b/README.zh.md
@@ -375,6 +375,7 @@ port = 443
 max_connections = 512
 # workers = 1            # SO_REUSEPORT epoll workers: 1 = single-threaded (default); 0 = one per CPU; N spreads load across cores
 idle_timeout_sec = 120
+# max_connection_lifetime_sec = 0   # Recycle a relay older than N sec (TCP RST) so mobile clients reconnect cleanly after a long background — fixes the "updating" hang on resume. 0 = unlimited; try 1800-3600
 handshake_timeout_sec = 15
 graceful_shutdown_timeout_sec = 15
 log_level = "info"        # debug | info | warn | err
@@ -431,6 +432,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[server] workers` | `1` | SO_REUSEPORT epoll 工作线程数。`1` = 单线程；`0` = 每个 CPU 一个；`N` 将中继/加密负载分散到多个核心。当 `>1` 时，SIGHUP 配置重载需要重启 |
 | `[server] idle_timeout_sec` | `120` | 连接空闲超时 |
 | `[server] idle_timeout_jitter_pct` | `15` | 对空闲超时施加每连接 ±% 的抖动，避免固定值成为指纹（`0` 表示禁用） |
+| `[server] max_connection_lifetime_sec` | `0` | 通过 TCP RST 回收存活超过 N 秒的已建立中继，强制客户端干净地重连。修复移动端长时间后台后恢复时卡在"更新中"的问题（长寿命 TCP 的拥塞窗口会塌缩，重新同步极慢）。`0` = 无限制；建议 `1800`–`3600` |
 | `[server] handshake_timeout_sec` | `15` | 握手完成超时 |
 | `[server] graceful_shutdown_timeout_sec` | `15` | 强制关闭前 SIGTERM 排空超时 |
 | `[server] middleproxy_buffer_kb` | `1024` | ME 每连接缓冲区（KiB）。低于 1024 在媒体流量下可能导致溢出 |

--- a/config.toml.example
+++ b/config.toml.example
@@ -71,6 +71,15 @@ port = 443
 # constant timeout isn't itself a behavioral fingerprint. 0 disables. Default 15.
 # idle_timeout_jitter_pct = 15
 
+# Recycle an established relay older than this many seconds with a TCP RST, forcing
+# the client to open a fresh connection. Fixes the mobile "updating" hang on resume
+# after a long background: a TCP kept alive for hours collapses its congestion window
+# (heavy retransmits/reordering), so on resume the client reuses that degraded socket
+# and the re-sync trickles. The RST makes it reconnect cleanly; Telegram resumes
+# transparently across the brief drop. 0 = unlimited (default). Try 1800-3600 for
+# mobile-heavy deployments.
+# max_connection_lifetime_sec = 0
+
 # Seconds to complete TLS+MTProto handshake after first byte arrives.
 # handshake_timeout_sec = 15
 


### PR DESCRIPTION
Documents the v1.6.0 opt-in option \`max_connection_lifetime_sec\` (the resume "updating" hang fix, #351).

- \`config.toml.example\`: full commented block explaining the option + recommended range.
- \`README.md\` + all locale READMEs (ru/zh/fa/vi): quick-start example line + full config-reference table row.

Docs-only, no code change.