### PR TITLE
fix(dashboard): accept a signed ticket on the log WebSocket (Safari fix)

### DIFF
--- a/src/ctl/dashboard_assets/server.py
+++ b/src/ctl/dashboard_assets/server.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import base64
+import hashlib
 import hmac
 import json
 import os
@@ -192,6 +193,33 @@ def _dashboard_auth_ok(authorization) -> bool:
         return False
     _, _, pw = raw.partition(":")
     return hmac.compare_digest(pw, DASHBOARD_TOKEN)
+
+
+# Safari/WebKit does not replay cached HTTP Basic credentials on a WebSocket handshake (Chrome
+# and Firefox do). So the log WS also accepts a short-lived signed ticket that an already-
+# authenticated page fetches over a normal request (which DOES replay Basic auth everywhere) and
+# passes in the handshake URL. The ticket is a stateless HMAC over its own expiry under the
+# dashboard token — no server-side storage, ~30s validity.
+_WS_TICKET_TTL = 30  # seconds
+
+
+def _make_ws_ticket() -> str:
+    exp = str(int(time.time()) + _WS_TICKET_TTL)
+    sig = hmac.new(DASHBOARD_TOKEN.encode(), exp.encode(), hashlib.sha256).hexdigest()
+    return f"{exp}.{sig}"
+
+
+def _ws_ticket_ok(ticket) -> bool:
+    if not ticket or "." not in ticket:
+        return False
+    exp_s, _, sig = ticket.partition(".")
+    try:
+        if int(exp_s) < int(time.time()):
+            return False
+    except ValueError:
+        return False
+    expected = hmac.new(DASHBOARD_TOKEN.encode(), exp_s.encode(), hashlib.sha256).hexdigest()
+    return hmac.compare_digest(sig, expected)
 
 
 def _host_hostname(host_header: str) -> str:
@@ -2966,6 +2994,14 @@ def api_logs():
         return JSONResponse(list(_recent_logs))
 
 
+@app.get("/api/ws-ticket")
+async def ws_ticket():
+    # Gated by _dashboard_security (Basic auth) like every other route. The authenticated page
+    # fetches this, then opens /ws/logs with ?ticket=... — required for browsers (Safari) that
+    # don't replay Basic auth on the WebSocket handshake.
+    return {"ticket": _make_ws_ticket()}
+
+
 @app.websocket("/ws/logs")
 async def ws_logs(ws: WebSocket):
     # WebSocket upgrades bypass HTTP middleware, so enforce the same gates here as
@@ -2981,7 +3017,9 @@ async def ws_logs(ws: WebSocket):
     if ws_origin and urlparse(ws_origin).netloc != ws.headers.get("host", ""):
         await ws.close(code=1008)
         return
-    if not _dashboard_auth_ok(ws.headers.get("authorization")):
+    # Accept either replayed Basic auth (Chrome/Firefox) or a signed ticket from /api/ws-ticket
+    # (Safari, which doesn't replay Basic on WS handshakes).
+    if not (_dashboard_auth_ok(ws.headers.get("authorization")) or _ws_ticket_ok(ws.query_params.get("ticket"))):
         await ws.close(code=1008)
         return
     await ws.accept()

--- a/src/ctl/dashboard_assets/static/app.js
+++ b/src/ctl/dashboard_assets/static/app.js
@@ -1678,9 +1678,21 @@ function esc(s) {
   return d.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }
 
