### PR TITLE
feat(egress): hysteria2 share links + fix the CAP_NET_ADMIN that made `setup egress` a dead proxy

### DIFF
--- a/README.fa.md
+++ b/README.fa.md
@@ -244,6 +244,7 @@ sudo mtbuddy setup tunnel --iface awg1 /path/to/awg1.conf
 #   wireguard://                       -> تونل WG کرنل بومی (مانند `setup tunnel`).
 #   چند لینک                            -> استخر failover با urltest.
 sudo mtbuddy setup egress 'vless://...@host:443?security=reality&pbk=...&sni=...&flow=xtls-rprx-vision'
+# vless / vmess / trojan / ss / hysteria2 — hysteria2 is QUIC, so measure UDP to the endpoint first
 sudo mtbuddy setup egress 'wireguard://<privkey>@host:51820?publickey=...&address=10.0.0.2/32'
 
 # IPv6 hopping

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ sudo mtbuddy setup tunnel --iface awg1 /path/to/awg1.conf
 #   wireguard://                       -> native kernel WG tunnel (same as `setup tunnel`).
 #   multiple links                     -> a urltest failover pool.
 sudo mtbuddy setup egress 'vless://...@host:443?security=reality&pbk=...&sni=...&flow=xtls-rprx-vision'
+# vless / vmess / trojan / ss / hysteria2 — hysteria2 is QUIC, so measure UDP to the endpoint first
 sudo mtbuddy setup egress 'wireguard://<privkey>@host:51820?publickey=...&address=10.0.0.2/32'
 
 # IPv6 hopping

--- a/README.ru.md
+++ b/README.ru.md
@@ -242,6 +242,7 @@ sudo mtbuddy setup tunnel --iface awg1 /path/to/awg1.conf
 #   wireguard://                       -> нативный kernel-WG туннель (как `setup tunnel`).
 #   несколько ссылок                   -> пул с автопереключением (urltest).
 sudo mtbuddy setup egress 'vless://...@host:443?security=reality&pbk=...&sni=...&flow=xtls-rprx-vision'
+# vless / vmess / trojan / ss / hysteria2 — hysteria2 is QUIC, so measure UDP to the endpoint first
 sudo mtbuddy setup egress 'wireguard://<privkey>@host:51820?publickey=...&address=10.0.0.2/32'
 
 # IPv6 hopping

--- a/README.vi.md
+++ b/README.vi.md
@@ -245,6 +245,7 @@ sudo mtbuddy setup tunnel --iface awg1 /path/to/awg1.conf
 #   wireguard://                       -> tunnel WG kernel gốc (giống `setup tunnel`).
 #   nhiều liên kết                     -> pool tự chuyển dự phòng (urltest).
 sudo mtbuddy setup egress 'vless://...@host:443?security=reality&pbk=...&sni=...&flow=xtls-rprx-vision'
+# vless / vmess / trojan / ss / hysteria2 — hysteria2 is QUIC, so measure UDP to the endpoint first
 sudo mtbuddy setup egress 'wireguard://<privkey>@host:51820?publickey=...&address=10.0.0.2/32'
 
 # IPv6 hopping

--- a/README.zh.md
+++ b/README.zh.md
@@ -243,6 +243,7 @@ sudo mtbuddy setup tunnel --iface awg1 /path/to/awg1.conf
 #   wireguard://                       -> 原生内核 WG 隧道（等同 `setup tunnel`）。
 #   多个链接                            -> urltest 故障转移池。
 sudo mtbuddy setup egress 'vless://...@host:443?security=reality&pbk=...&sni=...&flow=xtls-rprx-vision'
+# vless / vmess / trojan / ss / hysteria2 — hysteria2 is QUIC, so measure UDP to the endpoint first
 sudo mtbuddy setup egress 'wireguard://<privkey>@host:51820?publickey=...&address=10.0.0.2/32'
 
 # IPv6 hopping

