### PR TITLE
feat: optional kernel SYN rate-limiter + per-endpoint DC connect timeout

### DIFF
--- a/README.fa.md
+++ b/README.fa.md
@@ -219,6 +219,13 @@ sudo mtbuddy setup masking --domain rutube.ru
 sudo mtbuddy setup nfqws
 sudo mtbuddy setup recovery
 
+# محدودیت نرخ SYN در سطح کرنل به ازای هر IP (ضدسیل، به‌صورت پیش‌فرض خاموش — اختیاری).
+# رگبارهای اولین SYNِ سوءاستفاده‌گرانه را در کرنل و پیش از accept() می‌اندازد؛ یک systemd
+# oneshotِ جداگانه تا CAP_NET_ADMIN هرگز به پراکسی داده نشود. پیش‌فرض، پریست امن‌تر برای CGNAT است.
+sudo mtbuddy setup syn-limit --preset soft   # soft 2/s·5 | medium 1/s·3 | hard 1/s·1
+sudo mtbuddy setup syn-limit --status
+sudo mtbuddy setup syn-limit --remove
+
 # Install web monitoring dashboard
 sudo mtbuddy setup dashboard
 
@@ -377,6 +384,7 @@ max_connections = 512
 idle_timeout_sec = 120
 # client_silence_close_sec = 0   # Close a relay whose server reply went unanswered by the client for N sec (breaks an iOS bad_salt wedge where "Updating" hangs ~90-120s) → instant clean reconnect. 0 = off; best-effort, can occasionally close a healthy conn — ~10-15 if you enable it
 handshake_timeout_sec = 15
+# dc_connect_timeout_sec = 10   # مهلت اتصال TCP به ازای هر endpoint به یک DC تلگرام؛ یک endpoint سیاه‌چاله‌شده را سریع ناموفق می‌کند تا failover به بعدی برود (در محدودهٔ handshake_timeout_sec). 0 = خاموش؛ هرگز روی اتصال‌های سالم (<1s) اثر نمی‌گذارد
 graceful_shutdown_timeout_sec = 15
 log_level = "info"        # debug | info | warn | err
 rate_limit_per_subnet = 0   # 0 = disabled (default; avoids carrier-NAT false positives). Set e.g. 30 for non-NAT hosts
@@ -434,6 +442,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[server] idle_timeout_jitter_pct` | `15` | لرزش ±٪ به ازای هر اتصال روی مهلت بی‌کاری تا یک مقدار ثابت به اثر انگشت تبدیل نشود (`0` غیرفعال می‌کند) |
 | `[server] client_silence_close_sec` | `0` | بستن ریلهٔ برقرارشده‌ای که آخرین پاسخ سرور N ثانیه بدون پاسخِ کلاینت مانده — که اتصال مجدد تمیز و فوری (~۴۵۰ms) را راه می‌اندازد. یک گیر iOS MtProtoKit را برطرف می‌کند: پس از رد شدن به‌خاطر نمک کهنه، کلاینت نمک را دور می‌اندازد و ارسال را متوقف می‌کند و «در حال به‌روزرسانی» ~۹۰-۱۲۰ ثانیه گیر می‌کند تا DC سوکت را ببندد. فقط وقتی فعال می‌شود که آخرین بستهٔ منتقل‌شده server→client باشد (اتصال idle سالمی که آخرین کارش ping/ack خودش بوده دست‌نخورده می‌ماند). یک راه‌حل موقتِ تلاش‌محور است: مقداری کمتر از کندترین پاسخ مجاز گاهی یک اتصال سالم را هم می‌بندد (فقط ~۴۵۰ms اتصال مجدد). `0` = خاموش (پیش‌فرض)؛ در صورت فعال‌سازی، ~`10`–`15` نقطهٔ شروع منطقی است، به سلیقهٔ خود تنظیم کنید |
 | `[server] handshake_timeout_sec` | `15` | مهلت تکمیل هندشیک |
+| `[server] dc_connect_timeout_sec` | `10` | مهلت اتصال TCP به ازای هر endpoint به یک endpointِ DC تلگرام. یک endpointِ فیلترشده/سیاه‌چاله‌شده هیچ `RST`ی نمی‌فرستد، پس کرنل حدود ۲ دقیقه در `SYN_SENT` می‌ماند؛ `handshake_timeout_sec` کل هندشیک را سقف می‌زند اما به‌صورت سراسری، پس یک endpointِ کندِ نخست، failover را برای بقیه گرسنه نگه می‌دارد. این مهلت، یک endpointِ مرده را سریع ناموفق می‌کند و به بعدی می‌رود (در محدودهٔ سقفِ `handshake_timeout_sec`). آن را کمتر از `handshake_timeout_sec` نگه دارید. `0` = خاموش؛ اتصال‌های سالم در کمتر از ۱ ثانیه تمام می‌شوند پس هرگز روی آن‌ها اثر نمی‌گذارد |
 | `[server] graceful_shutdown_timeout_sec` | `15` | مهلت تخلیه‌ی SIGTERM پیش از بستن اجباری |
 | `[server] middleproxy_buffer_kb` | `1024` | بافر ME برای هر اتصال (KiB). کمتر از 1024 ممکن است در ترافیک رسانه‌ای باعث سرریز شود |
 | `[server] tag` | — | برچسب تبلیغاتیِ 32 کاراکتر hex از [@MTProxybot](https://t.me/MTProxybot) |
@@ -471,6 +480,8 @@ alice = true   # bypass MiddleProxy for this user
 > **ترابری `dd` («امن»/بالشتک‌دار) به‌صورت پیش‌فرض رد می‌شود** (`[censorship].fake_tls_only = true`) — این فقط MTProto مبهم‌سازی‌شده با **بدون استتار TLS** است که مستقیماً توسط DPI به‌عنوان MTProto قابل‌اثرانگشت‌گیری است. به‌صورت پیش‌فرض پراکسی فقط FakeTLS (`ee`) را می‌پذیرد و `mtbuddy links` فقط لینک‌های `ee` را چاپ می‌کند. برای ارائه‌ی لینک‌های `dd` (سناریوهای سازگاری / DPI ضعیف‌تر)، مقدار `fake_tls_only = false` را تنظیم کنید. به [THREAT_MODEL.md](THREAT_MODEL.md) مراجعه کنید.
 >
 > هر دو نگهبانِ سوءاستفاده **به‌صورت پیش‌فرض خاموش‌اند** تا شبکه‌های بزرگ carrier-NAT، خروجی VPN یا دفاتر اشتراکی (با کلاینت‌های مشروع زیاد پشت یک IP/زیرشبکه) به‌اشتباه شناسایی و یکجا مسدود نشوند: محدودیت نرخ اتصال جدید به ازای هر زیرشبکه (`rate_limit_per_subnet = 0`) و نگهبان سیلِ هندشیکِ مبتنی بر IP دقیق (`handshake_flood_guard_enabled = false`). دسترسی پیشاپیش با secret هر کاربر، بودجهٔ سراسریِ هندشیک‌های در جریان و `max_connections` کنترل می‌شود. روی یک هاست تک‌مستأجر / بدون NAT که زیر سوءاستفادهٔ واقعی است، آن‌ها را روشن کنید: `rate_limit_per_subnet` را تنظیم کنید (مثلاً `30`) و `handshake_flood_guard_enabled = true` را قرار دهید (مقادیر `handshake_flood_guard_threshold` / پنجره / مدت مسدودسازی را تنظیم کنید).
+>
+> هر دوی موارد بالا *پس از* `accept()` اجرا می‌شوند (درون-پراکسی هستند). برای یک لایهٔ اضافیِ **سطح-کرنل** که رگبارهای اولین SYNِ سوءاستفاده‌گرانه را *پیش از* آنکه یک سوکت/`accept()` خرج کنند می‌اندازد، یک محدودکنندهٔ نرخ SYN به ازای هر IP مبدأ به‌صورت اختیاری وجود دارد: `sudo mtbuddy setup syn-limit --preset soft`. این یک قانونِ `hashlimit` در iptables است که به‌عنوان یک `mtproto-syn-limit.service` oneshotِ **جداگانه** نصب می‌شود، پس `CAP_NET_ADMIN` هرگز به پراکسی داده نمی‌شود. این نیز **به‌صورت پیش‌فرض خاموش** است و مشمول همان احتیاطِ carrier-NAT می‌شود (پریستِ `soft` با ۲/ثانیه·رگبار-۵ پیش‌فرضِ امن‌تر برای CGNAT است)؛ برای لغوْ `--remove`، وضعیت + شمارندهٔ drop در `mtbuddy status`. پس از تغییر پورت پراکسی، آن را دوباره اجرا کنید.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,13 @@ sudo mtbuddy setup masking --domain rutube.ru
 sudo mtbuddy setup nfqws
 sudo mtbuddy setup recovery
 
+# Optional kernel-level per-IP SYN rate-limit (anti-flood, OFF by default).
+# Drops abusive first-SYN bursts in the kernel BEFORE accept(); separate systemd
+# oneshot so CAP_NET_ADMIN is never granted to the proxy. Default preset is CGNAT-safer.
+sudo mtbuddy setup syn-limit --preset soft   # soft 2/s·5 | medium 1/s·3 | hard 1/s·1
+sudo mtbuddy setup syn-limit --status
+sudo mtbuddy setup syn-limit --remove
+
 # Install web monitoring dashboard
 sudo mtbuddy setup dashboard
 # Remove just the dashboard (leaves the proxy running)
@@ -380,6 +387,7 @@ max_connections = 512
 idle_timeout_sec = 120
 # client_silence_close_sec = 0   # Close a relay whose server reply went unanswered by the client for N sec (breaks an iOS bad_salt wedge where "Updating" hangs ~90-120s) → instant clean reconnect. 0 = off; best-effort, can occasionally close a healthy conn — ~10-15 if you enable it
 handshake_timeout_sec = 15
+# dc_connect_timeout_sec = 10   # Per-endpoint TCP-connect deadline to a Telegram DC; fails a black-holed endpoint fast so failover advances to the next one (within handshake_timeout_sec). 0 = off; never affects healthy connects (<1s)
 graceful_shutdown_timeout_sec = 15
 log_level = "info"        # debug | info | warn | err
 rate_limit_per_subnet = 0   # 0 = disabled (default; avoids carrier-NAT false positives). Set e.g. 30 for non-NAT hosts
@@ -438,6 +446,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[server] idle_timeout_jitter_pct` | `15` | Per-connection ±% jitter on the idle timeout so a constant value isn't a fingerprint (`0` disables) |
 | `[server] client_silence_close_sec` | `0` | Close an established relay where the server's last reply has gone unanswered by the client for N seconds, triggering an instant (~450ms) clean reconnect. Breaks an iOS MtProtoKit wedge: after a stale-salt rejection the client discards the salt and stops sending, so "Updating" hangs ~90-120s until the DC closes the socket. Fires only when the last payload was server→client (a healthy idle connection whose last word was its own ping/ack is untouched). Best-effort, not a clean fix: a value below your slowest legitimate response will occasionally close a healthy connection too (just a ~450ms reconnect). `0` = off (default); if enabled, ~`10`–`15` is a sane starting point, tune to taste |
 | `[server] handshake_timeout_sec` | `15` | Handshake completion timeout |
