### PR TITLE
fix(uninstall): remove the egress config backup — it holds the share links

### DIFF
--- a/src/ctl/uninstall.zig
+++ b/src/ctl/uninstall.zig
@@ -103,9 +103,16 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
 
     // sing-box tunnel egress provider artifacts (upstream.type=tunnel via sbx0).
     _ = sys.execForward(&.{ "rm", "-f", "/etc/systemd/system/mtproto-singbox-egress.service" }) catch {};
-    _ = sys.execForward(&.{ "rm", "-f", "/etc/mtproto-proxy/singbox-egress.json" }) catch {};
+    // Both the config and the copy `mtbuddy update`'s egress repair keeps beside it. That
+    // .bak is not clutter: it is a full sing-box config, so it carries the share links —
+    // server addresses, passwords, obfs passwords — and leaving it behind means an
+    // uninstall leaves credentials on disk.
+    _ = sys.execForward(&.{ "rm", "-f", "/etc/mtproto-proxy/singbox-egress.json", "/etc/mtproto-proxy/singbox-egress.json.bak" }) catch {};
     _ = sys.execForward(&.{ "rm", "-f", "/usr/local/bin/mtproto-singbox-route.sh" }) catch {};
     _ = sys.execForward(&.{ "rm", "-f", "/usr/local/bin/sing-box" }) catch {};
+    // rmdir, not rm -rf: it removes the directory only once it is empty, so anything an
+    // operator put there of their own is left alone rather than silently deleted.
+    _ = sys.execForward(&.{ "rmdir", "--ignore-fail-on-non-empty", "/etc/mtproto-proxy" }) catch {};
 
     _ = sys.execForward(&.{ "rm", "-f", "/etc/systemd/system/mtproto-mask-health.timer" }) catch {};
     // recovery.zig installs this script; update.zig treats its mere existence as "recovery


### PR DESCRIPTION
Found by running `mtbuddy uninstall` on a live host that had a repaired sing-box egress.

## The leftover

Uninstall removed `/etc/mtproto-proxy/singbox-egress.json` but not the `.bak` that the update-time egress repair (#396) keeps beside it:

```
=== what survived the uninstall ===
--- units ---   all gone
--- files ---
  LEFT: /etc/mtproto-proxy
--- network state ---
  ip rule: clean   table 200: clean   :443: free

# ls -la /etc/mtproto-proxy/
-rw------- 1 root root 497 singbox-egress.json.bak
```

That file is a **full sing-box config** — so it carries the share links: server addresses, passwords, obfs passwords. Leaving it behind turns "uninstall" into "uninstall, but your VPN credentials stay on disk".

The `.bak` is mine, added two commits ago, so this is cleaning up after myself.

## The fix

- the `rm -f` now takes both paths;
- the now-empty `/etc/mtproto-proxy` goes too — via `rmdir --ignore-fail-on-non-empty`, not `rm -rf`, so the directory is removed only once it is actually empty and anything an operator put there of their own survives rather than being silently deleted.

Verified on the host: recreated the leftover state, re-ran uninstall, directory gone.

## The rest of the uninstall audit was clean

Everything else this run checked came back correct — all five units inactive and `not-found`, `/opt/mtproto-proxy` gone, the systemd drop-in directory gone, the nginx masking vhost gone, `sbx0` gone, `ip rule fwmark 200` gone, routing table 200 empty, `:443` free, `systemctl --failed` empty, host DNS and egress still working.