### PR TITLE
fix(ctl): repair dead pool-failover timer + auto-heal stale WG sessions

### DIFF
--- a/src/ctl/tunnel_wg.zig
+++ b/src/ctl/tunnel_wg.zig
@@ -997,8 +997,12 @@ fn installTunnelPoolUnits(ui: *Tui, allocator: std.mem.Allocator) void {
         \\Description=Run MTProto tunnel pool failover checks
         \\
         \\[Timer]
-        \\OnBootSec=30s
-        \\OnUnitInactiveSec=30s
+        \\# OnCalendar (not OnBootSec+OnUnitInactiveSec): the latter never re-arms
+        \\# after a bare `systemctl restart` of just the .timer without a reboot,
+        \\# since OnBootSec already fired for this boot and OnUnitInactiveSec has
+        \\# no fresh unit-inactive transition to key off of. OnCalendar recomputes
+        \\# from wall-clock every time, so it can't get stuck this way.
+        \\OnCalendar=*-*-* *:*:00/30
         \\RandomizedDelaySec=5s
         \\Persistent=true
         \\
@@ -1032,6 +1036,13 @@ fn renderTunnelPoolScript(allocator: std.mem.Allocator) ![]const u8 {
         \\TABLE=200
         \\RULE_PRIORITY=1200
         \\PROBE_URL="https://core.telegram.org/getProxyConfig"
+        \\# A WG/AWG session can go quietly stale (e.g. after the host or its network
+        \\# path hiccups) without the interface ever going down -- same failure mode as
+        \\# a phone VPN that shows "connected" but passes nothing until toggled off/on.
+        \\# After this many CONSECUTIVE degraded checks for an interface, bounce it
+        \\# (down/up) once to force a fresh handshake before falling back to it. Kept
+        \\# >1 cycle so a single transient probe blip doesn't churn a healthy tunnel.
+        \\BOUNCE_AFTER_DEGRADED_CHECKS=2
         \\
         \\mkdir -p "$STATE_DIR"
         \\
@@ -1147,6 +1158,30 @@ fn renderTunnelPoolScript(allocator: std.mem.Allocator) ![]const u8 {
         \\    "$quick" up "$conf" >/dev/null 2>&1
         \\}
         \\
+        \\degraded_streak_path() {
+        \\    printf '%s/degraded-streak-%s\n' "$STATE_DIR" "$1"
+        \\}
+        \\
+        \\read_degraded_streak() {
+        \\    local f; f="$(degraded_streak_path "$1")"
+        \\    [[ -f "$f" ]] && cat "$f" 2>/dev/null || printf '0\n'
+        \\}
+        \\
+        \\write_degraded_streak() {
+        \\    printf '%s\n' "$2" > "$(degraded_streak_path "$1")" 2>/dev/null || true
+        \\}
+        \\
+        \\bounce_iface() {
+        \\    local iface="$1"
+        \\    local quick conf
+        \\    quick="$(quick_tool_for "$iface")" || return 1
+        \\    conf="$(conf_path_for "$iface")"
+        \\    [[ -f "$conf" ]] || return 1
+        \\    log "tunnel $iface degraded for $BOUNCE_AFTER_DEGRADED_CHECKS consecutive checks; bouncing to force a fresh handshake"
+        \\    "$quick" down "$conf" >/dev/null 2>&1 || true
+        \\    "$quick" up "$conf" >/dev/null 2>&1
+        \\}
+        \\
         \\policy_rule_exists() {
         \\    local mark_hex
         \\    mark_hex="$(printf '0x%x' "$MARK")"
@@ -1195,8 +1230,21 @@ fn renderTunnelPoolScript(allocator: std.mem.Allocator) ![]const u8 {
         \\    route_table_to_iface "$iface" || { reason="failed to install policy route"; return 1; }
         \\    policy_route_matches_iface "$iface" || { reason="policy route check failed"; return 1; }
         \\    if telegram_probe_iface "$iface"; then
+        \\        write_degraded_streak "$iface" 0
         \\        reason="healthy"
         \\        return 0
+        \\    fi
+        \\    local streak
+        \\    streak="$(( $(read_degraded_streak "$iface") + 1 ))"
+        \\    write_degraded_streak "$iface" "$streak"
+        \\    if [[ "$streak" -ge "$BOUNCE_AFTER_DEGRADED_CHECKS" ]]; then
+        \\        if bounce_iface "$iface" && telegram_probe_iface "$iface"; then
+        \\            write_degraded_streak "$iface" 0
+        \\            reason="healthy (recovered after bounce)"
+        \\            return 0
+        \\        fi
+        \\        log "tunnel $iface still unreachable after bounce"
+        \\        write_degraded_streak "$iface" 0
         \\    fi
         \\    # Usable (up + policy route installed) but can't reach Telegram through it.
         \\    # Return 2 ("degraded-usable") so pool selection PREFERS a tunnel that can
@@ -1514,10 +1562,30 @@ test "tunnel pool - script renders failover (prefer reachable, fall back to usab
     try std.testing.expect(std.mem.indexOf(u8, script, "pinned_interface") != null);
 }
 
-test "tunnel pool timer repeats after oneshot service exits" {
+test "tunnel pool script - degraded tunnel bounces after consecutive-failure threshold" {
+    const script = try renderTunnelPoolScript(std.testing.allocator);
+    defer std.testing.allocator.free(script);
+
+    // A stale WG/AWG session (interface up, no traffic passing -- the same failure
+    // mode as a phone VPN that needs a manual toggle) must self-heal via a down/up
+    // bounce, not just get marked degraded and reused forever.
+    try std.testing.expect(std.mem.indexOf(u8, script, "BOUNCE_AFTER_DEGRADED_CHECKS=2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "bounce_iface()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "\"$quick\" down \"$conf\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "\"$quick\" up \"$conf\"") != null);
+    // Streak resets on success so only CONSECUTIVE failures trigger a bounce.
+    try std.testing.expect(std.mem.indexOf(u8, script, "write_degraded_streak \"$iface\" 0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "recovered after bounce") != null);
+}
+
+test "tunnel pool timer uses OnCalendar for the failover-check schedule" {
+    // A boot-relative + unit-inactive-relative pair was confirmed live to permanently
+    // stop re-arming after a bare `systemctl restart` of just the .timer (no reboot):
+    // OnBootSec only fires once per boot, and the inactive-relative trigger has no
+    // fresh transition to key off of until the paired .service is kicked some other
+    // way. OnCalendar recomputes from wall-clock every time, so it can't get stuck.
     const source = @embedFile("tunnel_wg.zig");
-    const needle = "OnUnitInactiveSec" ++ "=30s";
-    try std.testing.expect(std.mem.indexOf(u8, source, needle) != null);
+    try std.testing.expect(std.mem.indexOf(u8, source, "OnCalendar=*-*-* *:*:00/30") != null);
 }
 
 test "tunnel deps - Debian uses explicit Amnezia Launchpad focal source" {


### PR DESCRIPTION
## Context

Investigated a report that the proxy on prod (`proxy.sleep3r.ru`) had effectively stopped working, on the theory that the WG/AWG tunnel goes stale the same way a phone VPN does after the host wakes from sleep or a network blip — connected-looking but passing nothing until manually toggled.

Live diagnosis on the box turned up a real, separate bug: `mtproto-tunnel-pool.timer` had been dormant for 10+ days. `systemctl status` reported it `active`, but `LastTriggerUSec` was stuck at its last firing on Jul 22 and `NextElapseUSecRealtime` was empty — the self-healing failover loop from the earlier audit remediation had silently stopped running.

Root cause: the timer used `OnBootSec=30s` + `OnUnitInactiveSec=30s`. That combination re-arms by chaining off the paired `.service`'s own inactive-transition. A bare `systemctl restart mtproto-tunnel-pool.timer` (no reboot) breaks the chain for good: `OnBootSec` already fired for the current boot and won't again, and `OnUnitInactiveSec` has no fresh transition to key off of until the `.service` is kicked some other way. Reproduced live — `systemctl restart` alone never re-armed it; manually running the `.service` once did (gave `OnUnitInactiveSec` a transition to compute from), confirming the fix.

## Changes

- Switch the generated timer to `OnCalendar=*-*-* *:*:00/30`, which recomputes from wall-clock every time and can't get stuck this way.
- `probe_iface()` could mark a tunnel "up but Telegram-unreachable" and, with a single tunnel in the pool, just keep routing through it degraded indefinitely — never actually attempting the equivalent of a manual VPN toggle. Track consecutive degraded checks per interface in a state file; after `BOUNCE_AFTER_DEGRADED_CHECKS` (2, ~60s at the 30s cadence) in a row, bounce the interface (`$quick down` / `up`) once to force a fresh handshake and re-probe, before falling back to degraded. Kept above 1 cycle so a single transient probe blip doesn't churn a healthy tunnel; the streak resets on success or after an attempted bounce so a genuinely-blocked destination isn't bounced every cycle forever.

## Not included (deliberate)

- The live incident also showed intermittent bursts of `media path connect failed after all candidates: error.ConnectTimedOut` against real Telegram DC IPs, while the tunnel itself tested healthy (fresh WG handshake, manual TCP connects to those same IPs succeeded, generic Telegram probe passed). That looks more like transient reachability to specific DC ranges through the tunnel's upstream than a stale local session, and isn't something this PR's health probe would catch or fix — needs more observation before changing anything there.

## Testing

- New/updated rendered-script assertion tests for both the `OnCalendar` schedule and the bounce-after-threshold behavior.
- `zig build test`: 269/269 pass.
- `zig build -Dtarget=x86_64-linux-gnu`: clean.
- Hotfixed the live timer on prod by hand (manual `systemctl start` of the `.service` to re-seed it) to restore monitoring immediately, ahead of this fix shipping.

## Follow-ups

- Watch prod for further `media path connect failed` bursts now that the pool-failover loop is confirmed running again; if they correlate with tunnel degradation next time, the bounce path here should catch it.