### PR TITLE
fix(egress): run the update-time repair before any network work (+ menu emoji)

### DIFF
--- a/src/ctl/main.zig
+++ b/src/ctl/main.zig
@@ -212,6 +212,24 @@ const Action = enum {
     exit,
 };
 
+/// Main-menu labels that live here instead of in i18n.zig — they are built from runtime
+/// state (which of the two WEB entries to show) rather than a fixed key.
+///
+/// Every entry in the main menu carries an "<emoji><two spaces>" prefix; these three were
+/// the only ones that did not, so the list rendered half-decorated. The emoji reuses the
+/// feature's own icon on both the setup and the remove entry, the way 📊 does for the
+/// dashboard. tui.codepointWidth already counts U+1F300..U+1FAFF as two columns, so the
+/// menu's row accounting is unaffected. Pinned by a test below.
+fn menuSynLimit(lang: i18n.Lang) []const u8 {
+    return tr(lang, "🚦  Kernel SYN rate-limit (anti-flood)", "🚦  Ограничение SYN на уровне ядра (анти-флуд)");
+}
+fn menuWebSetup(lang: i18n.Lang) []const u8 {
+    return tr(lang, "🌐  WEB proxy for Telegram Desktop (via an HTTPS site)", "🌐  WEB-прокси для Telegram Desktop (через HTTPS-сайт)");
+}
+fn menuWebRemove(lang: i18n.Lang) []const u8 {
+    return tr(lang, "🌐  Remove the WEB proxy relay", "🌐  Удалить релей WEB-прокси");
+}
+
 fn interactiveMain(ui: *Tui, allocator: std.mem.Allocator) !void {
     while (true) {
         const sys = @import("sys.zig");
@@ -234,7 +252,7 @@ fn interactiveMain(ui: *Tui, allocator: std.mem.Allocator) !void {
             try actions.append(allocator, .masking);
             try items.append(allocator, i18n.get(ui.lang, .menu_setup_tunnel));
             try actions.append(allocator, .tunnel);
-            try items.append(allocator, tr(ui.lang, "Kernel SYN rate-limit (anti-flood)", "Ограничение SYN на уровне ядра (анти-флуд)"));
+            try items.append(allocator, menuSynLimit(ui.lang));
             try actions.append(allocator, .synlimit);
 
             const has_dashboard = sys.isServiceActive("proxy-monitor");
@@ -253,10 +271,10 @@ fn interactiveMain(ui: *Tui, allocator: std.mem.Allocator) !void {
                 try actions.append(allocator, .recovery);
             }
             if (!web.isInstalled()) {
-                try items.append(allocator, tr(ui.lang, "WEB proxy for Telegram Desktop (via an HTTPS site)", "WEB-прокси для Telegram Desktop (через HTTPS-сайт)"));
+                try items.append(allocator, menuWebSetup(ui.lang));
                 try actions.append(allocator, .web);
             } else {
-                try items.append(allocator, tr(ui.lang, "Remove the WEB proxy relay", "Удалить релей WEB-прокси"));
+                try items.append(allocator, menuWebRemove(ui.lang));
                 try actions.append(allocator, .remove_web);
             }
             try items.append(allocator, i18n.get(ui.lang, .menu_ipv6_hop));
@@ -675,4 +693,32 @@ test {
     _ = @import("uninstall.zig");
     _ = @import("update.zig");
     _ = @import("web.zig");
+}
+
+test "every main-menu entry is decorated with an emoji" {
+    // The menu mixes i18n keys with labels built here from runtime state, and the local
+    // ones used to ship undecorated — so the list rendered half with icons, half without.
+    // A leading multi-byte codepoint is the check: every icon in this menu is one.
+    const keyed = [_]i18n.S{
+        .menu_install,          .menu_update,
+        .menu_setup_masking,    .menu_setup_tunnel,
+        .menu_setup_recovery,   .menu_setup_dashboard,
+        .menu_remove_dashboard, .menu_ipv6_hop,
+        .menu_status,           .menu_restart,
+        .menu_uninstall,        .menu_exit,
+    };
+    for ([_]i18n.Lang{ .en, .ru }) |lang| {
+        for (keyed) |k| {
+            const label = i18n.get(lang, k);
+            try std.testing.expect(label.len > 0);
+            try std.testing.expect(label[0] >= 0x80);
+        }
+        for ([_][]const u8{ menuSynLimit(lang), menuWebSetup(lang), menuWebRemove(lang) }) |label| {
+            try std.testing.expect(label.len > 0);
+            try std.testing.expect(label[0] >= 0x80);
+            // "<emoji><two spaces>", matching the i18n entries.
+            const sp = std.mem.indexOf(u8, label, "  ") orelse return error.TestExpectedEqual;
+            try std.testing.expect(sp > 0);
+        }
+    }
 }

--- a/src/ctl/update.zig
+++ b/src/ctl/update.zig
@@ -85,6 +85,22 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: UpdateOpts) !void {
         return;
     }
 
+    // ── Repair an existing sing-box egress ──
+    // FIRST, before anything that touches the network or the binaries.
+    //
+    // An egress provisioned before the TUN fixes hands 172.19.0.2 to systemd-resolved as
+    // sbx0's DNS server with a `~.` route-only domain, which kills name resolution for
+    // the WHOLE host — including this command. Run the repair any later and update dies
+    // at "Resolving latest release" and never reaches it, so the one symptom that most
+    // needs fixing is the one that prevents the fix. (Same shape as the 203/EXEC case:
+    // a host that cannot start the proxy never reaches a post-restart repair either.)
+    //
+    // Nothing here depends on the new binaries or on the release having been resolved:
+    // it reads config.toml, rewrites the drop-in and the sing-box config, and restarts
+    // the egress. It is idempotent and no-ops when no egress is configured, so running it
+    // even on an update that later fails is free — and leaves the host better off.
+    tunnel_singbox.refreshEgress(ui, allocator);
+
     const insecure_mode = opts.insecure or sys.envFlagSet("MTPROTO_INSECURE");
     const signature_available = release.signatureVerificationAvailable();
     if (!signature_available and !insecure_mode) {
@@ -231,16 +247,6 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: UpdateOpts) !void {
         release.writeServiceFile();
     }
     _ = sys.execForward(&.{ "systemctl", "daemon-reload" }) catch {};
-
-    // ── Repair an existing sing-box egress ──
-    // Deliberately BEFORE the restart below, unlike the TCPMSS/nfqws repairs further
-    // down. The drop-in half of this clears the stale
-    // `ExecStartPre=+/usr/local/bin/setup_tunnel.sh` that leaves a host restart-looping
-    // with 203/EXEC — and such a host never reaches the post-restart repairs at all,
-    // because the failed restart returns through the rollback branch. On a healthy host
-    // the ordering is right anyway: sbx0 comes back up with the corrected TUN before the
-    // proxy starts marking DC sockets into it.
-    tunnel_singbox.refreshEgress(ui, allocator);
 
     // ── Start service ──
     ui.step(ui.str(.update_starting));


### PR DESCRIPTION
The auto-repair from #396 shipped one ordering level too late, and a live host proved it.

## The bug

An egress provisioned before the TUN fixes hands `172.19.0.2` to systemd-resolved as sbx0's DNS server with a `~.` route-only domain — which kills name resolution for the **whole host**, including `mtbuddy update` itself.

Reproduced on a clean Ubuntu 24.04 box put back into the pre-1.12.0 state:

```
addr: 172.19.0.1/30   mtu 65535
resolvectl: DNS Servers: 172.19.0.2   DNS Domain: ~.
host DNS: DEAD
SO_MARK as mtproto: PermissionError: [Errno 1] Operation not permitted

# mtbuddy update --yes
  ● Resolving latest release......
  ✖ Couldn't reach GitHub to find the latest version. Check the server's internet and try again.
```

Update died before it ever reached `refreshEgress`. **The one symptom that most needs fixing was the one preventing the fix.**

This is the same shape as the 203/EXEC case the repair already accounts for — a host that cannot start the proxy never reaches a post-restart repair either — just one level further up. I got the first one right and missed the second.

## The fix

Moved to the top of `execute()`, before the release resolution and the binary swap. Nothing in it depends on either: it reads config.toml, rewrites the drop-in and the sing-box config, and restarts the egress. It no-ops when no egress is configured, so running it on an update that later fails costs nothing and leaves the host better off.

Same host, same broken state, after the move:

```
  ✔ egress drop-in no longer runs a stale tunnel helper
  ✔ sing-box egress tun repaired (172.19.0.1/32, stack gvisor, mtu 1400)
  ● Resolving latest release......
  ✔ Latest release: (v1.12.0)
  ✔ Artifact downloaded (mtproto-proxy-linux-x86_64_v3)
```

It heals itself, and the update then completes.

Final state verified on the host:

| | |
|---|---|
| address | `172.19.0.1/32` |
| mtu | `1400` |
| `resolvectl status sbx0` | clean — no DNS server, no `~.` |
| `getent hosts telegram.org` | resolves |
| caps | `cap_net_bind_service cap_net_admin` |
| `.bak` | kept, 497 bytes |
| bytes through the tunnel | **1,048,994** |
| second `mtbuddy update` | **0** repair lines |

## Also: the main menu was half-decorated

Every main-menu entry carries an `<emoji><two spaces>` prefix except three, which are built here from runtime state rather than from an i18n key — so the list rendered half with icons, half without:

```
🔗  Setup tunnel
    Kernel SYN rate-limit (anti-flood)          ← bare
📊  Install Monitoring Dashboard
    WEB proxy for Telegram Desktop (…)          ← bare
    Remove the WEB proxy relay                  ← bare
🔄  IPv6 hopping
```

Now 🚦 and 🌐, reusing one icon per feature across its setup/remove pair the way 📊 already does for the dashboard. `tui.codepointWidth` already counts U+1F300..U+1FAFF as two columns, so the menu's row accounting is unaffected.

A test pins the invariant — the menu mixes i18n keys with locally-built labels and only the latter had drifted, so a leading multi-byte codepoint is asserted for both languages across all of them. Mutation-checked: removing one emoji fails it.

`zig build test`: 361 (278 proxy + 83 mtbuddy).