### PR TITLE
fix(egress): repair an existing sing-box egress from `mtbuddy update`

### DIFF
--- a/src/ctl/toml.zig
+++ b/src/ctl/toml.zig
@@ -247,10 +247,13 @@ fn parseKeyValue(line: []const u8) ?KeyValue {
     return .{ .key = raw_key, .value = raw_value };
 }
 
+/// Allocates rather than formatting through a fixed buffer: a 512-byte ceiling here
+/// silently turned any longer value into error.OutOfMemory at the call site. That is not
+/// theoretical — `[upstream.xray] links` holds the whole share-link array on one line, and
+/// three VLESS-Reality links already exceed it, so a three-endpoint `setup egress` pool
+/// failed to write ANY of its config.toml keys (including `[upstream] type = tunnel`).
 fn formatKv(allocator: std.mem.Allocator, key: []const u8, value: []const u8) ![]const u8 {
-    var buf: [512]u8 = undefined;
-    const formatted = std.fmt.bufPrint(&buf, "{s} = {s}", .{ key, value }) catch return error.OutOfMemory;
-    return try allocator.dupe(u8, formatted);
+    return std.fmt.allocPrint(allocator, "{s} = {s}", .{ key, value });
 }
 
 test "parseKeyValue: escaped quote does not truncate at a following '#'" {
@@ -294,4 +297,36 @@ test "set/get round-trips a dotted (non-allowlisted) section with brackets" {
         if (std.mem.eql(u8, std.mem.trim(u8, line, " \t\r"), "[upstream.xray]")) count += 1;
     }
     try std.testing.expectEqual(@as(usize, 1), count);
+}
+
+test "TomlDoc.set survives a value longer than the old fixed buffer" {
+    // Regression: formatKv used a [512]u8 and reported error.OutOfMemory above it, which
+    // aborted wireUpstreamTunnel for any egress pool of three or more share links.
+    const a = std.testing.allocator;
+    var doc = TomlDoc.initEmpty(a);
+    defer doc.deinit();
+
+    var long: std.ArrayListUnmanaged(u8) = .empty;
+    defer long.deinit(a);
+    try long.append(a, '[');
+    for (0..3) |i| {
+        if (i != 0) try long.append(a, ',');
+        try long.append(a, '"');
+        try long.appendSlice(a, "vless://95e0edb9-4a0b-4312-a71f-1d4b8b6db79b@154.59.110.32:443" ++
+            "?type=tcp&security=reality&pbk=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" ++
+            "&sni=www.microsoft.com&sid=0123456789abcdef&flow=xtls-rprx-vision#endpoint");
+        try long.append(a, '"');
+    }
+    try long.append(a, ']');
+    try std.testing.expect(long.items.len > 512);
+
+    try doc.set("upstream.xray", "links", long.items);
+
+    const rendered = try doc.render(a);
+    defer a.free(rendered);
+    try std.testing.expect(std.mem.indexOf(u8, rendered, long.items) != null);
+
+    // And it is readable back in one piece.
+    const read_back = doc.get("upstream.xray", "links") orelse return error.TestExpectedEqual;
+    try std.testing.expectEqualStrings(long.items, read_back);
 }

