### PR TITLE
fix(ctl): make the already-multi-distro paths work, and fail honestly where they don't

### DIFF
--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -58,15 +58,36 @@ install_minisign_if_needed() {
       install_minisign_from_upstream
     fi
   elif command -v dnf >/dev/null 2>&1; then
-    dnf install -y minisign || fail "dnf could not install minisign"
+    # RHEL/Rocky need EPEL for minisign, which we are not going to enable on someone
+    # else's box — fall through to the pinned upstream binary instead of dying, exactly
+    # like the apt branch does. Same for the rest below.
+    dnf install -y minisign || {
+      step "dnf could not install minisign, using pinned upstream binary"
+      install_minisign_from_upstream
+    }
   elif command -v yum >/dev/null 2>&1; then
-    yum install -y minisign || fail "yum could not install minisign"
+    yum install -y minisign || {
+      step "yum could not install minisign, using pinned upstream binary"
+      install_minisign_from_upstream
+    }
   elif command -v apk >/dev/null 2>&1; then
-    apk add --no-cache minisign || fail "apk could not install minisign"
+    apk add --no-cache minisign || {
+      step "apk could not install minisign, using pinned upstream binary"
+      install_minisign_from_upstream
+    }
   elif command -v pacman >/dev/null 2>&1; then
-    pacman -Sy --noconfirm minisign || fail "pacman could not install minisign"
+    # NOT `pacman -Sy`: syncing the package database without also upgrading is a
+    # partial upgrade, and on a rolling distro it can pull a package whose dependencies
+    # the installed system no longer satisfies — i.e. break the host we came to help.
+    # We will not run a full `-Syu` on someone's machine either, so if the database is
+    # stale and this misses, the upstream binary covers it.
+    pacman -S --needed --noconfirm minisign || {
+      step "pacman could not install minisign, using pinned upstream binary"
+      install_minisign_from_upstream
+    }
   else
-    fail "minisign is required for signature verification, but no supported package manager was found (use --insecure or MTPROTO_INSECURE=1 to bypass)"
+    step "No supported package manager found, using pinned upstream minisign binary"
+    install_minisign_from_upstream
   fi
 
   command -v minisign >/dev/null 2>&1 \

--- a/src/ctl/install.zig
+++ b/src/ctl/install.zig
@@ -92,11 +92,15 @@ fn shouldInstallMinisignPackage(signature_available: bool, insecure_mode: bool, 
 const minisign_bootstrap_version = "0.12";
 const minisign_bootstrap_sha256 = "9a599b48ba6eb7b1e80f12f36b94ceca7c00b7a5173c95c3efc88d9822957e73";
 
-/// Install the pinned upstream minisign binary when apt has no minisign package.
-/// Mirrors deploy/bootstrap.sh: a SHA-256-verified tarball from the pinned
-/// jedisct1/minisign release, extracted for this CPU arch. Silent (runs under the
-/// deps spinner); returns true iff minisign is now resolvable on PATH.
-fn installMinisignFromUpstream(allocator: std.mem.Allocator) bool {
+/// Install the pinned upstream minisign binary when the host package manager has no
+/// minisign package. Mirrors deploy/bootstrap.sh: a SHA-256-verified tarball from the
+/// pinned jedisct1/minisign release, extracted for this CPU arch. Silent (runs under
+/// the deps spinner); returns true iff minisign is now resolvable on PATH.
+///
+/// Public because `mtbuddy update` needs the same fallback: it is the only path to a
+/// signature verifier on a host whose package manager we do not drive, and without it
+/// update refuses to run at all there.
+pub fn installMinisignFromUpstream(allocator: std.mem.Allocator) bool {
     const arch_name: []const u8 = switch (builtin.cpu.arch) {
         .x86_64 => "x86_64",
         .aarch64 => "aarch64",
@@ -635,7 +639,19 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
         sp.start();
         if (!sys.commandExists("apt-get")) {
             sp.stop(false, "");
-            ui.fail("apt-get is required to install system dependencies");
+            // Name the actual constraint instead of a missing binary: the installer is
+            // apt-shaped well past this point (nginx sites-enabled, ufw, the Amnezia
+            // PPA), so "install apt-get" would be actively bad advice.
+            ui.fail(localized(
+                ui,
+                "mtbuddy install supports Debian/Ubuntu hosts only — apt-get was not found",
+                "mtbuddy install пока поддерживает только Debian/Ubuntu — apt-get не найден",
+            ));
+            ui.info(localized(
+                ui,
+                "pacman (Arch) and dnf (RHEL/Fedora) support is tracked in https://github.com/sleep3r/mtproto.zig/issues/374",
+                "Поддержка pacman (Arch) и dnf (RHEL/Fedora) отслеживается в https://github.com/sleep3r/mtproto.zig/issues/374",
+            ));
             return;
         }
         if (!runRequiredWhileSpinning(ui, allocator, &.{ "env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "-o", "DPkg::Lock::Timeout=600", "update", "-qq" }, "apt-get update failed", &sp)) return;
@@ -647,9 +663,9 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
             "apt-get",                 "-o",
             "DPkg::Lock::Timeout=600", "install",
             "-y",                      "--no-install-recommends",
-            "iptables",                "xxd",
-            "curl",                    "openssl",
-            "tar",                     "passwd",
+            "iptables",                "curl",
+            "openssl",                 "tar",
+            "passwd",
         };
         if (!runRequiredWhileSpinning(ui, allocator, base_packages, "Failed to install system dependencies", &sp)) return;
         // qrencode powers the optional terminal/dashboard QR; the feature degrades

--- a/src/ctl/tunnel_wg.zig
+++ b/src/ctl/tunnel_wg.zig
@@ -53,6 +53,11 @@ pub const TunnelOpts = struct {
 const AwgRepositorySetup = enum {
     ubuntu_add_apt_repository,
     debian_launchpad_focal_source,
+    /// Not a Debian-family host. amneziawg-tools ships only in the Amnezia Launchpad
+    /// PPA (apt), is AUR-only on Arch — where pacman cannot install it and makepkg
+    /// refuses to run as root — and has no Fedora/EPEL package. There is nothing to
+    /// configure here, so say so instead of running apt commands that do not exist.
+    unsupported,
 };
 
 const ubuntu_awg_repo_prereqs = [_][]const u8{
@@ -652,6 +657,31 @@ fn looksLikeAwgConfig(content: []const u8) bool {
     return has_interface and has_peer;
 }
 fn ensureAmneziaWgInstalled(ui: *Tui, allocator: std.mem.Allocator) bool {
+    // Decide whether this host can work at all BEFORE running any apt command. Doing it
+    // the other way round reports "Failed to refresh apt package index" on a Fedora or
+    // Arch box, which reads as a transient mirror problem rather than "this feature is
+    // not available here".
+    const os_release = readFileAllocAbsolute(allocator, "/etc/os-release", 16 * 1024) catch null;
+    defer if (os_release) |content| allocator.free(content);
+    const repo_setup = awgRepositorySetupForOsRelease(os_release orelse "");
+
+    if (repo_setup == .unsupported) {
+        const ru = ui.lang == .ru;
+        ui.fail(if (ru)
+            "Туннели AmneziaWG работают только на Debian/Ubuntu"
+        else
+            "AmneziaWG tunnels need a Debian/Ubuntu host");
+        ui.info(if (ru)
+            "amneziawg-tools есть только в Amnezia Launchpad PPA: на Arch — лишь в AUR, в Fedora/EPEL пакета нет."
+        else
+            "amneziawg-tools ships only in the Amnezia Launchpad PPA: it is AUR-only on Arch and absent from Fedora/EPEL.");
+        ui.info(if (ru)
+            "Для VPN-эгресса на этом хосте используйте `mtbuddy setup egress \"<share-link>\"` — sing-box скачивается и работает на любом дистрибутиве."
+        else
+            "For VPN egress on this host use `mtbuddy setup egress \"<share-link>\"` instead — sing-box is a distro-independent download.");
+        return false;
+    }
+
     if (!runCommandChecked(
         ui,
         allocator,
@@ -659,13 +689,12 @@ fn ensureAmneziaWgInstalled(ui: *Tui, allocator: std.mem.Allocator) bool {
         "Failed to refresh apt package index",
     )) return false;
 
-    const os_release = readFileAllocAbsolute(allocator, "/etc/os-release", 16 * 1024) catch null;
-    defer if (os_release) |content| allocator.free(content);
-    const repo_setup = awgRepositorySetupForOsRelease(os_release orelse "");
-
     if (!installAwgRepositoryPrerequisites(ui, allocator, repo_setup)) return false;
 
     switch (repo_setup) {
+        // Handled above; `return false` rather than `unreachable`, which is UB in the
+        // ReleaseFast build that actually ships.
+        .unsupported => return false,
         .ubuntu_add_apt_repository => {
             if (!runCommandChecked(
                 ui,
@@ -723,12 +752,43 @@ fn awgRepositoryPrerequisitePackages(repo_setup: AwgRepositorySetup) []const []c
     return switch (repo_setup) {
         .ubuntu_add_apt_repository => &ubuntu_awg_repo_prereqs,
         .debian_launchpad_focal_source => &debian_awg_repo_prereqs,
+        .unsupported => &.{},
     };
 }
+/// Classify the host from /etc/os-release. ID_LIKE carries the derivatives — Raspbian
+/// reports ID=raspbian ID_LIKE=debian, Mint/Pop!_OS report ID_LIKE=ubuntu — so keying on
+/// ID alone would send them down the wrong arm.
+///
+/// An unreadable or unrecognised os-release falls back to apt-get's presence rather than
+/// straight to `.unsupported`: a Debian-family host with an exotic ID still works today,
+/// and this function must not start refusing it. Only a host with no apt at all — where
+/// every command below would fail anyway — is reported as unsupported.
 fn awgRepositorySetupForOsRelease(os_release: []const u8) AwgRepositorySetup {
+    return awgRepositorySetupFor(os_release, sys.commandExists("apt-get"));
+}
+/// The classification itself, with the one environment probe passed in so it stays a
+/// pure function: the tests below must assert the Arch/Fedora outcome unconditionally,
+/// and a `commandExists` call inside here would make them pass only on machines that
+/// happen to lack apt (i.e. skip on the Ubuntu CI runner, exactly where it matters).
+fn awgRepositorySetupFor(os_release: []const u8, apt_available: bool) AwgRepositorySetup {
     const id = osReleaseValue(os_release, "ID") orelse "";
+    const id_like = osReleaseValue(os_release, "ID_LIKE") orelse "";
+
     if (std.ascii.eqlIgnoreCase(id, "debian")) return .debian_launchpad_focal_source;
-    return .ubuntu_add_apt_repository;
+    if (std.ascii.eqlIgnoreCase(id, "ubuntu")) return .ubuntu_add_apt_repository;
+    if (osReleaseListContains(id_like, "ubuntu")) return .ubuntu_add_apt_repository;
+    if (osReleaseListContains(id_like, "debian")) return .debian_launchpad_focal_source;
+
+    return if (apt_available) .ubuntu_add_apt_repository else .unsupported;
+}
+/// ID_LIKE is a space-separated list ("ID_LIKE=ubuntu debian"), so a substring search
+/// would match "notubuntu" too. Compare whole entries.
+fn osReleaseListContains(list: []const u8, needle: []const u8) bool {
+    var it = std.mem.tokenizeAny(u8, list, " \t");
+    while (it.next()) |entry| {
+        if (std.ascii.eqlIgnoreCase(entry, needle)) return true;
+    }
+    return false;
 }
 fn osReleaseValue(content: []const u8, key: []const u8) ?[]const u8 {
     var lines = std.mem.splitScalar(u8, content, '\n');
@@ -1627,6 +1687,74 @@ test "tunnel deps - Ubuntu keeps add-apt-repository PPA path" {
     const prereqs = awgRepositoryPrerequisitePackages(.ubuntu_add_apt_repository);
     try std.testing.expect(containsString(prereqs, "software-properties-common"));
     try std.testing.expect(containsString(prereqs, "python3-launchpadlib"));
+}
+
+test "tunnel deps - Debian/Ubuntu derivatives follow ID_LIKE" {
+    // Raspbian is Debian with its own ID; Mint and Pop!_OS are Ubuntu with theirs.
+    // Keying on ID alone sent every one of them down the Ubuntu arm.
+    const raspbian =
+        \\PRETTY_NAME="Raspbian GNU/Linux 12 (bookworm)"
+        \\ID=raspbian
+        \\ID_LIKE=debian
+    ;
+    try std.testing.expectEqual(
+        AwgRepositorySetup.debian_launchpad_focal_source,
+        awgRepositorySetupFor(raspbian, false),
+    );
+
+    const mint =
+        \\PRETTY_NAME="Linux Mint 22"
+        \\ID=linuxmint
+        \\ID_LIKE="ubuntu debian"
+    ;
+    try std.testing.expectEqual(
+        AwgRepositorySetup.ubuntu_add_apt_repository,
+        awgRepositorySetupFor(mint, false),
+    );
+
+    // Whole-entry match: a distro whose ID_LIKE merely CONTAINS the substring is not
+    // a Debian derivative.
+    try std.testing.expect(!osReleaseListContains("notubuntu debianish", "ubuntu"));
+    try std.testing.expect(!osReleaseListContains("notubuntu debianish", "debian"));
+    try std.testing.expect(osReleaseListContains("rhel fedora", "fedora"));
+}
+
+test "tunnel deps - Arch and Fedora are reported as unsupported, not run through apt" {
+    // amneziawg-tools is AUR-only on Arch and absent from Fedora/EPEL. Both used to
+    // fall through to the Ubuntu arm and shell out to `add-apt-repository`, a command
+    // that does not exist there.
+    const arch =
+        \\PRETTY_NAME="Arch Linux"
+        \\ID=arch
+    ;
+    const fedora =
+        \\PRETTY_NAME="Fedora Linux 43 (Server Edition)"
+        \\ID=fedora
+        \\ID_LIKE=""
+    ;
+    const rocky =
+        \\PRETTY_NAME="Rocky Linux 9.4 (Blue Onyx)"
+        \\ID="rocky"
+        \\ID_LIKE="rhel centos fedora"
+    ;
+
+    for ([_][]const u8{ arch, fedora, rocky }) |os_release| {
+        try std.testing.expectEqual(AwgRepositorySetup.unsupported, awgRepositorySetupFor(os_release, false));
+    }
+
+    // The apt fallback is deliberately generous: an apt host with an ID we do not know
+    // keeps working exactly as before rather than newly refusing.
+    try std.testing.expectEqual(
+        AwgRepositorySetup.ubuntu_add_apt_repository,
+        awgRepositorySetupFor("ID=someunknownapthost", true),
+    );
+    try std.testing.expectEqual(
+        AwgRepositorySetup.unsupported,
+        awgRepositorySetupFor("", false),
+    );
+
+    // An unsupported host asks for no repository prerequisites at all.
+    try std.testing.expectEqual(@as(usize, 0), awgRepositoryPrerequisitePackages(.unsupported).len);
 }
 
 test "tunnel - converts Amnezia vpn link to AWG config" {

--- a/src/ctl/update.zig
+++ b/src/ctl/update.zig
@@ -98,10 +98,21 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: UpdateOpts) !void {
     // ── Ensure signature verifier dependency ──
     if (signature_available and !insecure_mode and !sys.commandExists("minisign")) {
         ui.step("Installing minisign for release signature verification...");
-        _ = sys.exec(allocator, &.{ "apt-get", "-o", "DPkg::Lock::Timeout=600", "update", "-qq" }) catch {};
-        _ = sys.exec(allocator, &.{ "apt-get", "-o", "DPkg::Lock::Timeout=600", "install", "-y", "minisign" }) catch {};
+        // apt first where it exists, then the pinned, SHA-256-verified upstream binary —
+        // the same order `mtbuddy install` uses. The fallback is what makes this work on
+        // a host we do not have a package manager for: without it, an apt-less system
+        // (or an apt release with no minisign, e.g. Ubuntu 20.04 focal) could never
+        // update at all, even though nothing else about updating is Debian-specific.
+        if (sys.commandExists("apt-get")) {
+            _ = sys.exec(allocator, &.{ "apt-get", "-o", "DPkg::Lock::Timeout=600", "update", "-qq" }) catch {};
+            _ = sys.exec(allocator, &.{ "apt-get", "-o", "DPkg::Lock::Timeout=600", "install", "-y", "minisign" }) catch {};
+        }
+        if (!sys.commandExists("minisign")) {
+            _ = install.installMinisignFromUpstream(allocator);
+        }
         if (!sys.commandExists("minisign")) {
             ui.fail("minisign is required for release signature verification");
+            ui.info("Neither the host package manager nor the pinned upstream binary could provide it (check network / checksum), or re-run with --insecure.");
             return;
         }
         ui.ok("minisign installed");


### PR DESCRIPTION
Groundwork for #374. **This does not add pacman/dnf support to the installer** — Debian/Ubuntu stays the only supported install target. It fixes the paths that *already* claim to handle other distros, and replaces three misleading failures with honest ones.

## `mtbuddy update` hard-failed on every non-apt host

`update.zig` ran apt unconditionally to fetch minisign and gave up if that produced nothing — while the pinned, SHA-256-verified upstream binary that `install.zig` already falls back to sat two files away. Nothing else about updating is Debian-specific; the signature verifier was the only thing in the way.

`installMinisignFromUpstream` is now `pub`, and update tries apt first (where apt exists), then it. This also fixes Ubuntu 20.04 focal, whose apt has no minisign — `install` handled that, `update` did not.

## `deploy/bootstrap.sh` dispatched five package managers but only apt could recover

The dnf/yum/apk/pacman branches called `fail` where the apt branch fell back to the upstream binary. RHEL and Rocky need EPEL for minisign, which is not something to enable on someone else's box — they now fall through like apt does.

`pacman -Sy` also became `pacman -S --needed`. Syncing the package database without upgrading is a partial upgrade, and on a rolling distro it can leave the host with a package whose dependencies it no longer satisfies — i.e. break the machine we came to help. Running a full `-Syu` on someone's box is not ours to do either, so a stale database now lands on the upstream binary instead.

## AmneziaWG: an explicit `.unsupported` arm

`awgRepositorySetupForOsRelease` was the only `/etc/os-release` read in the tree, and a two-way switch: `ID=debian`, or *assume Ubuntu*. An Arch or Fedora host silently took the Ubuntu arm.

- It now reads `ID_LIKE` too — Raspbian is `ID=raspbian ID_LIKE=debian`, Mint and Pop!_OS are `ID_LIKE=ubuntu`, and keying on `ID` alone sent every derivative down the wrong arm. Whole-entry match, not substring.
- A host that is neither Debian-family nor has apt at all is now reported as unsupported. `amneziawg-tools` ships only in the Amnezia Launchpad PPA: it is **AUR-only on Arch** (pacman cannot install AUR packages, and `makepkg` refuses to run as root — there is no root-only non-interactive path at all) and has **no Fedora/EPEL package**. The message points at `mtbuddy setup egress`, which is distro-independent.
- The check moved **ahead of the first `apt-get` call**, which previously reported "Failed to refresh apt package index" — reads as a transient mirror problem rather than "this feature is not available here".
- The classifier keeps an apt-presence fallback, so a Debian-family host with an exotic `ID` works exactly as before rather than newly refusing. It takes that probe as a parameter so the tests can assert the Arch/Fedora outcome on the apt-having CI runner instead of skipping there.

## Honest install gate

"apt-get is required to install system dependencies" → names the constraint and links #374. The installer is apt-shaped well past that gate (nginx `sites-enabled`, ufw, the PPA), so "install apt-get" would be actively bad advice. New user-facing strings are localized (en/ru).

## Dropped `xxd`

It was used by the pre-mtbuddy `deploy/install.sh` to hex-encode `tls_domain` for the share link (b87872d, `DOMAIN_HEX=$(echo -n "$TLS_DOMAIN" | xxd -p)`). The native installer has done that in Zig since #116. The base package list was its last reference anywhere in the tree.

## Tests

Two new `tunnel_wg` tests, mutation-checked — reverting the `.unsupported` arm and swapping the whole-entry `ID_LIKE` match for a substring search each fail one. `zig build test`: 278 proxy + 75 ctl, green.

The real gate for these files is the installer E2E (5 legs, systemd in privileged docker), which is Linux-only and cannot run on macOS — it runs here in CI.

## Not in scope

Tier 1+ of #374 (a package-manager abstraction, firewalld, the nginx `conf.d` layout, SELinux) is deliberately out. Notably `install.zig`'s `ufw` guard still silently skips on a firewalld host — harmless today because the apt gate aborts long before it, and it becomes reachable only when the installer actually supports those distros.