-function connectWS() {
+async function connectWS() {
   const proto = location.protocol === 'https:' ? 'wss' : 'ws';
-  const ws = new WebSocket(proto + '://' + location.host + '/ws/logs');
+  // Safari does not replay cached HTTP Basic credentials on a WebSocket handshake (Chrome and
+  // Firefox do), so the server would reject it. Fetch a short-lived ticket over a normal request
+  // (which replays Basic auth in every browser) and pass it in the URL. Falls back gracefully to
+  // the Basic-replay path if the ticket fetch fails.
+  let q = '';
+  try {
+    const r = await fetch('/api/ws-ticket', { cache: 'no-store' });
+    if (r.ok) {
+      const j = await r.json();
+      if (j && j.ticket) q = '?ticket=' + encodeURIComponent(j.ticket);
+    }
+  } catch (e) { /* fall back to Basic-auth replay */ }
+  const ws = new WebSocket(proto + '://' + location.host + '/ws/logs' + q);
   let initialBacklog = true;
 
   ws.onopen = () => {

--- a/src/ctl/dashboard_assets/static/index.html
+++ b/src/ctl/dashboard_assets/static/index.html
@@ -474,6 +474,6 @@
 </div>
 
 </div>
-<script src="/app.js?v=20260611-paper14"></script>
+<script src="/app.js?v=20260613-wsticket1"></script>
 </body>
 </html>

--- a/src/ctl/dashboard_assets/test_server.py
+++ b/src/ctl/dashboard_assets/test_server.py
@@ -88,6 +88,36 @@ def test_same_origin_mutation_allowed_through_guard(client):
     assert r.status_code not in (401, 403)
 
 
+def test_ws_ticket_roundtrip():
+    # A freshly minted ticket validates; tampered / garbage / wrong-token tickets do not.
+    t = server._make_ws_ticket()
+    assert server._ws_ticket_ok(t)
+    assert not server._ws_ticket_ok(t[:-1] + ("0" if t[-1] != "0" else "1"))
+    assert not server._ws_ticket_ok("nope")
+    assert not server._ws_ticket_ok("")
+    assert not server._ws_ticket_ok(None)
+    exp = t.split(".")[0]
+    import hmac as _hmac
+    import hashlib as _hashlib
+    forged = exp + "." + _hmac.new(b"other-token", exp.encode(), _hashlib.sha256).hexdigest()
+    assert not server._ws_ticket_ok(forged)
+
+
+def test_ws_ticket_endpoint_requires_auth(client):
+    assert client.get("/api/ws-ticket").status_code == 401
+    r = client.get("/api/ws-ticket", headers=_auth())
+    assert r.status_code == 200
+    assert server._ws_ticket_ok(r.json()["ticket"])
+
+
+def test_ws_rejects_unauthenticated(client):
+    # No Basic auth and no ticket → the handshake is closed before accept (Safari with neither
+    # would see this; with a ticket it connects). TestClient raises when the server denies.
+    with pytest.raises(Exception):
+        with client.websocket_connect("/ws/logs"):
+            pass
+
+
 def test_logs_fanout_is_per_client_cursor():
     # Regression for the destructive-drain bug: two independent cursors over the same recent
     # ring must each see all entries (no stealing between concurrent /ws/logs viewers).


### PR DESCRIPTION
The dashboard live-logs WebSocket failed in **Safari only** (`WebSocket connection to ws://localhost:61208/ws/logs failed: bad response from the server`); Chrome was fine.

## Cause
The `/ws/logs` handler requires HTTP Basic auth on the handshake, relying on the browser replaying the cached same-origin Basic credentials. **Safari/WebKit does not attach Basic auth to WebSocket handshakes** (long-standing behaviour); Chrome/Firefox do. So Safari hit the auth gate → `ws.close(1008)` → "bad response from the server".

## Fix
The WS now accepts **either** replayed Basic auth (unchanged) **or** a short-lived signed ticket:
- new `GET /api/ws-ticket` (gated by the existing Basic-auth middleware — a normal request, which replays Basic auth in *every* browser incl. Safari) returns an HMAC ticket over its own expiry under the dashboard token (~30s TTL, stateless).
- `app.js` fetches the ticket, then opens `/ws/logs?ticket=...`. Falls back to the Basic-replay path if the fetch fails.
- The Host-pin and Origin gates are untouched, so the DNS-rebinding / cross-origin defenses still hold.

## Tests
`test_server.py`: ticket round-trip (valid/tampered/garbage/wrong-token), `/api/ws-ticket` auth, unauthenticated-WS-rejected. Ticket logic verified standalone; `py_compile` clean.

Dashboard assets are `@embedFile`d into mtbuddy, so this ships with the next release (and reinstalling the dashboard rewrites the files).