### PR TITLE
feat(ctl): tunnel menu redesign + Esc/← "back" navigation in the TUI

### DIFF
--- a/src/ctl/i18n.zig
+++ b/src/ctl/i18n.zig
@@ -276,7 +276,7 @@ const en_strings = [_][]const u8{
     // tunnel_vpn_type_prompt
     "VPN type",
     // tunnel_vpn_amneziawg
-    "AmneziaWG",
+    "Amnezia (AmneziaWG)",
     // tunnel_pool_current
     "Configured tunnel pool:",
     // tunnel_pool_empty
@@ -452,7 +452,7 @@ const en_strings = [_][]const u8{
     // install_secret_gen_failed
     "Couldn't generate a secure secret on this system. Pass your own 32-hex secret with --secret instead.",
     // tui_nav_hint_menu
-    "↑↓ navigate  Enter select",
+    "↑↓ navigate  Enter select  Esc back",
     // tui_nav_hint_checkbox
     "↑↓ navigate  Space toggle  Enter confirm",
     // tui_exited
@@ -541,7 +541,7 @@ const ru_strings = [_][]const u8{
     // tunnel_vpn_type_prompt
     "Тип VPN",
     // tunnel_vpn_amneziawg
-    "AmneziaWG",
+    "Amnezia (AmneziaWG)",
     // tunnel_pool_current
     "Настроенный пул туннелей:",
     // tunnel_pool_empty
@@ -717,7 +717,7 @@ const ru_strings = [_][]const u8{
     // install_secret_gen_failed
     "Не удалось сгенерировать безопасный случайный секрет (системный генератор недоступен). Укажите свой 32-hex секрет через --secret.",
     // tui_nav_hint_menu
-    "↑↓ выбор  Enter выбрать",
+    "↑↓ выбор  Enter выбрать  Esc назад",
     // tui_nav_hint_checkbox
     "↑↓ выбор  Space отметить  Enter подтвердить",
     // tui_exited
@@ -747,7 +747,7 @@ test "i18n anchor strings — catches index drift between the S enum and the tab
     try std.testing.expectEqualStrings("English", get(.en, .lang_english));
     try std.testing.expectEqualStrings("Exited", get(.en, .tui_exited));
     try std.testing.expectEqualStrings("Выход", get(.ru, .tui_exited));
-    try std.testing.expectEqualStrings("↑↓ navigate  Enter select", get(.en, .tui_nav_hint_menu));
+    try std.testing.expectEqualStrings("↑↓ navigate  Enter select  Esc back", get(.en, .tui_nav_hint_menu));
     // install_secret_gen_failed sits just before the appended TUI keys.
     try std.testing.expect(std.mem.indexOf(u8, get(.en, .install_secret_gen_failed), "--secret") != null);
     try std.testing.expect(std.mem.indexOf(u8, get(.ru, .install_secret_gen_failed), "--secret") != null);

--- a/src/ctl/main.zig
+++ b/src/ctl/main.zig
@@ -254,23 +254,36 @@ fn interactiveMain(ui: *Tui, allocator: std.mem.Allocator) !void {
         try items.append(allocator, i18n.get(ui.lang, .menu_exit));
         try actions.append(allocator, .exit);
 
-        const choice_idx = try ui.menu(i18n.get(ui.lang, .menu_title), items.items);
+        const choice_idx = ui.menu(i18n.get(ui.lang, .menu_title), items.items) catch |e| switch (e) {
+            error.GoBack => continue, // top menu: nothing above to go back to, just redraw
+            else => return e,
+        };
         const action = actions.items[choice_idx];
+        if (action == .exit) return;
 
-        switch (action) {
-            .install => try install.runInteractive(ui, allocator),
-            .update => try update.runInteractive(ui, allocator),
-            .masking => try masking.runInteractive(ui, allocator),
-            .tunnel => try tunnelOrEgressInteractive(ui, allocator),
-            .dashboard => try dashboard.runInteractive(ui, allocator),
-            .remove_dashboard => dashboard.removeInteractive(ui),
-            .recovery => try recovery.runInteractive(ui, allocator),
-            .ipv6hop => try ipv6hop.runInteractive(ui, allocator),
-            .status => showStatus(ui, allocator),
-            .restart => restartProxy(ui, allocator),
-            .uninstall => try uninstall.runInteractive(ui, allocator),
-            .exit => return,
-        }
+        // If a sub-flow bubbles error.GoBack all the way up (Esc pressed where it isn't caught
+        // deeper), just return to the main menu instead of aborting mtbuddy.
+        dispatchAction(action, ui, allocator) catch |e| switch (e) {
+            error.GoBack => {},
+            else => return e,
+        };
+    }
+}
+
+fn dispatchAction(action: Action, ui: *Tui, allocator: std.mem.Allocator) !void {
+    switch (action) {
+        .install => try install.runInteractive(ui, allocator),
+        .update => try update.runInteractive(ui, allocator),
+        .masking => try masking.runInteractive(ui, allocator),
+        .tunnel => try tunnelOrEgressInteractive(ui, allocator),
+        .dashboard => try dashboard.runInteractive(ui, allocator),
+        .remove_dashboard => dashboard.removeInteractive(ui),
+        .recovery => try recovery.runInteractive(ui, allocator),
+        .ipv6hop => try ipv6hop.runInteractive(ui, allocator),
+        .status => showStatus(ui, allocator),
+        .restart => restartProxy(ui, allocator),
+        .uninstall => try uninstall.runInteractive(ui, allocator),
+        .exit => {},
     }
 }
 
@@ -279,13 +292,87 @@ fn interactiveMain(ui: *Tui, allocator: std.mem.Allocator) !void {
 // wireguard:// -> native WG tunnel). Dispatched here (not inside tunnel.zig) so tunnel
 // and egress don't import each other.
 fn tunnelOrEgressInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
+    // Management lives above the type choice and is shared by both backends. This level always
+    // shows: "Create new tunnel" is always offered, "Manage existing tunnels" appears only when
+    // there are tunnels to manage.
+    while (true) {
+        var item_buf: [2][]const u8 = undefined;
+        item_buf[0] = i18n.get(ui.lang, .tunnel_pool_action_create); // "Create new tunnel"
+        var count: usize = 1;
+        if (tunnel.hasExistingTunnels(allocator)) {
+            item_buf[1] = tr(ui.lang, "Manage existing tunnels", "Управление туннелями");
+            count = 2;
+        }
+        const idx = ui.menu(tr(ui.lang, "Tunnel", "Туннель"), item_buf[0..count]) catch |e| switch (e) {
+            error.GoBack => return, // back to main menu
+            else => return e,
+        };
+        var went_back = false;
+        if (idx == 0) {
+            createNewTunnel(ui, allocator) catch |e| switch (e) {
+                error.GoBack => went_back = true,
+                else => return e,
+            };
+        } else {
+            manageTunnels(ui, allocator) catch |e| switch (e) {
+                error.GoBack => went_back = true,
+                else => return e,
+            };
+        }
+        if (!went_back) return; // a completed action returns to the main menu; Esc re-shows this
+    }
+}
+
+// The type choice. Esc here propagates GoBack to the caller (back to the Tunnel menu, or the
+// main menu when there were no existing tunnels). Dispatched here — not inside tunnel.zig — so
+// the AmneziaWG and sing-box backends don't have to import each other.
+fn createNewTunnel(ui: *Tui, allocator: std.mem.Allocator) !void {
     const items = [_][]const u8{
-        i18n.get(ui.lang, .tunnel_vpn_amneziawg),
-        tr(ui.lang, "VPN share-link (VLESS-Reality / VMess / Trojan / Shadowsocks / WireGuard)", "VPN-ссылка (VLESS-Reality / VMess / Trojan / Shadowsocks / WireGuard)"),
+        i18n.get(ui.lang, .tunnel_vpn_amneziawg), // "Amnezia (AmneziaWG)"
+        tr(ui.lang, "3x-ui (VLESS-Reality / VMess / Trojan / Shadowsocks / WireGuard)", "3x-ui (VLESS-Reality / VMess / Trojan / Shadowsocks / WireGuard)"),
     };
     const idx = try ui.menu(i18n.get(ui.lang, .tunnel_vpn_type_prompt), &items);
     if (idx == 1) return tunnel_singbox.runInteractive(ui, allocator);
-    return tunnel.runInteractive(ui, allocator);
+    return tunnel.runCreateAmnezia(ui, allocator, null);
+}
+
+// Backend-agnostic management of the existing tunnel pool (any of awg*/wg*/sbx*). Replace
+// routes by interface type; delete is already generic.
+fn manageTunnels(ui: *Tui, allocator: std.mem.Allocator) !void {
+    const pool = try tunnel.loadConfiguredTunnelPool(allocator);
+    defer tunnel.freeInterfaceList(allocator, pool);
+    const known = try tunnel.loadKnownTunnelInterfaces(allocator);
+    defer tunnel.freeInterfaceList(allocator, known);
+
+    if (known.len == 0) {
+        ui.info(i18n.get(ui.lang, .tunnel_pool_empty));
+        return;
+    }
+    ui.info(i18n.get(ui.lang, .tunnel_pool_current));
+    tunnel.printTunnelPoolRuntimeStatus(ui, allocator, known, pool);
+
+    var items: std.ArrayList([]const u8) = .empty;
+    defer {
+        for (items.items) |it| allocator.free(it);
+        items.deinit(allocator);
+    }
+    for (known) |iface| {
+        try items.append(allocator, try std.fmt.allocPrint(allocator, "{s}: {s}", .{ i18n.get(ui.lang, .tunnel_pool_action_replace), iface }));
+    }
+    for (known) |iface| {
+        try items.append(allocator, try std.fmt.allocPrint(allocator, "{s}: {s}", .{ tr(ui.lang, "Delete tunnel", "Удалить туннель"), iface }));
+    }
+
+    const selected = try ui.menu(i18n.get(ui.lang, .tunnel_pool_action_prompt), items.items);
+    if (selected < known.len) {
+        const iface = known[selected];
+        // sing-box egress always owns sbx0 and re-runs its own share-link flow; AmneziaWG/WG
+        // tunnels are replaced in place via the Amnezia create path targeting that interface.
+        if (std.mem.startsWith(u8, iface, "sbx")) return tunnel_singbox.runInteractive(ui, allocator);
+        return tunnel.runCreateAmnezia(ui, allocator, iface);
+    }
+    const del_iface = known[selected - known.len];
+    return tunnel.deleteTunnelInteractive(ui, allocator, del_iface);
 }
 
 fn restartProxy(ui: *Tui, allocator: std.mem.Allocator) void {

--- a/src/ctl/tui.zig
+++ b/src/ctl/tui.zig
@@ -557,6 +557,9 @@ pub const Tui = struct {
             } else if (ev.key == .enter) {
                 self.print("\n", .{});
                 return selected;
+            } else if (ev.key == .escape or ev.key == .left) {
+                self.print("\n", .{});
+                return error.GoBack;
             } else if (ev.key == .ctrl_c) {
                 self.print("\n\n  {s}{s}{s}\n", .{ Color.dim, i18n.get(self.lang, .tui_exited), Color.reset });
                 self.exitRawMode();
@@ -582,7 +585,10 @@ pub const Tui = struct {
         self.print("\n  {s}╭─ {s}{s}\n", .{ Color.gray, prompt, Color.reset });
         self.print("  {s}╰─❯{s} {s}  ", .{ Color.gray, Color.reset, hint_str });
 
-        const line = self.readLine() catch return default;
+        const line = self.readLineOrBack() catch |err| switch (err) {
+            error.GoBack => return error.GoBack,
+            else => return default,
+        };
         const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r', '\n' });
 
         if (trimmed.len == 0) return default;
@@ -630,7 +636,10 @@ pub const Tui = struct {
             self.print("  {s}╰─❯{s} ", .{ Color.gray, Color.reset });
         }
 
-        const line = self.readLine() catch return default orelse error.InputError;
+        const line = self.readLineOrBack() catch |err| switch (err) {
+            error.GoBack => return error.GoBack,
+            else => return default orelse error.InputError,
+        };
         const trimmed = std.mem.trim(u8, line, &[_]u8{ ' ', '\t', '\r', '\n' });
 
         if (trimmed.len == 0) {
@@ -918,7 +927,17 @@ pub const Tui = struct {
     // ── Line reading ───────────────────────────────────────────────────────
 
     fn readLine(self: *Self) ![]const u8 {
+        return self.readLineSeeded(null);
+    }
+
+    /// Like readLine, but the buffer can be pre-seeded with a first byte that was already
+    /// consumed in raw mode (see readLineOrBack). The rest of the line is read cooked.
+    fn readLineSeeded(self: *Self, seed: ?u8) ![]const u8 {
         var pos: usize = 0;
+        if (seed) |s| {
+            self.line_buf[0] = s;
+            pos = 1;
+        }
         while (pos < self.line_buf.len) {
             var byte: [1]u8 = undefined;
             const n = std.posix.read(self.in_fd, &byte) catch return error.InputError;
@@ -939,6 +958,52 @@ pub const Tui = struct {
             if (n == 0 or byte[0] == '\n') break;
         }
         return self.line_buf[0..pos];
+    }
+
+    /// Read a line for a prompt, but return error.GoBack if the user presses Esc/← at the
+    /// empty prompt (the natural "I want to step back" moment). The first key is read in raw
+    /// mode: Esc/← → back, Ctrl+C → exit, Enter → empty line. A printable first byte is echoed
+    /// and the rest of the line is read in cooked mode, so UTF-8 input and long pastes behave
+    /// exactly as a normal line read. Non-TTY (piped) input has no "back" — it reads straight.
+    fn readLineOrBack(self: *Self) ![]const u8 {
+        if (!self.is_tty) return self.readLine();
+
+        self.enterRawMode();
+        var seed: ?u8 = null;
+        var got_enter = false;
+        while (true) {
+            const ev = self.readKey() catch |err| {
+                self.exitRawMode();
+                return err;
+            };
+            switch (ev.key) {
+                .escape, .left => {
+                    self.exitRawMode();
+                    return error.GoBack;
+                },
+                .ctrl_c => {
+                    self.exitRawMode();
+                    self.print("\n\n  {s}{s}{s}\n", .{ Color.dim, i18n.get(self.lang, .tui_exited), Color.reset });
+                    std.process.exit(0);
+                },
+                .enter => {
+                    got_enter = true;
+                    break;
+                },
+                .char => {
+                    self.writeRaw(&[_]u8{ev.ch}); // echo the byte we consumed in raw mode
+                    seed = ev.ch;
+                    break;
+                },
+                else => continue, // arrows/space/backspace at an empty prompt: ignore
+            }
+        }
+        self.exitRawMode();
+        if (got_enter) {
+            self.writeRaw("\n");
+            return self.line_buf[0..0];
+        }
+        return self.readLineSeeded(seed);
     }
 };
 

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -22,17 +22,6 @@ const TUNNEL_POOL_SERVICE = "/etc/systemd/system/mtproto-tunnel-pool.service";
 const TUNNEL_POOL_TIMER = "/etc/systemd/system/mtproto-tunnel-pool.timer";
 const TUNNEL_POOL_STATE = "/run/mtproto-proxy/tunnel-pool.state";
 
-const InteractiveTunnelSelection = struct {
-    iface: []const u8,
-    action: InteractiveTunnelAction,
-};
-
-const InteractiveTunnelAction = enum {
-    create,
-    replace,
-    delete,
-};
-
 /// Run in CLI mode.
 pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) !void {
     var opts = tunnel_wg.TunnelOpts{};
@@ -67,124 +56,87 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
     try tunnel_wg.execute(ui, allocator, opts);
 }
 
-/// Run in interactive mode.
-pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
-    ui.section(i18n.get(ui.lang, .menu_setup_tunnel));
+/// True if any tunnel interface (awg*/wg*/sbx*) is already configured/known.
+pub fn hasExistingTunnels(allocator: std.mem.Allocator) bool {
+    const known = loadKnownTunnelInterfaces(allocator) catch return false;
+    defer freeInterfaceList(allocator, known);
+    return known.len > 0;
+}
 
-    const selection = chooseInteractiveTunnelTarget(ui, allocator) catch |err| {
-        switch (err) {
-            error.InvalidInterfaceName => ui.fail("Invalid tunnel interface name. Use names like awg0, awg1, wg0."),
-            error.NoFreeInterface => ui.fail("No free awgN interface name found"),
-            else => ui.fail("Failed to prepare tunnel pool selection"),
-        }
-        return;
-    };
-    defer allocator.free(selection.iface);
+/// Free a list returned by loadKnownTunnelInterfaces / loadConfiguredTunnelPool. Exposed so
+/// the main.zig orchestrator (which owns the manage/create menus) can hold these lists without
+/// importing tunnel_wg directly.
+pub fn freeInterfaceList(allocator: std.mem.Allocator, list: []const []const u8) void {
+    tunnel_wg.freeOwnedStringSlice(allocator, list);
+}
 
-    if (selection.action == .delete) {
-        try deleteTunnelInteractive(ui, allocator, selection.iface);
-        return;
-    }
+/// Create (iface_opt == null → next free interface) or replace (iface_opt set) an AmneziaWG /
+/// WireGuard tunnel from a pasted config or vpn:// share link. The management/type menus that
+/// reach this live in main.zig; this is just the AmneziaWG create wizard. Esc steps back one
+/// field (confirm → config), and Esc at the config prompt returns error.GoBack to the caller.
+pub fn runCreateAmnezia(ui: *Tui, allocator: std.mem.Allocator, iface_opt: ?[]const u8) !void {
+    // Header names the chosen type so the two create flows (this and 3x-ui) read consistently.
+    ui.section(i18n.get(ui.lang, .tunnel_vpn_amneziawg));
 
-    // VPN type was already chosen in the interactive menu (AmneziaWG vs share-link); this
-    // path is the AmneziaWG flow.
-    if (selection.action == .replace) {
+    const iface: []u8 = if (iface_opt) |i|
+        try allocator.dupe(u8, i)
+    else
+        tunnel_wg.selectTunnelInterface(allocator, "") catch |err| {
+            switch (err) {
+                error.InvalidInterfaceName => ui.fail("Invalid tunnel interface name. Use names like awg0, awg1, wg0."),
+                error.NoFreeInterface => ui.fail("No free awgN interface name found"),
+                else => ui.fail("Failed to pick a tunnel interface"),
+            }
+            return;
+        };
+    defer allocator.free(iface);
+
+    // On a fresh create the auto-picked awgN is an internal detail (the share-link flow doesn't
+    // surface its sbx0 either) — only show the target interface when replacing a specific one.
+    if (iface_opt != null) {
         ui.warn(i18n.get(ui.lang, .tunnel_pool_replace_warn));
+        ui.stepOk(i18n.get(ui.lang, .tunnel_pool_selected_iface), iface);
     }
-    ui.stepOk(i18n.get(ui.lang, .tunnel_pool_selected_iface), selection.iface);
 
     var conf_buf: [16 * 1024]u8 = undefined;
-    const conf_source = try ui.input(
-        i18n.get(ui.lang, .tunnel_conf_prompt),
-        i18n.get(ui.lang, .tunnel_conf_help),
-        null,
-        &conf_buf,
-    );
-
-    if (!try ui.confirm(i18n.get(ui.lang, .confirm_proceed), true)) {
-        ui.info(i18n.get(ui.lang, .aborting));
-        return;
-    }
-
-    try tunnel_wg.execute(ui, allocator, .{ .awg_source = conf_source, .iface = selection.iface });
+    var conf_source: []const u8 = "";
+    var step: usize = 0;
+    while (true) switch (step) {
+        0 => {
+            conf_source = ui.input(
+                i18n.get(ui.lang, .tunnel_conf_prompt),
+                i18n.get(ui.lang, .tunnel_conf_help),
+                null,
+                &conf_buf,
+            ) catch |e| switch (e) {
+                error.GoBack => return error.GoBack,
+                else => return e,
+            };
+            step = 1;
+        },
+        1 => {
+            const ok = ui.confirm(i18n.get(ui.lang, .confirm_proceed), true) catch |e| {
+                if (e == error.GoBack) {
+                    step = 0;
+                    continue;
+                }
+                return e;
+            };
+            if (!ok) {
+                ui.info(i18n.get(ui.lang, .aborting));
+                return;
+            }
+            step = 2;
+        },
+        else => {
+            try tunnel_wg.execute(ui, allocator, .{ .awg_source = conf_source, .iface = iface });
+            return;
+        },
+    };
 }
 
 fn tr(lang: i18n.Lang, en: []const u8, ru: []const u8) []const u8 {
     return if (lang == .ru) ru else en;
-}
-
-fn chooseInteractiveTunnelTarget(ui: *Tui, allocator: std.mem.Allocator) !InteractiveTunnelSelection {
-    const pool = try loadConfiguredTunnelPool(allocator);
-    defer tunnel_wg.freeOwnedStringSlice(allocator, pool);
-    const known = try loadKnownTunnelInterfaces(allocator);
-    defer tunnel_wg.freeOwnedStringSlice(allocator, known);
-
-    if (known.len == 0) {
-        ui.info(i18n.get(ui.lang, .tunnel_pool_empty));
-    } else {
-        ui.info(i18n.get(ui.lang, .tunnel_pool_current));
-        printTunnelPoolRuntimeStatus(ui, allocator, known, pool);
-    }
-
-    const next_iface = try tunnel_wg.selectTunnelInterface(allocator, "");
-    defer allocator.free(next_iface);
-
-    var items: std.ArrayList([]const u8) = .empty;
-    defer {
-        for (items.items) |item| allocator.free(item);
-        items.deinit(allocator);
-    }
-
-    try items.append(
-        allocator,
-        try std.fmt.allocPrint(
-            allocator,
-            "{s} ({s})",
-            .{ i18n.get(ui.lang, .tunnel_pool_action_create), next_iface },
-        ),
-    );
-
-    for (known) |iface| {
-        try items.append(
-            allocator,
-            try std.fmt.allocPrint(
-                allocator,
-                "{s}: {s}",
-                .{ i18n.get(ui.lang, .tunnel_pool_action_replace), iface },
-            ),
-        );
-    }
-
-    for (known) |iface| {
-        try items.append(
-            allocator,
-            try std.fmt.allocPrint(
-                allocator,
-                "{s}: {s}",
-                .{ tr(ui.lang, "Delete tunnel", "Удалить туннель"), iface },
-            ),
-        );
-    }
-
-    const selected = try ui.menu(i18n.get(ui.lang, .tunnel_pool_action_prompt), items.items);
-    if (selected == 0) {
-        return .{
-            .iface = try allocator.dupe(u8, next_iface),
-            .action = .create,
-        };
-    }
-
-    if (selected <= known.len) {
-        return .{
-            .iface = try allocator.dupe(u8, known[selected - 1]),
-            .action = .replace,
-        };
-    }
-
-    return .{
-        .iface = try allocator.dupe(u8, known[selected - known.len - 1]),
-        .action = .delete,
-    };
 }
 
 fn tunnelShowTool(iface: []const u8) ?[]const u8 {
@@ -239,7 +191,7 @@ fn tunnelRuntimeStatus(allocator: std.mem.Allocator, iface: []const u8) []const 
     return "up, no endpoint";
 }
 
-fn printTunnelPoolRuntimeStatus(ui: *Tui, allocator: std.mem.Allocator, interfaces: []const []const u8, pool: []const []const u8) void {
+pub fn printTunnelPoolRuntimeStatus(ui: *Tui, allocator: std.mem.Allocator, interfaces: []const []const u8, pool: []const []const u8) void {
     for (interfaces, 0..) |iface, idx| {
         const status = tunnelRuntimeStatus(allocator, iface);
         const source = if (tunnel_wg.containsInterface(pool, iface)) "pool" else "config";
@@ -258,7 +210,7 @@ const TunnelDeleteResult = struct {
     remaining_count: usize,
 };
 
-fn deleteTunnelInteractive(ui: *Tui, allocator: std.mem.Allocator, iface: []const u8) !void {
+pub fn deleteTunnelInteractive(ui: *Tui, allocator: std.mem.Allocator, iface: []const u8) !void {
     if (!sys.isRoot()) {
         ui.fail(i18n.get(ui.lang, .error_not_root));
         return;
@@ -405,14 +357,14 @@ fn refreshTunnelPoolRuntime(allocator: std.mem.Allocator) void {
     sys.execSilent(allocator, &.{TUNNEL_SCRIPT});
 }
 
-fn loadConfiguredTunnelPool(allocator: std.mem.Allocator) ![]const []const u8 {
+pub fn loadConfiguredTunnelPool(allocator: std.mem.Allocator) ![]const []const u8 {
     var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch return &.{};
     defer doc.deinit();
 
     return try tunnel_wg.loadTunnelPoolFromDoc(allocator, &doc);
 }
 
-fn loadKnownTunnelInterfaces(allocator: std.mem.Allocator) ![]const []const u8 {
+pub fn loadKnownTunnelInterfaces(allocator: std.mem.Allocator) ![]const []const u8 {
     var list: std.ArrayList([]const u8) = .empty;
     errdefer {
         for (list.items) |item| allocator.free(item);

--- a/src/ctl/tunnel_singbox.zig
+++ b/src/ctl/tunnel_singbox.zig
@@ -219,28 +219,51 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
 /// Interactive entry: prompt for a share-link (or several, for a failover pool), then run
 /// the same dispatch as `run`. Reached from the interactive "Setup tunnel" VPN-type chooser.
 pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
-    ui.info(trL(ui, "VPN share-link egress — paste a link. Several links (space/newline/comma-separated) form a failover pool.", "Egress из VPN-ссылки — вставь ссылку. Несколько ссылок (через пробел/перенос/запятую) образуют failover-пул."));
-    var buf: [16 * 1024]u8 = undefined;
-    const input = ui.input(
-        trL(ui, "Share-link(s)", "Ссылка(и)"),
-        trL(ui, "vless:// vmess:// trojan:// ss://  (sing-box tunnel)  |  wireguard://  (native tunnel)", "vless:// vmess:// trojan:// ss://  (sing-box-туннель)  |  wireguard://  (нативный туннель)"),
-        null,
-        &buf,
-    ) catch return;
+    // Header names the chosen type so this reads consistently with the Amnezia create flow.
+    ui.section(trL(ui, "3x-ui", "3x-ui"));
+    ui.info(trL(ui, "Paste a share-link. Several links (space/newline/comma-separated) form a failover pool.", "Вставь ссылку. Несколько ссылок (через пробел/перенос/запятую) образуют failover-пул."));
 
+    var buf: [16 * 1024]u8 = undefined;
     var links: std.ArrayListUnmanaged([]const u8) = .empty;
     defer links.deinit(allocator);
-    var it = std.mem.tokenizeAny(u8, input, " \t\r\n,");
-    while (it.next()) |tok| links.append(allocator, tok) catch {};
-    if (links.items.len == 0) {
-        ui.fail(trL(ui, "No share-link provided.", "Ссылка не введена."));
-        return;
-    }
-    if (!(ui.confirm(trL(ui, "Proceed?", "Продолжить?"), true) catch false)) {
-        ui.info(trL(ui, "Aborting.", "Отмена."));
-        return;
-    }
-    return dispatchLinks(ui, allocator, links.items);
+
+    var step: usize = 0;
+    while (true) switch (step) {
+        0 => {
+            const input = ui.input(
+                trL(ui, "Share-link(s)", "Ссылка(и)"),
+                trL(ui, "vless:// vmess:// trojan:// ss://  (sing-box tunnel)  |  wireguard://  (native tunnel)", "vless:// vmess:// trojan:// ss://  (sing-box-туннель)  |  wireguard://  (нативный туннель)"),
+                null,
+                &buf,
+            ) catch |e| {
+                if (e == error.GoBack) return error.GoBack; // back to the type choice
+                return; // EOF / no input — abort
+            };
+            links.clearRetainingCapacity();
+            var it = std.mem.tokenizeAny(u8, input, " \t\r\n,");
+            while (it.next()) |tok| links.append(allocator, tok) catch {};
+            if (links.items.len == 0) {
+                ui.fail(trL(ui, "No share-link provided.", "Ссылка не введена."));
+                continue; // re-prompt
+            }
+            step = 1;
+        },
+        1 => {
+            const ok = ui.confirm(trL(ui, "Proceed?", "Продолжить?"), true) catch |e| {
+                if (e == error.GoBack) {
+                    step = 0;
+                    continue; // step back to the link prompt
+                }
+                return;
+            };
+            if (!ok) {
+                ui.info(trL(ui, "Aborting.", "Отмена."));
+                return;
+            }
+            step = 2;
+        },
+        else => return dispatchLinks(ui, allocator, links.items),
+    };
 }
 
 /// wireguard:// links -> native L3 tunnel. Convert each link to a WG/AmneziaWG .conf


### PR DESCRIPTION
Two interactive-TUI (`mtbuddy`) changes.

## 1. Tunnel menu — management lifted above the type choice, shared by both backends
Before: picking **AmneziaWG** opened a tunnel-pool management menu, while **VPN share-link** skipped straight to link input — asymmetric, and the pool state looked "mixed" because each backend showed its own partial view.

After:
- `Setup tunnel` with **no** tunnels → straight to the type choice; **with** existing tunnels → `Manage existing tunnels` / `Create new tunnel` first.
- Type choice relabelled to **`Amnezia (AmneziaWG)`** and **`3x-ui (VLESS-Reality / VMess / Trojan / Shadowsocks / WireGuard)`**.
- **Management is backend-agnostic** — one list of every interface (`awg*`/`wg*`/`sbx*`); replace routes by type (`sbx*` → share-link flow, else AmneziaWG-replace), delete was already generic.
- Orchestration (`createNewTunnel`/`manageTunnels`) lives in `main.zig` (it touches both backends, which can't import each other); `tunnel.zig` exposes the building blocks + a single `runCreateAmnezia(iface_opt)`. Removed the now-dead `chooseInteractiveTunnelTarget`.

## 2. Global "back" (Esc / ←)
Previously menus only did ↑↓ + Enter; Esc/← were decoded but ignored (only Ctrl+C escaped, hard-exit).
- `menu()`: Esc/← → `error.GoBack`.
- `input()`/`confirm()`: Esc at an empty prompt → `error.GoBack`. First key is read raw (Esc = back); a printable first byte is echoed and the rest read cooked, so UTF-8 / long pastes are unchanged (no hand-rolled editor).
- `interactiveMain` catches `GoBack` from the main menu (redraw) and from any sub-flow (return to main menu) — Esc never aborts mtbuddy.
- The tunnel **create wizard steps back one field** on Esc (confirm → config). Other multi-field wizards currently **cancel back to the main menu** on Esc; field-granular step-back there is a mechanical follow-up using the same `step`-loop pattern.
- Nav hint: `↑↓ navigate  Enter select  Esc back` / `↑↓ выбор  Enter выбрать  Esc назад`.

## Verification
- `zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux -Dcpu=x86_64_v3+aes` ✓, `zig build test` ✓. Proxy binary/logic untouched (CLI-only change).
- Needs a manual interactive pass (can't drive a TTY in CI): create with/without existing tunnels, both types reachable, manage lists all interfaces, Esc/← steps back, Esc at top menu is a no-op, RU labels render.