+| `[server] dc_connect_timeout_sec` | `10` | Per-endpoint deadline for the TCP connect to a Telegram DC endpoint. A filtered/black-holed endpoint sends no RST, so the kernel sits in `SYN_SENT` ~2 min; `handshake_timeout_sec` already caps the whole handshake but globally, so a slow first endpoint starves failover for the rest. This fails one dead endpoint fast and advances to the next (within the `handshake_timeout_sec` ceiling). Keep below `handshake_timeout_sec`. `0` = off; healthy connects finish in <1s so it never affects them |
 | `[server] graceful_shutdown_timeout_sec` | `15` | SIGTERM drain timeout before force-close |
 | `[server] middleproxy_buffer_kb` | `2048` | ME per-connection buffer (KiB). Must hold one max RPC frame; below 1024 truncates 1 MiB media parts |
 | `[server] tag` | — | 32 hex-char promotion tag from [@MTProxybot](https://t.me/MTProxybot) |
@@ -476,6 +485,8 @@ alice = true   # bypass MiddleProxy for this user
 > **The `dd` ("secure"/padded) transport is rejected by default** (`[censorship].fake_tls_only = true`) — it is plain obfuscated MTProto with **no TLS disguise**, directly fingerprintable as MTProto by DPI. By default the proxy accepts only FakeTLS (`ee`), and `mtbuddy links` prints only `ee` links. To hand out `dd` links (lower-DPI / compatibility scenarios), set `fake_tls_only = false`. See [THREAT_MODEL.md](THREAT_MODEL.md).
 >
 > Both abuse guards are **off by default** so large carrier-NAT, VPN-egress, or shared-office networks (many legitimate clients behind one source IP/subnet) aren't false-positived and blocked together: the per-subnet new-connection rate limit (`rate_limit_per_subnet = 0`) and the exact-IP handshake flood guard (`handshake_flood_guard_enabled = false`). Access is already gated by the per-user secret, the global handshake-inflight budget, and `max_connections`. On a single-tenant / non-NAT host under real abuse, turn them on: set `rate_limit_per_subnet` (e.g. `30`) and `handshake_flood_guard_enabled = true` (tune `handshake_flood_guard_threshold` / window / block).
+>
+> Both of the above run *after* `accept()` (they're in-proxy). For an additional **kernel-level** layer that drops abusive first-SYN bursts *before* they cost a socket/`accept()`, there's an optional per-source-IP SYN rate-limiter: `sudo mtbuddy setup syn-limit --preset soft`. It's an iptables `hashlimit` rule installed as a **separate** `mtproto-syn-limit.service` oneshot, so `CAP_NET_ADMIN` is never granted to the proxy. Also **off by default** and subject to the same carrier-NAT caveat (the `soft` 2/s·burst-5 preset is the CGNAT-safer default); `--remove` to undo, status + drop counter in `mtbuddy status`. Re-run it after changing the proxy port.
 
 ---
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -213,6 +213,13 @@ sudo mtbuddy setup masking --domain rutube.ru
 sudo mtbuddy setup nfqws
 sudo mtbuddy setup recovery
 
+# Опциональное ограничение SYN на уровне ядра (анти-флуд, по умолчанию ВЫКЛ).
+# Дропает абьюзные SYN-всплески в ядре ДО accept(); отдельный systemd-oneshot,
+# поэтому CAP_NET_ADMIN не выдаётся прокси. Пресет по умолчанию безопаснее для CGNAT.
+sudo mtbuddy setup syn-limit --preset soft   # soft 2/с·5 | medium 1/с·3 | hard 1/с·1
+sudo mtbuddy setup syn-limit --status
+sudo mtbuddy setup syn-limit --remove
+
 # Установить web dashboard
 sudo mtbuddy setup dashboard
 # Удалить только дашборд (прокси продолжит работать)
@@ -364,6 +371,7 @@ max_connections = 512
 idle_timeout_sec = 120
 # client_silence_close_sec = 0   # Закрывать релей, где ответ сервера остался без ответа клиента N сек (ломает iOS-затык на bad_salt, где «обновление» висит ~90-120с) → мгновенный чистый реконнект. 0 = выкл; best-effort, изредка закрывает и здоровый коннект — ~10-15 если включаете
 handshake_timeout_sec = 15
+# dc_connect_timeout_sec = 10   # Дедлайн TCP-connect до эндпоинта Telegram DC; быстро отбрасывает заблэкхоленный эндпоинт, чтобы failover перешёл к следующему (в рамках handshake_timeout_sec). 0 = выкл; на здоровые коннекты (<1с) не влияет
 graceful_shutdown_timeout_sec = 15
 log_level = "info"
 rate_limit_per_subnet = 0   # 0 = выключено (по умолчанию; не ложно-срабатывает на carrier-NAT). Для не-NAT хостов задайте напр. 30
@@ -413,6 +421,7 @@ alice = true
 | `[server] handshake_flood_guard_window_sec` | `30` | Окно подсчёта для `handshake_flood_guard_threshold` |
 | `[server] handshake_flood_guard_block_sec` | `120` | Длительность временного deny для шумного IP |
 | `[server] idle_timeout_jitter_pct` | `15` | Джиттер ±% на idle-таймаут соединения, чтобы константа не была сигнатурой (`0` — выключить) |
+| `[server] dc_connect_timeout_sec` | `10` | Per-endpoint дедлайн TCP-connect до эндпоинта Telegram DC. Заблэкхоленный эндпоинт не шлёт RST, и ядро держит `SYN_SENT` ~2 мин; `handshake_timeout_sec` уже ограничивает весь handshake, но глобально, поэтому медленный первый эндпоинт съедает бюджет failover для остальных. Это быстро отбрасывает один мёртвый эндпоинт и переходит к следующему (в пределах `handshake_timeout_sec`). Держите ниже `handshake_timeout_sec`. `0` = выкл; здоровые коннекты (<1с) не затрагиваются |
 | `[server] client_silence_close_sec` | `0` | Закрывать установленный релей, где последний ответ сервера остался без ответа клиента N секунд — это даёт мгновенный (~450мс) чистый реконнект. Ломает затык iOS MtProtoKit: после отказа по протухшей соли клиент выбрасывает соль и перестаёт слать, и «обновление» висит ~90-120с, пока DC сам не закроет сокет. Срабатывает только когда последним по проводу был s2c (здоровый idle-коннект, чьё последнее слово — свой пинг/ack, не трогается). Best-effort, не полное лечение: значение ниже самого медленного легитимного ответа изредка закроет и здоровый коннект (лишний ~450мс реконнект). `0` = выкл (дефолт); если включаете, ~`10`–`15` разумная отправная точка, дальше под себя |
 | `[censorship] tls_domain` | `"google.com"` | Домен для TLS-маскировки |
 | `[censorship] mask` | `true` | Forward invalid clients на `tls_domain` |
@@ -432,6 +441,8 @@ alice = true
 > **Транспорт `dd` («secure»/padded) по умолчанию отключён** (`[censorship].fake_tls_only = true`) — это обычный обфусцированный MTProto **без TLS-маскировки**, который DPI фингерпринтит напрямую как MTProto. По умолчанию прокси принимает только FakeTLS (`ee`), и `mtbuddy links` печатает только `ee`-ссылки. Чтобы раздавать `dd`-ссылки (сценарии с низким DPI / совместимость), задайте `fake_tls_only = false`. См. [THREAT_MODEL.md](THREAT_MODEL.md).
 >
 > Оба стража **по умолчанию выключены**, чтобы carrier-NAT, VPN-egress и офисные сети (много легитимных клиентов за одним IP/подсетью) не получали ложных блокировок скопом: per-subnet rate limit (`rate_limit_per_subnet = 0`) и exact-IP handshake flood guard (`handshake_flood_guard_enabled = false`). Доступ и так закрыт per-user secret, глобальным handshake-inflight бюджетом и `max_connections`. На single-tenant / не-NAT хосте под реальным абьюзом включите: задайте `rate_limit_per_subnet` (например `30`) и `handshake_flood_guard_enabled = true` (настройте `handshake_flood_guard_threshold` / window / block).
+>
+> Оба стража выше работают *после* `accept()` (внутри прокси). Для дополнительного **уровня ядра**, который дропает абьюзные SYN-всплески *до* того, как они займут сокет/`accept()`, есть опциональный лимитер SYN по IP-источнику: `sudo mtbuddy setup syn-limit --preset soft`. Это правило iptables `hashlimit`, поставленное как **отдельный** oneshot `mtproto-syn-limit.service`, поэтому `CAP_NET_ADMIN` прокси не выдаётся. Тоже **выключен по умолчанию** и с той же оговоркой про carrier-NAT (пресет `soft` 2/с·burst-5 — безопаснее для CGNAT); `--remove` для отката, статус + счётчик дропов в `mtbuddy status`. Перезапустите после смены порта прокси.
 
 ---
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -219,6 +219,13 @@ sudo mtbuddy setup masking --domain rutube.ru
 sudo mtbuddy setup nfqws
 sudo mtbuddy setup recovery
 
+# Tùy chọn: giới hạn tốc độ SYN theo mỗi IP ở cấp kernel (chống lụt, MẶC ĐỊNH TẮT).
+# Chặn các đợt SYN-đầu-tiên gây lạm dụng ngay trong kernel TRƯỚC accept(); một systemd
+# oneshot riêng để CAP_NET_ADMIN không bao giờ được cấp cho proxy. Preset mặc định an toàn hơn cho CGNAT.
+sudo mtbuddy setup syn-limit --preset soft   # soft 2/s·5 | medium 1/s·3 | hard 1/s·1
+sudo mtbuddy setup syn-limit --status
+sudo mtbuddy setup syn-limit --remove
+
 # Install web monitoring dashboard
 sudo mtbuddy setup dashboard
 
@@ -378,6 +385,7 @@ max_connections = 512
 idle_timeout_sec = 120
 # client_silence_close_sec = 0   # Close a relay whose server reply went unanswered by the client for N sec (breaks an iOS bad_salt wedge where "Updating" hangs ~90-120s) → instant clean reconnect. 0 = off; best-effort, can occasionally close a healthy conn — ~10-15 if you enable it
 handshake_timeout_sec = 15
+# dc_connect_timeout_sec = 10   # Hạn chót TCP-connect cho mỗi endpoint tới một DC Telegram; làm hỏng nhanh một endpoint bị black-hole để failover chuyển sang endpoint kế tiếp (trong phạm vi handshake_timeout_sec). 0 = tắt; không bao giờ ảnh hưởng các kết nối khỏe mạnh (<1s)
 graceful_shutdown_timeout_sec = 15
 log_level = "info"        # debug | info | warn | err
 rate_limit_per_subnet = 0   # 0 = disabled (default; avoids carrier-NAT false positives). Set e.g. 30 for non-NAT hosts
@@ -434,6 +442,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[server] idle_timeout_sec` | `120` | Thời gian chờ kết nối nhàn rỗi |
 | `[server] idle_timeout_jitter_pct` | `15` | Jitter ±% trên mỗi kết nối cho thời gian chờ nhàn rỗi để một giá trị cố định không trở thành dấu vân tay (`0` để tắt) |
 | `[server] client_silence_close_sec` | `0` | Đóng một relay đã thiết lập mà phản hồi cuối của máy chủ không được client trả lời trong N giây, kích hoạt kết nối lại sạch tức thì (~450ms). Khắc phục một lỗi treo của iOS MtProtoKit: sau khi bị từ chối do salt cũ, client vứt bỏ salt và ngừng gửi, "Đang cập nhật" treo ~90-120s cho đến khi DC đóng socket. Chỉ kích hoạt khi payload cuối là server→client (một kết nối idle khỏe mạnh mà động thái cuối là ping/ack của chính nó sẽ không bị đụng tới). Đây là giải pháp tạm thời best-effort: giá trị thấp hơn phản hồi hợp lệ chậm nhất đôi khi cũng đóng một kết nối khỏe mạnh (chỉ ~450ms kết nối lại). `0` = tắt (mặc định); nếu bật, ~`10`–`15` là điểm khởi đầu hợp lý, tự điều chỉnh |
+| `[server] dc_connect_timeout_sec` | `10` | Hạn chót cho mỗi endpoint đối với việc TCP connect tới một endpoint DC Telegram. Một endpoint bị lọc/black-hole không gửi RST, nên kernel nằm chờ ở SYN_SENT ~2 phút; handshake_timeout_sec đã giới hạn toàn bộ bắt tay nhưng theo cách toàn cục, nên một endpoint đầu tiên chậm sẽ bỏ đói failover của phần còn lại. Cái này làm hỏng nhanh một endpoint chết và chuyển sang endpoint kế tiếp (trong phạm vi trần handshake_timeout_sec). Giữ thấp hơn handshake_timeout_sec. 0 = tắt; các kết nối khỏe mạnh hoàn tất trong <1s nên nó không bao giờ ảnh hưởng đến chúng |
 | `[server] handshake_timeout_sec` | `15` | Thời gian chờ hoàn tất bắt tay |
 | `[server] graceful_shutdown_timeout_sec` | `15` | Thời gian chờ rút cạn khi SIGTERM trước khi buộc đóng |
 | `[server] middleproxy_buffer_kb` | `1024` | Bộ đệm ME cho mỗi kết nối (KiB). Dưới 1024 có thể gây tràn với lưu lượng media |
@@ -472,6 +481,8 @@ alice = true   # bypass MiddleProxy for this user
 > **Lớp truyền tải `dd` ("secure"/padded) bị từ chối theo mặc định** (`[censorship].fake_tls_only = true`) — đó là MTProto được làm rối thông thường, **không có ngụy trang TLS**, có thể bị DPI nhận diện trực tiếp là MTProto. Theo mặc định proxy chỉ chấp nhận FakeTLS (`ee`), và `mtbuddy links` chỉ in các liên kết `ee`. Để phát các liên kết `dd` (cho các tình huống ít DPI / tương thích), hãy đặt `fake_tls_only = false`. Xem [THREAT_MODEL.md](THREAT_MODEL.md).
 >
 > Cả hai bộ chống lạm dụng đều **mặc định bị tắt** để các mạng carrier-NAT lớn, mạng VPN-egress hoặc mạng văn phòng dùng chung (nhiều client hợp lệ sau một IP/subnet nguồn) không bị nhận diện nhầm và chặn cùng nhau: giới hạn tốc độ kết nối mới theo mỗi subnet (`rate_limit_per_subnet = 0`) và bộ chống lụt bắt tay theo IP chính xác (`handshake_flood_guard_enabled = false`). Quyền truy cập đã được kiểm soát bởi secret theo từng người dùng, ngân sách bắt tay đang chờ toàn cục và `max_connections`. Trên một máy đơn người thuê / không NAT khi thực sự bị lạm dụng, hãy bật chúng lên: đặt `rate_limit_per_subnet` (ví dụ `30`) và `handshake_flood_guard_enabled = true` (tinh chỉnh `handshake_flood_guard_threshold` / cửa sổ / thời gian chặn).
+>
+> Cả hai bộ ở trên đều chạy sau `accept()` (chúng nằm trong proxy). Để có thêm một lớp ở cấp kernel chặn các đợt SYN-đầu-tiên gây lạm dụng trước khi chúng tốn một socket/`accept()`, có một bộ giới hạn tốc độ SYN theo mỗi IP nguồn tùy chọn: `sudo mtbuddy setup syn-limit --preset soft`. Đó là một quy tắc `iptables hashlimit` được cài như một `mtproto-syn-limit.service` oneshot riêng, nên `CAP_NET_ADMIN` không bao giờ được cấp cho proxy. Cũng mặc định tắt và chịu cùng lưu ý về carrier-NAT (preset soft 2/s·burst-5 là mặc định an toàn hơn cho CGNAT); `--remove` để gỡ bỏ, status + bộ đếm drop trong `mtbuddy status`. Chạy lại nó sau khi thay đổi cổng proxy.
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -218,6 +218,12 @@ sudo mtbuddy reload
 sudo mtbuddy setup masking --domain rutube.ru
 sudo mtbuddy setup nfqws
 sudo mtbuddy setup recovery
+# 可选的内核级每 IP SYN 速率限制（防洪水，默认关闭）。
+# 在 accept() 之前就在内核里丢弃滥用性的首个 SYN 突发；用独立的 systemd
+# oneshot 实现，因此从不授予代理 CAP_NET_ADMIN。默认预设对 CGNAT 更安全。
+sudo mtbuddy setup syn-limit --preset soft   # soft 2/s·5 | medium 1/s·3 | hard 1/s·1
+sudo mtbuddy setup syn-limit --status
+sudo mtbuddy setup syn-limit --remove
 
 # Install web monitoring dashboard
 sudo mtbuddy setup dashboard
@@ -377,6 +383,7 @@ max_connections = 512
 idle_timeout_sec = 120
 # client_silence_close_sec = 0   # Close a relay whose server reply went unanswered by the client for N sec (breaks an iOS bad_salt wedge where "Updating" hangs ~90-120s) → instant clean reconnect. 0 = off; best-effort, can occasionally close a healthy conn — ~10-15 if you enable it
 handshake_timeout_sec = 15
+# dc_connect_timeout_sec = 10   # 连接到某个 Telegram DC 端点的每端点 TCP-connect 截止时间；让被黑洞的端点快速失败，从而（在 handshake_timeout_sec 内）让故障转移推进到下一个。0 = 关闭；从不影响健康连接（<1 秒）
 graceful_shutdown_timeout_sec = 15
 log_level = "info"        # debug | info | warn | err
 rate_limit_per_subnet = 0   # 0 = disabled (default; avoids carrier-NAT false positives). Set e.g. 30 for non-NAT hosts
@@ -432,6 +439,7 @@ alice = true   # bypass MiddleProxy for this user
 | `[server] workers` | `1` | SO_REUSEPORT epoll 工作线程数。`1` = 单线程；`0` = 每个 CPU 一个；`N` 将中继/加密负载分散到多个核心。当 `>1` 时，SIGHUP 配置重载需要重启 |
 | `[server] idle_timeout_sec` | `120` | 连接空闲超时 |
 | `[server] idle_timeout_jitter_pct` | `15` | 对空闲超时施加每连接 ±% 的抖动，避免固定值成为指纹（`0` 表示禁用） |
+| `[server] dc_connect_timeout_sec` | `10` | 连接到某个 Telegram DC 端点的每端点 TCP-connect 截止时间。被过滤/黑洞的端点不会发送 RST，因此内核会在 SYN_SENT 状态停留约 2 分钟；handshake_timeout_sec 虽已对整个握手设上限，但那是全局的，所以一个慢的首个端点会让其余的故障转移挨饿。该项让单个失效端点快速失败并推进到下一个（在 handshake_timeout_sec 上限之内）。保持低于 handshake_timeout_sec。`0` = 关闭；健康连接在 <1 秒内完成，因此从不受其影响 |
 | `[server] client_silence_close_sec` | `0` | 当服务器最后一条回复已 N 秒未被客户端应答时关闭该已建立中继，触发即时（~450 毫秒）干净重连。修复 iOS MtProtoKit 卡死：盐过期被拒后客户端丢弃盐、停止发送，"更新中"卡住 ~90-120 秒直到 DC 关闭套接字。仅当最后一个负载是 server→client 时才触发（最后一次动作是自身 ping/ack 的健康空闲连接不受影响）。尽力而为的权宜之计：低于最慢合法响应的值偶尔也会关掉健康连接（仅 ~450ms 重连）。`0` = 关闭（默认）；如启用，~`10`–`15` 为合理起点，自行调整 |
 | `[server] handshake_timeout_sec` | `15` | 握手完成超时 |
 | `[server] graceful_shutdown_timeout_sec` | `15` | 强制关闭前 SIGTERM 排空超时 |
@@ -471,6 +479,8 @@ alice = true   # bypass MiddleProxy for this user
 > **`dd`（“安全”/填充）传输默认被拒绝**（`[censorship].fake_tls_only = true`）—— 它是纯粹混淆的 MTProto，**没有任何 TLS 伪装**，可被 DPI 直接识别为 MTProto 特征。默认情况下代理只接受 FakeTLS（`ee`），且 `mtbuddy links` 只打印 `ee` 链接。若要发放 `dd` 链接（低 DPI / 兼容性场景），请设置 `fake_tls_only = false`。参见 [THREAT_MODEL.md](THREAT_MODEL.md)。
 >
 > 两个滥用防护默认均关闭，以免大型运营商 NAT、VPN 出口或共享办公网络（许多合法客户端共用一个源 IP/子网）被误判并一起拦截：每子网的新建连接速率限制（`rate_limit_per_subnet = 0`）与精确 IP 的握手洪水防护（`handshake_flood_guard_enabled = false`）。访问本就已由每用户密钥、全局握手在途预算以及 `max_connections` 把关。在遭受真实滥用的单租户 / 非 NAT 主机上，请将它们开启：设置 `rate_limit_per_subnet`（如 `30`）并设 `handshake_flood_guard_enabled = true`（调整 `handshake_flood_guard_threshold` / 窗口 / 拦截时长）。
+>
+> 上述两者都在 accept() 之后运行（它们在代理进程内）。如果还需要一个内核级的层级，在滥用性的首个 SYN 突发耗费 socket/accept() 之前就将其丢弃，可使用一个可选的每源 IP SYN 速率限制器：`sudo mtbuddy setup syn-limit --preset soft`。它是一条 iptables hashlimit 规则，作为独立的 mtproto-syn-limit.service oneshot 安装，因此从不授予代理 CAP_NET_ADMIN。同样默认关闭，并受同样的运营商 NAT 注意事项约束（soft 2/s·burst-5 预设是对 CGNAT 更安全的默认值）；用 --remove 撤销，drop 计数与状态见 mtbuddy status。更改代理端口后请重新运行它。
 
 ---
 

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -37,7 +37,7 @@ Secondary assets:
 `mtproto.zig` aims to:
 - make MTProto traffic resemble common TLS traffic
 - reduce fingerprinting by DPI and active probes
-- enforce connection caps; provide an opt-in per-subnet rate limiter and a per-IP handshake flood guard (both disabled by default to avoid carrier-NAT false positives)
+- enforce connection caps; provide an opt-in per-subnet rate limiter and a per-IP handshake flood guard (both disabled by default to avoid carrier-NAT false positives), plus an opt-in kernel-level per-IP SYN rate-limiter (`mtbuddy setup syn-limit`) that drops abusive first-SYN bursts before `accept()` — installed as a separate systemd unit so `CAP_NET_ADMIN` is not granted to the proxy
 - fail safely on invalid handshakes and malformed frames
 - verify release artifacts (signature + checksum) in default install/update flows
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -88,6 +88,13 @@ port = 443
 # Seconds to complete TLS+MTProto handshake after first byte arrives.
 # handshake_timeout_sec = 15
 
+# Per-endpoint deadline (seconds) for the TCP connect to a Telegram DC endpoint; 0 = off.
+# A filtered/black-holed endpoint sends no RST, so the kernel sits in SYN_SENT for ~2 min.
+# handshake_timeout_sec caps the whole client handshake, but globally — this fails one dead
+# endpoint fast so failover advances to the next within that ceiling. Keep it below
+# handshake_timeout_sec. Healthy connects finish in <1s, so this never affects them.
+# dc_connect_timeout_sec = 10
+
 # Per-connection MiddleProxy stream buffer size in KiB. Must exceed the largest single
 # RPC_PROXY_ANS frame: a max download part is 1 MiB + framing, so 2048 (default) carries
 # 1 MiB media parts with headroom. 1024 truncates them; oversized frames close the

--- a/src/config.zig
+++ b/src/config.zig
@@ -258,6 +258,18 @@ pub const Config = struct {
     idle_timeout_jitter_pct: u8 = 15,
     /// Handshake read timeout after first byte arrives
     handshake_timeout_sec: u32 = 15,
+    /// Per-endpoint deadline for completing the TCP connect to a Telegram DC endpoint;
+    /// 0 = disabled (rely solely on handshake_timeout_sec). When an endpoint is filtered
+    /// / black-holed it sends no RST, so the kernel keeps the connect in SYN_SENT for
+    /// ~2 min. handshake_timeout_sec (measured from the client's first byte) already caps
+    /// the whole client handshake — but it's GLOBAL, so a slow first endpoint can starve
+    /// the failover budget for the remaining endpoints. This fires per endpoint: if the
+    /// connect() hasn't completed within the deadline, the endpoint is abandoned and
+    /// failover advances to the next one (within the overall handshake_timeout_sec ceiling).
+    /// Keep it comfortably below handshake_timeout_sec so a dead first endpoint still
+    /// leaves time to try another. A healthy connect completes in well under a second, so
+    /// this never affects working endpoints; default ON at 10s.
+    dc_connect_timeout_sec: u32 = 10,
     /// Graceful shutdown drain timeout on SIGTERM.
     /// The proxy stops accepting new clients and drains active relays
     /// for this many seconds before forced close.
@@ -694,6 +706,8 @@ pub const Config = struct {
                     } else if (std.mem.eql(u8, key, "handshake_timeout_sec")) {
                         const parsed = std.fmt.parseInt(u32, value, 10) catch cfg.handshake_timeout_sec;
                         cfg.handshake_timeout_sec = @max(@as(u32, 5), parsed);
+                    } else if (std.mem.eql(u8, key, "dc_connect_timeout_sec")) {
+                        cfg.dc_connect_timeout_sec = std.fmt.parseInt(u32, value, 10) catch cfg.dc_connect_timeout_sec;
                     } else if (std.mem.eql(u8, key, "graceful_shutdown_timeout_sec")) {
                         const parsed = std.fmt.parseInt(u32, value, 10) catch cfg.graceful_shutdown_timeout_sec;
                         cfg.graceful_shutdown_timeout_sec = @max(@as(u32, 1), parsed);
@@ -936,6 +950,7 @@ test "parse config - valid complete" {
         \\max_connections = 6000
         \\idle_timeout_sec = 180
         \\handshake_timeout_sec = 30
+        \\dc_connect_timeout_sec = 7
         \\fast_mode = true
         \\
         \\[censorship]
@@ -958,6 +973,7 @@ test "parse config - valid complete" {
     try std.testing.expectEqual(@as(u32, 6000), cfg.max_connections);
     try std.testing.expectEqual(@as(u32, 180), cfg.idle_timeout_sec);
     try std.testing.expectEqual(@as(u32, 30), cfg.handshake_timeout_sec);
+    try std.testing.expectEqual(@as(u32, 7), cfg.dc_connect_timeout_sec);
     try std.testing.expectEqualStrings("example.com", cfg.tls_domain);
     try std.testing.expect(cfg.use_middle_proxy);
     try std.testing.expect(cfg.mask);
@@ -985,6 +1001,7 @@ test "parse config - missing fields defaults" {
     try std.testing.expectEqual(@as(u32, 512), cfg.max_connections);
     try std.testing.expectEqual(@as(u32, 120), cfg.idle_timeout_sec);
     try std.testing.expectEqual(@as(u32, 15), cfg.handshake_timeout_sec);
+    try std.testing.expectEqual(@as(u32, 10), cfg.dc_connect_timeout_sec); // Default 10s, ON
     try std.testing.expectEqual(@as(u32, 15), cfg.graceful_shutdown_timeout_sec);
     try std.testing.expectEqualStrings("google.com", cfg.tls_domain);
     try std.testing.expect(cfg.mask_target == null);

--- a/src/ctl/config_cmd.zig
+++ b/src/ctl/config_cmd.zig
@@ -652,6 +652,7 @@ fn printEffective(ui: *Tui, allocator: std.mem.Allocator, path: []const u8) !voi
     ui.print("max_connections = {d}\n", .{cfg.max_connections});
     ui.print("idle_timeout_sec = {d}\n", .{cfg.idle_timeout_sec});
     ui.print("handshake_timeout_sec = {d}\n", .{cfg.handshake_timeout_sec});
+    ui.print("dc_connect_timeout_sec = {d}\n", .{cfg.dc_connect_timeout_sec});
     ui.print("graceful_shutdown_timeout_sec = {d}\n", .{cfg.graceful_shutdown_timeout_sec});
     ui.print("middleproxy_buffer_kb = {d}\n", .{cfg.middleproxy_buffer_kb});
     ui.print("log_level = \"{s}\"\n", .{@tagName(cfg.log_level)});

--- a/src/ctl/main.zig
+++ b/src/ctl/main.zig
@@ -19,6 +19,7 @@ const install = @import("install.zig");
 const update = @import("update.zig");
 const masking = @import("masking.zig");
 const nfqws = @import("nfqws.zig");
+const synlimit = @import("synlimit.zig");
 const tunnel = @import("tunnel.zig");
 const recovery = @import("recovery.zig");
 const dashboard = @import("dashboard.zig");
@@ -133,6 +134,8 @@ pub fn main(init: std.process.Init) !void {
                     return masking.run(&ui, allocator, &remaining_args);
                 } else if (std.mem.eql(u8, sub, "nfqws")) {
                     return nfqws.run(&ui, allocator, &remaining_args);
+                } else if (std.mem.eql(u8, sub, "syn-limit")) {
+                    return synlimit.run(&ui, allocator, &remaining_args);
                 } else if (std.mem.eql(u8, sub, "tunnel")) {
                     return tunnel.run(&ui, allocator, &remaining_args);
                 } else if (std.mem.eql(u8, sub, "egress")) {
@@ -148,11 +151,11 @@ pub fn main(init: std.process.Init) !void {
                         Color.reset,
                         sub,
                     });
-                    ui.hint(tr(ui.lang, "Available: masking, nfqws, tunnel, egress, recovery, dashboard", "Доступно: masking, nfqws, tunnel, egress, recovery, dashboard"));
+                    ui.hint(tr(ui.lang, "Available: masking, nfqws, syn-limit, tunnel, egress, recovery, dashboard", "Доступно: masking, nfqws, syn-limit, tunnel, egress, recovery, dashboard"));
                     return;
                 }
             } else {
-                ui.fail(tr(ui.lang, "Usage: mtbuddy setup <masking|nfqws|tunnel|egress|recovery|dashboard>", "Использование: mtbuddy setup <masking|nfqws|tunnel|egress|recovery|dashboard>"));
+                ui.fail(tr(ui.lang, "Usage: mtbuddy setup <masking|nfqws|syn-limit|tunnel|egress|recovery|dashboard>", "Использование: mtbuddy setup <masking|nfqws|syn-limit|tunnel|egress|recovery|dashboard>"));
                 return;
             }
         } else if (std.mem.eql(u8, cmd, "ipv6-hop")) {
@@ -193,6 +196,7 @@ const Action = enum {
     update,
     masking,
     tunnel,
+    synlimit,
     recovery,
     dashboard,
     remove_dashboard,
@@ -225,6 +229,8 @@ fn interactiveMain(ui: *Tui, allocator: std.mem.Allocator) !void {
             try actions.append(allocator, .masking);
             try items.append(allocator, i18n.get(ui.lang, .menu_setup_tunnel));
             try actions.append(allocator, .tunnel);
+            try items.append(allocator, tr(ui.lang, "Kernel SYN rate-limit (anti-flood)", "Ограничение SYN на уровне ядра (анти-флуд)"));
+            try actions.append(allocator, .synlimit);
 
             const has_dashboard = sys.isServiceActive("proxy-monitor");
             const has_recovery = sys.isServiceActive("mtproto-mask-health.timer");
@@ -276,6 +282,7 @@ fn dispatchAction(action: Action, ui: *Tui, allocator: std.mem.Allocator) !void 
         .update => try update.runInteractive(ui, allocator),
         .masking => try masking.runInteractive(ui, allocator),
         .tunnel => try tunnelOrEgressInteractive(ui, allocator),
+        .synlimit => try synlimit.runInteractive(ui, allocator),
         .dashboard => try dashboard.runInteractive(ui, allocator),
         .remove_dashboard => dashboard.removeInteractive(ui),
         .recovery => try recovery.runInteractive(ui, allocator),
@@ -435,6 +442,8 @@ fn showStatus(ui: *Tui, allocator: std.mem.Allocator) void {
         ui.info(tr(ui.lang, "Extra TCP protection (nfqws) is not running", "Дополнительная TCP-защита (nfqws) не запущена"));
     }
 
+    synlimit.printStatus(ui, allocator);
+
     const timer_active = sys.isServiceActive("mtproto-mask-health.timer");
     if (timer_active) {
         ui.ok(tr(ui.lang, "DPI auto-recovery is active", "Автовосстановление DPI активно"));
@@ -515,6 +524,7 @@ fn printHelp(lang: i18n.Lang) void {
     printCmd(&ui, "update", tr(lang, "Update to latest GitHub release", "Обновить до последнего GitHub релиза"));
     printCmd(&ui, "setup masking", tr(lang, "Setup local Nginx DPI masking", "Настроить локальную DPI-маскировку через Nginx"));
     printCmd(&ui, "setup nfqws", tr(lang, "Setup nfqws TCP desync (Zapret)", "Настроить nfqws TCP desync (Zapret)"));
+    printCmd(&ui, "setup syn-limit [--preset soft|medium|hard] [--remove]", tr(lang, "Kernel per-IP inbound SYN rate-limit (off by default)", "Ограничение входящих SYN по IP в ядре (по умолчанию выкл)"));
     printCmd(&ui, "setup tunnel [--deps-only] [--iface awgN] <conf|vpn://>", tr(lang, "Setup AmneziaWG tunnel pool member", "Настроить участника пула туннелей AmneziaWG"));
     printCmd(&ui, "setup egress [--deps-only] <share-link...>", tr(lang, "Setup VPN share-link egress", "Настроить egress через VPN-ссылку"));
     printCmd(&ui, "setup dashboard", tr(lang, "Install web monitoring dashboard", "Установить веб-дашборд мониторинга"));
@@ -643,6 +653,7 @@ test {
     _ = @import("tui.zig");
     _ = @import("release.zig");
     _ = @import("nfqws.zig");
+    _ = @import("synlimit.zig");
     _ = @import("masking.zig");
     _ = @import("uninstall.zig");
     _ = @import("update.zig");

--- a/src/ctl/synlimit.zig
+++ b/src/ctl/synlimit.zig
@@ -1,0 +1,493 @@
+//! Setup syn-limit command for mtbuddy.
+//!
+//! Installs an OPTIONAL kernel-level per-source-IP inbound SYN rate-limiter on the
+//! proxy port, via iptables `-m hashlimit`. This drops abusive first-SYN bursts in
+//! the kernel BEFORE accept(), complementing (not replacing) the in-proxy flood
+//! guards which only act after accept() and default OFF anyway.
+//!
+//! Idea borrowed from MTproxy-reanimation (which does the same with nftables for
+//! Telemt/MTProxyMax). We use iptables `hashlimit` to match our existing iptables
+//! stack (TCPMSS, nfqws) — no new nftables dependency — and we run it as a SEPARATE
+//! systemd oneshot unit so CAP_NET_ADMIN never has to be granted to mtproto-proxy.
+//!
+//! Default OFF and gated behind a loud CGNAT/VPN warning: like the in-proxy guards,
+//! a per-IP SYN limiter false-positives when many real users share one egress IP.
+
+const std = @import("std");
+const tui_mod = @import("tui.zig");
+const sys = @import("sys.zig");
+const toml = @import("toml.zig");
+
+const Tui = tui_mod.Tui;
+const Color = tui_mod.Color;
+
+const INSTALL_DIR = "/opt/mtproto-proxy";
+const SERVICE_NAME = "mtproto-syn-limit";
+const SCRIPT_PATH = "/usr/local/sbin/mtproto-syn-limit.sh";
+const UNIT_PATH = "/etc/systemd/system/" ++ SERVICE_NAME ++ ".service";
+const CHAIN = "MTPROTO_SYNLIMIT";
+
+/// Token-bucket presets, mirroring MTproxy-reanimation's hard/medium/soft. Rates use
+/// the iptables `<n>/second` syntax. `soft` is the default when enabling because the
+/// stricter presets false-positive behind carrier-grade NAT / shared VPN egress.
+pub const Preset = enum {
+    soft,
+    medium,
+    hard,
+
+    pub fn rate(self: Preset) []const u8 {
+        return switch (self) {
+            .soft => "2/second",
+            .medium => "1/second",
+            .hard => "1/second",
+        };
+    }
+
+    pub fn burst(self: Preset) []const u8 {
+        return switch (self) {
+            .soft => "5",
+            .medium => "3",
+            .hard => "1",
+        };
+    }
+};
+
+pub const Action = enum { status, apply, remove };
+
+pub const SynLimitOpts = struct {
+    action: Action = .status,
+    rate: []const u8 = "2/second",
+    burst: []const u8 = "5",
+};
+
+/// Run in CLI mode.
+pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) !void {
+    // Default action is .status; any apply/remove flag below overrides it.
+    var opts = SynLimitOpts{};
+    while (args.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--remove") or std.mem.eql(u8, arg, "--uninstall") or std.mem.eql(u8, arg, "--disable")) {
+            opts.action = .remove;
+        } else if (std.mem.eql(u8, arg, "--status")) {
+            opts.action = .status;
+        } else if (std.mem.eql(u8, arg, "--preset")) {
+            const val = args.next() orelse continue;
+            const preset = parsePreset(val) orelse {
+                ui.fail("Unknown preset (expected: soft, medium, hard)");
+                return;
+            };
+            opts.rate = preset.rate();
+            opts.burst = preset.burst();
+            opts.action = .apply;
+        } else if (std.mem.eql(u8, arg, "--rate")) {
+            const val = args.next() orelse continue;
+            if (!isValidRate(val)) {
+                ui.fail("Invalid --rate (expected like 2/second, 1/minute)");
+                return;
+            }
+            opts.rate = val;
+            opts.action = .apply;
+        } else if (std.mem.eql(u8, arg, "--burst")) {
+            const val = args.next() orelse continue;
+            if (!isValidNumber(val)) {
+                ui.fail("Invalid --burst (expected a positive integer)");
+                return;
+            }
+            opts.burst = val;
+            opts.action = .apply;
+        }
+    }
+    try execute(ui, allocator, opts);
+}
+
+/// Run in interactive mode.
+pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
+    ui.section(tr(ui, "Kernel SYN rate-limit (anti-flood)", "Ограничение SYN на уровне ядра (анти-флуд)"));
+
+    ui.print("  {s}{s}{s}\n", .{ Color.dim, tr(ui,
+        "Drops abusive first-SYN bursts per source IP in the kernel, before they",
+        "Дропает абьюзные SYN-всплески по каждому IP-источнику в ядре, до того как они"), Color.reset });
+    ui.print("  {s}{s}{s}\n\n", .{ Color.dim, tr(ui,
+        "ever reach the proxy. Complements the in-proxy guards (which run after accept).",
+        "достигнут прокси. Дополняет защиту внутри прокси (которая работает после accept)."), Color.reset });
+
+    // The same NAT/VPN false-positive that keeps the in-proxy flood guard OFF by default.
+    ui.warn(tr(ui,
+        "Per-IP limit: behind carrier-NAT / shared VPN egress many real users share one IP",
+        "Лимит на IP: за carrier-NAT / общим VPN-выходом много реальных пользователей делят один IP"));
+    ui.print("  {s}{s}{s}\n\n", .{ Color.dim, tr(ui,
+        "and can be throttled together. Leave it off unless you see a SYN flood.",
+        "и могут быть зарезаны вместе. Оставьте выключенным, если нет SYN-флуда."), Color.reset });
+
+    printStatus(ui, allocator);
+    ui.writeRaw("\n");
+
+    const items = [_][]const u8{
+        tr(ui, "Enable — Soft (2/s, burst 5) — recommended", "Включить — Мягкий (2/с, burst 5) — рекомендуется"),
+        tr(ui, "Enable — Medium (1/s, burst 3)", "Включить — Средний (1/с, burst 3)"),
+        tr(ui, "Enable — Hard (1/s, burst 1)", "Включить — Жёсткий (1/с, burst 1)"),
+        tr(ui, "Disable / remove", "Отключить / удалить"),
+    };
+    const idx = ui.menu(tr(ui, "SYN rate-limit", "Ограничение SYN"), &items) catch |e| switch (e) {
+        error.GoBack => return,
+        else => return e,
+    };
+
+    switch (idx) {
+        0, 1, 2 => {
+            const preset: Preset = switch (idx) {
+                0 => .soft,
+                1 => .medium,
+                else => .hard,
+            };
+            if (!try ui.confirm(tr(ui, "Apply this SYN rate-limit now?", "Применить это ограничение SYN сейчас?"), true)) {
+                ui.info(tr(ui, "Aborted", "Отменено"));
+                return;
+            }
+            try execute(ui, allocator, .{ .action = .apply, .rate = preset.rate(), .burst = preset.burst() });
+        },
+        else => try execute(ui, allocator, .{ .action = .remove }),
+    }
+}
+
+pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: SynLimitOpts) !void {
+    if (opts.action == .status) {
+        ui.section(tr(ui, "Kernel SYN rate-limit", "Ограничение SYN на уровне ядра"));
+        printStatus(ui, allocator);
+        if (!sys.isServiceActive(SERVICE_NAME)) {
+            ui.writeRaw("\n");
+            ui.hint(tr(ui, "Enable: mtbuddy setup syn-limit --preset soft", "Включить: mtbuddy setup syn-limit --preset soft"));
+        }
+        return;
+    }
+
+    if (!sys.isRoot()) {
+        ui.fail(tr(ui, "This action requires root.", "Это действие требует root."));
+        return;
+    }
+
+    const ipt = iptablesCommands();
+
+    // ── Remove ──
+    if (opts.action == .remove) {
+        ui.step(tr(ui, "Removing kernel SYN rate-limit...", "Удаление ограничения SYN на уровне ядра..."));
+        _ = sys.execForward(&.{ "systemctl", "stop", SERVICE_NAME }) catch {};
+        _ = sys.execForward(&.{ "systemctl", "disable", SERVICE_NAME }) catch {};
+        sys.execSilent(allocator, &.{ "rm", "-f", UNIT_PATH });
+        _ = sys.execForward(&.{ "systemctl", "daemon-reload" }) catch {};
+        // Belt-and-suspenders: clear live rules regardless of whether the unit's
+        // ExecStop ran (port may have changed since apply, so delete every jump by
+        // listing INPUT and replaying as deletes — robust to a changed --dport).
+        flushChain(allocator, ipt.iptables);
+        flushChain(allocator, ipt.ip6tables);
+        sys.execSilent(allocator, &.{ "rm", "-f", SCRIPT_PATH });
+        ui.ok(tr(ui, "Kernel SYN rate-limit removed", "Ограничение SYN на уровне ядра удалено"));
+        return;
+    }
+
+    // ── Apply ──
+    // Read the proxy port from config. Copy it into a stack buffer BEFORE deinit() —
+    // toml.get() aliases the doc's heap, which deinit frees (same caveat as nfqws).
+    var port_buf: [16]u8 = undefined;
+    var port: []const u8 = "443";
+    var proxy_protocol = false;
+    {
+        var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch null;
+        if (doc) |*d| {
+            defer d.deinit();
+            const raw = d.get("server", "port") orelse "443";
+            const n = @min(raw.len, port_buf.len);
+            @memcpy(port_buf[0..n], raw[0..n]);
+            port = port_buf[0..n];
+            if (d.get("server", "accept_proxy_protocol")) |v| {
+                proxy_protocol = std.mem.indexOf(u8, v, "true") != null;
+            }
+        }
+    }
+    if (!isValidNumber(port)) {
+        ui.fail(tr(ui, "Could not read a valid proxy port from config.toml", "Не удалось прочитать корректный порт прокси из config.toml"));
+        return;
+    }
+
+    // A PROXY-protocol front means the kernel sees the load balancer's IP, not the
+    // client's — the limiter would throttle the LB. Warn loudly (don't refuse: for a
+    // single trusted LB the operator may still want a global cap).
+    if (proxy_protocol) {
+        ui.warn(tr(ui,
+            "accept_proxy_protocol is ON: the kernel sees your load balancer's IP, not real clients.",
+            "accept_proxy_protocol включён: ядро видит IP балансировщика, а не реальных клиентов."));
+        ui.print("  {s}{s}{s}\n", .{ Color.dim, tr(ui,
+            "The per-IP SYN limiter will throttle the LB. Only enable if you understand this.",
+            "Лимитер SYN per-IP будет резать балансировщик. Включайте, только если понимаете это."), Color.reset });
+    }
+
+    ui.step(tr(ui, "Installing kernel SYN rate-limit...", "Установка ограничения SYN на уровне ядра..."));
+
+    // Generate the apply/flush script and the systemd oneshot unit.
+    var script_buf: [2048]u8 = undefined;
+    const script = renderScript(&script_buf, .{
+        .port = port,
+        .rate = opts.rate,
+        .burst = opts.burst,
+        .iptables = ipt.iptables,
+        .ip6tables = ipt.ip6tables,
+    }) catch {
+        ui.fail(tr(ui, "Failed to render SYN-limit script", "Не удалось сформировать скрипт ограничения SYN"));
+        return;
+    };
+    sys.writeFileMode(SCRIPT_PATH, script, 0o755) catch {
+        ui.fail(tr(ui, "Failed to write SYN-limit script", "Не удалось записать скрипт ограничения SYN"));
+        return;
+    };
+    sys.writeFile(UNIT_PATH, unitContent()) catch {
+        ui.fail(tr(ui, "Failed to write systemd unit", "Не удалось записать systemd unit"));
+        return;
+    };
+
+    _ = sys.execForward(&.{ "systemctl", "daemon-reload" }) catch {};
+    sys.execSilent(allocator, &.{ "systemctl", "enable", SERVICE_NAME });
+    _ = sys.execForward(&.{ "systemctl", "restart", SERVICE_NAME }) catch {};
+
+    // Verify the rule actually landed: if xt_hashlimit is missing the script's strict
+    // IPv4 lines fail and the oneshot is marked failed — surface that instead of a
+    // silent no-op that looks installed.
+    if (!sys.isServiceActive(SERVICE_NAME) or !chainHasDrop(allocator, ipt.iptables)) {
+        ui.fail(tr(ui, "SYN rate-limit did not apply (is the hashlimit iptables module available?)", "Ограничение SYN не применилось (доступен ли модуль iptables hashlimit?)"));
+        ui.hint("journalctl -u " ++ SERVICE_NAME ++ " --no-pager -n 20");
+        return;
+    }
+
+    ui.ok(tr(ui, "Kernel SYN rate-limit active", "Ограничение SYN на уровне ядра активно"));
+    ui.summaryBox(tr(ui, "Inbound SYN rate-limit", "Ограничение входящих SYN"), &.{
+        .{ .label = tr(ui, "Port:", "Порт:"), .value = port, .style = .label_value },
+        .{ .label = tr(ui, "Rate:", "Частота:"), .value = opts.rate, .style = .label_value },
+        .{ .label = tr(ui, "Burst:", "Burst:"), .value = opts.burst, .style = .label_value },
+        .{ .label = tr(ui, "Service:", "Сервис:"), .value = SERVICE_NAME, .style = .label_value },
+        .{ .label = "", .value = "", .style = .blank },
+        .{ .label = tr(ui, "Per source-IP, dropped pre-accept() in the kernel", "По каждому IP-источнику, дроп до accept() в ядре"), .style = .success },
+        .{ .label = tr(ui, "Re-run after changing the proxy port", "Перезапустите после смены порта прокси"), .style = .highlight },
+    });
+}
+
+/// Print a one-line status (+ drop counter when active). Used by `setup syn-limit`
+/// and by `mtbuddy status`.
+pub fn printStatus(ui: *Tui, allocator: std.mem.Allocator) void {
+    if (sys.isServiceActive(SERVICE_NAME)) {
+        const drops = dropCount(allocator);
+        if (drops) |d| {
+            var buf: [96]u8 = undefined;
+            const msg = std.fmt.bufPrint(&buf, "{s} ({s} {s})", .{
+                tr(ui, "Kernel SYN rate-limit is active", "Ограничение SYN на уровне ядра активно"),
+                d,
+                tr(ui, "SYNs dropped", "SYN дропнуто"),
+            }) catch tr(ui, "Kernel SYN rate-limit is active", "Ограничение SYN на уровне ядра активно");
+            ui.ok(msg);
+            allocator.free(d);
+        } else {
+            ui.ok(tr(ui, "Kernel SYN rate-limit is active", "Ограничение SYN на уровне ядра активно"));
+        }
+    } else {
+        ui.info(tr(ui, "Kernel SYN rate-limit is not installed", "Ограничение SYN на уровне ядра не установлено"));
+    }
+}
+
+// ── Rendering (pure, testable) ──
+
+const ScriptParams = struct {
+    port: []const u8,
+    rate: []const u8,
+    burst: []const u8,
+    iptables: []const u8,
+    ip6tables: []const u8,
+};
+
+/// Render the apply/flush shell script. Deliberately uses only `for`/`[ ]`/`if`
+/// constructs with NO `{`/`}` so it can be produced with std.fmt (which would treat
+/// braces as placeholders). The strict IPv4 lines carry no `|| true` so a missing
+/// hashlimit module fails the systemd oneshot instead of silently no-op'ing; IPv6 is
+/// best-effort (hosts without IPv6 must not fail the unit).
+pub fn renderScript(buf: []u8, p: ScriptParams) ![]const u8 {
+    return std.fmt.bufPrint(buf,
+        \\#!/bin/sh
+        \\# Generated by mtbuddy — MTProto proxy inbound SYN rate-limiter.
+        \\# Drops first-SYN packets exceeding RATE per source IP (token bucket of BURST).
+        \\# Managed by the {[svc]s}.service systemd unit. Do not edit by hand.
+        \\set -u
+        \\CHAIN={[chain]s}
+        \\PORT={[port]s}
+        \\RATE={[rate]s}
+        \\BURST={[burst]s}
+        \\IPT={[iptables]s}
+        \\IP6T={[ip6tables]s}
+        \\MODE="$1"
+        \\
+        \\# Idempotent reset: drop the jump, flush + delete the chain (both families).
+        \\for T in "$IPT" "$IP6T"; do
+        \\    "$T" -D INPUT -p tcp --dport "$PORT" --syn -j "$CHAIN" 2>/dev/null || true
+        \\    "$T" -F "$CHAIN" 2>/dev/null || true
+        \\    "$T" -X "$CHAIN" 2>/dev/null || true
+        \\done
+        \\
+        \\[ "$MODE" = flush ] && exit 0
+        \\
+        \\# IPv4 (required — a failure here fails the unit so the operator notices).
+        \\"$IPT" -N "$CHAIN" 2>/dev/null || true
+        \\"$IPT" -A "$CHAIN" -m hashlimit --hashlimit-name mtproto_syn --hashlimit-mode srcip --hashlimit-above "$RATE" --hashlimit-burst "$BURST" --hashlimit-htable-expire 60000 -j DROP
+        \\"$IPT" -A "$CHAIN" -j RETURN
+        \\"$IPT" -I INPUT -p tcp --dport "$PORT" --syn -j "$CHAIN"
+        \\
+        \\# IPv6 (best-effort — hosts without IPv6 must not fail the unit).
+        \\"$IP6T" -N "$CHAIN" 2>/dev/null || true
+        \\"$IP6T" -A "$CHAIN" -m hashlimit --hashlimit-name mtproto_syn --hashlimit-mode srcip --hashlimit-above "$RATE" --hashlimit-burst "$BURST" --hashlimit-htable-expire 60000 -j DROP 2>/dev/null || true
+        \\"$IP6T" -A "$CHAIN" -j RETURN 2>/dev/null || true
+        \\"$IP6T" -I INPUT -p tcp --dport "$PORT" --syn -j "$CHAIN" 2>/dev/null || true
+        \\exit 0
+        \\
+    , .{
+        .svc = SERVICE_NAME,
+        .chain = CHAIN,
+        .port = p.port,
+        .rate = p.rate,
+        .burst = p.burst,
+        .iptables = p.iptables,
+        .ip6tables = p.ip6tables,
+    });
+}
+
+fn unitContent() []const u8 {
+    return "[Unit]\n" ++
+        "Description=MTProto proxy inbound SYN rate-limiter\n" ++
+        "After=network.target\n" ++
+        "Before=mtproto-proxy.service\n" ++
+        "\n" ++
+        "[Service]\n" ++
+        "Type=oneshot\n" ++
+        "RemainAfterExit=yes\n" ++
+        "ExecStart=/bin/sh " ++ SCRIPT_PATH ++ " apply\n" ++
+        "ExecStop=/bin/sh " ++ SCRIPT_PATH ++ " flush\n" ++
+        "\n" ++
+        "[Install]\n" ++
+        "WantedBy=multi-user.target\n";
+}
+
+// ── Helpers ──
+
+const IptablesCommands = struct {
+    iptables: []const u8,
+    ip6tables: []const u8,
+};
+
+fn iptablesCommands() IptablesCommands {
+    return .{
+        .iptables = sys.commandOrPath("iptables", &.{ "/usr/sbin/iptables", "/sbin/iptables" }),
+        .ip6tables = sys.commandOrPath("ip6tables", &.{ "/usr/sbin/ip6tables", "/sbin/ip6tables" }),
+    };
+}
+
+/// Delete every INPUT jump to our chain (robust to a changed --dport), then flush +
+/// delete the chain. Mirrors uninstall.zig's TCPMSS list-replay-delete approach.
+fn flushChain(allocator: std.mem.Allocator, ipt: []const u8) void {
+    var cmd_buf: [512]u8 = undefined;
+    const cmd = std.fmt.bufPrint(
+        &cmd_buf,
+        "{s} -S INPUT 2>/dev/null | grep -- '-j {s}' | while read -r line; do rule=$(printf '%s' \"$line\" | sed 's/^-A /-D /'); {s} $rule 2>/dev/null || true; done; {s} -F {s} 2>/dev/null || true; {s} -X {s} 2>/dev/null || true",
+        .{ ipt, CHAIN, ipt, ipt, CHAIN, ipt, CHAIN },
+    ) catch return;
+    sys.execSilent(allocator, &.{ "bash", "-c", cmd });
+}
+
+fn chainHasDrop(allocator: std.mem.Allocator, ipt: []const u8) bool {
+    const result = sys.exec(allocator, &.{ ipt, "-nL", CHAIN }) catch return false;
+    defer result.deinit();
+    if (result.exit_code != 0) return false;
+    return std.mem.indexOf(u8, result.stdout, "DROP") != null;
+}
+
+/// Sum the DROP rule's packet counter from `iptables -nvxL CHAIN`. Returns an owned
+/// slice (caller frees) or null when unavailable.
+fn dropCount(allocator: std.mem.Allocator) ?[]const u8 {
+    const ipt = iptablesCommands().iptables;
+    const result = sys.exec(allocator, &.{ ipt, "-nvxL", CHAIN }) catch return null;
+    defer result.deinit();
+    if (result.exit_code != 0) return null;
+    var lines = std.mem.splitScalar(u8, result.stdout, '\n');
+    while (lines.next()) |line| {
+        if (std.mem.indexOf(u8, line, "DROP") == null) continue;
+        var tok = std.mem.tokenizeAny(u8, line, " \t");
+        const pkts = tok.next() orelse continue;
+        if (!isValidNumber(pkts)) continue;
+        return allocator.dupe(u8, pkts) catch null;
+    }
+    return null;
+}
+
+fn parsePreset(s: []const u8) ?Preset {
+    if (std.mem.eql(u8, s, "soft")) return .soft;
+    if (std.mem.eql(u8, s, "medium")) return .medium;
+    if (std.mem.eql(u8, s, "hard")) return .hard;
+    return null;
+}
+
+fn isValidNumber(s: []const u8) bool {
+    if (s.len == 0 or s.len > 6) return false;
+    for (s) |c| {
+        if (c < '0' or c > '9') return false;
+    }
+    return true;
+}
+
+/// Validate an iptables hashlimit rate string like "2/second" / "1/minute". Strict
+/// because it is baked verbatim into a generated shell script.
+fn isValidRate(s: []const u8) bool {
+    const slash = std.mem.indexOfScalar(u8, s, '/') orelse return false;
+    const num = s[0..slash];
+    const unit = s[slash + 1 ..];
+    if (!isValidNumber(num)) return false;
+    return std.mem.eql(u8, unit, "second") or
+        std.mem.eql(u8, unit, "minute") or
+        std.mem.eql(u8, unit, "hour") or
+        std.mem.eql(u8, unit, "day");
+}
+
+fn tr(ui: *Tui, en: []const u8, ru: []const u8) []const u8 {
+    return if (ui.lang == .ru) ru else en;
+}
+
+test "preset rate/burst" {
+    try std.testing.expectEqualStrings("2/second", Preset.soft.rate());
+    try std.testing.expectEqualStrings("5", Preset.soft.burst());
+    try std.testing.expectEqualStrings("1/second", Preset.hard.rate());
+    try std.testing.expectEqualStrings("1", Preset.hard.burst());
+}
+
+test "rate/number validation" {
+    try std.testing.expect(isValidRate("2/second"));
+    try std.testing.expect(isValidRate("10/minute"));
+    try std.testing.expect(!isValidRate("2/fortnight"));
+    try std.testing.expect(!isValidRate("/second"));
+    try std.testing.expect(!isValidRate("2"));
+    try std.testing.expect(!isValidRate("2/second; rm -rf"));
+    try std.testing.expect(isValidNumber("443"));
+    try std.testing.expect(!isValidNumber(""));
+    try std.testing.expect(!isValidNumber("44a"));
+    try std.testing.expect(!isValidNumber("1234567"));
+}
+
+test "renderScript bakes params and stays brace-free for std.fmt" {
+    var buf: [2048]u8 = undefined;
+    const out = try renderScript(&buf, .{
+        .port = "443",
+        .rate = "2/second",
+        .burst = "5",
+        .iptables = "/usr/sbin/iptables",
+        .ip6tables = "/usr/sbin/ip6tables",
+    });
+    try std.testing.expect(std.mem.indexOf(u8, out, "PORT=443") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "--hashlimit-above \"$RATE\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "RATE=2/second") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "BURST=5") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "CHAIN=MTPROTO_SYNLIMIT") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "-I INPUT -p tcp --dport \"$PORT\" --syn -j \"$CHAIN\"") != null);
+    // No raw curly braces should survive into the generated script.
+    try std.testing.expect(std.mem.indexOfScalar(u8, out, '{') == null);
+    try std.testing.expect(std.mem.indexOfScalar(u8, out, '}') == null);
+}

--- a/src/ctl/uninstall.zig
+++ b/src/ctl/uninstall.zig
@@ -74,6 +74,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
         "mtproto-proxy",
         "proxy-monitor",
         "nfqws-mtproto",
+        "mtproto-syn-limit",
         "mtproto-mask-health.timer",
         "mtproto-mask-health.service",
         "mtproto-tunnel-pool.timer",
@@ -198,6 +199,24 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
         \\fi
     ;
     _ = sys.execForward(&.{ "bash", "-c", tcpmss_cleanup }) catch {};
+
+    // Clear the optional kernel SYN rate-limiter (mtbuddy setup syn-limit). The unit was
+    // already stopped/removed in the services loop above; here we tear down its live
+    // iptables chain (both families) by replay-deleting every INPUT jump to it — robust
+    // to a --dport that changed since apply — then flush + delete the chain and remove
+    // the generated apply/flush script.
+    const synlimit_cleanup =
+        \\for ipt in iptables ip6tables; do
+        \\  "$ipt" -S INPUT 2>/dev/null | grep -- '-j MTPROTO_SYNLIMIT' | while read -r line; do
+        \\    rule=$(printf '%s' "$line" | sed 's/^-A /-D /')
+        \\    "$ipt" $rule 2>/dev/null || true
+        \\  done
+        \\  "$ipt" -F MTPROTO_SYNLIMIT 2>/dev/null || true
+        \\  "$ipt" -X MTPROTO_SYNLIMIT 2>/dev/null || true
+        \\done
+        \\rm -f /usr/local/sbin/mtproto-syn-limit.sh
+    ;
+    _ = sys.execForward(&.{ "bash", "-c", synlimit_cleanup }) catch {};
 
     // Revert the port-specific ufw allow rule the installer added.
     if (sys.commandExists("ufw")) {

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -481,6 +481,10 @@ const ConnectionSlot = struct {
 
     created_at_ms: i64 = 0,
     first_byte_at_ms: i64 = 0,
+    /// When the current upstream connect() was initiated (phase .connecting_upstream).
+    /// Reset on every endpoint attempt so dc_connect_timeout_sec is per-endpoint, not
+    /// cumulative across failover. 0 when not connecting upstream.
+    upstream_connect_started_ms: i64 = 0,
     last_activity_ms: i64 = 0,
     /// Last time client->server payload was relayed (0 until the client first speaks while
     /// relaying), and last time server->client payload was relayed. When the server spoke more
@@ -3848,6 +3852,9 @@ const EventLoop = struct {
         slot.upstream_kind = kind;
         slot.current_upstream_addr = addr;
         slot.phase = .connecting_upstream;
+        // Stamp the per-endpoint connect deadline base. tryNextDcEndpoint re-enters here
+        // for each endpoint, so this resets per attempt (see dc_connect_timeout_sec).
+        slot.upstream_connect_started_ms = nowMs();
 
         // For proxy upstreams, stash the real target address for the proxy handshake.
         if (connect_result.proxy_handshake != .none) {
@@ -4276,6 +4283,22 @@ const EventLoop = struct {
 
             if (slot.phase == .closing) {
                 self.closeSlot(slot, "closing phase");
+                continue;
+            }
+
+            // Per-endpoint upstream connect deadline. Fires only while a connect() is still
+            // in flight; lets failover advance to the next DC endpoint quickly instead of
+            // burning the whole (global) handshake_timeout_sec on one black-holed endpoint.
+            if (slot.phase == .connecting_upstream and self.state.config.dc_connect_timeout_sec > 0 and
+                slot.upstream_connect_started_ms > 0 and
+                now_ms - slot.upstream_connect_started_ms > secondsToMs(self.state.config.dc_connect_timeout_sec))
+            {
+                const failed_kind = slot.upstream_kind;
+                self.cleanupFailedUpstreamConnect(slot);
+                // Mirror onUpstreamConnectComplete's failure path: DC endpoints fail over to
+                // the next candidate; any other upstream kind (mask/proxy/middle) just closes.
+                if (failed_kind == .dc and self.tryNextDcEndpoint(slot, error.ConnectTimedOut)) continue;
+                self.closeSlot(slot, "dc connect timeout");
                 continue;
             }
 


### PR DESCRIPTION
Two improvements drawn from analysing [MTproxy-reanimation](https://github.com/Liafanx/MTproxy-reanimation) (a tuning wrapper for Telemt/MTProxyMax). That project is not a proxy fork — its value is *OS/network-level* techniques applied around a proxy. Of its five techniques, only two are worth porting; the other three we already do better or they conflict with our invariants (see "Not ported" below). Each kept technique was adversarially verified against our actual code.

---

## 1. `mtbuddy setup syn-limit` — optional kernel SYN rate-limiter (T1)

A **default-OFF**, per-source-IP inbound **SYN** rate-limiter on the proxy port via iptables `-m hashlimit`, run as a **separate systemd oneshot** (`mtproto-syn-limit.service`).

**Why it's not redundant with our in-proxy guards:** the handshake flood guard and per-/24 subnet limiter both run *after* `accept()` and **both default OFF** (NAT/VPN false-positives). So today every abusive SYN still costs a kernel socket + an `accept()` syscall. A kernel `hashlimit` drops excess SYNs **pre-accept** — a different layer, complementary not duplicate.

**Design choices**
- **iptables hashlimit**, not nftables — matches our existing stack (TCPMSS, nfqws); no new dependency.
- **Separate oneshot unit** so `CAP_NET_ADMIN` never has to be granted to `mtproto-proxy`.
- **Default OFF** behind a loud CGNAT/VPN warning (same shared-egress-IP problem that keeps the in-proxy guards off). Warns when `accept_proxy_protocol` is set (kernel sees the LB IP, not clients).
- Presets mirror the source: **soft** `2/s burst 5` (default when enabling, CGNAT-safer), **medium** `1/s burst 3`, **hard** `1/s burst 1`.
- Drop counter in `mtbuddy status`; verifies the rule actually landed (`xt_hashlimit` present) instead of a silent no-op.
- Idempotent apply + full uninstall cleanup (replay-delete INPUT jumps → flush → delete chain, v4 & v6). Generated script is brace-free (so `std.fmt` renders it) and rate/burst/port are validated before being baked in.

```
mtbuddy setup syn-limit --preset soft        # enable (CGNAT-safer default)
mtbuddy setup syn-limit --rate 1/second --burst 3
mtbuddy setup syn-limit --remove
mtbuddy setup syn-limit --status
```

## 2. `dc_connect_timeout_sec` — per-endpoint DC connect timeout (T2)

Default **10s**. A filtered/black-holed DC endpoint sends no RST, so the kernel sits in `SYN_SENT` ~2 min. `handshake_timeout_sec` (15s from the client's first byte) already caps the whole handshake — so we are **not** exposed to an unbounded hang — but that cap is **global**, so a slow first endpoint starves the failover budget for the rest. This fails one dead endpoint fast and lets failover advance to the next, within the overall handshake ceiling.

Mirrors `onUpstreamConnectComplete`'s failure path exactly (`cleanupFailedUpstreamConnect` → `tryNextDcEndpoint` for `.dc`, else `closeSlot`), driven from the timer tick. The deadline base is stamped per attempt and gated on `phase == .connecting_upstream`, so it can never touch an established relay; a healthy connect finishes in <1s, so working endpoints are unaffected. Deliberately does **not** raise `handshake_timeout_sec` (that would widen the active-probe/slow-loris window our DD-decision + flood guards exist to shrink).

---

## Not ported (verified against our code)
- **iOS keepalive sysctl (60/15/3):** no-op for us — relay sockets already set `SO_KEEPALIVE 60/10/3` + `TCP_USER_TIMEOUT=30s` (stricter), and a host-wide sysctl can't touch the pre-handshake sockets that lack `SO_KEEPALIVE` (already reaped by our idle/handshake timeouts).
- **iOS MSS=92 + separate port DNAT:** a second port = a second `tg://` link (our links are immutable once distributed — hard no); the MSS half overlaps/conflicts with our existing `TCPMSS=88`; and it's a mechanism-free folk remedy for the iOS resume hang we already root-caused to the client MtProtoKit `bad_server_salt` bug (shipped `client_silence_close_sec`, filed Telegram-iOS#2197).
- **Deployment autodetection + systemd persistence:** already implemented for our own stack.

## Testing
- `zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux -Dcpu=x86_64_v3+aes` ✅
- `zig build test` ✅ (new unit tests: SYN-limit preset/rate/number validation + brace-free script render; `dc_connect_timeout_sec` parse/default).
- Proxy core change is byte-transparent and off the happy path; the firewall feature is opt-in and isolated in its own unit.