--- a/src/ctl/sharelink.zig
+++ b/src/ctl/sharelink.zig
@@ -102,7 +102,7 @@ fn base64Decode(a: std.mem.Allocator, s_in: []const u8) ![]u8 {
 
 // ── Parsed link model ──────────────────────────────────────────────────────────
 
-pub const Scheme = enum { vless, vmess, trojan, shadowsocks, wireguard, unknown };
+pub const Scheme = enum { vless, vmess, trojan, shadowsocks, hysteria2, wireguard, unknown };
 
 pub fn detectScheme(link_in: []const u8) Scheme {
     const link = std.mem.trim(u8, link_in, " \t\r\n");
@@ -110,6 +110,7 @@ pub fn detectScheme(link_in: []const u8) Scheme {
     if (std.mem.startsWith(u8, link, "vmess://")) return .vmess;
     if (std.mem.startsWith(u8, link, "trojan://")) return .trojan;
     if (std.mem.startsWith(u8, link, "ss://")) return .shadowsocks;
+    if (std.mem.startsWith(u8, link, "hysteria2://") or std.mem.startsWith(u8, link, "hy2://")) return .hysteria2;
     if (std.mem.startsWith(u8, link, "wireguard://") or std.mem.startsWith(u8, link, "wg://")) return .wireguard;
     return .unknown;
 }
@@ -138,6 +139,13 @@ pub const XrayLink = struct {
     fingerprint: ?[]const u8 = null, // utls fp (chrome,...)
     public_key: ?[]const u8 = null, // reality pbk
     short_id: ?[]const u8 = null, // reality sid
+    // hysteria2
+    obfs: ?[]const u8 = null, // only "salamander" exists
+    obfs_password: ?[]const u8 = null,
+    /// hysteria2 `insecure=1`: skip certificate verification. Hysteria servers are
+    /// commonly self-signed, and unlike the Xray family the scheme has no Reality-style
+    /// pinning we can emit faithfully, so the link has to say so explicitly.
+    insecure: bool = false,
 };
 
 fn splitHostPort(hp: []const u8) !struct { host: []const u8, port: u16 } {
@@ -270,6 +278,90 @@ fn parseSs(a: std.mem.Allocator, link: []const u8) !XrayLink {
     };
 }
 
+/// Parse `hysteria2://[auth@]host[:port][/][?params][#name]`.
+///
+/// Deliberately its own parser rather than another `parseUriCred` caller — the grammar
+/// differs in three ways that each silently break that one:
+///   * a PATH. `hysteria share` always emits the trailing `/` before `?`, and
+///     splitHostPort would run parseInt over "443/" and fail the whole link.
+///   * auth is OPTIONAL, while parseUriCred returns error.BadLink without an `@`.
+///   * the port is optional and defaults to 443.
+/// Every test written from the vless template would pass while every real link failed.
+fn parseHysteria2(a: std.mem.Allocator, link: []const u8) !XrayLink {
+    const prefix_len: usize = if (std.mem.startsWith(u8, link, "hysteria2://"))
+        "hysteria2://".len
+    else
+        "hy2://".len;
+    var rest = link[prefix_len..];
+
+    var name: []const u8 = "egress";
+    if (std.mem.indexOfScalar(u8, rest, '#')) |h| {
+        name = try percentDecodeAlloc(a, rest[h + 1 ..]);
+        rest = rest[0..h];
+    }
+    var query: []const u8 = "";
+    if (std.mem.indexOfScalar(u8, rest, '?')) |q| {
+        query = rest[q + 1 ..];
+        rest = rest[0..q];
+    }
+
+    // Optional auth, then an optional path we drop (the scheme carries no path semantics
+    // sing-box can use; upstream emits "/" purely so the URI is well-formed).
+    var authority = rest;
+    var auth: ?[]const u8 = null;
+    if (std.mem.lastIndexOfScalar(u8, authority, '@')) |at| {
+        auth = try percentDecodeAlloc(a, authority[0..at]);
+        authority = authority[at + 1 ..];
+    }
+    if (std.mem.indexOfScalar(u8, authority, '/')) |slash| authority = authority[0..slash];
+    if (authority.len == 0) return error.BadAddress;
+
+    const hp = try splitHysteria2HostPort(authority);
+
+    var l = XrayLink{
+        .scheme = .hysteria2,
+        .name = name,
+        .address = try a.dupe(u8, hp.host),
+        .port = hp.port,
+        // QUIC is always TLS; there is no plaintext hysteria2. Recorded so the generator
+        // can key off the same field the rest of the family uses.
+        .security = "tls",
+    };
+    if (auth) |p| l.password = p;
+
+    if (queryParam(query, "sni")) |v| l.sni = try percentDecodeAlloc(a, v);
+    if (queryParam(query, "obfs")) |v| l.obfs = try percentDecodeAlloc(a, v);
+    if (queryParam(query, "obfs-password")) |v| l.obfs_password = try percentDecodeAlloc(a, v);
+    if (queryParam(query, "insecure")) |v| l.insecure = std.mem.eql(u8, v, "1") or std.ascii.eqlIgnoreCase(v, "true");
+    // pinSHA256 / ech are carried into validateLink as a rejection, not silently dropped.
+    if (queryParam(query, "pinSHA256")) |v| l.fingerprint = try percentDecodeAlloc(a, v);
+    if (queryParam(query, "ech")) |v| l.path = try percentDecodeAlloc(a, v);
+
+    return l;
+}
+
+/// Host/port for hysteria2: the port is optional (443), and a `,`-separated port-hopping
+/// list is refused here rather than truncated — sing-box wants `server_ports: ["a:b"]`
+/// with a COLON, so quietly keeping the first port would build a config that connects to
+/// the wrong place.
+fn splitHysteria2HostPort(hp: []const u8) !struct { host: []const u8, port: u16 } {
+    if (std.mem.indexOfScalar(u8, hp, ',') != null) return error.UnsupportedPortHopping;
+
+    if (hp.len > 0 and hp[0] == '[') {
+        const close = std.mem.indexOfScalar(u8, hp, ']') orelse return error.BadAddress;
+        const host = hp[1..close];
+        if (host.len == 0) return error.BadAddress;
+        if (close + 1 >= hp.len) return .{ .host = host, .port = 443 };
+        if (hp[close + 1] != ':') return error.BadAddress;
+        return .{ .host = host, .port = std.fmt.parseInt(u16, hp[close + 2 ..], 10) catch return error.BadAddress };
+    }
+
+    const colon = std.mem.lastIndexOfScalar(u8, hp, ':') orelse return .{ .host = hp, .port = 443 };
+    const port = std.fmt.parseInt(u16, hp[colon + 1 ..], 10) catch return error.BadAddress;
+    if (colon == 0) return error.BadAddress;
+    return .{ .host = hp[0..colon], .port = port };
+}
+
 /// Parse any Xray-family share link into an XrayLink (arena-owned strings).
 pub fn parseXrayLink(a: std.mem.Allocator, link_in: []const u8) !XrayLink {
     const link = std.mem.trim(u8, link_in, " \t\r\n");
@@ -278,6 +370,7 @@ pub fn parseXrayLink(a: std.mem.Allocator, link_in: []const u8) !XrayLink {
         .trojan => parseUriCred(a, link, .trojan, "trojan://"),
         .vmess => parseVmess(a, link),
         .shadowsocks => parseSs(a, link),
+        .hysteria2 => parseHysteria2(a, link),
         else => error.UnsupportedScheme,
     };
 }
@@ -307,6 +400,29 @@ pub fn validateLink(l: XrayLink, buf: []u8) ?[]const u8 {
     const net = l.network;
     if (!(net.len == 0 or std.mem.eql(u8, net, "tcp") or std.mem.eql(u8, net, "ws") or std.mem.eql(u8, net, "grpc"))) {
         return std.fmt.bufPrint(buf, "unsupported transport '{s}' for {s} — only tcp/ws/grpc are supported", .{ net, l.address }) catch "unsupported transport";
+    }
+    if (l.scheme == .hysteria2) {
+        // pinSHA256 pins sha256 of the whole DER certificate, colon-hex. sing-box's
+        // nearest field pins the SPKI, base64 — a different preimage AND a different
+        // encoding, not convertible without holding the certificate. Worse, a 64-char hex
+        // pin decodes as valid base64 into 48 wrong bytes, so `sing-box check` passes and
+        // every handshake fails. Refuse rather than emit something that looks fine.
+        if (l.fingerprint != null) {
+            return std.fmt.bufPrint(buf, "pinSHA256 has no sing-box equivalent ({s}) — use a link with a real certificate, or insecure=1", .{l.address}) catch "pinSHA256 unsupported";
+        }
+        if (l.path != null) {
+            return std.fmt.bufPrint(buf, "hysteria2 ECH is not supported ({s})", .{l.address}) catch "hysteria2 ech unsupported";
+        }
+        if (l.obfs) |o| {
+            if (!std.ascii.eqlIgnoreCase(o, "salamander")) {
+                return std.fmt.bufPrint(buf, "unknown hysteria2 obfs '{s}' for {s} — only salamander exists", .{ o, l.address }) catch "unknown hysteria2 obfs";
+            }
+            const pw = l.obfs_password orelse "";
+            if (pw.len == 0) {
+                return std.fmt.bufPrint(buf, "hysteria2 obfs=salamander needs obfs-password ({s})", .{l.address}) catch "missing obfs-password";
+            }
+        }
+        return null;
     }
     if (l.scheme == .shadowsocks) {
         const m = l.method orelse "";

--- a/src/ctl/tunnel_singbox.zig
+++ b/src/ctl/tunnel_singbox.zig
@@ -119,10 +119,21 @@ const TUN_STACK = "gvisor";
 ///     every proxy start and steals the route from sbx0.
 /// sbx0's own routing is installed by the sing-box unit's ExecStartPost, and the default
 /// (non-tunnel) unit has no ExecStartPre at all, so the reset is a no-op everywhere else.
+/// CAP_NET_ADMIN is the other half, and without it `setup egress` produces a proxy that
+/// accepts clients and fails EVERY DC connection. Wiring the egress sets
+/// `[upstream] type = tunnel`, so the proxy starts SO_MARKing its DC sockets — and
+/// SO_MARK needs CAP_NET_ADMIN. Only the AmneziaWG unit ever granted it, so a host that
+/// went straight to `setup egress` without ever running `setup tunnel` ran under the
+/// default unit's CAP_NET_BIND_SERVICE alone and every connect failed with EPERM
+/// ("upstream connect start failed"), while setup still printed "egress up". Reproduced
+/// and fixed on a live host. systemd MERGES these two directives across drop-ins, so the
+/// unit's own CAP_NET_BIND_SERVICE is kept rather than replaced.
+///
 /// It lives in the drop-in because that is what survives: a hand-added line is wiped by
 /// the next `setup egress`.
 const PROXY_EGRESS_DROPIN = "[Unit]\nAfter=" ++ SB_SERVICE_NAME ++ "\nWants=" ++ SB_SERVICE_NAME ++ "\n" ++
-    "\n[Service]\nExecStartPre=\n";
+    "\n[Service]\nExecStartPre=\n" ++
+    "AmbientCapabilities=CAP_NET_ADMIN\nCapabilityBoundingSet=CAP_NET_ADMIN\n";
 const TUN_TABLE = "200"; // same policy-routing table the AmneziaWG tunnel uses
 const TUN_FWMARK = "200"; // proxy SO_MARK for tunnel egress
 
@@ -643,7 +654,10 @@ pub fn refreshEgress(ui: *Tui, allocator: std.mem.Allocator) void {
 fn refreshProxyDropin(ui: *Tui, allocator: std.mem.Allocator) void {
     const existing = sys.readFileAllocAbsolute(allocator, PROXY_DROPIN_PATH, 16 * 1024) orelse return;
     defer allocator.free(existing);
-    if (std.mem.indexOf(u8, existing, "\nExecStartPre=\n") != null) return;
+    // Content comparison, not a marker search: the drop-in has grown twice now (the
+    // ExecStartPre reset, then CAP_NET_ADMIN), and a marker check would have skipped a
+    // host that already had the first and still needed the second.
+    if (std.mem.eql(u8, existing, PROXY_EGRESS_DROPIN)) return;
 
     sys.writeFile(PROXY_DROPIN_PATH, PROXY_EGRESS_DROPIN) catch return;
     _ = sys.exec(allocator, &.{ "systemctl", "daemon-reload" }) catch {};
@@ -890,6 +904,15 @@ test "the egress drop-in resets ExecStartPre so a stale tunnel helper can't brea
     // And it still orders the proxy after the egress, which is why the drop-in exists.
     try std.testing.expect(std.mem.indexOf(u8, PROXY_EGRESS_DROPIN, "After=" ++ SB_SERVICE_NAME) != null);
     try std.testing.expect(std.mem.indexOf(u8, PROXY_EGRESS_DROPIN, "Wants=" ++ SB_SERVICE_NAME) != null);
+
+    // And it grants CAP_NET_ADMIN. Wiring the egress sets [upstream] type = tunnel, so
+    // the proxy SO_MARKs its DC sockets — which needs that capability. Without it a host
+    // that never ran `setup tunnel` runs under the default unit (CAP_NET_BIND_SERVICE
+    // only) and EVERY DC connect fails with EPERM while setup reports success.
+    // Verified on a live host: adding it turned "upstream connect start failed" into a
+    // relaying connection.
+    try std.testing.expect(std.mem.indexOf(u8, PROXY_EGRESS_DROPIN, "AmbientCapabilities=CAP_NET_ADMIN") != null);
+    try std.testing.expect(std.mem.indexOf(u8, PROXY_EGRESS_DROPIN, "CapabilityBoundingSet=CAP_NET_ADMIN") != null);
 }
 
 test "egress auto-repair: detects a stale config and accepts a freshly generated one" {

--- a/src/ctl/tunnel_singbox.zig
+++ b/src/ctl/tunnel_singbox.zig
@@ -8,10 +8,18 @@
 //!   wireguard://                         -> native kernel WG/AmneziaWG tunnel (reuses
 //!                                           tunnel_wg.zig: policy routing + pool)
 //!   vless:// vmess:// trojan:// ss://     -> a local sing-box client in TUN mode (sbx0);
-//!                                           the proxy's SO_MARK'd DC traffic is policy-
+//!   hysteria2:// (hy2://)                    the proxy's SO_MARK'd DC traffic is policy-
 //!                                           routed through it (fwmark 200 -> table 200 ->
 //!                                           sbx0). >1 link -> a sing-box urltest failover
 //!                                           pool. VLESS-Reality camouflages the hop as TLS.
+//!
+//! hysteria2 is QUIC, i.e. the ONLY scheme here whose egress leg is UDP. That matters on
+//! the hosts this command exists for: providers that block the Telegram DCs commonly also
+//! police UDP hard (measured: WireGuard capped near 1.5 Mbit/s on any port), and the
+//! failure looks like a healthy tunnel moving no bytes. Measure the path before choosing
+//! it. Note also that its headline congestion control (Brutal) needs a bandwidth the
+//! share-link grammar deliberately does not carry, so a link-provisioned hysteria2 egress
+//! runs BBR — the same algorithm the TCP schemes already get.
 //!
 //! The proxy relay is unchanged (it just SO_MARKs, as for any tunnel). The two providers
 //! are mutually exclusive on table 200 — setting one up retires the other. Share-link
@@ -180,6 +188,24 @@ fn sbTls(a: std.mem.Allocator, l: XrayLink) ![]const u8 {
     return "";
 }
 
+/// TLS block for hysteria2. Separate from sbTls on purpose, and the separation is
+/// load-bearing twice over:
+///   * a hy2 link carries no `security=` param, so l.security would leave sbTls returning
+///     "" — and sing-box's hysteria2 outbound refuses to load without TLS at all;
+///   * both of sbTls's branches emit `"utls"`, which cannot work over QUIC — sing-box's
+///     uTLS client has no STDConfig, so sing-quic fails every connection with
+///     "unsupported usage for uTLS". And `sing-box check` PASSES, the unit starts, the
+///     ok line prints: a green deploy on a 100%-dead egress.
+/// A test pins the absence of "utls" so a future refactor cannot merge these back.
+fn sbTlsHy2(a: std.mem.Allocator, l: XrayLink) ![]const u8 {
+    const sni = l.sni orelse l.address;
+    return std.fmt.allocPrint(
+        a,
+        ",\"tls\":{{\"enabled\":true,\"server_name\":{s},\"insecure\":{s}}}",
+        .{ js(a, sni), if (l.insecure) "true" else "false" },
+    );
+}
+
 fn sbTransport(a: std.mem.Allocator, l: XrayLink) ![]const u8 {
     const sni = l.sni orelse l.host orelse l.address;
     if (std.mem.eql(u8, l.network, "ws")) {
@@ -191,6 +217,8 @@ fn sbTransport(a: std.mem.Allocator, l: XrayLink) ![]const u8 {
 }
 
 fn sbOutbound(a: std.mem.Allocator, l: XrayLink, tag: []const u8) ![]const u8 {
+    // The Xray-family TLS/transport blocks. The hysteria2 arm below uses neither — it
+    // builds its own TLS and has no transport concept.
     const tls = try sbTls(a, l);
     const tr = try sbTransport(a, l);
     return switch (l.scheme) {
@@ -201,6 +229,16 @@ fn sbOutbound(a: std.mem.Allocator, l: XrayLink, tag: []const u8) ![]const u8 {
         .vmess => std.fmt.allocPrint(a, "{{\"type\":\"vmess\",\"tag\":{s},\"server\":{s},\"server_port\":{d},\"uuid\":{s},\"alter_id\":{d},\"security\":{s}{s}{s}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.id.?), l.alter_id, js(a, l.cipher), tls, tr }),
         .trojan => std.fmt.allocPrint(a, "{{\"type\":\"trojan\",\"tag\":{s},\"server\":{s},\"server_port\":{d},\"password\":{s}{s}{s}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.password.?), tls, tr }),
         .shadowsocks => std.fmt.allocPrint(a, "{{\"type\":\"shadowsocks\",\"tag\":{s},\"server\":{s},\"server_port\":{d},\"method\":{s},\"password\":{s}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.method.?), js(a, l.password.?) }),
+        .hysteria2 => blk: {
+            // No `tr`: hysteria2 is QUIC end to end, it has no ws/grpc transport to carry.
+            const hy_tls = try sbTlsHy2(a, l);
+            const pw = if (l.password) |p| try std.fmt.allocPrint(a, ",\"password\":{s}", .{js(a, p)}) else "";
+            const obfs = if (l.obfs) |o|
+                try std.fmt.allocPrint(a, ",\"obfs\":{{\"type\":{s},\"password\":{s}}}", .{ js(a, o), js(a, l.obfs_password orelse "") })
+            else
+                "";
+            break :blk std.fmt.allocPrint(a, "{{\"type\":\"hysteria2\",\"tag\":{s},\"server\":{s},\"server_port\":{d}{s}{s}{s}}}", .{ js(a, tag), js(a, l.address), l.port, pw, obfs, hy_tls });
+        },
         else => error.UnsupportedScheme,
     };
 }
@@ -244,7 +282,7 @@ fn dispatchLinks(ui: *Tui, allocator: std.mem.Allocator, link_list: []const []co
     for (link_list) |l| {
         const s = detectScheme(l);
         if (s == .unknown) {
-            ui.fail("Unrecognized share-link scheme (want vless/vmess/trojan/ss/wireguard)");
+            ui.fail("Unrecognized share-link scheme (want vless/vmess/trojan/ss/hysteria2/wireguard)");
             return;
         }
         if (schemeFamily(s) != fam0) {
@@ -277,7 +315,7 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
     }
     if (links.items.len == 0) {
         ui.fail("Usage: mtbuddy setup egress [--deps-only] <share-link> [<share-link>...]");
-        ui.hint("vless:// vmess:// trojan:// ss://  ->  sing-box TUN tunnel (upstream.type=tunnel)");
+        ui.hint("vless:// vmess:// trojan:// ss:// hysteria2://  ->  sing-box TUN tunnel (upstream.type=tunnel)");
         ui.hint("wireguard://                       ->  native kernel WG tunnel");
         return;
     }
@@ -300,7 +338,7 @@ pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
         0 => {
             const input = ui.input(
                 trL(ui, "Share-link(s)", "Ссылка(и)"),
-                trL(ui, "vless:// vmess:// trojan:// ss://  (sing-box tunnel)  |  wireguard://  (native tunnel)", "vless:// vmess:// trojan:// ss://  (sing-box-туннель)  |  wireguard://  (нативный туннель)"),
+                trL(ui, "vless:// vmess:// trojan:// ss:// hysteria2://  (sing-box tunnel)  |  wireguard://  (native tunnel)", "vless:// vmess:// trojan:// ss:// hysteria2://  (sing-box-туннель)  |  wireguard://  (нативный туннель)"),
                 null,
                 &buf,
             ) catch |e| {
@@ -438,6 +476,11 @@ fn setupSingboxTunnel(ui: *Tui, allocator: std.mem.Allocator, link_texts: []cons
         ui.fail("Failed to write the systemd unit");
         return;
     };
+    if (!singboxConfigLoads(allocator, sb_bin, SB_CONFIG_PATH)) {
+        ui.fail("The installed sing-box rejects the generated config — the egress was NOT started");
+        ui.info("Run `" ++ SB_CONFIG_PATH ++ "` through `sing-box check -c` for the reason. An outbound type this build does not know (hysteria2 needs sing-box 1.5.0+) rejects the whole file, including the other endpoints in a pool.");
+        return;
+    }
     _ = sys.exec(allocator, &.{ "systemctl", "daemon-reload" }) catch {};
     _ = sys.exec(allocator, &.{ "systemctl", "enable", "--now", SB_SERVICE_NAME }) catch {};
     ui.ok("sing-box tunnel egress up (tun " ++ TUN_IFACE ++ ")");
@@ -679,6 +722,19 @@ fn refreshSingboxConfig(ui: *Tui, allocator: std.mem.Allocator) void {
         egressManualHint(ui);
         return;
     };
+
+    // Never restart into a config this sing-box cannot load: put the old one back first.
+    const sb_bin: []const u8 = if (sys.fileExists(SB_BIN)) SB_BIN else "sing-box";
+    if (!singboxConfigLoads(allocator, sb_bin, SB_CONFIG_PATH)) {
+        _ = sys.exec(allocator, &.{ "cp", "-f", SB_CONFIG_PATH ++ ".bak", SB_CONFIG_PATH }) catch {};
+        ui.warn(trL(
+            ui,
+            "The installed sing-box rejects the repaired egress config — restored the previous one and left the egress running.",
+            "Установленный sing-box не принимает починенный конфиг egress — вернул прежний, egress работает как работал.",
+        ));
+        return;
+    }
+
     // A restart, not `enable --now`: sing-box parses its config only at startup, and
     // `--now` is a no-op on a unit that is already running — which is exactly the host
     // this repair exists for.
@@ -688,6 +744,22 @@ fn refreshSingboxConfig(ui: *Tui, allocator: std.mem.Allocator) void {
         "sing-box egress tun repaired (" ++ TUN_ADDR ++ ", stack " ++ TUN_STACK ++ ", mtu " ++ TUN_MTU ++ ")",
         "sing-box egress tun починен (" ++ TUN_ADDR ++ ", stack " ++ TUN_STACK ++ ", mtu " ++ TUN_MTU ++ ")",
     ));
+}
+
+/// `sing-box check -c <path>`: does the installed binary accept this config at all?
+///
+/// The reason this exists is version skew. ensureSingboxInstalled keeps whatever sing-box
+/// is already on the host, and an outbound type it does not know — hysteria2 needs 1.5.0+
+/// — makes it reject the WHOLE config, taking any co-configured vless/trojan outbound
+/// down with it. Without the probe that lands as "egress up" plus a dead unit.
+///
+/// Returns true when the check passes OR could not be run at all: a missing//unrunnable
+/// binary is ensureSingboxInstalled's problem, and failing closed on it would refuse
+/// configs that are perfectly fine.
+fn singboxConfigLoads(allocator: std.mem.Allocator, sb_bin: []const u8, path: []const u8) bool {
+    const r = sys.exec(allocator, &.{ sb_bin, "check", "-c", path }) catch return true;
+    defer r.deinit();
+    return r.exit_code == 0;
 }
 
 fn ensureSingboxInstalled(ui: *Tui, allocator: std.mem.Allocator) bool {
@@ -910,6 +982,99 @@ test "egress auto-repair: reads the share links back out of [upstream.xray]" {
     const blank_entry = try parseTomlStringArray(a, "[\"\"]");
     defer a.free(blank_entry);
     try std.testing.expectEqual(@as(usize, 0), blank_entry.len);
+}
+
+test "hysteria2: real-world link shapes parse, and the config is QUIC-correct" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // Exactly what `hysteria share` emits: a trailing '/' before the query. The Xray
+    // parser ran parseInt over "40443/" and failed the whole link.
+    const canonical = try parseXrayLink(a, "hysteria2://letmein@example.com:40443/?sni=cover.example&obfs=salamander&obfs-password=cats#EU");
+    try std.testing.expectEqual(Scheme.hysteria2, canonical.scheme);
+    try std.testing.expectEqualStrings("example.com", canonical.address);
+    try std.testing.expectEqual(@as(u16, 40443), canonical.port);
+    try std.testing.expectEqualStrings("letmein", canonical.password.?);
+    try std.testing.expectEqualStrings("cover.example", canonical.sni.?);
+    try std.testing.expectEqualStrings("salamander", canonical.obfs.?);
+    try std.testing.expectEqualStrings("cats", canonical.obfs_password.?);
+    try std.testing.expectEqualStrings("EU", canonical.name);
+
+    // Auth is optional, and so is the port (443).
+    const bare = try parseXrayLink(a, "hy2://example.com");
+    try std.testing.expectEqualStrings("example.com", bare.address);
+    try std.testing.expectEqual(@as(u16, 443), bare.port);
+    try std.testing.expect(bare.password == null);
+
+    // user:pass@ is one opaque auth string, and percent-decoded.
+    const userpass = try parseXrayLink(a, "hysteria2://bob%3As3cret@1.2.3.4:443/#n");
+    try std.testing.expectEqualStrings("bob:s3cret", userpass.password.?);
+
+    // IPv6 literal, with and without a port.
+    const v6 = try parseXrayLink(a, "hysteria2://pw@[2001:db8::1]:8443/?insecure=1#v6");
+    try std.testing.expectEqualStrings("2001:db8::1", v6.address);
+    try std.testing.expectEqual(@as(u16, 8443), v6.port);
+    try std.testing.expect(v6.insecure);
+
+    // Port hopping is refused, not silently truncated to the first port: sing-box wants
+    // server_ports:["a:b"] with a colon, so keeping 40443 would dial the wrong place.
+    try std.testing.expectError(error.UnsupportedPortHopping, parseXrayLink(a, "hysteria2://pw@example.com:40443,50000-60000/#hop"));
+
+    // ── generated config ──
+    const cfg = try genSingboxConfig(a, &.{canonical});
+    _ = try std.json.parseFromSlice(std.json.Value, a, cfg, .{});
+    try std.testing.expect(std.mem.indexOf(u8, cfg, "\"type\":\"hysteria2\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, cfg, "\"password\":\"letmein\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, cfg, "\"obfs\":{\"type\":\"salamander\",\"password\":\"cats\"}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, cfg, "\"server_name\":\"cover.example\"") != null);
+    // TLS must be present — sing-box's hysteria2 outbound refuses to load without it.
+    try std.testing.expect(std.mem.indexOf(u8, cfg, "\"tls\":{\"enabled\":true") != null);
+    // And uTLS must NOT be: it has no STDConfig, so sing-quic fails every connection with
+    // "unsupported usage for uTLS" while `sing-box check` still passes.
+    try std.testing.expect(std.mem.indexOf(u8, cfg, "utls") == null);
+    // No ws/grpc transport block on a QUIC outbound either.
+    try std.testing.expect(std.mem.indexOf(u8, cfg, "\"transport\"") == null);
+
+    // insecure rides through as a real JSON bool.
+    const insecure_cfg = try genSingboxConfig(a, &.{v6});
+    try std.testing.expect(std.mem.indexOf(u8, insecure_cfg, "\"insecure\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, cfg, "\"insecure\":false") != null);
+
+    // Mixed pool with an Xray member: one urltest, both outbound types, utls only on the
+    // vless member.
+    const vless = try parseXrayLink(a, "vless://95e0edb9-4a0b-4312-a71f-1d4b8b6db79b@154.59.110.32:443?type=tcp&security=reality&pbk=P&sni=s.example&sid=S&flow=xtls-rprx-vision#v");
+    const pool = try genSingboxConfig(a, &.{ vless, canonical });
+    _ = try std.json.parseFromSlice(std.json.Value, a, pool, .{});
+    try std.testing.expect(std.mem.indexOf(u8, pool, "\"urltest\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, pool, "\"type\":\"hysteria2\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, pool, "\"reality\"") != null);
+}
+
+test "hysteria2: links we cannot emit faithfully are rejected, not degraded" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    var buf: [256]u8 = undefined;
+
+    const ok = try parseXrayLink(a, "hysteria2://pw@example.com:443/#n");
+    try std.testing.expect(validateLink(ok, &buf) == null);
+
+    // pinSHA256: hysteria pins the DER cert (colon-hex), sing-box pins the SPKI (base64).
+    // A 64-char hex pin even decodes as valid base64 into 48 wrong bytes, so a naive
+    // pass-through gives a config that checks clean and fails every handshake.
+    const pinned = try parseXrayLink(a, "hysteria2://pw@example.com:443/?pinSHA256=deadbeef#n");
+    try std.testing.expect(validateLink(pinned, &buf) != null);
+
+    const ech = try parseXrayLink(a, "hysteria2://pw@example.com:443/?ech=AEX+DQBB#n");
+    try std.testing.expect(validateLink(ech, &buf) != null);
+
+    // salamander is the only obfs that exists, and it is useless without its password.
+    const bad_obfs = try parseXrayLink(a, "hysteria2://pw@example.com:443/?obfs=xplus&obfs-password=p#n");
+    try std.testing.expect(validateLink(bad_obfs, &buf) != null);
+
+    const obfs_no_pw = try parseXrayLink(a, "hysteria2://pw@example.com:443/?obfs=salamander#n");
+    try std.testing.expect(validateLink(obfs_no_pw, &buf) != null);
 }
 
 test "vmess scy maps to cipher and is emitted" {


### PR DESCRIPTION
Two commits. Both were verified **on live hosts**, not by reading source — which is how the second one was found at all.

Test rig: two Ubuntu 24.04 boxes on Cogent/NL. **A** = `154.59.110.43` (mtproto proxy), **B** = `154.59.110.118` (hysteria2 v2 server, self-signed cert, salamander obfs).

---

## 1. `hysteria2://` / `hy2://` share links (#388)

sing-box already ships with the QUIC build tag and its hysteria2 outbound needs nothing from the proxy or the TUN routing — `upstream.zig` only ever makes TCP sockets, sing-box terminates them in its netstack and re-dials on its own outbound, so the UDP exists solely on the host→endpoint leg. Nothing in `src/proxy/`, ufw, or the TCPMSS/nfqws rules changes.

The work isn't the switch arm. Three things here each produce a *green deploy on a completely dead egress*, and each now has a test that fails without its guard:

- **`sbTlsHy2`** — a hy2 link carries no `security=`, so the shared `sbTls` returns `""`, and sing-box's hysteria2 outbound refuses to load without TLS. Forcing `security="tls"` is worse: both `sbTls` branches emit `utls`, which cannot work over QUIC at all (no `STDConfig`, so sing-quic fails every connection with *"unsupported usage for uTLS"*) while `sing-box check` still passes and the unit still starts. A test pins the absence of `utls`.
- **`parseHysteria2`** — its own parser, because the grammar breaks `parseUriCred` three ways: a trailing path (`hysteria share` always emits `/` before `?`, and `splitHostPort` would `parseInt("443/")`), optional auth (`parseUriCred` returns `BadLink` without `@`), and an optional port. Every test written from the vless template would have passed while every real link failed.
- **`pinSHA256` refused, not translated** — hysteria pins sha256 of the DER cert as colon-hex; sing-box pins the SPKI as base64. Different preimage, different encoding. And a 64-char hex pin *decodes as valid base64* into 48 wrong bytes, so a pass-through checks clean and fails every handshake. ECH, unknown obfs, salamander-without-password and port hopping are refused the same way.

Plus a `sing-box check -c` gate before the egress starts (and before the update-time repair restarts it): an outbound type the installed binary doesn't know — hysteria2 needs 1.5.0+, and `ensureSingboxInstalled` keeps whatever sing-box is already there — rejects the **whole** config, taking any co-configured pool member with it. The repair restores its `.bak` in that case.

## 2. `setup egress` produced a completely dead proxy

This is the one that matters, and it is **pre-existing, not new**.

Wiring the egress sets `[upstream] type = tunnel`, so the proxy SO_MARKs its DC sockets — and SO_MARK needs `CAP_NET_ADMIN`. Nothing in the egress path granted it. Only the AmneziaWG unit did, so a host that had run `setup tunnel` at some point inherited it *by accident*; a host that went straight to `setup egress` ran under the default unit's `CAP_NET_BIND_SERVICE` alone:

```
route:   user=tester dc_idx=1 dc_abs=1 ... -> [ipv4]:443
closing: ... reason=upstream connect start failed c2s=0 s2c=0
```

…while setup printed `✔ sing-box tunnel egress up` and `✔ upstream set to tunnel`. The proxy accepted clients and relayed nothing.

Confirmed directly as the cause on the host:

```
# setpriv --reuid=mtproto --regid=mtproto --clear-groups python3 -c 'setsockopt(SO_MARK)'
SO_MARK: DENIED ([Errno 1] Operation not permitted)
```

The drop-in now grants it. systemd *merges* `AmbientCapabilities` / `CapabilityBoundingSet` across drop-ins, so the unit's own `CAP_NET_BIND_SERVICE` is kept — verified on the host, the effective set becomes `cap_net_bind_service cap_net_admin`. The update-time repair backfills it on existing hosts; its idempotency check became a content comparison, because the drop-in has grown twice now and a marker search would skip a host that already had the `ExecStartPre` reset and still needed the capability.

---

## Measured on the live rig

**UDP viability** (the thing I'd been treating as a blocker), A→B:

| | result |
|---|---|
| TCP baseline | 5500 Mbit/s |
| UDP @ 100 Mbit/s | 99.9 Mbit/s received, **0.091% loss** |
| UDP @ 500 Mbit/s | 433 Mbit/s, 13% loss (1 vCPU receiver) |

**The full chain** — real FakeTLS client → proxy → SO_MARK → sbx0 → hysteria2 (salamander obfs) → Telegram DC:

- `setup egress 'hysteria2://…@…:40443/?insecure=1&obfs=salamander&obfs-password=…&sni=cover.example#hy2test'` → parsed, sing-box installed, sbx0 up, upstream wired
- generated outbound: `{"type":"hysteria2","server":"…","server_port":40443,"password":"…","obfs":{"type":"salamander","password":"…"},"tls":{…}}`
- hysteria server log: `client connected {"addr": "154.59.110.43:50929", "id": "user"}`
- DC connect through the tunnel: **1 ms**, local address `172.19.0.1`
- proxy with the fix: `phase=relaying c2s=64` (was `upstream connect start failed`)
- bulk through hysteria2: **10,486,179 bytes @ 11.4 MB/s**

**Falsification** — stop hysteria on B and the marked path must die, because a bare `connect()` proves nothing (sing-box terminates the TCP locally, so it succeeds either way — the exact "connects succeeding proves nothing" trap):

| hysteria on B | bytes through sbx0 |
|---|---|
| running | 1,048,994 |
| **stopped** | **0** |
| restarted | 1,048,994 |

## The v1.12.0 TUN fixes, confirmed on a real host

These had shipped verified only against upstream source. Now measured:

```
address:  172.19.0.1/32          ← was /30
mtu 1400                          ← was the 65535 default
resolvectl status sbx0: (empty)   ← was DNS Servers: 172.19.0.2 + domain ~.
getent hosts telegram.org: OK     ← host DNS survives
tun: {'address': ['172.19.0.1/32'], 'stack': 'gvisor', 'mtu': 1400}
```

## Two properties documented, not argued

In the module doc and the READMEs: hysteria2 is the only scheme whose egress leg is UDP, which matters because providers that block the Telegram DCs commonly police UDP hard and the failure looks like a healthy tunnel moving no bytes (this rig's provider does **not** — measured above). And Brutal needs a bandwidth the share-link grammar deliberately does not carry, so a link-provisioned hysteria2 egress runs BBR.

`zig build test`: 360 (278 proxy + 82 mtbuddy). The hysteria2 guards are mutation-checked — routing hy2 through `sbTls`, keeping the trailing path, accepting `pinSHA256`, or truncating a port-hopping list each fails a test.