--- a/src/ctl/tunnel_singbox.zig
+++ b/src/ctl/tunnel_singbox.zig
@@ -445,8 +445,8 @@ fn setupSingboxTunnel(ui: *Tui, allocator: std.mem.Allocator, link_texts: []cons
     if (sys.fileExists(CONFIG_PATH)) {
         // Order mtproto-proxy after the egress so sbx0 + its route exist before the proxy
         // marks DC sockets — otherwise a reboot races and DC connects fail until retry.
-        _ = sys.exec(allocator, &.{ "mkdir", "-p", "/etc/systemd/system/mtproto-proxy.service.d" }) catch {};
-        sys.writeFile("/etc/systemd/system/mtproto-proxy.service.d/egress.conf", PROXY_EGRESS_DROPIN) catch {};
+        _ = sys.exec(allocator, &.{ "mkdir", "-p", PROXY_DROPIN_DIR }) catch {};
+        sys.writeFile(PROXY_DROPIN_PATH, PROXY_EGRESS_DROPIN) catch {};
         _ = sys.exec(allocator, &.{ "systemctl", "daemon-reload" }) catch {};
         wireUpstreamTunnel(allocator, link_texts) catch {
             ui.warn("tunnel is up, but updating config.toml failed — set [upstream] type=tunnel, [upstream.tunnel] interface=" ++ TUN_IFACE ++ " manually");
@@ -481,6 +481,213 @@ fn wireUpstreamTunnel(allocator: std.mem.Allocator, link_texts: []const []const 
     try arr.append(allocator, ']');
     try doc.set("upstream.xray", "links", arr.items);
     try doc.save(CONFIG_PATH);
+}
+
+const PROXY_DROPIN_DIR = "/etc/systemd/system/mtproto-proxy.service.d";
+const PROXY_DROPIN_PATH = PROXY_DROPIN_DIR ++ "/egress.conf";
+
+/// Split a TOML string-array value (`["a","b"]`) into its elements, as slices INTO
+/// `value`. Deliberately forgiving rather than a real TOML array parser: the only value
+/// it reads is `[upstream.xray] links`, which wireUpstreamTunnel writes itself as plain
+/// quoted share links with no escaping, so nothing fancier can be in there.
+fn parseTomlStringArray(a: std.mem.Allocator, value: []const u8) ![]const []const u8 {
+    var out: std.ArrayListUnmanaged([]const u8) = .empty;
+    errdefer out.deinit(a);
+
+    var i: usize = 0;
+    while (i < value.len) {
+        const open = std.mem.indexOfScalarPos(u8, value, i, '"') orelse break;
+        const close = std.mem.indexOfScalarPos(u8, value, open + 1, '"') orelse break;
+        if (close > open + 1) try out.append(a, value[open + 1 .. close]);
+        i = close + 1;
+    }
+    return out.toOwnedSlice(a);
+}
+
+const SB_SERVER_KEY = "\"server\":\"";
+const SB_PORT_KEY = "\"server_port\":";
+
+/// The `"server":"H","server_port":N` descriptor `sbOutbound` emits, spanning from
+/// `start` to the end of the port digits. Returns null when the pair is malformed.
+fn egressEndpointAt(cfg: []const u8, start: usize) ?[]const u8 {
+    const port_at = std.mem.indexOfPos(u8, cfg, start + SB_SERVER_KEY.len, SB_PORT_KEY) orelse return null;
+    var end = port_at + SB_PORT_KEY.len;
+    while (end < cfg.len and std.ascii.isDigit(cfg[end])) end += 1;
+    if (end == port_at + SB_PORT_KEY.len) return null;
+    return cfg[start..end];
+}
+
+fn countEgressEndpoints(cfg: []const u8) usize {
+    var n: usize = 0;
+    var i: usize = 0;
+    while (std.mem.indexOfPos(u8, cfg, i, SB_SERVER_KEY)) |at| : (n += 1) {
+        i = at + SB_SERVER_KEY.len;
+    }
+    return n;
+}
+
+/// Do `existing` and `cfg` describe the same set of egress endpoints?
+///
+/// `[upstream.xray] links` is a best-effort RECORD, not the source of truth:
+/// setupSingboxTunnel writes singbox-egress.json and starts the egress BEFORE it updates
+/// config.toml, and a failure there is a warning, not a rollback. So a host can genuinely
+/// be running endpoints the recorded links no longer mention — growing a single-endpoint
+/// egress into a pool used to do exactly that, because the old formatKv ceiling aborted
+/// the config.toml write once the link array passed 512 bytes.
+///
+/// Regenerating blindly there would swap a live pool for a dead endpoint, restart into
+/// it, and report success. So repair only what we can prove is the same egress: every
+/// endpoint currently configured must survive into the new config, and the count must
+/// match so nothing is added either. Both sides come from the same generator, so an
+/// in-sync host compares equal by construction.
+fn sameEgressEndpoints(existing: []const u8, cfg: []const u8) bool {
+    if (countEgressEndpoints(existing) != countEgressEndpoints(cfg)) return false;
+
+    var i: usize = 0;
+    while (std.mem.indexOfPos(u8, existing, i, SB_SERVER_KEY)) |at| {
+        const descriptor = egressEndpointAt(existing, at) orelse return false;
+        if (std.mem.indexOf(u8, cfg, descriptor) == null) return false;
+        i = at + descriptor.len;
+    }
+    return true;
+}
+
+/// Does this sing-box config already carry the repaired TUN shape?
+fn singboxConfigIsCurrent(cfg: []const u8) bool {
+    return std.mem.indexOf(u8, cfg, "\"" ++ TUN_ADDR ++ "\"") != null and
+        std.mem.indexOf(u8, cfg, "\"stack\":\"" ++ TUN_STACK ++ "\"") != null and
+        std.mem.indexOf(u8, cfg, "\"mtu\":" ++ TUN_MTU) != null;
+}
+
+fn egressManualHint(ui: *Tui) void {
+    ui.warn(trL(
+        ui,
+        "The sing-box egress predates the TUN fixes and could not be regenerated automatically.",
+        "sing-box egress создан до починки TUN, и перегенерировать его автоматически не вышло.",
+    ));
+    ui.info(trL(
+        ui,
+        // -F, because in a POSIX regex `[upstream.xray]` is a bracket EXPRESSION: it
+        // matches one character from that set, so `^[upstream.xray]` never matches the
+        // section header and does match `user1 = "<secret>"` — printing secrets instead
+        // of links.
+        "Re-run: mtbuddy setup egress '<share-link>' [...]  (recover the links with: grep -A2 -F '[upstream.xray]' " ++ CONFIG_PATH ++ ")",
+        "Запустите заново: mtbuddy setup egress '<share-link>' [...]  (ссылки можно достать: grep -A2 -F '[upstream.xray]' " ++ CONFIG_PATH ++ ")",
+    ));
+}
+
+/// Repair an egress provisioned before the TUN fixes, in place — the `mtbuddy update`
+/// counterpart of install.refreshTcpmssLoopbackExclusion / nfqws.refreshLoopbackExclusion.
+///
+/// The files `setup egress` writes are created once, at setup time, and an ordinary
+/// update regenerates none of them. Without this an upgraded host keeps the /30 address
+/// (whose next address sing-tun hands to systemd-resolved as sbx0's DNS server, killing
+/// all resolution), the system stack and the default MTU (every bulk transfer dropped
+/// while the egress reports itself up), and the orphaned
+/// `ExecStartPre=+/usr/local/bin/setup_tunnel.sh` that restart-loops the proxy with
+/// 203/EXEC — until somebody happens to re-run `setup egress` by hand.
+///
+/// No-op when no egress is configured, and no-op again once repaired.
+pub fn refreshEgress(ui: *Tui, allocator: std.mem.Allocator) void {
+    if (!sys.fileExists(SB_SERVICE_PATH)) return;
+    refreshProxyDropin(ui, allocator);
+    refreshSingboxConfig(ui, allocator);
+}
+
+/// Repairs an EXISTING drop-in only. A host whose egress predates this never had the
+/// ordering either, and quietly adding an After=/Wants= to a unit during an update is a
+/// bigger step than clearing a line that is actively breaking it.
+fn refreshProxyDropin(ui: *Tui, allocator: std.mem.Allocator) void {
+    const existing = sys.readFileAllocAbsolute(allocator, PROXY_DROPIN_PATH, 16 * 1024) orelse return;
+    defer allocator.free(existing);
+    if (std.mem.indexOf(u8, existing, "\nExecStartPre=\n") != null) return;
+
+    sys.writeFile(PROXY_DROPIN_PATH, PROXY_EGRESS_DROPIN) catch return;
+    _ = sys.exec(allocator, &.{ "systemctl", "daemon-reload" }) catch {};
+    ui.ok(trL(
+        ui,
+        "egress drop-in no longer runs a stale tunnel helper",
+        "egress drop-in больше не запускает устаревший tunnel-хелпер",
+    ));
+}
+
+fn refreshSingboxConfig(ui: *Tui, allocator: std.mem.Allocator) void {
+    const existing = sys.readFileAllocAbsolute(allocator, SB_CONFIG_PATH, 1024 * 1024) orelse return;
+    defer allocator.free(existing);
+    if (singboxConfigIsCurrent(existing)) return;
+
+    // The share links wireUpstreamTunnel recorded are the only way to rebuild the
+    // outbounds. Anything missing or unparseable here means we cannot regenerate
+    // faithfully — say so and change nothing rather than write a config that drops
+    // somebody's egress.
+    var doc = toml.TomlDoc.load(allocator, CONFIG_PATH) catch {
+        egressManualHint(ui);
+        return;
+    };
+    defer doc.deinit();
+    const raw = doc.get("upstream.xray", "links") orelse {
+        egressManualHint(ui);
+        return;
+    };
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const texts = parseTomlStringArray(a, raw) catch {
+        egressManualHint(ui);
+        return;
+    };
+    if (texts.len == 0) {
+        egressManualHint(ui);
+        return;
+    }
+
+    const parsed = a.alloc(XrayLink, texts.len) catch return;
+    for (texts, 0..) |t, i| {
+        parsed[i] = parseXrayLink(a, t) catch {
+            egressManualHint(ui);
+            return;
+        };
+        var vbuf: [256]u8 = undefined;
+        if (validateLink(parsed[i], &vbuf) != null) {
+            egressManualHint(ui);
+            return;
+        }
+    }
+
+    const cfg = genSingboxConfig(a, parsed) catch {
+        egressManualHint(ui);
+        return;
+    };
+
+    if (!sameEgressEndpoints(existing, cfg)) {
+        ui.warn(trL(
+            ui,
+            "The sing-box egress is running endpoints that [upstream.xray] links no longer describes — leaving it alone.",
+            "sing-box egress работает на эндпоинтах, которых уже нет в [upstream.xray] links — не трогаю его.",
+        ));
+        egressManualHint(ui);
+        return;
+    }
+
+    // Keep the file we are about to replace. The endpoints match, so this should never be
+    // needed — but it is one copy of the only on-disk record of a working egress.
+    _ = sys.exec(allocator, &.{ "cp", "-f", SB_CONFIG_PATH, SB_CONFIG_PATH ++ ".bak" }) catch {};
+
+    sys.writeFileMode(SB_CONFIG_PATH, cfg, 0o600) catch {
+        egressManualHint(ui);
+        return;
+    };
+    // A restart, not `enable --now`: sing-box parses its config only at startup, and
+    // `--now` is a no-op on a unit that is already running — which is exactly the host
+    // this repair exists for.
+    _ = sys.execForward(&.{ "systemctl", "restart", SB_SERVICE_NAME }) catch {};
+    ui.ok(trL(
+        ui,
+        "sing-box egress tun repaired (" ++ TUN_ADDR ++ ", stack " ++ TUN_STACK ++ ", mtu " ++ TUN_MTU ++ ")",
+        "sing-box egress tun починен (" ++ TUN_ADDR ++ ", stack " ++ TUN_STACK ++ ", mtu " ++ TUN_MTU ++ ")",
+    ));
 }
 
 fn ensureSingboxInstalled(ui: *Tui, allocator: std.mem.Allocator) bool {
@@ -611,6 +818,98 @@ test "the egress drop-in resets ExecStartPre so a stale tunnel helper can't brea
     // And it still orders the proxy after the egress, which is why the drop-in exists.
     try std.testing.expect(std.mem.indexOf(u8, PROXY_EGRESS_DROPIN, "After=" ++ SB_SERVICE_NAME) != null);
     try std.testing.expect(std.mem.indexOf(u8, PROXY_EGRESS_DROPIN, "Wants=" ++ SB_SERVICE_NAME) != null);
+}
+
+test "egress auto-repair: detects a stale config and accepts a freshly generated one" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const vless = try parseXrayLink(a, "vless://95e0edb9-4a0b-4312-a71f-1d4b8b6db79b@154.59.110.32:443?type=tcp&security=reality&pbk=PBK&sni=www.microsoft.com&sid=SID&flow=xtls-rprx-vision#v");
+    const fresh = try genSingboxConfig(a, &.{vless});
+    try std.testing.expect(singboxConfigIsCurrent(fresh));
+
+    // What `setup egress` wrote before v1.12.0: /30 address, system stack, no mtu. Each
+    // of the three defects on its own must be enough to trigger a regeneration, or a
+    // partially-repaired host is left in place.
+    const legacy = "{\"inbounds\":[{\"type\":\"tun\",\"interface_name\":\"sbx0\",\"address\":[\"172.19.0.1/30\"],\"auto_route\":false,\"stack\":\"system\"}]}";
+    try std.testing.expect(!singboxConfigIsCurrent(legacy));
+
+    const only_addr_stale = "{\"address\":[\"172.19.0.1/30\"],\"stack\":\"gvisor\",\"mtu\":1400}";
+    try std.testing.expect(!singboxConfigIsCurrent(only_addr_stale));
+
+    const only_stack_stale = "{\"address\":[\"172.19.0.1/32\"],\"stack\":\"system\",\"mtu\":1400}";
+    try std.testing.expect(!singboxConfigIsCurrent(only_stack_stale));
+
+    const only_mtu_missing = "{\"address\":[\"172.19.0.1/32\"],\"stack\":\"gvisor\"}";
+    try std.testing.expect(!singboxConfigIsCurrent(only_mtu_missing));
+}
+
+test "egress auto-repair: refuses to regenerate when the recorded links moved on" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const A = try parseXrayLink(a, "vless://95e0edb9-4a0b-4312-a71f-1d4b8b6db79b@154.59.110.32:443?type=tcp&security=reality&pbk=P&sni=s.example&sid=S&flow=xtls-rprx-vision#A");
+    const B = try parseXrayLink(a, "vless://95e0edb9-4a0b-4312-a71f-1d4b8b6db79b@198.51.100.7:443?type=tcp&security=reality&pbk=P&sni=s.example&sid=S&flow=xtls-rprx-vision#B");
+    const C = try parseXrayLink(a, "ss://YWVzLTI1Ni1nY206ZzdaR000c0JwNUZ1elBndktRZ1lnQQ==@203.0.113.9:9443#C");
+
+    const only_a = try genSingboxConfig(a, &.{A});
+    const pool_bc = try genSingboxConfig(a, &.{ B, C });
+
+    // Same egress, regenerated: every endpoint survives, so the repair may proceed.
+    try std.testing.expect(sameEgressEndpoints(only_a, try genSingboxConfig(a, &.{A})));
+    try std.testing.expect(sameEgressEndpoints(pool_bc, try genSingboxConfig(a, &.{ B, C })));
+
+    // The dangerous case: config.toml still records A while the host actually runs B+C
+    // (setup egress writes the JSON and starts the egress BEFORE updating config.toml,
+    // and that write used to abort on a long link array). Regenerating from A would
+    // replace a live pool with one dead endpoint.
+    try std.testing.expect(!sameEgressEndpoints(pool_bc, only_a));
+
+    // And the other direction: never quietly ADD endpoints the host was not running.
+    try std.testing.expect(!sameEgressEndpoints(only_a, try genSingboxConfig(a, &.{ A, B })));
+
+    // Same count, different host — a bare count check would let this through.
+    try std.testing.expect(!sameEgressEndpoints(only_a, try genSingboxConfig(a, &.{B})));
+
+    // A legacy (pre-1.12.0) config compares by endpoint, not by TUN shape: the outbound
+    // JSON is byte-identical across the TUN fix, so an in-sync host still matches.
+    const legacy_a = "{\"inbounds\":[{\"type\":\"tun\",\"address\":[\"172.19.0.1/30\"],\"stack\":\"system\"}]," ++
+        "\"outbounds\":[{\"type\":\"vless\",\"tag\":\"egress-0\",\"server\":\"154.59.110.32\",\"server_port\":443,\"uuid\":\"u\"}]}";
+    try std.testing.expect(!singboxConfigIsCurrent(legacy_a));
+    try std.testing.expect(sameEgressEndpoints(legacy_a, only_a));
+    try std.testing.expect(!sameEgressEndpoints(legacy_a, pool_bc));
+}
+
+test "egress auto-repair: reads the share links back out of [upstream.xray]" {
+    const a = std.testing.allocator;
+
+    // Exactly what wireUpstreamTunnel writes, as TomlDoc.get hands it back.
+    const one = try parseTomlStringArray(a, "[\"vless://a@1.2.3.4:443#x\"]");
+    defer a.free(one);
+    try std.testing.expectEqual(@as(usize, 1), one.len);
+    try std.testing.expectEqualStrings("vless://a@1.2.3.4:443#x", one[0]);
+
+    const pool = try parseTomlStringArray(a, "[\"vless://a@1.2.3.4:443#x\",\"ss://b@5.6.7.8:9443#y\"]");
+    defer a.free(pool);
+    try std.testing.expectEqual(@as(usize, 2), pool.len);
+    try std.testing.expectEqualStrings("ss://b@5.6.7.8:9443#y", pool[1]);
+
+    // Whitespace the operator may have introduced by hand, and the empty forms: an empty
+    // list must come back empty so the caller falls through to the manual hint rather
+    // than regenerating an outbound-less config.
+    const spaced = try parseTomlStringArray(a, "[ \"vless://a@1.2.3.4:443\" , \"trojan://c@9.9.9.9:443\" ]");
+    defer a.free(spaced);
+    try std.testing.expectEqual(@as(usize, 2), spaced.len);
+
+    const empty = try parseTomlStringArray(a, "[]");
+    defer a.free(empty);
+    try std.testing.expectEqual(@as(usize, 0), empty.len);
+
+    const blank_entry = try parseTomlStringArray(a, "[\"\"]");
+    defer a.free(blank_entry);
+    try std.testing.expectEqual(@as(usize, 0), blank_entry.len);
 }
 
 test "vmess scy maps to cipher and is emitted" {

--- a/src/ctl/update.zig
+++ b/src/ctl/update.zig
@@ -13,6 +13,7 @@ const web = @import("web.zig");
 const recovery = @import("recovery.zig");
 const install = @import("install.zig");
 const nfqws = @import("nfqws.zig");
+const tunnel_singbox = @import("tunnel_singbox.zig");
 
 const Tui = tui_mod.Tui;
 const Color = tui_mod.Color;
@@ -230,6 +231,16 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: UpdateOpts) !void {
         release.writeServiceFile();
     }
     _ = sys.execForward(&.{ "systemctl", "daemon-reload" }) catch {};
+
+    // ── Repair an existing sing-box egress ──
+    // Deliberately BEFORE the restart below, unlike the TCPMSS/nfqws repairs further
+    // down. The drop-in half of this clears the stale
+    // `ExecStartPre=+/usr/local/bin/setup_tunnel.sh` that leaves a host restart-looping
+    // with 203/EXEC — and such a host never reaches the post-restart repairs at all,
+    // because the failed restart returns through the rollback branch. On a healthy host
+    // the ordering is right anyway: sbx0 comes back up with the corrected TUN before the
+    // proxy starts marking DC sockets into it.
+    tunnel_singbox.refreshEgress(ui, allocator);
 
     // ── Start service ──
     ui.step(ui.str(.update_starting));


### PR DESCRIPTION
v1.12.0 fixed the sing-box TUN — but only for hosts that ran `setup egress` again afterwards. The files that command writes are created once, at setup time, and an ordinary update regenerates none of them, so every already-provisioned egress kept all three defects:

- the `/30` address, whose next address sing-tun hands to systemd-resolved as sbx0's DNS server, killing **all** host DNS;
- the system stack and the default MTU — every bulk transfer dropped, while the egress reports itself up;
- the orphaned `ExecStartPre=+/usr/local/bin/setup_tunnel.sh` that restart-loops the proxy with 203/EXEC.

The v1.12.0 release notes documented the manual recovery. This makes it automatic, the way v1.11.0 taught `mtbuddy update` to repair the TCPMSS script and the nfqws unit.

## Ordering: before the proxy restart, not after

Unlike `refreshTcpmssLoopbackExclusion` / `refreshLoopbackExclusion`, this runs **before** the "Start service" restart. A host stuck in the 203/EXEC loop never reaches the post-restart repairs at all — the failed restart returns through the rollback branch. On a healthy host the ordering is right anyway: sbx0 comes back with the corrected TUN before the proxy starts marking DC sockets into it.

Net effect: a looping host now recovers in **one** `mtbuddy update` instead of the update → setup egress → update dance the release notes had to prescribe.

## The dangerous part, and the guard

The config is regenerated from the share links `setup egress` records at `[upstream.xray] links` — a key nothing had ever read back.

That record is **best-effort, not the source of truth**: `setup egress` writes singbox-egress.json and starts the egress *before* it updates config.toml, and a failure there is a `ui.warn` + `return`, not a rollback. So a host can genuinely be running endpoints the recorded links no longer mention.

Adversarial review found the concrete path, reachable purely through mtbuddy on Linux:

1. `setup egress 'vless://A'` → JSON = {A}, config.toml `links = ["vless://A"]`
2. A gets blocked; operator runs `setup egress 'vless://B' 'vless://C' 'vless://D'`. The JSON and the running egress become B/C/D — then the config.toml write hits the old `formatKv` 512-byte ceiling and aborts. config.toml still says A.
3. A naive repair would regenerate from A, overwrite the live B/C/D pool, restart into a dead endpoint, and print "repaired".

sbx0 comes up regardless (the TUN inbound doesn't care whether the outbound reaches anything), so `default dev sbx0 table 200` is reinstalled and every marked DC connection is swallowed. Total outage, reported as a successful update, with no copy of what was destroyed.

So the repair compares endpoints before writing: every `"server"`/`"server_port"` currently configured must survive into the new config, **and** the count must match so nothing is silently added either. On any mismatch it changes nothing and tells the operator to re-run `setup egress`. Both sides come from the same generator, so an in-sync host matches by construction — and the outbound JSON is byte-identical across the TUN fix, so a legacy pre-1.12.0 config still compares equal. The file being replaced is copied to `.bak` first.

## Also: the bug that makes that case reachable

`TomlDoc.formatKv` formatted through a `[512]u8` and reported `error.OutOfMemory` above it, so any longer value aborted the whole write. `[upstream.xray] links` holds the share-link array on one line and three VLESS-Reality links already exceed it — so a three-endpoint `setup egress` pool failed to write **any** of its config.toml keys, including `[upstream] type = tunnel`. It allocates now. (Verified by mutation: restoring the ceiling fails the new test.)

## Restart, not `enable --now`

`setup egress` only `enable --now`s the egress unit, which is a `start` — a no-op on an already-running unit — while sing-box parses its config only at startup. That is exactly the host this repair exists for, so it issues a real `restart`.

## Scope guards

- No-op unless `/etc/systemd/system/mtproto-singbox-egress.service` exists.
- No-op again once repaired (the freshly generated config satisfies the shape check by construction), so it writes at most once per host, ever.
- Repairs an **existing** drop-in only — it never adds `After=`/`Wants=` to a unit that never had it.
- Reads config.toml, never writes it. The installer E2E's byte-identical-config.toml assertion across `mtbuddy update` is unaffected, and the E2E host has no egress unit anyway (`setup egress --deps-only` returns before writing one), so the whole path stays inert there.

## Tests

358 total (278 proxy + 80 mtbuddy). New coverage for the stale-shape detection (each of the three defects alone must trigger a regeneration), the link-array reader including the whitespace and empty forms, the endpoint-identity guard in both directions plus the same-count-different-host case, and a long value round-tripping through `TomlDoc.set`.

All mutation-checked: neutering either half of the identity guard, dropping the empty-entry skip, ignoring the address in the shape check, or restoring the 512-byte ceiling each fails a test.

Two review findings are fixed in this branch rather than deferred: the identity guard above, and the recovery hint's `grep -A2 '^[upstream.xray]'` — in a POSIX regex that is a bracket *expression*, so it never matched the section header and did match `user1 = "<secret>"`. It uses `-F` now.

Still Linux-only at runtime and not reachable from CI; the logic is unit-tested and the mechanism was verified against the pinned upstream sources in #395.