### PR TITLE
fix: harden proxy, WEB relay and VPN setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,6 @@ zig-out
 !README.md
 .env
 .env.*
-deploy
 GEMINI.md
 Makefile
 test_*.zig

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Run tests
         run: zig build test
 
+      - name: Check formatting
+        run: zig fmt --check build.zig src
+
+      - name: Test shipping optimization
+        run: zig build test -Doptimize=ReleaseSafe
+
       - name: Debug build
         run: zig build
 
@@ -38,10 +44,64 @@ jobs:
       - name: Cross-compile for Linux x86_64_v3+aes
         run: zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux -Dcpu=x86_64_v3+aes
 
+      # The published image's CPU profiles are read out of the Dockerfile itself rather than
+      # repeated here, so editing either file can't quietly ship an image that relays with
+      # std's bitsliced software AES. That is not hypothetical: `x86_64+aes` (what the amd64
+      # image used to build with) leaves has_hardware_support false, because std needs aes
+      # AND avx on x86, and `aarch64` with no -Dcpu misses the `aes` feature entirely.
+      - name: Probe helper regression tests
+        run: python3 -m unittest discover -s test -p test_probe_helpers.py
+
+      - name: Verify the Docker image CPU profiles enable hardware AES
+        run: |
+          cat > /tmp/check_aes_target.zig <<'EOF'
+          const std = @import("std");
+
+          comptime {
+              if (!std.crypto.core.aes.has_hardware_support) {
+                  @compileError("this target/cpu pair relays with software AES");
+              }
+          }
+
+          pub fn main() void {}
+          EOF
+          amd64_cpu="$(sed -n 's/^ARG ZIG_CPU_AMD64=//p' Dockerfile)"
+          arm64_cpu="$(sed -n 's/^ARG ZIG_CPU_ARM64=//p' Dockerfile)"
+          test -n "$amd64_cpu" && test -n "$arm64_cpu" \
+            || { echo "could not read ZIG_CPU_* defaults from Dockerfile" >&2; exit 1; }
+          for pair in "x86_64-linux:$amd64_cpu" "aarch64-linux:$arm64_cpu"; do
+            echo "checking ${pair}"
+            zig build-obj -femit-bin=/tmp/check_aes.o \
+              -target "${pair%%:*}" -mcpu "${pair#*:}" /tmp/check_aes_target.zig
+          done
+
       - name: Verify binary exists
         run: |
           ls -lh zig-out/bin/mtproto-proxy
           file zig-out/bin/mtproto-proxy
+
+  dashboard:
+    name: Dashboard API Tests
+    runs-on: ubuntu-latest
+    # No Zig needed and no dependency on the build: the dashboard is a Python control plane
+    # that ships with mtbuddy, and its auth / Host-pin / CSRF gates had no CI coverage at all
+    # until this job — the suite existed but nothing ever ran it.
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install dashboard runtime + test dependencies
+        # A venv, not `pip install --user`: the runner's system Python is externally managed.
+        run: |
+          python3 -m venv /tmp/dashboard-venv
+          /tmp/dashboard-venv/bin/pip install --quiet fastapi httpx psutil uvicorn pytest
+
+      - name: Run dashboard security tests
+        run: |
+          # test_server.py importorskip's its deps, so a missing wheel would turn the whole
+          # suite into a green skip that proves nothing. Import them here first so that
+          # failure is loud and the pytest run below can only be a real result.
+          /tmp/dashboard-venv/bin/python -c "import fastapi, httpx, psutil, uvicorn"
+          /tmp/dashboard-venv/bin/python -m pytest -q src/ctl/dashboard_assets/test_server.py
 
   e2e:
     name: E2E Integration
@@ -58,8 +118,18 @@ jobs:
       - name: Run E2E harness
         run: zig build e2e
 
+      - name: Run E2E with shipping optimization
+        run: zig build e2e -Doptimize=ReleaseFast
+
       - name: Run WEB proxy bridge-page contract tests
         run: zig build web-bridge
+
+  docker-build:
+    name: Docker build (no publish)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - run: docker build --platform linux/amd64 -t mtproto-ci .
 
   bench:
     name: Bench (No Soak)

--- a/.github/workflows/installer-e2e.yml
+++ b/.github/workflows/installer-e2e.yml
@@ -6,18 +6,16 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/installer-e2e.yml"
-      - "deploy/bootstrap.sh"
-      - "src/ctl/**"
-      - "src/version.zig"
+      - "deploy/**"
+      - "src/**"
       - "test/installer-e2e/**"
       - "build.zig"
   pull_request:
     branches: [main]
     paths:
       - ".github/workflows/installer-e2e.yml"
-      - "deploy/bootstrap.sh"
-      - "src/ctl/**"
-      - "src/version.zig"
+      - "deploy/**"
+      - "src/**"
       - "test/installer-e2e/**"
       - "build.zig"
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -44,6 +44,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Two rungs per architecture: a baseline artifact that runs anywhere, and a tuned
+        # one with hardware AES. Every relayed byte passes through AES-CTR twice, so the
+        # baseline rung relays with std's bitsliced software AES and is CPU-bound under load.
+        # aarch64 had only the baseline rung: `generic` carries `fuse_aes` (a scheduling
+        # hint) but not the `aes` feature, so every published ARM binary used software AES
+        # with no artifact an operator could switch to. `generic+aes` needs the ARMv8 crypto
+        # extensions — present on every ARM server part (Graviton, Ampere, Neoverse, Apple),
+        # absent on Cortex-A72 — hence a separate `_crypto` artifact rather than making the
+        # only aarch64 download require them.
         include:
           - target: x86_64-linux
             artifact_name: mtproto-proxy-linux-x86_64
@@ -57,6 +66,10 @@ jobs:
             artifact_name: mtproto-proxy-linux-aarch64
             binary: mtproto-proxy
             cpu: ""
+          - target: aarch64-linux
+            artifact_name: mtproto-proxy-linux-aarch64_crypto
+            binary: mtproto-proxy
+            cpu: generic+aes
           - target: x86_64-linux
             artifact_name: mtbuddy-linux-x86_64
             binary: mtbuddy
@@ -69,6 +82,13 @@ jobs:
             artifact_name: mtbuddy-linux-aarch64
             binary: mtbuddy
             cpu: ""
+          # mtbuddy gains nothing from AES itself, but release.zig derives the buddy asset
+          # name from the proxy asset it picked, so the tuned rung needs a matching buddy or
+          # mtbuddy's own self-update finds no download.
+          - target: aarch64-linux
+            artifact_name: mtbuddy-linux-aarch64_crypto
+            binary: mtbuddy
+            cpu: generic+aes
 
     steps:
       - name: Checkout release tag
@@ -81,15 +101,20 @@ jobs:
         with:
           version: 0.16.0
 
-      - name: Verify AES-enabled x86_64_v3 profile
-        if: contains(matrix.cpu, 'x86_64_v3')
+      # Runs for every leg that pins a CPU, not just x86_64_v3: a tuned artifact whose name
+      # promises hardware AES but whose -Dcpu does not actually select it is invisible at
+      # runtime (std silently falls back to the bitsliced software AES) and is exactly the
+      # trap `x86_64+aes` fell into — std needs aes AND avx on x86, so `+aes` alone builds
+      # soft AES. The baseline legs (cpu: "") are software-AES on purpose and are skipped.
+      - name: Verify the pinned CPU profile really enables hardware AES
+        if: matrix.cpu != ''
         run: |
           cat > /tmp/check_aes_target.zig <<'EOF'
           const std = @import("std");
 
           comptime {
               if (!std.crypto.core.aes.has_hardware_support) {
-                  @compileError("x86_64_v3 release artifacts must be built with +aes");
+                  @compileError("tuned release artifacts must be built with a hardware-AES cpu");
               }
           }
 
@@ -130,12 +155,14 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y minisign
 
-          printf '%s\n' "${MINISIGN_SECRET_KEY}" > /tmp/minisign.key
-          chmod 600 /tmp/minisign.key
+          umask 077
+          signing_key="$(mktemp "$RUNNER_TEMP/minisign.XXXXXX")"
+          trap 'rm -f "$signing_key"' EXIT
+          printf '%s\n' "${MINISIGN_SECRET_KEY}" > "$signing_key"
           printf '%s\n' "untrusted comment: mtproto.zig minisign public key" > dist/minisign.pub
           printf '%s\n' "${PINNED_MINISIGN_PUBKEY}" >> dist/minisign.pub
           minisign -S \
-            -s /tmp/minisign.key \
+            -s "$signing_key" \
             -m dist/${{ matrix.artifact_name }}.tar.gz.sha256 \
             -x dist/${{ matrix.artifact_name }}.tar.gz.sha256.minisig \
             -t "tag:${{ needs.release-please.outputs.tag_name }} artifact:${{ matrix.artifact_name }}"

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ zig-out/
 telemt/
 .DS_Store
 VALIDATION.md
-config.toml
+/config.toml
 .env
 .ruff_cache/
 *.session
@@ -21,10 +21,16 @@ fix_tui.py
 bundle.sh
 codebase.txt
 .agent/skills/local-env/
+.agents/
+.codex/
+.worktrees/
 
-# Internal planning docs — kept local, not published
+# Local Markdown documents, plans and audits are not release inputs.
+# Existing published README/CHANGELOG files remain tracked.
+*.md
+AUDIT-*.md
 ROADMAP_1.0.md
 PRODUCT_VISION.md
 
-# dashboard auth token (generated at runtime)
+# Dashboard authentication token generated at runtime.
 src/ctl/dashboard_assets/dashboard.token

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,25 +13,47 @@
 ARG ZIG_VERSION=0.16.0
 ARG ZIG_SHA256=
 
-FROM debian:bookworm-slim AS builder
+# CPU profiles, one per published architecture. Every relayed byte goes through AES-CTR
+# twice, so a build that misses std's hardware-AES backend relays with the bitsliced
+# software one and becomes CPU-bound under load. `zig build-obj -mcpu <profile>` with a
+# comptime assert on std.crypto.core.aes.has_hardware_support is what qualifies these two
+# strings; ci.yml re-runs that assert on exactly these lines so neither can regress.
+#
+#   amd64: `+aes` alone is NOT enough — std/crypto/aes.zig selects the AES-NI backend only
+#          when the target has aes AND avx, and the x86_64 baseline model carries neither
+#          (`aes` depends on sse2 only). x86_64+aes+avx is the most conservative pair that
+#          turns it on: AES-NI is Westmere (2010), AVX is Sandy Bridge (2011), so it stays
+#          below the x86_64_v3 (Haswell/AVX2) bar the release artifacts use.
+#   arm64: aarch64's `generic` model carries `fuse_aes` — a scheduling hint, not the `aes`
+#          feature — so the default build has no hardware AES either. `generic+aes` requires
+#          the ARMv8 crypto extensions, which every ARM server part has (Graviton, Ampere,
+#          Neoverse, Apple) but Cortex-A72 (Raspberry Pi 4) does not; build with
+#          `--build-arg ZIG_CPU_ARM64=generic` there.
+ARG ZIG_CPU_AMD64=x86_64+aes+avx
+ARG ZIG_CPU_ARM64=generic+aes
+
+FROM --platform=$BUILDPLATFORM debian:bookworm-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171 AS builder
 ARG ZIG_VERSION
 ARG ZIG_SHA256
 ARG TARGETARCH
+ARG BUILDARCH
+ARG ZIG_CPU_AMD64
+ARG ZIG_CPU_ARM64
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl xz-utils \
     && rm -rf /var/lib/apt/lists/* \
-    && if [ -z "$TARGETARCH" ]; then \
-        TARGETARCH="$(dpkg --print-architecture 2>/dev/null || uname -m)"; \
+    && if [ -z "$BUILDARCH" ]; then \
+        BUILDARCH="$(dpkg --print-architecture 2>/dev/null || uname -m)"; \
        fi \
     # Per-arch known-good SHA256 for the default ZIG_VERSION (0.16.0). The Zig
     # toolchain tarball is ALWAYS checksum-verified — a compromised mirror/CDN
     # can't slip in a backdoored compiler. Override ZIG_SHA256 if you bump
     # ZIG_VERSION via --build-arg.
-    && case "$TARGETARCH" in \
+    && case "$BUILDARCH" in \
         amd64|x86_64)  ZIG_ARCH=x86_64;  ZIG_SHA256_DEFAULT=70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00 ;; \
         arm64|aarch64) ZIG_ARCH=aarch64; ZIG_SHA256_DEFAULT=ea4b09bfb22ec6f6c6ceac57ab63efb6b46e17ab08d21f69f3a48b38e1534f17 ;; \
-        *)      echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+        *)      echo "unsupported BUILDARCH=$BUILDARCH" >&2; exit 1 ;; \
        esac \
     && ZIG_SHA256="${ZIG_SHA256:-$ZIG_SHA256_DEFAULT}" \
     && curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused \
@@ -47,17 +69,18 @@ WORKDIR /build
 
 COPY build.zig build.zig.zon ./
 COPY src ./src
+COPY deploy ./deploy
 
 RUN set -eu \
     && arch="${TARGETARCH:-$(dpkg --print-architecture 2>/dev/null || uname -m)}" \
     && case "$arch" in \
         amd64|x86_64) \
             target="x86_64-linux"; \
-            cpu="x86_64+aes"; \
+            cpu="$ZIG_CPU_AMD64"; \
             ;; \
         arm64|aarch64) \
             target="aarch64-linux"; \
-            cpu=""; \
+            cpu="$ZIG_CPU_ARM64"; \
             ;; \
         *) \
             echo "unsupported TARGETARCH=$arch" >&2; \
@@ -70,15 +93,20 @@ RUN set -eu \
          zig build -Doptimize=ReleaseFast -Dtarget="$target"; \
        fi
 
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && apt-get install -y --no-install-recommends curl ca-certificates libcap2-bin \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /build/zig-out/bin/mtproto-proxy /usr/local/bin/mtproto-proxy
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+RUN groupadd --gid 10001 mtproto \
+    && useradd --uid 10001 --gid 10001 --no-create-home --shell /usr/sbin/nologin mtproto \
+    && mkdir -p /etc/mtproto-proxy \
+    && chown mtproto:mtproto /etc/mtproto-proxy \
+    && setcap cap_net_bind_service=+ep /usr/local/bin/mtproto-proxy
 
 WORKDIR /etc/mtproto-proxy
 
@@ -87,6 +115,12 @@ WORKDIR /etc/mtproto-proxy
 # publicly-known access secrets as the live config (that would defeat active-probe
 # resistance for everyone running the image unchanged).
 COPY config.toml.example /usr/share/doc/mtproto-proxy/config.toml.example
+
+VOLUME ["/etc/mtproto-proxy"]
+USER 10001:10001
+# Process liveness only; enable/scrape the configured metrics /healthz endpoint for
+# event-loop health. Metrics is optional, so the image must not require port 9400.
+HEALTHCHECK --interval=30s --timeout=3s CMD kill -0 1 || exit 1
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["/etc/mtproto-proxy/config.toml"]

--- a/Makefile
+++ b/Makefile
@@ -31,17 +31,18 @@ deploy: build ## Build and push proxy + mtbuddy to server (binary-only; PUSH_CON
 	@# touches the live config/secrets. Pushing a stale or drifted local config.toml over a
 	@# live deploy can break every share link (secrets/tls_domain) and the egress mode. Run
 	@# `make deploy PUSH_CONFIG=1` deliberately when you intend to overwrite the remote config.
-	@if [ "$(PUSH_CONFIG)" = "1" ]; then \
-		if [ -f $(CONFIG) ]; then echo "PUSH_CONFIG=1: pushing $(CONFIG) -> remote config.toml"; scp $(CONFIG) root@$(SERVER):/opt/mtproto-proxy/config.toml; fi; \
+	@set -e; if [ "$(PUSH_CONFIG)" = "1" ]; then \
+		if [ -f "$(CONFIG)" ]; then echo "PUSH_CONFIG=1: pushing $(CONFIG) -> remote config.toml"; scp "$(CONFIG)" root@$(SERVER):/opt/mtproto-proxy/config.toml; fi; \
 		if [ -f .env ]; then \
-			tmp=$$(mktemp) && awk '{print "export " $$0}' .env > "$$tmp" && \
+			tmp=$$(mktemp); trap 'rm -f "$$tmp"' EXIT; awk '{print "export " $$0}' .env > "$$tmp"; \
 			scp "$$tmp" root@$(SERVER):/opt/mtproto-proxy/env.sh && \
-			ssh root@$(SERVER) 'chmod 600 /opt/mtproto-proxy/env.sh'; rm -f "$$tmp"; \
+			ssh root@$(SERVER) 'chmod 600 /opt/mtproto-proxy/env.sh'; \
 		fi; \
 	else echo "binary-only deploy (config/env left untouched; use PUSH_CONFIG=1 to push them)"; fi
-	ssh root@$(SERVER) 'install -m 0755 /opt/mtproto-proxy/mtproto-proxy.new /opt/mtproto-proxy/mtproto-proxy'
-	ssh root@$(SERVER) 'install -m 0755 /usr/local/bin/mtbuddy.new /usr/local/bin/mtbuddy'
-	ssh root@$(SERVER) 'chown -R mtproto:mtproto /opt/mtproto-proxy/ && systemctl restart mtproto-proxy && systemctl is-active --quiet mtproto-proxy'
+	ssh root@$(SERVER) 'chmod 0755 /opt/mtproto-proxy/mtproto-proxy.new && mv -f /opt/mtproto-proxy/mtproto-proxy.new /opt/mtproto-proxy/mtproto-proxy'
+	ssh root@$(SERVER) 'chmod 0755 /usr/local/bin/mtbuddy.new && mv -f /usr/local/bin/mtbuddy.new /usr/local/bin/mtbuddy'
+	ssh root@$(SERVER) 'chown root:root /opt/mtproto-proxy && chown mtproto:mtproto /opt/mtproto-proxy/config.toml && systemctl restart mtproto-proxy && systemctl is-active --quiet mtproto-proxy'
+	ssh root@$(SERVER) 'if systemctl is-active --quiet mtproto-web-relay; then systemctl restart mtproto-web-relay; fi'
 	ssh root@$(SERVER) 'if [ -f /etc/systemd/system/proxy-monitor.service ]; then mtbuddy setup dashboard --quiet; fi'
 
 # ── dashboard ─────────────────────────────────────────────────────────────────

--- a/build.zig
+++ b/build.zig
@@ -17,7 +17,7 @@ pub fn build(b: *std.Build) void {
         "Build the internet-facing proxy with runtime safety on (ReleaseSafe) even in release builds (default: true)",
     ) orelse true;
     const dataplane_optimize: std.builtin.OptimizeMode =
-        if (dataplane_safety and optimize == .ReleaseFast) .ReleaseSafe else optimize;
+        if (dataplane_safety and (optimize == .ReleaseFast or optimize == .ReleaseSmall)) .ReleaseSafe else optimize;
     const pinned_minisign_pubkey = "RWT8YwmUuq/3WpUnYJjD6rAfQugYdZKWr61U3O+2kdNvriLSyrvVU/NO";
     const minisign_pubkey = b.option(
         []const u8,
@@ -27,6 +27,7 @@ pub fn build(b: *std.Build) void {
 
     const build_options = b.addOptions();
     build_options.addOption([]const u8, "minisign_pubkey", minisign_pubkey);
+    build_options.addOption([]const u8, "proxy_service", @embedFile("deploy/mtproto-proxy.service"));
     const build_options_mod = build_options.createModule();
     const version_mod = b.createModule(.{
         .root_source_file = b.path("src/version.zig"),
@@ -44,6 +45,12 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    const child_process_mod = b.createModule(.{
+        .root_source_file = b.path("src/proxy/child_process.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
     const exe_mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
@@ -51,6 +58,7 @@ pub fn build(b: *std.Build) void {
         .imports = &.{
             .{ .name = "version", .module = version_mod },
             .{ .name = "linux_io", .module = linux_io_mod },
+            .{ .name = "child_process", .module = child_process_mod },
         },
     });
 
@@ -89,7 +97,8 @@ pub fn build(b: *std.Build) void {
         .root_module = bench_mod,
     });
 
-    b.installArtifact(bench_exe);
+    const install_bench = b.addInstallArtifact(bench_exe, .{});
+    b.step("install-bench", "Install the optional benchmark binary").dependOn(&install_bench.step);
 
     const run_bench_cmd = b.addRunArtifact(bench_exe);
     if (b.args) |args| {
@@ -119,12 +128,14 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/proxy/http_fetch.zig"),
         .target = target,
         .optimize = optimize,
+        .imports = &.{.{ .name = "child_process", .module = child_process_mod }},
     });
 
     const proxy_net_helpers_mod = b.createModule(.{
         .root_source_file = b.path("src/proxy/net_helpers.zig"),
         .target = target,
         .optimize = optimize,
+        .imports = &.{.{ .name = "child_process", .module = child_process_mod }},
     });
 
     // The WEB proxy hostname rules and bridge-capability derivation are shared: the relay
@@ -141,6 +152,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
         .imports = &.{
+            .{ .name = "cover_page", .module = b.createModule(.{ .root_source_file = b.path("src/web/page.zig"), .target = target, .optimize = optimize }) },
             .{ .name = "tunnel", .module = tunnel_mod },
             .{ .name = "version", .module = version_mod },
             .{ .name = "linux_io", .module = linux_io_mod },
@@ -156,6 +168,7 @@ pub fn build(b: *std.Build) void {
         .name = "mtbuddy",
         .root_module = ctl_mod,
     });
+    ctl_exe.pie = target.result.os.tag == .linux;
 
     b.installArtifact(ctl_exe);
 
@@ -174,6 +187,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
         .imports = &.{
+            .{ .name = "child_process", .module = child_process_mod },
             .{ .name = "version", .module = version_mod },
             .{ .name = "linux_io", .module = linux_io_mod },
         },
@@ -192,6 +206,15 @@ pub fn build(b: *std.Build) void {
     const run_ctl_tests = b.addRunArtifact(ctl_tests);
 
     const test_step = b.step("test", "Run unit tests");
+    const obf_gen = b.addExecutable(.{
+        .name = "e2e-obf-handshake-gen",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/e2e_obf_handshake_gen.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    test_step.dependOn(&obf_gen.step);
     test_step.dependOn(&run_unit_tests.step);
     test_step.dependOn(&run_ctl_tests.step);
 
@@ -199,11 +222,42 @@ pub fn build(b: *std.Build) void {
     if (target.query.isNative() and target.result.os.tag == .linux) {
         const run_mtbuddy_help_ru = b.addRunArtifact(ctl_exe);
         run_mtbuddy_help_ru.addArgs(&.{ "--lang", "ru", "--help" });
+        _ = run_mtbuddy_help_ru.captureStdOut(.{});
+        _ = run_mtbuddy_help_ru.captureStdErr(.{});
         test_step.dependOn(&run_mtbuddy_help_ru.step);
+        const bad_invocations = [_][]const []const u8{
+            &.{"unknown-command"},
+            &.{"--lang"},
+            &.{ "setup", "unknown" },
+            &.{ "setup", "masking", "--lang", "ru" },
+            &.{ "config", "validate", "--config" },
+            &.{ "install", "--secert", "bad" },
+            &.{ "update", "--unknown" },
+            &.{ "setup", "web", "--unknown" },
+            &.{ "setup", "egress", "--unknown" },
+            &.{ "setup", "tunnel", "--unknown" },
+            &.{ "setup", "masking", "--unknown" },
+            &.{ "setup", "dashboard", "--unknown" },
+            &.{ "setup", "nfqws", "--unknown" },
+            &.{ "setup", "recovery", "--unknown" },
+            &.{ "setup", "syn-limit", "--unknown" },
+            &.{ "ipv6-hop", "--unknown" },
+        };
+        for (bad_invocations) |argv| {
+            const bad_usage = b.addRunArtifact(ctl_exe);
+            bad_usage.addArgs(argv);
+            bad_usage.expectExitCode(1);
+            _ = bad_usage.captureStdOut(.{});
+            _ = bad_usage.captureStdErr(.{});
+            test_step.dependOn(&bad_usage.step);
+        }
     }
 
     // E2E / integration harness (process-level scenarios).
-    const e2e_cmd = b.addSystemCommand(&.{ "python3", "test/e2e/run.py" });
+    const e2e_cmd = b.addSystemCommand(&.{"python3"});
+    e2e_cmd.addFileArg(b.path("test/e2e/run.py"));
+    e2e_cmd.addArg("--obf-gen");
+    e2e_cmd.addFileArg(obf_gen.getEmittedBin());
     e2e_cmd.step.dependOn(&exe.step);
     e2e_cmd.addArg("--proxy-bin");
     e2e_cmd.addFileArg(exe.getEmittedBin());
@@ -219,7 +273,8 @@ pub fn build(b: *std.Build) void {
     // that fail silently when they are wrong — so it is driven by a scripted client in
     // node rather than left unexercised. Kept out of `test` because it needs python3 and
     // node; the runner skips cleanly when node is absent.
-    const web_bridge_cmd = b.addSystemCommand(&.{ "python3", "test/web-bridge/run.py" });
+    const web_bridge_cmd = b.addSystemCommand(&.{"python3"});
+    web_bridge_cmd.addFileArg(b.path("test/web-bridge/run.py"));
     const web_bridge_step = b.step("web-bridge", "Run WEB proxy bridge-page contract tests");
     web_bridge_step.dependOn(&web_bridge_cmd.step);
 }

--- a/config.toml.example
+++ b/config.toml.example
@@ -17,6 +17,12 @@ use_middle_proxy = true
 # ad_tag = "1234567890abcdef1234567890abcdef"
 
 [server]
+# Optional HTTPS Date source for small clock corrections (within +/-120 seconds).
+# Larger drift is rejected: configure host NTP instead.
+# clock_sync_url = "https://example.com/"
+# Accept PROXY protocol only behind a trusted, firewalled load balancer.
+# Never expose this mode directly to untrusted clients: source addresses can be forged.
+# accept_proxy_protocol = false
 port = 443
 
 # Bind address for the listen socket. When uncommented, the proxy listens
@@ -226,7 +232,9 @@ port = 443
 # Concurrency caps. Each session is one desktop client; each stream is one
 # MTProto socket it opens, and each costs a connection against
 # [server].max_connections on the proxy side.
-# max_sessions = 64
+# max_sessions = 32
+# Aggregate relay input/output/fragment/frame buffer ceiling across all clients (MiB).
+# max_buffer_mb = 128
 # max_streams = 32
 
 # TLS terminator that accepts a PROXY-protocol header, used ONLY for masked
@@ -274,9 +282,10 @@ port = 443
 # "http"       — route via HTTP CONNECT proxy
 # type = "auto"
 
-# When type is socks5/http, allow MiddleProxy metadata refresh to fall back to a
-# DIRECT fetch if the configured upstream is unreachable. Default false (the
-# upstream is treated as mandatory). Note: socks5/http/tunnel metadata refresh
+# When true, an unresolved or unconfigured socks5/http upstream allows ALL
+# traffic to use DIRECT egress from this host's IP, not just metadata refresh.
+# Default false: fail closed and treat the upstream as mandatory.
+# Note: socks5/http/tunnel metadata refresh
 # shells out to `curl`, so curl must be installed for those modes.
 # allow_direct_fallback = false
 
@@ -319,6 +328,18 @@ port = 443
 # links = ["vless://...@host:443?security=reality&pbk=...&sni=...&sid=...&flow=xtls-rprx-vision"]
 
 [censorship]
+# Bound ordinary masking connections; 0 opts into unlimited lifetime.
+# WEB carrier connections using mask_backend use their own idle limits instead.
+# mask_relay_max_secs = 300
+# Optional SNI fronting allowlist. Arrays must fit on one line.
+# mask_sni_safelist = []
+# Use RST instead of a TLS alert when unknown_sni_action = "reject".
+# reject_rst = false
+# Fake encrypted certificate record size (256..16384 bytes; 0=randomized).
+# fake_cert_size = 0
+# Delay settings apply only when desync=true (opt-in).
+# desync_split_delay_ms = 3
+# desync_split_jitter_ms = 3
 # Domain to impersonate in TLS ServerHello and forward unauthenticated clients to.
 # Since June 2026 pick a popular domain that negotiates single-round X25519MLKEM768
 # (post-quantum) — a classical-x25519-only domain now marks iOS clients (and everyone

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -26,6 +26,8 @@ FORWARD_ARGS=()
 for arg in "$@"; do
   if [ "$arg" = "--insecure" ]; then
     INSECURE_MODE=1
+    export MTPROTO_INSECURE=1
+    continue
   fi
   FORWARD_ARGS+=("$arg")
 done
@@ -226,13 +228,15 @@ download_artifact() {
     # (and possibly vulnerable) build as the current 'latest'.
     printf '%s\n' "$sig_out" | grep -Fq "tag:${TAG} " \
       || fail "Signature trusted-comment tag mismatch for $sha_name (expected tag:${TAG})"
-    printf '%s\n' "$sig_out" | grep -Fq "artifact:${artifact}" \
+    printf '%s\n' "$sig_out" | awk -v token="artifact:${artifact}" '{ for (i=1;i<=NF;i++) if ($i == token) found=1 } END { exit !found }' \
       || fail "Signature trusted-comment artifact mismatch for $sha_name (expected artifact:${artifact})"
   else
     step "INSECURE mode: skipping minisign signature verification"
   fi
 
   step "Verifying checksum for $artifact"
+  awk -v artifact="$artifact" 'NF != 2 || ($2 != artifact && $2 != "*" artifact) { bad=1 } END { exit (bad || NR != 1) }' "$TMP/${sha_name}" \
+    || fail "Checksum filename mismatch for $artifact"
   if command -v sha256sum >/dev/null 2>&1; then
     (cd "$TMP" && sha256sum -c "${sha_name}" >/dev/null) || fail "Checksum verification failed: $artifact"
   elif command -v shasum >/dev/null 2>&1; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -12,6 +12,7 @@ set -e
 CONFIG="${1:-/etc/mtproto-proxy/config.toml}"
 
 if [ ! -f "$CONFIG" ]; then
+    echo "mtproto-proxy: keep a named /etc/mtproto-proxy volume to preserve generated secrets across container recreation." >&2
     SECRET="$(head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n')"
     mkdir -p "$(dirname "$CONFIG")"
     cat > "$CONFIG" <<EOF

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
     ".": {
       "release-type": "simple",
       "changelog-path": "CHANGELOG.md",
+      "skip-changelog": true,
       "include-component-in-tag": false,
       "include-v-in-tag": true,
       "draft": false,

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -13,8 +13,8 @@ fn ip4(bytes: [4]u8, port: u16) net.IpAddress {
 
 fn nowNs() u64 {
     var ts: std.posix.timespec = undefined;
-    const rc = std.os.linux.clock_gettime(std.os.linux.CLOCK.MONOTONIC, &ts);
-    if (std.os.linux.errno(rc) != .SUCCESS) return 0;
+    const rc = std.posix.system.clock_gettime(.MONOTONIC, &ts);
+    if (std.posix.errno(rc) != .SUCCESS) return 0;
     return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
 }
 
@@ -66,7 +66,7 @@ pub fn main(init: std.process.Init) !void {
 
     switch (opts.mode) {
         .bench => try runBench(allocator),
-        .handshake => try runHandshakeBench(allocator, opts.iterations),
+        .handshake => try runHandshakeBench(opts.iterations),
         .handshake_path => try runHandshakePathBench(allocator, opts),
         .soak => try runSoak(allocator, opts),
     }
@@ -125,17 +125,27 @@ fn runBench(allocator: std.mem.Allocator) !void {
     }
 }
 
-fn runHandshakeBench(allocator: std.mem.Allocator, iterations: usize) !void {
-    const bench_secret = [_]u8{0x42} ** 16;
-    const user_secrets = [_]tls.UserSecret{.{ .name = "bench", .secret = bench_secret }};
+fn runHandshakeBench(iterations: usize) !void {
+    for ([_]usize{ 1, 32, 256, 1024 }) |users| {
+        for ([_]usize{ 200, 2048, tls.max_authenticated_hello_len }) |hello_len| {
+            try runHandshakeCase(@max(1, iterations / users), users, hello_len);
+        }
+    }
+}
 
-    var handshake = [_]u8{0} ** 96;
+fn runHandshakeCase(iterations: usize, users: usize, hello_len: usize) !void {
+    const bench_secret = [_]u8{0x42} ** 16;
+    var secrets: [1024]tls.UserSecret = undefined;
+    for (secrets[0..users]) |*secret| secret.* = .{ .name = "miss", .secret = .{0x11} ** 16 };
+    secrets[users - 1] = .{ .name = "bench", .secret = bench_secret };
+    const user_secrets = secrets[0..users];
+
+    var handshake_buf = [_]u8{0} ** tls.max_authenticated_hello_len;
+    const handshake = handshake_buf[0..hello_len];
     handshake[constants.tls_digest_pos + constants.tls_digest_len] = 32;
     @memset(handshake[44..76], 0xaa);
 
-    var canonical_input = handshake;
-    @memset(canonical_input[constants.tls_digest_pos..][0..constants.tls_digest_len], 0);
-    const canonical = crypto.sha256Hmac(&bench_secret, &canonical_input);
+    const canonical = crypto.sha256Hmac(&bench_secret, handshake);
 
     @memcpy(handshake[constants.tls_digest_pos..][0..28], canonical[0..28]);
     const ts: u32 = 0x11223344;
@@ -146,8 +156,8 @@ fn runHandshakeBench(allocator: std.mem.Allocator, iterations: usize) !void {
     handshake[constants.tls_digest_pos + 31] = canonical[31] ^ ts_bytes[3];
 
     var warmup: usize = 0;
-    while (warmup < 1000) : (warmup += 1) {
-        const ok = try tls.validateTlsHandshake(allocator, &handshake, &user_secrets, true, 0);
+    while (warmup < @min(iterations, 10)) : (warmup += 1) {
+        const ok = try tls.validateTlsHandshake(handshake, user_secrets, true, 0);
         if (ok == null) return error.BenchmarkValidationFailed;
     }
 
@@ -155,7 +165,7 @@ fn runHandshakeBench(allocator: std.mem.Allocator, iterations: usize) !void {
     var matched: usize = 0;
     var i: usize = 0;
     while (i < iterations) : (i += 1) {
-        const ok = try tls.validateTlsHandshake(allocator, &handshake, &user_secrets, true, 0);
+        const ok = try tls.validateTlsHandshake(handshake, user_secrets, true, 0);
         if (ok != null) matched += 1;
     }
 
@@ -166,7 +176,7 @@ fn runHandshakeBench(allocator: std.mem.Allocator, iterations: usize) !void {
     else
         @as(u64, @intCast((@as(u128, iterations) * std.time.ns_per_s) / elapsed_ns));
 
-    std.debug.print("benchmark: validateTlsHandshake\n", .{});
+    std.debug.print("benchmark: validateTlsHandshake users={d} hello_bytes={d} MiB_hashed_per_sec={d}\n", .{ users, hello_len, bytesPerSecToMiB(@intCast(iterations * users * hello_len), elapsed_ns) });
     std.debug.print("iterations matched ns_per_op ops_per_sec\n", .{});
     std.debug.print("{d} {d} {d} {d}\n", .{ iterations, matched, ns_per_op, ops_per_sec });
 }
@@ -259,6 +269,8 @@ fn runSoak(allocator: std.mem.Allocator, opts: Options) !void {
 
     var threads: std.ArrayList(std.Thread) = .empty;
     defer threads.deinit(allocator);
+    try threads.ensureTotalCapacity(allocator, opts.threads);
+    errdefer for (threads.items) |thread| thread.join();
 
     for (0..opts.threads) |worker_id| {
         const worker = WorkerArgs{
@@ -267,7 +279,7 @@ fn runSoak(allocator: std.mem.Allocator, opts: Options) !void {
             .shared = &shared,
         };
         const thread = try std.Thread.spawn(.{}, soakWorker, .{worker});
-        try threads.append(allocator, thread);
+        threads.appendAssumeCapacity(thread);
     }
 
     for (threads.items) |thread| {
@@ -429,7 +441,7 @@ fn parseArgs(args_source: std.process.Args, allocator: std.mem.Allocator) !Optio
             continue;
         }
         if (std.mem.startsWith(u8, arg, "--threads=")) {
-            opts.threads = try parsePositiveUsize(arg["--threads=".len..]);
+            opts.threads = try std.fmt.parseInt(usize, arg["--threads=".len..], 10);
             continue;
         }
         if (std.mem.startsWith(u8, arg, "--max-payload=")) {
@@ -488,6 +500,9 @@ fn printUsage() void {
         \\Flags:
         \\  --iterations=N       iterations for handshake and handshake-path
         \\  --candidate-count=N  candidate list size for handshake-path (1..16)
+        \\  --seconds=N          soak duration
+        \\  --threads=N          soak workers (0 = auto)
+        \\  --max-payload=N      maximum soak payload bytes
         \\
     , .{});
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -9,6 +9,19 @@ const UserIpLimit = @import("proxy/user_ip_limit.zig").UserIpLimit;
 const default_tls_domain = "google.com";
 const default_local_mask_target = "127.0.0.1";
 
+fn parsePort(value: []const u8) !u16 {
+    if (value.len == 0) return error.InvalidPort;
+    for (value) |c| if (!std.ascii.isDigit(c)) return error.InvalidPort;
+    const port = std.fmt.parseInt(u16, value, 10) catch return error.InvalidPort;
+    if (port == 0) return error.InvalidPort;
+    return port;
+}
+
+fn warnUnknownKey(key: []const u8) void {
+    if (@import("builtin").is_test) return; // Fuzz inputs intentionally contain arbitrary keys.
+    std.log.scoped(.config).warn("unknown configuration key '{s}'; ignored", .{key});
+}
+
 /// Ceiling for an [access.user_max_ips] entry. The cap sizes the per-user table the
 /// enforcement side allocates, so the two must agree.
 const max_user_ips: u32 = UserIpLimit.max_cap;
@@ -98,8 +111,8 @@ fn parseBool(value: []const u8) bool {
         std.ascii.eqlIgnoreCase(value, "on");
 }
 
-fn stripInlineComment(value: []const u8) []const u8 {
-    var in_quotes = false;
+fn stripInlineComment(value: []const u8) ![]const u8 {
+    var quote: u8 = 0;
     var escaped = false;
     var i: usize = 0;
 
@@ -111,21 +124,26 @@ fn stripInlineComment(value: []const u8) []const u8 {
             continue;
         }
 
-        if (in_quotes and ch == '\\') {
+        if (quote == '"' and ch == '\\') {
             escaped = true;
             continue;
         }
 
-        if (ch == '"') {
-            in_quotes = !in_quotes;
+        if (ch == quote and quote != 0) {
+            quote = 0;
+            continue;
+        }
+        if (quote == 0 and (ch == '"' or ch == '\'')) {
+            quote = ch;
             continue;
         }
 
-        if (!in_quotes and (ch == '#' or ch == ';')) {
+        if (quote == 0 and ch == '#') {
             return std.mem.trim(u8, value[0..i], &[_]u8{ ' ', '\t' });
         }
     }
 
+    if (quote != 0 or escaped) return error.UnterminatedString;
     return std.mem.trim(u8, value, &[_]u8{ ' ', '\t' });
 }
 
@@ -436,9 +454,9 @@ pub const Config = struct {
     /// Max lifetime (seconds) for a masking-relay connection (a probe forwarded to the
     /// backend). 0 = unlimited. Bounds how long an active prober/scanner can hold a
     /// backend connection open through us; idle masking relays are already idle-timed.
-    mask_relay_max_secs: u32 = 0,
+    mask_relay_max_secs: u32 = 300,
     /// Size (bytes) of the fake encrypted-certificate AppData record in the FakeTLS
-    /// ServerHello. 0 = default (~2878, a typical nginx + Let's Encrypt ECDSA chain). Set
+    /// ServerHello. 0 = a per-process random size in 2400..3600. Set
     /// it to the first encrypted-flight record size your masking backend actually serves so
     /// an active prober sees the same cert-record size on both the accept and mask paths
     /// (measure with e.g. `openssl s_client -msg`). Clamped to 256..16384.
@@ -467,7 +485,7 @@ pub const Config = struct {
     /// fatal alert; pick whichever your masked domain actually does. Default off.
     reject_rst: bool = false,
     /// TCP desync: split ServerHello into 1-byte + rest to evade DPI
-    desync: bool = true,
+    desync: bool = false,
     /// Base delay (ms) between the 1-byte desync split and the rest of the ServerHello.
     desync_split_delay_ms: u32 = 3,
     /// Random extra delay (0..jitter ms) added to desync_split_delay_ms per connection.
@@ -540,6 +558,17 @@ pub const Config = struct {
 
     pub fn middleProxyBufferBytes(self: *const Config) usize {
         return @as(usize, self.middleproxy_buffer_kb) * 1024;
+    }
+
+    pub const relay_read_buffer_size: usize = 32 * 1024;
+
+    pub fn middleProxyC2sScratchBytes(self: *const Config) usize {
+        return self.middleProxyBufferBytes() + 108 * (relay_read_buffer_size + 1) + 256;
+    }
+
+    pub fn middleProxySharedBytes(self: *const Config) usize {
+        const workers = if (self.workers == 0) std.Thread.getCpuCount() catch 1 else self.workers;
+        return (self.middleProxyC2sScratchBytes() + self.middleProxyBufferBytes() + relay_read_buffer_size + 16 + 65535 + 2048) * std.math.clamp(workers, 1, 256);
     }
 
     pub fn ownsTlsDomain(self: *const Config) bool {
@@ -621,8 +650,40 @@ pub const Config = struct {
         return self.mask and self.maskTargetIsLocal() and self.port == self.mask_port;
     }
 
+    /// Startup validation shared by the runtime and --check-config.
+    pub fn validate(self: *const Config) !void {
+        if (self.port == 0 or self.mask_port == 0 or self.metrics.port == 0 or self.web.port == 0) return error.InvalidPort;
+        if (self.hasLocalMaskPortCollision()) return error.MaskPortCollision;
+        if (self.bind_address) |host| _ = net.IpAddress.parse(host, self.port) catch return error.InvalidBindAddress;
+        if (self.metrics.enabled) _ = net.IpAddress.parse(self.metrics.effectiveHost(), self.metrics.port) catch return error.InvalidMetricsHost;
+        if (self.web.enabled) {
+            const domain = self.web.domain orelse return error.MissingWebDomain;
+            if (domain.len == 0 or domain.len > 253 or std.mem.indexOfScalar(u8, domain, '.') == null) return error.InvalidWebDomain;
+            for (domain) |c| if (!(std.ascii.isAlphanumeric(c) or c == '.' or c == '-')) return error.InvalidWebDomain;
+            _ = net.IpAddress.parse(self.web.effectiveHost(), self.web.port) catch return error.InvalidWebHost;
+            const path = self.web.effectiveWsPath();
+            if (path.len == 0 or path[0] != '/' or std.mem.startsWith(u8, path, "//") or std.mem.indexOfAny(u8, path, "?#\\\r\n") != null) return error.InvalidWebSocketPath;
+            if (self.web.port == self.port or self.web.port == self.mask_port) return error.WebPortCollision;
+        }
+        const user = self.upstream_proxy_username orelse "";
+        const password = self.upstream_proxy_password orelse "";
+        if (self.upstream_mode == .socks5 or self.upstream_mode == .http) {
+            const host = self.upstream_proxy_host orelse return error.MissingUpstreamHost;
+            if (host.len == 0 or self.upstream_proxy_port == 0) return error.InvalidUpstreamAddress;
+            for (host) |c| if (c <= 0x20 or c == 0x7f) return error.InvalidUpstreamAddress;
+            if (user.len == 0 and password.len > 0) return error.InvalidUpstreamCredentials;
+        }
+        if (self.upstream_mode == .socks5 and (user.len > 255 or password.len > 255)) return error.InvalidUpstreamCredentials;
+        if (self.upstream_mode == .http and (user.len > 511 or password.len > 511 or user.len + password.len > 511 or std.mem.indexOfScalar(u8, user, ':') != null)) return error.InvalidUpstreamCredentials;
+    }
+
     /// Emit startup warnings for configuration values known to cause issues.
     pub fn emitWarnings(self: *const Config) void {
+        if (self.metrics.enabled and !std.mem.eql(u8, self.metrics.effectiveHost(), "127.0.0.1") and
+            !std.mem.eql(u8, self.metrics.effectiveHost(), "::1"))
+        {
+            std.log.scoped(.config).warn("metrics on {s} has no authentication and exposes user names and traffic counters; restrict access with a firewall", .{self.metrics.effectiveHost()});
+        }
         if (self.web.enabled) {
             const log = std.log.scoped(.config);
             // Every WEB client costs one masked connection for its carrier plus one per
@@ -674,8 +735,8 @@ pub const Config = struct {
                     // through-the-LB path is refused unless the LB is a relay source.
                     log.warn(
                         "[web].only with [server].accept_proxy_protocol: connections arriving " ++
-                            "through the load balancer are masked unless its address is listed in " ++
-                            "[web].relay_sources (IP literals, not CIDRs).",
+                            "through the load balancer are masked. Relay connections must bypass " ++
+                            "the LB; never trust a public LB in [web].relay_sources, which trusts all its clients.",
                         .{},
                     );
                 }
@@ -712,12 +773,12 @@ pub const Config = struct {
         }
         if (self.use_middle_proxy and self.max_connections > 2000) {
             const log = std.log.scoped(.config);
-            const mem_per_conn_mb = (self.middleProxyBufferBytes() * 2) / (1024 * 1024);
-            const shared_mb = (self.middleProxyBufferBytes() * 2) / (1024 * 1024);
+            const connection_mib = std.math.divCeil(u64, @as(u64, self.middleProxyBufferBytes()) * 2 * self.max_connections, 1024 * 1024) catch unreachable;
+            const shared_mb = std.math.divCeil(u64, self.middleProxySharedBytes(), 1024 * 1024) catch unreachable;
             log.warn(
                 "max_connections={d} with middleproxy_buffer_kb={d} may require " ++
                     "up to {d} MB + {d} MB shared RAM at full capacity. Ensure your VPS has sufficient memory.",
-                .{ self.max_connections, self.middleproxy_buffer_kb, mem_per_conn_mb * self.max_connections, shared_mb },
+                .{ self.max_connections, self.middleproxy_buffer_kb, connection_mib, shared_mb },
             );
         }
 
@@ -759,7 +820,10 @@ pub const Config = struct {
             .limited(1024 * 1024),
         );
         defer allocator.free(content);
-        return parse(allocator, content);
+        const cfg = try parse(allocator, content);
+        errdefer cfg.deinit(allocator);
+        try cfg.validate();
+        return cfg;
     }
 
     pub fn parse(allocator: std.mem.Allocator, content: []const u8) !Config {
@@ -823,6 +887,9 @@ pub const Config = struct {
                 if (in_upstream_socks5_section or in_upstream_http_section or in_upstream_tunnel_section) {
                     in_upstream_section = false;
                 }
+                if (!(in_users_section or in_direct_users_section or in_user_max_conns_section or in_user_expirations_section or in_user_max_ips_section or in_censorship_section or in_server_section or in_general_section or in_metrics_section or in_web_section or in_upstream_section or in_upstream_socks5_section or in_upstream_http_section or in_upstream_tunnel_section)) {
+                    if (!@import("builtin").is_test) std.log.scoped(.config).warn("unknown configuration section '{s}'; ignored", .{header});
+                }
                 continue;
             }
 
@@ -830,11 +897,11 @@ pub const Config = struct {
             if (std.mem.indexOfScalar(u8, line, '=')) |eq_pos| {
                 const key = std.mem.trim(u8, line[0..eq_pos], &[_]u8{ ' ', '\t' });
                 var value = std.mem.trim(u8, line[eq_pos + 1 ..], &[_]u8{ ' ', '\t' });
-                value = stripInlineComment(value);
+                value = try stripInlineComment(value);
                 if (value.len == 0) continue;
 
                 // Strip quotes from value
-                if (value.len >= 2 and value[0] == '"' and value[value.len - 1] == '"') {
+                if (value.len >= 2 and (value[0] == '"' or value[0] == '\'') and value[value.len - 1] == value[0]) {
                     value = value[1 .. value.len - 1];
                 }
 
@@ -850,12 +917,14 @@ pub const Config = struct {
                         try cfg.users.put(key, secret);
                     } else {
                         const name = try allocator.dupe(u8, key);
+                        errdefer allocator.free(name);
                         try cfg.users.put(name, secret);
                     }
                 } else if (in_direct_users_section) {
                     if (!parseBool(value)) continue;
                     if (!cfg.direct_users.contains(key)) {
                         const name = try allocator.dupe(u8, key);
+                        errdefer allocator.free(name);
                         try cfg.direct_users.put(name, {});
                     }
                 } else if (in_user_max_conns_section) {
@@ -865,7 +934,9 @@ pub const Config = struct {
                     if (cfg.user_max_conns.?.getKey(key)) |_| {
                         try cfg.user_max_conns.?.put(key, cap);
                     } else {
-                        try cfg.user_max_conns.?.put(try allocator.dupe(u8, key), cap);
+                        const name = try allocator.dupe(u8, key);
+                        errdefer allocator.free(name);
+                        try cfg.user_max_conns.?.put(name, cap);
                     }
                 } else if (in_user_expirations_section) {
                     const ts = parseExpiryToUnix(value) orelse continue;
@@ -873,7 +944,9 @@ pub const Config = struct {
                     if (cfg.user_expirations.?.getKey(key)) |_| {
                         try cfg.user_expirations.?.put(key, ts);
                     } else {
-                        try cfg.user_expirations.?.put(try allocator.dupe(u8, key), ts);
+                        const name = try allocator.dupe(u8, key);
+                        errdefer allocator.free(name);
+                        try cfg.user_expirations.?.put(name, ts);
                     }
                 } else if (in_user_max_ips_section) {
                     const parsed = std.fmt.parseInt(u32, value, 10) catch continue;
@@ -891,7 +964,9 @@ pub const Config = struct {
                     if (cfg.user_max_ips.?.getKey(key)) |_| {
                         try cfg.user_max_ips.?.put(key, cap);
                     } else {
-                        try cfg.user_max_ips.?.put(try allocator.dupe(u8, key), cap);
+                        const name = try allocator.dupe(u8, key);
+                        errdefer allocator.free(name);
+                        try cfg.user_max_ips.?.put(name, cap);
                     }
                 } else if (in_general_section) {
                     if (std.mem.eql(u8, key, "use_middle_proxy")) {
@@ -904,29 +979,29 @@ pub const Config = struct {
                     } else if (std.mem.eql(u8, key, "ad_tag")) {
                         // telemt compatibility: [general].ad_tag
                         // If [server].tag is present and valid, it has priority.
-                        if (!server_tag_set and value.len == 32) {
+                        if (value.len != 0) {
+                            if (value.len != 32) return error.InvalidAdTag;
                             var tag: [16]u8 = undefined;
-                            if (std.fmt.hexToBytes(&tag, value)) |_| {
-                                cfg.tag = tag;
-                            } else |_| {}
+                            _ = std.fmt.hexToBytes(&tag, value) catch return error.InvalidAdTag;
+                            if (!server_tag_set) cfg.tag = tag;
                         }
-                    }
+                    } else warnUnknownKey(key);
                 } else if (in_server_section) {
                     if (std.mem.eql(u8, key, "port")) {
-                        cfg.port = std.fmt.parseInt(u16, value, 10) catch blk: {
-                            std.log.scoped(.config).warn("invalid server.port \"{s}\"; falling back to 443", .{value});
-                            break :blk 443;
-                        };
+                        cfg.port = try parsePort(value);
                     } else if (std.mem.eql(u8, key, "bind_address")) {
+                        const replacement = if (value.len > 0) try allocator.dupe(u8, value) else null;
                         if (cfg.bind_address) |prev| allocator.free(prev);
-                        cfg.bind_address = try allocator.dupe(u8, value);
+                        cfg.bind_address = replacement;
                     } else if (std.mem.eql(u8, key, "clock_sync_url")) {
+                        if (value.len != 0 and !std.mem.startsWith(u8, value, "https://")) return error.InsecureClockSyncUrl;
+                        const replacement = if (value.len > 0) try allocator.dupe(u8, value) else null;
                         if (cfg.clock_sync_url) |prev| allocator.free(prev);
-                        cfg.clock_sync_url = try allocator.dupe(u8, value);
+                        cfg.clock_sync_url = replacement;
                     } else if (std.mem.eql(u8, key, "accept_proxy_protocol")) {
                         cfg.accept_proxy_protocol = parseBool(value);
                     } else if (std.mem.eql(u8, key, "backlog")) {
-                        cfg.backlog = std.fmt.parseInt(u32, value, 10) catch 4096;
+                        cfg.backlog = std.fmt.parseInt(u31, value, 10) catch return error.InvalidBacklog;
                     } else if (std.mem.eql(u8, key, "max_connections")) {
                         const parsed = std.fmt.parseInt(u32, value, 10) catch cfg.max_connections;
                         cfg.max_connections = @max(@as(u32, 32), parsed);
@@ -946,27 +1021,28 @@ pub const Config = struct {
                         const parsed = std.fmt.parseInt(u32, value, 10) catch cfg.graceful_shutdown_timeout_sec;
                         cfg.graceful_shutdown_timeout_sec = @max(@as(u32, 1), parsed);
                     } else if (std.mem.eql(u8, key, "tag")) {
-                        if (value.len == 32) {
+                        if (value.len != 0) {
+                            if (value.len != 32) return error.InvalidAdTag;
                             var tag: [16]u8 = undefined;
-                            if (std.fmt.hexToBytes(&tag, value)) |_| {
-                                cfg.tag = tag;
-                                server_tag_set = true;
-                            } else |_| {}
+                            _ = std.fmt.hexToBytes(&tag, value) catch return error.InvalidAdTag;
+                            cfg.tag = tag;
+                            server_tag_set = true;
                         }
                     } else if (std.mem.eql(u8, key, "public_ip")) {
+                        const replacement = if (value.len > 0) try allocator.dupe(u8, value) else null;
                         if (cfg.public_ip) |prev| allocator.free(prev);
-                        cfg.public_ip = try allocator.dupe(u8, value);
+                        cfg.public_ip = replacement;
                     } else if (std.mem.eql(u8, key, "public_port")) {
-                        const parsed = std.fmt.parseInt(u16, value, 10) catch 0;
-                        if (parsed > 0) cfg.public_port = parsed;
+                        cfg.public_port = try parsePort(value);
                     } else if (std.mem.eql(u8, key, "middle_proxy_nat_ip")) {
+                        const replacement = if (value.len > 0) try allocator.dupe(u8, value) else null;
                         if (cfg.middle_proxy_nat_ip) |prev| allocator.free(prev);
-                        cfg.middle_proxy_nat_ip = try allocator.dupe(u8, value);
+                        cfg.middle_proxy_nat_ip = replacement;
                     } else if (std.mem.eql(u8, key, "fast_mode")) {
                         cfg.fast_mode = parseBool(value);
                     } else if (std.mem.eql(u8, key, "middleproxy_buffer_kb")) {
                         const parsed = std.fmt.parseInt(u32, value, 10) catch cfg.middleproxy_buffer_kb;
-                        cfg.middleproxy_buffer_kb = @max(@as(u32, 64), parsed);
+                        cfg.middleproxy_buffer_kb = std.math.clamp(parsed, 64, 16 * 1024);
                     } else if (std.mem.eql(u8, key, "log_level")) {
                         if (std.mem.eql(u8, value, "debug")) {
                             cfg.log_level = .debug;
@@ -995,7 +1071,7 @@ pub const Config = struct {
                         cfg.idle_timeout_jitter_pct = @min(@as(u8, 100), parsed);
                     } else if (std.mem.eql(u8, key, "unsafe_override_limits")) {
                         cfg.unsafe_override_limits = parseBool(value);
-                    }
+                    } else warnUnknownKey(key);
                 } else if (in_censorship_section) {
                     if (std.mem.eql(u8, key, "tls_domain")) {
                         // The top-level empty-value guard runs BEFORE quote
@@ -1006,15 +1082,16 @@ pub const Config = struct {
                         // Free the previous heap dupe (but never the compile-time
                         // default) before overwriting, so a duplicate tls_domain
                         // key does not leak.
+                        const replacement = try allocator.dupe(u8, value);
                         if (cfg.tls_domain.ptr != default_tls_domain.ptr) allocator.free(cfg.tls_domain);
-                        cfg.tls_domain = try allocator.dupe(u8, value);
+                        cfg.tls_domain = replacement;
                     } else if (std.mem.eql(u8, key, "mask")) {
                         cfg.mask = parseBool(value);
                     } else if (std.mem.eql(u8, key, "mask_target")) {
                         if (cfg.mask_target) |target| allocator.free(target);
                         cfg.mask_target = if (value.len > 0) try allocator.dupe(u8, value) else null;
                     } else if (std.mem.eql(u8, key, "mask_port")) {
-                        cfg.mask_port = std.fmt.parseInt(u16, value, 10) catch 443;
+                        cfg.mask_port = try parsePort(value);
                     } else if (std.mem.eql(u8, key, "desync")) {
                         cfg.desync = parseBool(value);
                     } else if (std.mem.eql(u8, key, "desync_split_delay_ms")) {
@@ -1032,58 +1109,69 @@ pub const Config = struct {
                     } else if (std.mem.eql(u8, key, "reject_rst")) {
                         cfg.reject_rst = parseBool(value);
                     } else if (std.mem.eql(u8, key, "mask_sni_safelist")) {
+                        const replacement = try parseStringArrayValue(allocator, value);
                         freeStringSlice(allocator, cfg.mask_sni_safelist);
-                        cfg.mask_sni_safelist = parseStringArrayValue(allocator, value) catch &.{};
+                        cfg.mask_sni_safelist = replacement;
                     } else if (std.mem.eql(u8, key, "mask_relay_max_secs")) {
                         cfg.mask_relay_max_secs = std.fmt.parseInt(u32, value, 10) catch cfg.mask_relay_max_secs;
                     } else if (std.mem.eql(u8, key, "fake_cert_size")) {
                         cfg.fake_cert_size = std.fmt.parseInt(u32, value, 10) catch cfg.fake_cert_size;
-                    }
+                    } else warnUnknownKey(key);
                 } else if (in_metrics_section) {
                     if (std.mem.eql(u8, key, "enabled")) {
                         cfg.metrics.enabled = parseBool(value);
                     } else if (std.mem.eql(u8, key, "host")) {
+                        const replacement = if (value.len > 0) try allocator.dupe(u8, value) else null;
                         if (cfg.metrics.host) |prev| allocator.free(prev);
-                        cfg.metrics.host = try allocator.dupe(u8, value);
+                        cfg.metrics.host = replacement;
                     } else if (std.mem.eql(u8, key, "port")) {
-                        cfg.metrics.port = std.fmt.parseInt(u16, value, 10) catch cfg.metrics.port;
-                    }
+                        cfg.metrics.port = try parsePort(value);
+                    } else warnUnknownKey(key);
                 } else if (in_web_section) {
                     if (std.mem.eql(u8, key, "enabled")) {
                         cfg.web.enabled = parseBool(value);
                     } else if (std.mem.eql(u8, key, "only") or std.mem.eql(u8, key, "web_only")) {
                         cfg.web.only = parseBool(value);
                     } else if (std.mem.eql(u8, key, "domain")) {
+                        const replacement = if (value.len > 0) try allocator.dupe(u8, value) else null;
                         if (cfg.web.domain) |prev| allocator.free(prev);
-                        cfg.web.domain = if (value.len > 0) try allocator.dupe(u8, value) else null;
+                        cfg.web.domain = replacement;
                     } else if (std.mem.eql(u8, key, "listen") or std.mem.eql(u8, key, "host")) {
+                        const replacement = if (value.len > 0) try allocator.dupe(u8, value) else null;
                         if (cfg.web.host) |prev| allocator.free(prev);
-                        cfg.web.host = if (value.len > 0) try allocator.dupe(u8, value) else null;
+                        cfg.web.host = replacement;
                     } else if (std.mem.eql(u8, key, "port")) {
-                        cfg.web.port = std.fmt.parseInt(u16, value, 10) catch cfg.web.port;
+                        cfg.web.port = try parsePort(value);
                     } else if (std.mem.eql(u8, key, "backend")) {
+                        const replacement = if (value.len > 0) try allocator.dupe(u8, value) else null;
                         if (cfg.web.backend) |prev| allocator.free(prev);
-                        cfg.web.backend = if (value.len > 0) try allocator.dupe(u8, value) else null;
+                        cfg.web.backend = replacement;
                     } else if (std.mem.eql(u8, key, "mask_backend")) {
+                        const replacement = if (value.len > 0) try allocator.dupe(u8, value) else null;
                         if (cfg.web.mask_backend) |prev| allocator.free(prev);
-                        cfg.web.mask_backend = if (value.len > 0) try allocator.dupe(u8, value) else null;
+                        cfg.web.mask_backend = replacement;
                     } else if (std.mem.eql(u8, key, "cert")) {
+                        const replacement = if (value.len > 0) try allocator.dupe(u8, value) else null;
                         if (cfg.web.cert) |prev| allocator.free(prev);
-                        cfg.web.cert = if (value.len > 0) try allocator.dupe(u8, value) else null;
+                        cfg.web.cert = replacement;
                     } else if (std.mem.eql(u8, key, "key")) {
+                        const replacement = if (value.len > 0) try allocator.dupe(u8, value) else null;
                         if (cfg.web.key) |prev| allocator.free(prev);
-                        cfg.web.key = if (value.len > 0) try allocator.dupe(u8, value) else null;
+                        cfg.web.key = replacement;
                     } else if (std.mem.eql(u8, key, "mode")) {
+                        const replacement = if (value.len > 0) try allocator.dupe(u8, value) else null;
                         if (cfg.web.mode) |prev| allocator.free(prev);
-                        cfg.web.mode = if (value.len > 0) try allocator.dupe(u8, value) else null;
+                        cfg.web.mode = replacement;
                     } else if (std.mem.eql(u8, key, "ws_path")) {
+                        const replacement = if (value.len > 0) try allocator.dupe(u8, value) else null;
                         if (cfg.web.ws_path) |prev| allocator.free(prev);
-                        cfg.web.ws_path = if (value.len > 0) try allocator.dupe(u8, value) else null;
+                        cfg.web.ws_path = replacement;
                     } else if (std.mem.eql(u8, key, "trust_forwarded_for")) {
                         cfg.web.trust_forwarded_for = parseBool(value);
                     } else if (std.mem.eql(u8, key, "client_ip_header")) {
+                        const replacement = if (value.len > 0) try allocator.dupe(u8, value) else null;
                         if (cfg.web.client_ip_header) |prev| allocator.free(prev);
-                        cfg.web.client_ip_header = if (value.len > 0) try allocator.dupe(u8, value) else null;
+                        cfg.web.client_ip_header = replacement;
                     } else if (std.mem.eql(u8, key, "check_origin")) {
                         cfg.web.check_origin = parseBool(value);
                     } else if (std.mem.eql(u8, key, "max_sessions")) {
@@ -1093,9 +1181,10 @@ pub const Config = struct {
                     } else if (std.mem.eql(u8, key, "max_buffer_mb")) {
                         cfg.web.max_buffer_mb = @max(8, std.fmt.parseInt(u32, value, 10) catch cfg.web.max_buffer_mb);
                     } else if (std.mem.eql(u8, key, "relay_sources")) {
+                        const replacement = try parseStringArrayValue(allocator, value);
                         freeStringSlice(allocator, cfg.web.relay_sources);
-                        cfg.web.relay_sources = parseStringArrayValue(allocator, value) catch &.{};
-                    }
+                        cfg.web.relay_sources = replacement;
+                    } else warnUnknownKey(key);
                 } else if (in_upstream_section) {
                     if (std.mem.eql(u8, key, "type")) {
                         if (parseUpstreamMode(value)) |mode| {
@@ -1103,32 +1192,34 @@ pub const Config = struct {
                         }
                     } else if (std.mem.eql(u8, key, "allow_direct_fallback")) {
                         cfg.allow_direct_fallback = parseBool(value);
-                    }
+                    } else warnUnknownKey(key);
                 } else if (in_upstream_socks5_section or in_upstream_http_section) {
                     if (std.mem.eql(u8, key, "host")) {
                         if (cfg.upstream_proxy_host) |h| allocator.free(h);
                         cfg.upstream_proxy_host = try allocator.dupe(u8, value);
                     } else if (std.mem.eql(u8, key, "port")) {
-                        cfg.upstream_proxy_port = std.fmt.parseInt(u16, value, 10) catch 0;
+                        cfg.upstream_proxy_port = try parsePort(value);
                     } else if (std.mem.eql(u8, key, "username")) {
                         if (cfg.upstream_proxy_username) |u| allocator.free(u);
                         cfg.upstream_proxy_username = try allocator.dupe(u8, value);
                     } else if (std.mem.eql(u8, key, "password")) {
                         if (cfg.upstream_proxy_password) |p| allocator.free(p);
                         cfg.upstream_proxy_password = try allocator.dupe(u8, value);
-                    }
+                    } else warnUnknownKey(key);
                 } else if (in_upstream_tunnel_section) {
                     if (std.mem.eql(u8, key, "interface")) {
+                        const replacement = if (value.len > 0) try allocator.dupe(u8, value) else null;
                         if (cfg.upstream_tunnel_interface) |prev| allocator.free(prev);
-                        cfg.upstream_tunnel_interface = try allocator.dupe(u8, value);
+                        cfg.upstream_tunnel_interface = replacement;
                     } else if (std.mem.eql(u8, key, "interfaces")) {
+                        const replacement = try parseStringArrayValue(allocator, value);
                         freeStringSlice(allocator, cfg.upstream_tunnel_interfaces);
-                        cfg.upstream_tunnel_interfaces = parseStringArrayValue(allocator, value) catch &.{};
+                        cfg.upstream_tunnel_interfaces = replacement;
                     } else if (std.mem.eql(u8, key, "pinned_interface")) {
                         if (cfg.upstream_tunnel_pinned_interface) |iface| allocator.free(iface);
                         cfg.upstream_tunnel_pinned_interface = if (value.len > 0) try allocator.dupe(u8, value) else null;
-                    }
-                }
+                    } else warnUnknownKey(key);
+                } else warnUnknownKey(key);
             }
         }
 
@@ -1241,6 +1332,7 @@ pub const Config = struct {
     /// Get user secrets as a flat slice for handshake validation.
     pub fn getUserSecrets(self: *const Config, allocator: std.mem.Allocator) ![]const UserSecret {
         var list: std.ArrayList(UserSecret) = .empty;
+        errdefer list.deinit(allocator);
         var it = @constCast(&self.users).iterator();
         while (it.next()) |entry| {
             try list.append(allocator, .{
@@ -1323,7 +1415,7 @@ test "parse config - missing fields defaults" {
     try std.testing.expect(cfg.mask_target == null);
     try std.testing.expect(!cfg.use_middle_proxy); // Default is false
     try std.testing.expect(cfg.mask); // Default is true
-    try std.testing.expect(cfg.desync); // Default is true
+    try std.testing.expect(!cfg.desync); // Splitting the first byte is opt-in.
     try std.testing.expect(!cfg.fast_mode); // Default is false
     try std.testing.expect(cfg.fake_tls_only); // Default is true (secure: dd off)
     try std.testing.expectEqual(@as(u32, 2048), cfg.middleproxy_buffer_kb);
@@ -1664,7 +1756,7 @@ test "parse config - tag default null" {
     try std.testing.expect(cfg.tag == null);
 }
 
-test "parse config - invalid tag ignored" {
+test "parse config - invalid tag rejected" {
     const content =
         \\[server]
         \\tag = tooshort
@@ -1673,10 +1765,7 @@ test "parse config - invalid tag ignored" {
         \\alice = "00112233445566778899aabbccddeeff"
     ;
 
-    var cfg = try Config.parse(std.testing.allocator, content);
-    defer cfg.deinit(std.testing.allocator);
-
-    try std.testing.expect(cfg.tag == null);
+    try std.testing.expectError(error.InvalidAdTag, Config.parse(std.testing.allocator, content));
 }
 
 test "parse config - general ad_tag alias" {
@@ -2523,6 +2612,23 @@ test "parse config - [web].only parses, aliases web_only, and defaults false" {
     }
 }
 
+test "optional empty strings are unset and malformed arrays and tags are rejected" {
+    var cfg = try Config.parse(std.testing.allocator,
+        \\[server]
+        \\public_ip = ""
+        \\bind_address = ""
+        \\[metrics]
+        \\host = ""
+    );
+    defer cfg.deinit(std.testing.allocator);
+    try std.testing.expect(cfg.public_ip == null);
+    try std.testing.expect(cfg.bind_address == null);
+    try std.testing.expect(cfg.metrics.host == null);
+    try std.testing.expectError(error.InvalidStringArray, Config.parse(std.testing.allocator, "[web]\nrelay_sources = [\n"));
+    try std.testing.expectError(error.InvalidAdTag, Config.parse(std.testing.allocator, "[server]\ntag = \"bad\"\n"));
+    try std.testing.expectError(error.InvalidBacklog, Config.parse(std.testing.allocator, "[server]\nbacklog = 4294967295\n"));
+}
+
 test "[web].only without [web].enabled never activates the gate" {
     // The trusted-peer set is keyed on `enabled` (proxy/trusted_peers.zig), so honouring
     // `only` on its own would mask every connection including the relay's — a proxy with
@@ -2536,6 +2642,25 @@ test "[web].only without [web].enabled never activates the gate" {
     defer cfg.deinit(std.testing.allocator);
     try std.testing.expect(cfg.web.only);
     try std.testing.expect(!cfg.web.onlyActive());
+}
+
+test "startup validation rejects zero ports and invalid upstream credentials" {
+    const allocator = std.testing.allocator;
+    for ([_][]const u8{ "[server]\nport = 0", "[metrics]\nport = 0", "[web]\nport = 0", "[censorship]\nmask_port = 0" }) |input| {
+        try std.testing.expectError(error.InvalidPort, Config.parse(allocator, input));
+    }
+    var cfg = try Config.parse(allocator, "[upstream]\ntype = \"socks5\"\n[upstream.socks5]\nhost = \"127.0.0.1\"\nport = 1080\n");
+    defer cfg.deinit(allocator);
+    try cfg.validate();
+    cfg.upstream_proxy_username = try allocator.dupe(u8, &([_]u8{'u'} ** 256));
+    try std.testing.expectError(error.InvalidUpstreamCredentials, cfg.validate());
+}
+
+test "inline comments preserve semicolons and reject unterminated quotes" {
+    try std.testing.expectEqualStrings("abc;def", try stripInlineComment("abc;def # comment"));
+    try std.testing.expectEqualStrings("'a#b'", try stripInlineComment("'a#b' # comment"));
+    try std.testing.expectError(error.UnterminatedString, stripInlineComment("\"unfinished"));
+    try std.testing.expectError(error.UnterminatedString, Config.parse(std.testing.allocator, "[server]\ntls_domain = \"unfinished"));
 }
 
 test "parse config - [web] cert/key paths round-trip and free cleanly" {

--- a/src/crypto/crypto.zig
+++ b/src/crypto/crypto.zig
@@ -35,14 +35,6 @@ pub const AesCtr = struct {
         };
     }
 
-    pub fn initFromSlices(key: []const u8, iv: []const u8) !AesCtr {
-        if (key.len != 32) return error.InvalidKeyLength;
-        if (iv.len != 16) return error.InvalidIvLength;
-        const k: *const [32]u8 = key[0..32];
-        const iv_val = std.mem.readInt(u128, iv[0..16], .big);
-        return init(k, iv_val);
-    }
-
     /// Number of AES blocks processed in parallel on the relay hot path.
     /// 8 is optimal for x86_64 AES-NI (the +aes release target) and correct on
     /// any backend (encryptWide handles arbitrary counts). Every relayed byte
@@ -78,7 +70,21 @@ pub const AesCtr = struct {
             i += wide_bytes;
         }
 
-        // 3. Tail: remaining < wide_bytes via the single-block buffer path, which
+        inline for (.{ 4, 2, 1 }) |blocks| {
+            const bytes = blocks * 16;
+            if (i + bytes <= data.len) {
+                var counters: [bytes]u8 = undefined;
+                inline for (0..blocks) |b| {
+                    std.mem.writeInt(u128, counters[b * 16 ..][0..16], self.ctr +% b, .big);
+                }
+                const chunk: *[bytes]u8 = data[i..][0..bytes];
+                self.enc_ctx.xorWide(blocks, chunk, chunk, counters);
+                self.ctr +%= blocks;
+                i += bytes;
+            }
+        }
+
+        // 3. Tail: remaining < 16 bytes via the single-block buffer path, which
         //    also refills self.buffer for keystream continuity into the next call.
         while (i < data.len) {
             if (self.buffer_pos >= 16) {
@@ -96,15 +102,6 @@ pub const AesCtr = struct {
         }
     }
 
-    /// Encrypt/decrypt into a new buffer.
-    pub fn process(self: *AesCtr, allocator: std.mem.Allocator, data: []const u8) ![]u8 {
-        const result = try allocator.alloc(u8, data.len);
-        @memcpy(result, data);
-        self.apply(result);
-        return result;
-    }
-
-    /// Securely wipe key material.
     pub fn wipe(self: *AesCtr) void {
         std.crypto.secureZero(u8, &self.key);
         std.crypto.secureZero(u8, &self.buffer);
@@ -179,6 +176,16 @@ pub const AesCbc = struct {
         var prev: [16]u8 = self.iv;
 
         var offset: usize = 0;
+        while (offset + 128 <= data.len) : (offset += 128) {
+            const block: *[128]u8 = data[offset..][0..128];
+            const saved = block.*;
+            self.dec_ctx.decryptWide(8, block, &saved);
+            inline for (0..8) |b| {
+                const previous = if (b == 0) &prev else saved[(b - 1) * 16 ..][0..16];
+                xorBlockInPlace(block[b * 16 ..][0..16], previous);
+            }
+            prev = saved[112..128].*;
+        }
         while (offset < data.len) : (offset += block_size) {
             const block: *[16]u8 = data[offset..][0..16];
             const saved = block.*;
@@ -238,32 +245,49 @@ pub fn md5(data: []const u8) [16]u8 {
 
 // ============= Secure Random =============
 
+threadlocal var thread_csprng: ?std.Random.DefaultCsprng = null;
+
+fn secureRandom() std.Random {
+    if (thread_csprng == null) {
+        var seed: [std.Random.DefaultCsprng.secret_seed_length]u8 = undefined;
+        defer std.crypto.secureZero(u8, &seed);
+        std.Io.Threaded.global_single_threaded.io().random(&seed);
+        thread_csprng = std.Random.DefaultCsprng.init(seed);
+    }
+    return thread_csprng.?.random();
+}
+
 /// Fill buffer with cryptographically secure random bytes.
 pub fn randomBytes(buf: []u8) void {
-    var source: std.Random.IoSource = .{
-        .io = std.Io.Threaded.global_single_threaded.io(),
-    };
-    source.interface().bytes(buf);
+    secureRandom().bytes(buf);
 }
 
 /// Generate a random integer in [0, max).
 pub fn randomRange(comptime T: type, max: T) T {
     if (max == 0) return 0;
-    var source: std.Random.IoSource = .{
-        .io = std.Io.Threaded.global_single_threaded.io(),
-    };
-    return source.interface().uintLessThan(T, max);
+    return secureRandom().uintLessThan(T, max);
 }
 
 /// Generate a random integer in the full range of T.
 pub fn randomInt(comptime T: type) T {
-    var source: std.Random.IoSource = .{
-        .io = std.Io.Threaded.global_single_threaded.io(),
-    };
-    return source.interface().int(T);
+    return secureRandom().int(T);
 }
 
 // ============= Tests =============
+
+test "CBC wide decryption agrees across split calls" {
+    const key = [_]u8{0x12} ** 32;
+    const iv = [_]u8{0x34} ** 16;
+    var data: [400]u8 = undefined;
+    for (&data, 0..) |*b, i| b.* = @truncate(i);
+    const original = data;
+    var enc = AesCbc.init(&key, &iv);
+    try enc.encryptInPlace(&data);
+    var dec = AesCbc.init(&key, &iv);
+    try dec.decryptInPlace(data[0..144]);
+    try dec.decryptInPlace(data[144..]);
+    try std.testing.expectEqualSlices(u8, &original, &data);
+}
 
 test "AesCtr roundtrip" {
     const key = [_]u8{0} ** 32;

--- a/src/ctl/config_cmd.zig
+++ b/src/ctl/config_cmd.zig
@@ -28,9 +28,9 @@ const ConfigCmdOpts = struct {
 pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) !void {
     const sub = args.next() orelse {
         ui.fail("Usage: mtbuddy config <validate|doctor|print-effective> [--config <path>] [--network]");
-        return;
+        return error.BadUsage;
     };
-    const opts = parseConfigOpts(args);
+    const opts = try parseConfigOpts(args);
 
     if (std.mem.eql(u8, sub, "validate")) {
         try validate(ui, allocator, opts.path);
@@ -47,18 +47,21 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
 
     ui.fail("Unknown config subcommand");
     ui.hint("Available: validate, doctor, print-effective");
+    return error.BadUsage;
 }
 
 fn isNetworkFlag(arg: []const u8) bool {
     return std.mem.eql(u8, arg, "--network");
 }
 
-fn parseConfigOpts(args: *std.process.Args.Iterator) ConfigCmdOpts {
+fn parseConfigOpts(args: *std.process.Args.Iterator) !ConfigCmdOpts {
     var path: ?[]const u8 = null;
     var network = false;
     while (args.next()) |arg| {
         if (std.mem.eql(u8, arg, "--config") or std.mem.eql(u8, arg, "-c")) {
-            path = args.next() orelse path;
+            const value = args.next() orelse return error.MissingConfigPath;
+            if (std.mem.startsWith(u8, value, "-")) return error.MissingConfigPath;
+            path = value;
             continue;
         }
         if (isNetworkFlag(arg)) {
@@ -67,6 +70,8 @@ fn parseConfigOpts(args: *std.process.Args.Iterator) ConfigCmdOpts {
         }
         if (arg.len > 0 and arg[0] != '-') {
             path = arg;
+        } else {
+            return error.UnknownOption;
         }
     }
     return .{ .path = path orelse defaultConfigPath(), .network = network };
@@ -168,7 +173,7 @@ fn validate(ui: *Tui, allocator: std.mem.Allocator, path: []const u8) !void {
                 ui.warn("[web].only sends every refused MTProto connection to the remote masking target — run `mtbuddy setup masking` for a local one");
             }
             if (cfg.accept_proxy_protocol) {
-                ui.warn("[web].only with accept_proxy_protocol: traffic via the load balancer is masked unless its IP is in [web].relay_sources");
+                ui.warn("[web].only: relays must connect directly, bypassing the LB. Never add a public LB to relay_sources: that trusts every forwarded client");
             }
         }
         // Warnings, not errors: `validate` is routinely run against a config copied off
@@ -235,8 +240,8 @@ fn doctor(ui: *Tui, allocator: std.mem.Allocator, path: []const u8, network: boo
         else => {},
     }
 
-    if (cfg.use_middle_proxy and cfg.middleproxy_buffer_kb < 1024) {
-        ui.warn("middleproxy_buffer_kb < 1024 may break media downloads");
+    if (cfg.use_middle_proxy and cfg.middleproxy_buffer_kb < 2048) {
+        ui.warn("middleproxy_buffer_kb < 2048 may break media downloads");
         warnings += 1;
     }
     if (cfg.use_middle_proxy and cfg.max_connections > 2000) {
@@ -781,6 +786,46 @@ fn printEffective(ui: *Tui, allocator: std.mem.Allocator, path: []const u8) !voi
 
     ui.print("[access.users] count = {d}\n", .{cfg.users.count()});
     ui.print("[access.direct_users] count = {d}\n", .{cfg.direct_users.count()});
+    ui.writeRaw("\n# Complete scalar settings (internal field names; credentials redacted)\n");
+    printResolvedFields(ui, "", cfg);
+}
+
+fn printResolvedFields(ui: *Tui, comptime prefix: []const u8, value: anytype) void {
+    @setEvalBranchQuota(20_000);
+    inline for (std.meta.fields(@TypeOf(value))) |field| {
+        const name = prefix ++ field.name;
+        const v = @field(value, field.name);
+        if (comptime std.mem.indexOf(u8, name, "password") != null or std.mem.indexOf(u8, name, "secret") != null) {
+            ui.print("# {s} = <redacted>\n", .{name});
+        } else switch (@typeInfo(field.type)) {
+            .bool, .int, .float => ui.print("# {s} = {any}\n", .{ name, v }),
+            .@"enum" => ui.print("# {s} = {s}\n", .{ name, @tagName(v) }),
+            .pointer => |ptr| if (comptime ptr.size == .slice and ptr.child == u8) {
+                ui.print("# {s} = {s}\n", .{ name, v });
+            } else if (comptime ptr.size == .slice and ptr.child == []const u8) {
+                ui.print("# {s} = [", .{name});
+                for (v, 0..) |item, index| {
+                    if (index != 0) ui.writeRaw(", ");
+                    ui.print("{s}", .{item});
+                }
+                ui.writeRaw("]\n");
+            },
+            .optional => |opt| {
+                if (v) |present| {
+                    if (comptime opt.child == []const u8 or opt.child == []u8) {
+                        ui.print("# {s} = {s}\n", .{ name, present });
+                    } else switch (@typeInfo(opt.child)) {
+                        .int, .bool, .array => ui.print("# {s} = {any}\n", .{ name, present }),
+                        else => {},
+                    }
+                } else ui.print("# {s} = <unset>\n", .{name});
+            },
+            .@"struct" => if (comptime std.mem.eql(u8, field.name, "web") or std.mem.eql(u8, field.name, "metrics") or std.mem.eql(u8, field.name, "drs")) {
+                printResolvedFields(ui, name ++ ".", v);
+            },
+            else => {},
+        }
+    }
 }
 
 fn isLoopbackHost(host: []const u8) bool {

--- a/src/ctl/dashboard.zig
+++ b/src/ctl/dashboard.zig
@@ -16,7 +16,9 @@ const SummaryLine = tui_mod.SummaryLine;
 
 const INSTALL_DIR = "/opt/mtproto-proxy/monitor";
 const VENV_DIR = INSTALL_DIR ++ "/.venv";
-const VENV_PYTHON = VENV_DIR ++ "/bin/python";
+const STAGED_VENV_DIR = VENV_DIR ++ ".new";
+const VENV_PYTHON = STAGED_VENV_DIR ++ "/bin/python";
+const UV_BIN = INSTALL_DIR ++ "/bin/uv";
 const UV_PYTHON_INSTALL_DIR = INSTALL_DIR ++ "/.uv-python";
 const UV_SUBPROCESS_PATH = "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 const UV_PYTHON_INSTALL_ENV = "UV_PYTHON_INSTALL_DIR=" ++ UV_PYTHON_INSTALL_DIR;
@@ -27,14 +29,14 @@ const SERVICE_NAME = "proxy-monitor";
 const SERVICE_FILE = "/etc/systemd/system/" ++ SERVICE_NAME ++ ".service";
 
 const VENV_CREATE_ARGV = [_][]const u8{
-    "env", UV_SUBPROCESS_PATH, UV_PYTHON_INSTALL_ENV, "uv", "venv", VENV_DIR, "--python", "python3",
+    "env", UV_SUBPROCESS_PATH, UV_PYTHON_INSTALL_ENV, UV_BIN, "venv", STAGED_VENV_DIR, "--python", "python3",
 };
 
 const PIP_INSTALL_ARGV = [_][]const u8{
     "env",
     UV_SUBPROCESS_PATH,
     UV_PYTHON_INSTALL_ENV,
-    "uv",
+    UV_BIN,
     "pip",
     "install",
     "--python",
@@ -74,6 +76,9 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
             opts.quiet = true;
         } else if (std.mem.eql(u8, arg, "--remove") or std.mem.eql(u8, arg, "--uninstall")) {
             do_remove = true;
+        } else {
+            ui.print("Unknown option: {s}\n", .{arg});
+            return error.UnknownOption;
         }
     }
     if (do_remove) return removeDashboard(ui);
@@ -137,8 +142,10 @@ pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
 }
 
 /// Check if `uv` is available on the system.
-fn uvExists() bool {
-    return sys.commandExists("uv");
+fn uvExists(allocator: std.mem.Allocator) bool {
+    const result = sys.exec(allocator, &.{ UV_BIN, "--version" }) catch return false;
+    defer result.deinit();
+    return result.exit_code == 0 and std.mem.eql(u8, std.mem.trim(u8, result.stdout, " \r\n\t"), "uv " ++ UV_VERSION);
 }
 
 /// Install `uv` from GitHub releases (astral.sh is blocked in some regions).
@@ -183,8 +190,8 @@ fn bootstrapUv(ui: *Tui, allocator: std.mem.Allocator) bool {
         \\  exit 1
         \\fi
         \\tar -xzf "$TMP_DIR/uv.tar.gz" -C "$TMP_DIR" --strip-components=1
-        \\install -m 0755 "$TMP_DIR/uv" /usr/local/bin/uv
-        \\if [ -f "$TMP_DIR/uvx" ]; then install -m 0755 "$TMP_DIR/uvx" /usr/local/bin/uvx; fi
+        \\install -d -m 0755 /opt/mtproto-proxy/monitor/bin
+        \\install -m 0755 "$TMP_DIR/uv" /opt/mtproto-proxy/monitor/bin/uv
     ,
         .{uv_url},
     ) catch {
@@ -207,8 +214,8 @@ fn bootstrapUv(ui: *Tui, allocator: std.mem.Allocator) bool {
         return false;
     }
 
-    if (!sys.commandExists("uv")) {
-        ui.fail("uv binary installed but not found on PATH");
+    if (!uvExists(allocator)) {
+        ui.fail("Installed uv version did not match the pinned release");
         return false;
     }
 
@@ -223,7 +230,7 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: DashboardOpts) !voi
     }
 
     // ── Ensure uv is available ──
-    if (!uvExists()) {
+    if (!uvExists(allocator)) {
         if (!bootstrapUv(ui, allocator)) {
             return;
         }
@@ -238,19 +245,21 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: DashboardOpts) !voi
         ui.fail("Failed to write server.py");
         return;
     };
-    sys.writeFile(INSTALL_DIR ++ "/static/index.html", index_html) catch {};
-    sys.writeFile(INSTALL_DIR ++ "/static/style.css", style_css) catch {};
-    sys.writeFile(INSTALL_DIR ++ "/static/app.js", app_js) catch {};
-    sys.writeFile(INSTALL_DIR ++ "/static/logo.svg", logo_svg) catch {};
+    try sys.writeFile(INSTALL_DIR ++ "/proxy.service", @import("build_options").proxy_service);
+    try sys.writeFile(INSTALL_DIR ++ "/static/index.html", index_html);
+    try sys.writeFile(INSTALL_DIR ++ "/static/style.css", style_css);
+    try sys.writeFile(INSTALL_DIR ++ "/static/app.js", app_js);
+    try sys.writeFile(INSTALL_DIR ++ "/static/logo.svg", logo_svg);
 
     ui.ok("Dashboard files extracted to " ++ INSTALL_DIR);
 
     // ── Create virtualenv & install dependencies ──
     ui.step("Setting up Python virtualenv via uv...");
 
-    // Remove stale venv first — `make deploy` chowns everything to mtproto:mtproto,
-    // so `uv venv` (running as root) can fail to overwrite it.
-    _ = sys.exec(allocator, &.{ "rm", "-rf", VENV_DIR }) catch {};
+    // Rebuild only the staging environment; failed downloads leave the live one intact.
+    const cleanup = try sys.exec(allocator, &.{ "rm", "-rf", STAGED_VENV_DIR });
+    defer cleanup.deinit();
+    if (cleanup.exit_code != 0) return error.StagingCleanupFailed;
 
     // The systemd unit uses ProtectHome=yes. uv-managed interpreters installed
     // under /root/.local/share/uv/python become invisible to ExecStart, so keep
@@ -287,6 +296,16 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: DashboardOpts) !voi
     }
 
     ui.ok("Python dependencies installed");
+
+    const activate = try sys.exec(allocator, &.{
+        "sh", "-c",
+        "set -e; rm -rf '" ++ VENV_DIR ++ ".previous'; " ++
+            "if [ -e '" ++ VENV_DIR ++ "' ]; then mv '" ++ VENV_DIR ++ "' '" ++ VENV_DIR ++ ".previous'; fi; " ++
+            "if ! mv '" ++ STAGED_VENV_DIR ++ "' '" ++ VENV_DIR ++ "'; then " ++
+            "mv '" ++ VENV_DIR ++ ".previous' '" ++ VENV_DIR ++ "'; exit 1; fi",
+    });
+    defer activate.deinit();
+    if (activate.exit_code != 0) return error.VenvActivationFailed;
 
     // ── Setup Systemd Service ──
     ui.step("Configuring systemd service...");
@@ -373,5 +392,6 @@ test "dashboard venv keeps uv-managed Python outside ProtectHome paths" {
     try std.testing.expectEqualStrings("env", argv[0]);
     try std.testing.expectEqualStrings("PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", argv[1]);
     try std.testing.expectEqualStrings("UV_PYTHON_INSTALL_DIR=/opt/mtproto-proxy/monitor/.uv-python", argv[2]);
-    try std.testing.expectEqualStrings("uv", argv[3]);
+    try std.testing.expectEqualStrings(UV_BIN, argv[3]);
+    try std.testing.expectEqualStrings(STAGED_VENV_DIR, argv[5]);
 }

--- a/src/ctl/dashboard_assets/server.py
+++ b/src/ctl/dashboard_assets/server.py
@@ -2,6 +2,10 @@
 """MTProto Proxy Dashboard — API server."""
 
 import asyncio
+import functools
+import copy
+import ipaddress
+from contextlib import asynccontextmanager
 import base64
 import hashlib
 import hmac
@@ -27,7 +31,7 @@ except ModuleNotFoundError:
         tomllib = None
 
 import psutil
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Request
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Request, HTTPException
 from fastapi.responses import JSONResponse, PlainTextResponse, Response
 from fastapi.staticfiles import StaticFiles
 import uvicorn
@@ -38,6 +42,32 @@ def _proxy_config_candidates():
         Path(__file__).parent.parent / "config.toml",  # /opt/mtproto-proxy/config.toml
         Path("/opt/mtproto-proxy/config.toml"),
     ]
+
+
+def _strip_inline_comment(value: str) -> str:
+    """Drop a trailing '#'/';' comment, ignoring one inside a quoted string.
+
+    Mirrors stripInlineComment() in src/config.zig, which is what the proxy itself uses —
+    the dashboard must read a value exactly the way the running proxy does. Splitting on a
+    bare '#' truncated any quoted value containing one (`password = "s3cr#t"` became the
+    unbalanced `"s3cr`), and since that mangled value is pre-filled into the Routing card
+    and POSTed straight back on the next save, it silently rewrote the live credential.
+    """
+    in_quotes = None
+    escaped = False
+    for i, ch in enumerate(value):
+        if escaped:
+            escaped = False
+            continue
+        if in_quotes == '"' and ch == "\\":
+            escaped = True
+            continue
+        if ch in ('"', "'") and (in_quotes is None or in_quotes == ch):
+            in_quotes = ch if in_quotes is None else None
+            continue
+        if not in_quotes and ch in "#;":
+            return value[:i].strip()
+    return value.strip()
 
 
 def _load_dashboard_config() -> dict:
@@ -67,9 +97,7 @@ def _load_dashboard_config() -> dict:
                         continue
                     key, value = line.split("=", 1)
                     key = key.strip()
-                    value = value.strip()
-                    if "#" in value:
-                        value = value.split("#", 1)[0].strip()
+                    value = _strip_inline_comment(value.strip())
                     if len(value) >= 2 and value[0] == '"' and value[-1] == '"':
                         value = value[1:-1]
                     if key == "host":
@@ -141,7 +169,13 @@ def _proxy_version() -> str | None:
     return version
 
 
-app = FastAPI()
+@asynccontextmanager
+async def _lifespan(app):
+    yield
+    await asyncio.to_thread(stop_log_thread)
+
+
+app = FastAPI(lifespan=_lifespan)
 
 # ── Dashboard authentication & hardening ─────────────────────────────────────
 # The dashboard is a ROOT-privileged control plane: it can rewrite config.toml,
@@ -155,7 +189,7 @@ app = FastAPI()
 #   3. An Origin check on state-changing requests — defeats CSRF (a cross-origin
 #      "simple" POST the browser would auto-attach Basic credentials to).
 # Default bind stays 127.0.0.1; reach it over an SSH tunnel.
-_DASHBOARD_TOKEN_FILE = Path(__file__).parent / "dashboard.token"
+_DASHBOARD_TOKEN_FILE = Path(os.environ.get("MTPROTO_DASHBOARD_TOKEN_FILE", str(Path(__file__).parent / "dashboard.token")))
 
 
 def _load_or_create_dashboard_token() -> str:
@@ -192,7 +226,7 @@ def _dashboard_auth_ok(authorization) -> bool:
     except Exception:
         return False
     _, _, pw = raw.partition(":")
-    return hmac.compare_digest(pw, DASHBOARD_TOKEN)
+    return hmac.compare_digest(pw.encode("utf-8"), DASHBOARD_TOKEN.encode("utf-8"))
 
 
 # Safari/WebKit does not replay cached HTTP Basic credentials on a WebSocket handshake (Chrome
@@ -219,7 +253,7 @@ def _ws_ticket_ok(ticket) -> bool:
     except ValueError:
         return False
     expected = hmac.new(DASHBOARD_TOKEN.encode(), exp_s.encode(), hashlib.sha256).hexdigest()
-    return hmac.compare_digest(sig, expected)
+    return hmac.compare_digest(sig.encode("utf-8"), expected.encode("utf-8"))
 
 
 def _host_hostname(host_header: str) -> str:
@@ -239,7 +273,7 @@ async def _dashboard_security(request: Request, call_next):
 
     if request.method not in ("GET", "HEAD", "OPTIONS"):
         origin = request.headers.get("origin")
-        if origin and urlparse(origin).netloc != host_header:
+        if (origin and urlparse(origin).netloc != host_header) or (not origin and request.headers.get("x-requested-with") != "mtbuddy"):
             return PlainTextResponse("cross-origin request blocked", status_code=403)
 
     if not _dashboard_auth_ok(request.headers.get("authorization")):
@@ -258,14 +292,13 @@ async def _dashboard_security(request: Request, call_next):
     # Real CSP, not just frame-ancestors: block injected/external SCRIPT (the dashboard's
     # only script is the external /app.js — there are no inline <script> blocks), which
     # bounds the blast radius of any future escaping mistake on this root control plane.
-    # style-src keeps 'unsafe-inline' for the page's inline style= attributes + Google
-    # Fonts CSS; style injection is far less dangerous than script execution.
+    # Inline styles are used by the local UI; no third-party fonts are fetched.
     response.headers.setdefault(
         "Content-Security-Policy",
         "default-src 'self'; "
         "script-src 'self'; "
-        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
-        "font-src 'self' https://fonts.gstatic.com data:; "
+        "style-src 'self' 'unsafe-inline'; "
+        "font-src 'self' data:; "
         "img-src 'self' data:; "
         "connect-src 'self'; "
         "base-uri 'none'; "
@@ -289,10 +322,15 @@ MAX_HISTORY = 90
 # --- Thread-safe log buffer ---
 _log_buffer = queue.Queue(maxsize=500)
 _log_thread_started = False
+_log_stop = threading.Event()
+_log_start_lock = threading.Lock()
+_log_thread = None
+_log_process = None
 
 
 def _log_reader_thread():
-    while True:
+    global _log_process
+    while not _log_stop.is_set():
         try:
             proc = subprocess.Popen(
                 ["journalctl", "-u", "mtproto-proxy", "-f", "--no-pager", "-n", "80"],
@@ -300,7 +338,12 @@ def _log_reader_thread():
                 stderr=subprocess.DEVNULL,
                 text=True,
             )
+            _log_process = proc
+            if _log_stop.is_set():
+                proc.terminate()
             for line in proc.stdout:
+                if _log_stop.is_set():
+                    break
                 text = line.strip()
                 if not text:
                     continue
@@ -325,19 +368,50 @@ def _log_reader_thread():
                         pass
                     _log_buffer.put_nowait(entry)
             proc.wait()
-        except Exception:
-            pass
-        time.sleep(2)
+        except FileNotFoundError:
+            print("[dashboard] journalctl unavailable; live logs disabled", file=sys.stderr)
+            return
+        except Exception as exc:
+            print(f"[dashboard] journal follower failed: {type(exc).__name__}", file=sys.stderr)
+        finally:
+            _log_process = None
+        _log_stop.wait(2)
 
 
 def ensure_log_thread():
-    global _log_thread_started
-    if not _log_thread_started:
+    global _log_thread_started, _log_thread
+    with _log_start_lock:
+        if _log_thread_started:
+            return
         _log_thread_started = True
-        threading.Thread(target=_log_reader_thread, daemon=True).start()
+        if shutil.which("journalctl") is None or not Path("/run/systemd/system").is_dir():
+            print("[dashboard] systemd journal unavailable; live logs disabled", file=sys.stderr)
+            try:
+                _log_buffer.put_nowait({"text": "Systemd journal unavailable; live logs disabled", "cls": "error", "ts": time.strftime("%H:%M:%S")})
+            except queue.Full:
+                pass
+            return
+        _log_stop.clear()
+        _log_thread = threading.Thread(target=_log_reader_thread, daemon=True)
+        _log_thread.start()
 
 
-ensure_log_thread()
+def stop_log_thread():
+    global _log_thread_started
+    _log_stop.set()
+    proc = _log_process
+    if proc is not None:
+        try:
+            proc.terminate()
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=2)
+        except ProcessLookupError:
+            pass
+    if _log_thread is not None:
+        _log_thread.join(timeout=3)
+    _log_thread_started = False
 
 _recent_logs = []
 # Absolute sequence number of _recent_logs[0]. Each appended line has a monotonically
@@ -378,6 +452,30 @@ def _logs_since(cursor):
         return list(_recent_logs[start_idx:]), end
 
 
+def _cached_for(seconds, config_sensitive=False):
+    def decorate(fn):
+        lock = threading.Lock()
+        cached = {"until": 0, "key": None, "value": None}
+        @functools.wraps(fn)
+        def wrapped():
+            key = None
+            if config_sensitive:
+                key = []
+                for path in _proxy_config_candidates():
+                    try:
+                        stat = path.stat()
+                        key.append((str(path), stat.st_mtime_ns, stat.st_size))
+                    except OSError:
+                        key.append((str(path), None))
+            with lock:
+                if cached["value"] is None or time.monotonic() >= cached["until"] or key != cached["key"]:
+                    cached.update(value=fn(), until=time.monotonic() + seconds, key=key)
+                return copy.deepcopy(cached["value"])
+        return wrapped
+    return decorate
+
+
+@_cached_for(10)
 def _proxy_stats() -> dict:
     try:
         out = subprocess.check_output(
@@ -450,8 +548,8 @@ def _proxy_stats() -> dict:
         s["unassigned_active"] = max(active_total - users_active_total, 0)
 
         return s
-    except Exception:
-        return {}
+    except Exception as exc:
+        return {"error": f"Proxy statistics unavailable ({type(exc).__name__})"}
 
 
 def _proxy_listening(port: int) -> bool:
@@ -482,8 +580,8 @@ def _proxy_listening(port: int) -> bool:
 
 
 def _proxy_info() -> dict:
-    for proc in psutil.process_iter(["name", "create_time", "pid", "memory_info"]):
-        if proc.info["name"] == "mtproto-proxy":
+    for proc in psutil.process_iter(["name", "create_time", "pid", "memory_info", "cmdline"]):
+        if proc.info["name"] == "mtproto-proxy" and "web-relay" not in (proc.info.get("cmdline") or []):
             el = time.time() - proc.info["create_time"]
             h, rem = divmod(int(el), 3600)
             m, sec = divmod(rem, 60)
@@ -596,6 +694,7 @@ def _dedupe(values: list[str]) -> list[str]:
     return out
 
 
+@_cached_for(2, config_sensitive=True)
 def _load_proxy_runtime_config() -> dict:
     defaults = {
         "public_ip": "",
@@ -634,6 +733,7 @@ def _load_proxy_runtime_config() -> dict:
             break
 
     if cfg_path is None:
+        defaults["error"] = "Proxy config is missing"
         return defaults
 
     result = {
@@ -665,6 +765,9 @@ def _load_proxy_runtime_config() -> dict:
 
     section = ""
     try:
+        if tomllib is not None:
+            raw = cfg_path.read_text(encoding="utf-8")
+            tomllib.loads("\n".join(_strip_inline_comment(line) for line in raw.splitlines()))
         with open(cfg_path, "r", encoding="utf-8", errors="replace") as f:
             for raw_line in f:
                 line = raw_line.strip()
@@ -680,12 +783,7 @@ def _load_proxy_runtime_config() -> dict:
 
                 key, value = line.split("=", 1)
                 key = key.strip()
-                value = value.strip()
-
-                if "#" in value:
-                    value = value.split("#", 1)[0].strip()
-                if ";" in value:
-                    value = value.split(";", 1)[0].strip()
+                value = _strip_inline_comment(value.strip())
 
                 if len(value) >= 2 and value[0] == '"' and value[-1] == '"':
                     value = value[1:-1]
@@ -778,7 +876,8 @@ def _load_proxy_runtime_config() -> dict:
                     if key and value:
                         result["disabled_users"][key] = value
 
-    except Exception:
+    except Exception as exc:
+        defaults["error"] = f"Proxy config could not be read ({type(exc).__name__})"
         return defaults
 
     if not result["upstream_tunnel_interfaces"] and not result["upstream_tunnel_interfaces_configured"]:
@@ -1439,13 +1538,13 @@ def _routing_status() -> dict:
             "host": str(cfg.get("upstream_socks5_host", "") or ""),
             "port": int(cfg.get("upstream_socks5_port", 0) or 0),
             "username": str(cfg.get("upstream_socks5_username", "") or ""),
-            "password": str(cfg.get("upstream_socks5_password", "") or ""),
+            "password_set": bool(cfg.get("upstream_socks5_password")),
         },
         "upstream_http": {
             "host": str(cfg.get("upstream_http_host", "") or ""),
             "port": int(cfg.get("upstream_http_port", 0) or 0),
             "username": str(cfg.get("upstream_http_username", "") or ""),
-            "password": str(cfg.get("upstream_http_password", "") or ""),
+            "password_set": bool(cfg.get("upstream_http_password")),
         },
         "healthy": healthy,
     }
@@ -1574,13 +1673,11 @@ PUBLIC_IP_TTL = 300  # 5 minutes
 def _detect_public_ip() -> str:
     """Auto-detect public IP, cached for 5 minutes."""
     now = time.time()
-    if now - _public_ip_cache["ts"] < PUBLIC_IP_TTL and _public_ip_cache["ip"]:
+    if now - _public_ip_cache["ts"] < PUBLIC_IP_TTL:
         return _public_ip_cache["ip"]
 
     for url in (
-        "https://ifconfig.me/ip",
         "https://api.ipify.org",
-        "https://icanhazip.com",
     ):
         try:
             out = subprocess.check_output(
@@ -1589,7 +1686,7 @@ def _detect_public_ip() -> str:
                 timeout=5,
                 stderr=subprocess.DEVNULL,
             ).strip()
-            if out and re.match(r"^[\d.]+$", out):
+            if out and ipaddress.ip_address(out).version == 4:
                 _public_ip_cache.update(ts=now, ip=out)
                 return out
         except Exception:
@@ -1715,6 +1812,71 @@ def _find_config_path() -> Path | None:
     return None
 
 
+def _write_config_atomic(cfg_path: Path, text: str) -> None:
+    """Replace config.toml in one step, keeping the previous content as .bak.
+
+    Path.write_text() is open('w') — truncate, then write. An ENOSPC, an OOM kill or a lost
+    VPS in that window leaves a zero-length config.toml, and every mutator restarts the proxy
+    immediately afterwards, so the user secrets (which live nowhere but this file, and are
+    what every distributed tg:// link is derived from) would be gone with no way back. Writing
+    a sibling temp file and renaming it over the target makes the swap atomic: a reader sees
+    the old file or the new one, never a half-written one.
+    """
+    tmp = cfg_path.with_name(cfg_path.name + ".tmp")
+    backup = cfg_path.with_name(cfg_path.name + ".bak")
+
+    # config.toml is installed 0640 and holds every user secret. os.replace() keeps the *temp*
+    # file's mode and owner, not the target's, so create it 0600 and copy the original's
+    # metadata across — otherwise the umask would quietly republish the secrets as 0644.
+    try:
+        st = cfg_path.stat()
+    except OSError:
+        st = None
+
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+            f.flush()
+            os.fsync(f.fileno())
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+    if st is not None:
+        try:
+            os.chmod(tmp, st.st_mode & 0o7777)
+            os.chown(tmp, st.st_uid, st.st_gid)
+        except OSError:
+            pass
+        # One previous copy, so a bad edit is recoverable by hand. A hard link rather than a
+        # copy: it is the same inode, so the backup carries the original's 0640 with no window
+        # where the secrets sit at the umask's mode. `mtbuddy uninstall` removes
+        # /opt/mtproto-proxy wholesale, so this does not outlive the install.
+        try:
+            if backup.exists():
+                backup.unlink()
+            os.link(cfg_path, backup)
+        except OSError:
+            pass
+
+    os.replace(tmp, cfg_path)
+
+    # fsync the directory too: without it the rename itself can be lost on a power cut even
+    # though the new file's bytes were fsynced.
+    try:
+        dir_fd = os.open(cfg_path.parent, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except OSError:
+        pass
+
+
 def _restart_proxy():
     """Restart mtproto-proxy systemd service."""
     try:
@@ -1723,9 +1885,10 @@ def _restart_proxy():
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             timeout=10,
+            check=True,
         )
-    except Exception:
-        pass
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise HTTPException(status_code=503, detail="Configuration saved, but proxy restart failed") from exc
     # Invalidate caches
     _users_cache["ts"] = 0
     _mask_cache["ts"] = 0
@@ -1748,8 +1911,6 @@ def _set_toml_key(
     for i, line in enumerate(lines):
         stripped = line.strip()
         if stripped.startswith("[") and stripped.endswith("]"):
-            if in_section and insert_idx is None:
-                insert_idx = i
             in_section = stripped.lower() == section_l
             if in_section:
                 section_found = True
@@ -1771,7 +1932,10 @@ def _set_toml_key(
 
         indent_len = len(line) - len(line.lstrip(" \t"))
         indent = line[:indent_len]
-        lines[i] = f"{indent}{key} = {value_literal}\n"
+        original_value = line.split("=", 1)[1].rstrip("\r\n")
+        clean_value = _strip_inline_comment(original_value)
+        comment = original_value[original_value.find(clean_value) + len(clean_value):] if clean_value else ""
+        lines[i] = f"{indent}{key} = {value_literal}{comment}\n"
         return lines
 
     if section_found:
@@ -1804,7 +1968,7 @@ def _set_middle_proxy_enabled(enabled: bool) -> bool:
     )
     value = "true" if enabled else "false"
     lines = _set_toml_key(lines, "[general]", "use_middle_proxy", value)
-    cfg_path.write_text("".join(lines), encoding="utf-8")
+    _write_config_atomic(cfg_path, "".join(lines))
     return True
 
 
@@ -1824,7 +1988,7 @@ def _set_upstream_type(upstream_type: str) -> bool:
         lines, "[upstream]", "type", _toml_string_literal(upstream_type)
     )
 
-    cfg_path.write_text("".join(lines), encoding="utf-8")
+    _write_config_atomic(cfg_path, "".join(lines))
     return True
 
 
@@ -1843,7 +2007,7 @@ def _set_upstream_tunnel_interface(interface: str) -> bool:
     lines = _set_toml_key(
         lines, "[upstream.tunnel]", "pinned_interface", _toml_string_literal(iface)
     )
-    cfg_path.write_text("".join(lines), encoding="utf-8")
+    _write_config_atomic(cfg_path, "".join(lines))
     return True
 
 
@@ -1963,7 +2127,7 @@ def _remove_tunnel_from_config(interface: str) -> dict | None:
                 _toml_string_literal(""),
             )
 
-        cfg_path.write_text("".join(lines), encoding="utf-8")
+        _write_config_atomic(cfg_path, "".join(lines))
 
     return {
         "removed_from_pool": in_pool,
@@ -1988,7 +2152,7 @@ def _clear_tunnel_config() -> bool:
     lines = _set_toml_key(
         lines, "[upstream.tunnel]", "pinned_interface", _toml_string_literal("")
     )
-    cfg_path.write_text("".join(lines), encoding="utf-8")
+    _write_config_atomic(cfg_path, "".join(lines))
     return True
 
 
@@ -2050,66 +2214,8 @@ def _delete_tunnel_config_files(interface: str) -> bool:
 
 
 def _write_default_proxy_service() -> bool:
-    content = """[Unit]
-Description=MTProto Proxy (Zig)
-Documentation=https://github.com/sleep3r/mtproto.zig
-After=network-online.target
-Wants=network-online.target
-
-[Service]
-# Type=simple (NOT notify): must match the installer (release.zig / tunnel.zig).
-# Containerized systemd (Docker/LXC) often fails to deliver the sd_notify datagram,
-# which with Restart=always restart-loops a perfectly healthy proxy. Re-enable
-# Type=notify + WatchdogSec only behind container detection + ping validation.
-Type=simple
-User=mtproto
-Group=mtproto
-WorkingDirectory=/opt/mtproto-proxy
-ExecStart=/opt/mtproto-proxy/mtproto-proxy /opt/mtproto-proxy/config.toml
-ExecReload=/bin/kill -HUP $MAINPID
-KillSignal=SIGTERM
-TimeoutStopSec=25
-Restart=always
-RestartSec=3
-
-NoNewPrivileges=yes
-ProtectSystem=strict
-ProtectHome=yes
-PrivateTmp=yes
-ReadOnlyPaths=/opt/mtproto-proxy
-
-# Syscall + kernel surface reduction (mirrors deploy/mtproto-proxy.service).
-SystemCallFilter=@system-service
-SystemCallArchitectures=native
-SystemCallErrorNumber=EPERM
-RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
-MemoryDenyWriteExecute=yes
-RestrictNamespaces=yes
-LockPersonality=yes
-RestrictRealtime=yes
-RestrictSUIDSGID=yes
-ProtectKernelTunables=yes
-ProtectKernelModules=yes
-ProtectKernelLogs=yes
-ProtectControlGroups=yes
-ProtectClock=yes
-ProtectHostname=yes
-ProtectProc=invisible
-ProcSubset=pid
-PrivateDevices=yes
-RemoveIPC=yes
-UMask=0077
-
-AmbientCapabilities=CAP_NET_BIND_SERVICE
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE
-
-LimitNOFILE=131582
-TasksMax=65535
-
-[Install]
-WantedBy=multi-user.target
-"""
     try:
+        content = Path(__file__).with_name("proxy.service").read_text(encoding="utf-8")
         PROXY_SERVICE_FILE.write_text(content, encoding="utf-8")
         return True
     except Exception:
@@ -2172,11 +2278,13 @@ def _delete_tunnel_interface(interface: str) -> dict | None:
     else:
         result["controller_ok"] = None
 
-    _restart_proxy()
+    restarted = bool(result["removed_from_pool"] or result["removed_last"])
+    if restarted:
+        _restart_proxy()
     _awg_cache["ts"] = 0
     _routing_cache["ts"] = 0
     result["interface"] = iface
-    result["restarted"] = True
+    result["restarted"] = restarted
     return result
 
 
@@ -2202,7 +2310,7 @@ def _set_upstream_proxy_target(
     host: str,
     port: int,
     username: str,
-    password: str,
+    password: str | None,
 ) -> bool:
     cfg_path = _find_config_path()
     if cfg_path is None:
@@ -2235,8 +2343,9 @@ def _set_upstream_proxy_target(
     lines = _set_toml_key(lines, section, "host", _toml_string_literal(host_value))
     lines = _set_toml_key(lines, section, "port", str(port))
     lines = _set_toml_key(lines, section, "username", _toml_string_literal(user_value))
-    lines = _set_toml_key(lines, section, "password", _toml_string_literal(pass_value))
-    cfg_path.write_text("".join(lines), encoding="utf-8")
+    if password is not None:
+        lines = _set_toml_key(lines, section, "password", _toml_string_literal(pass_value))
+    _write_config_atomic(cfg_path, "".join(lines))
     return True
 
 
@@ -2280,7 +2389,7 @@ def _add_user_to_config(name: str, secret: str) -> bool:
 
     new_line = f'{name} = "{secret}"\n'
     lines.insert(insert_idx, new_line)
-    cfg_path.write_text("".join(lines), encoding="utf-8")
+    _write_config_atomic(cfg_path, "".join(lines))
     return True
 
 
@@ -2302,7 +2411,7 @@ def _remove_user_from_config(name: str) -> bool:
 
     for line in lines:
         stripped = line.strip()
-        if stripped.lower() == "[access.users]":
+        if stripped.lower() in ("[access.users]", "[access.disabled_users]"):
             in_users = True
             in_direct = False
             new_lines.append(line)
@@ -2327,7 +2436,7 @@ def _remove_user_from_config(name: str) -> bool:
         new_lines.append(line)
 
     if removed:
-        cfg_path.write_text("".join(new_lines), encoding="utf-8")
+        _write_config_atomic(cfg_path, "".join(new_lines))
     return removed
 
 
@@ -2390,7 +2499,7 @@ def _set_user_direct(name: str, direct: bool) -> bool:
             new_lines.append("\n[access.direct_users]\n")
             new_lines.append(f"{name} = true\n")
 
-    cfg_path.write_text("".join(new_lines), encoding="utf-8")
+    _write_config_atomic(cfg_path, "".join(new_lines))
     return True
 
 
@@ -2465,7 +2574,7 @@ def _disable_user_in_config(name: str) -> bool:
         new_lines.append(f"\n[access.disabled_users]\n")
         new_lines.append(f'{name} = "{secret}"\n')
 
-    cfg_path.write_text("".join(new_lines), encoding="utf-8")
+    _write_config_atomic(cfg_path, "".join(new_lines))
     return True
 
 
@@ -2510,10 +2619,10 @@ def _enable_user_in_config(name: str) -> bool:
     # Add back to [access.users]
     if not _add_user_to_config_lines(new_lines, name, secret):
         # Fallback: just write the lines and use existing helper
-        cfg_path.write_text("".join(new_lines), encoding="utf-8")
+        _write_config_atomic(cfg_path, "".join(new_lines))
         return _add_user_to_config(name, secret)
 
-    cfg_path.write_text("".join(new_lines), encoding="utf-8")
+    _write_config_atomic(cfg_path, "".join(new_lines))
     return True
 
 
@@ -2547,10 +2656,25 @@ def _add_user_to_config_lines(lines: list[str], name: str, secret: str) -> bool:
 
 
 
+_mutation_lock = threading.RLock()
+_egress_lock = threading.Lock()
+
+
+def _serialized(lock):
+    def decorate(fn):
+        @functools.wraps(fn)
+        def wrapped(*args, **kwargs):
+            with lock:
+                return fn(*args, **kwargs)
+        return wrapped
+    return decorate
+
+
 @app.get("/api/stats")
+@_serialized(threading.Lock())
 def api_stats():
     global _prev_net, _net_history, _cpu_history, _mem_history
-    cpu = psutil.cpu_percent(interval=0.3)
+    cpu = psutil.cpu_percent(interval=None)
     mem = psutil.virtual_memory()
     net = psutil.net_io_counters()
     d, rem = divmod(int(time.time() - psutil.boot_time()), 86400)
@@ -2574,6 +2698,7 @@ def api_stats():
 
     return JSONResponse(
         {
+            "errors": [message for message in (_load_proxy_runtime_config().get("error"), _proxy_stats().get("error")) if message],
             "cpu": round(cpu, 1),
             "cpu_history": list(_cpu_history),
             "mem_used": round(mem.used / 1048576),
@@ -2598,6 +2723,7 @@ def api_stats():
 
 
 @app.get("/api/egress")
+@_serialized(_egress_lock)
 def api_egress():
     """Return tunnel/egress health metrics for all active interfaces.
 
@@ -2682,12 +2808,9 @@ def api_egress():
 
 
 @app.post("/api/routing/middle")
-async def api_routing_middle(request: Request):
+@_serialized(_mutation_lock)
+def api_routing_middle(body: dict):
     """Set [general].use_middle_proxy. Body: { enabled: bool }"""
-    try:
-        body = await request.json()
-    except Exception:
-        return JSONResponse({"ok": False, "error": "invalid json"}, status_code=400)
 
     raw_enabled = body.get("enabled", None)
     if not isinstance(raw_enabled, bool):
@@ -2705,12 +2828,9 @@ async def api_routing_middle(request: Request):
 
 
 @app.post("/api/routing/upstream")
-async def api_routing_upstream(request: Request):
+@_serialized(_mutation_lock)
+def api_routing_upstream(body: dict):
     """Set [upstream].type. Body: { type: auto|direct|tunnel|socks5|http }"""
-    try:
-        body = await request.json()
-    except Exception:
-        return JSONResponse({"ok": False, "error": "invalid json"}, status_code=400)
 
     upstream_type = str(body.get("type", "")).strip().lower()
     if upstream_type not in {"auto", "direct", "tunnel", "socks5", "http"}:
@@ -2755,12 +2875,9 @@ async def api_routing_upstream(request: Request):
 
 
 @app.post("/api/routing/tunnel-interface")
-async def api_routing_tunnel_interface(request: Request):
+@_serialized(_mutation_lock)
+def api_routing_tunnel_interface(body: dict):
     """Set [upstream.tunnel].pinned_interface. Body: { interface: str }"""
-    try:
-        body = await request.json()
-    except Exception:
-        return JSONResponse({"ok": False, "error": "invalid json"}, status_code=400)
 
     clear = bool(body.get("clear", False))
     iface = "" if clear else str(body.get("interface", "")).strip()
@@ -2791,12 +2908,9 @@ async def api_routing_tunnel_interface(request: Request):
 
 
 @app.post("/api/routing/tunnel-delete")
-async def api_routing_tunnel_delete(request: Request):
+@_serialized(_mutation_lock)
+def api_routing_tunnel_delete(body: dict):
     """Hard-delete a tunnel interface. Body: { interface: str }"""
-    try:
-        body = await request.json()
-    except Exception:
-        return JSONResponse({"ok": False, "error": "invalid json"}, status_code=400)
 
     iface = str(body.get("interface", "")).strip()
     if not _valid_tunnel_interface_name(iface):
@@ -2815,14 +2929,11 @@ async def api_routing_tunnel_delete(request: Request):
 
 
 @app.post("/api/routing/proxy-target")
-async def api_routing_proxy_target(request: Request):
+@_serialized(_mutation_lock)
+def api_routing_proxy_target(body: dict):
     """Set [upstream.socks5]/[upstream.http] target + auth.
     Body: { type: socks5|http, host: str, port: int, username?: str, password?: str }
     """
-    try:
-        body = await request.json()
-    except Exception:
-        return JSONResponse({"ok": False, "error": "invalid json"}, status_code=400)
 
     proxy_type = str(body.get("type", "")).strip().lower()
     if proxy_type not in {"socks5", "http"}:
@@ -2846,9 +2957,9 @@ async def api_routing_proxy_target(request: Request):
         )
 
     username = str(body.get("username", "") or "")
-    password = str(body.get("password", "") or "")
+    password = str(body.get("password", "") or "") if "password" in body else None
 
-    if "\n" in username or "\r" in username or "\n" in password or "\r" in password:
+    if "\n" in username or "\r" in username or "\n" in (password or "") or "\r" in (password or ""):
         return JSONResponse(
             {"ok": False, "error": "username/password must not contain newlines"},
             status_code=400,
@@ -2867,7 +2978,7 @@ async def api_routing_proxy_target(request: Request):
             "host": host,
             "port": port,
             "username": username,
-            "password": password,
+            "password_set": bool(_load_proxy_runtime_config().get(f"upstream_{proxy_type}_password")),
             "restarted": True,
         }
     )
@@ -2944,12 +3055,9 @@ async def api_qr(text: str = ""):
 
 
 @app.post("/api/users/add")
-async def api_user_add(request: Request):
+@_serialized(_mutation_lock)
+def api_user_add(body: dict):
     """Add a new user. Body: { name: str, secret?: str }"""
-    try:
-        body = await request.json()
-    except Exception:
-        return JSONResponse({"ok": False, "error": "invalid json"}, status_code=400)
 
     raw_name = str(body.get("name", "")).strip()
     if not raw_name or len(raw_name) > 64:
@@ -2998,12 +3106,9 @@ async def api_user_add(request: Request):
 
 
 @app.post("/api/users/remove")
-async def api_user_remove(request: Request):
+@_serialized(_mutation_lock)
+def api_user_remove(body: dict):
     """Remove a user. Body: { name: str }"""
-    try:
-        body = await request.json()
-    except Exception:
-        return JSONResponse({"ok": False, "error": "invalid json"}, status_code=400)
 
     name = str(body.get("name", "")).strip()
     if not name:
@@ -3018,12 +3123,9 @@ async def api_user_remove(request: Request):
 
 
 @app.post("/api/users/direct")
-async def api_user_direct(request: Request):
+@_serialized(_mutation_lock)
+def api_user_direct(body: dict):
     """Toggle direct status. Body: { name: str, direct: bool }"""
-    try:
-        body = await request.json()
-    except Exception:
-        return JSONResponse({"ok": False, "error": "invalid json"}, status_code=400)
 
     name = str(body.get("name", "")).strip()
     direct = bool(body.get("direct", False))
@@ -3047,12 +3149,9 @@ async def api_user_direct(request: Request):
 
 
 @app.post("/api/users/toggle")
-async def api_user_toggle(request: Request):
+@_serialized(_mutation_lock)
+def api_user_toggle(body: dict):
     """Enable or disable a user. Body: { name: str, enabled: bool }"""
-    try:
-        body = await request.json()
-    except Exception:
-        return JSONResponse({"ok": False, "error": "invalid json"}, status_code=400)
 
     name = str(body.get("name", "")).strip()
     if not name:
@@ -3086,6 +3185,7 @@ async def api_user_toggle(request: Request):
 
 @app.get("/api/logs")
 def api_logs():
+    ensure_log_thread()
     _drain_to_recent()
     with _recent_lock:
         return JSONResponse(list(_recent_logs))
@@ -3120,6 +3220,7 @@ async def ws_logs(ws: WebSocket):
         await ws.close(code=1008)
         return
     await ws.accept()
+    ensure_log_thread()
     _drain_to_recent()
     # Per-client cursor: send the current backlog, then only entries newer than what THIS
     # client has already seen. No destructive sharing between concurrent viewers.

--- a/src/ctl/dashboard_assets/static/app.js
+++ b/src/ctl/dashboard_assets/static/app.js
@@ -503,7 +503,7 @@ function openShareModal(name, link) {
 async function apiCall(url, body) {
   const r = await fetch(url, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'mtbuddy' },
     body: JSON.stringify(body)
   });
   const data = await r.json();
@@ -644,7 +644,9 @@ function setupTunnelDeleteModal() {
     try {
       const data = await apiCall('/api/routing/tunnel-delete', { interface: iface });
       const left = Array.isArray(data.remaining_pool) ? data.remaining_pool.length : 0;
-      const msg = data.removed_last
+      const msg = data.kept_config
+        ? ('Tunnel ' + iface + ': foreign configuration retained; ' + (data.restarted ? 'removed from proxy routing.' : 'nothing changed.'))
+        : data.removed_last
         ? ('Tunnel ' + iface + ' deleted. No tunnels left; upstream switched to auto.')
         : ('Tunnel ' + iface + ' deleted. ' + left + ' tunnel(s) remain.');
       showToast(msg, 'success');
@@ -1009,7 +1011,12 @@ function setupRoutingControls() {
       setRoutingAction('Updating ' + proxyType + ' target…');
 
       try {
-        const data = await apiCall('/api/routing/proxy-target', { type: proxyType, host, port, username, password });
+        const body = { type: proxyType, host, port, username };
+        if ($('routingProxyClearPass').checked) body.password = '';
+        else if (password) body.password = password;
+        const data = await apiCall('/api/routing/proxy-target', body);
+        proxyPassInput.value = '';
+        $('routingProxyClearPass').checked = false;
         setRoutingAction('Updated ' + data.type + ' target to ' + data.host + ':' + data.port + '. Proxy restarted.', 'ok');
         showToast('Updated ' + data.type + ' target. Proxy restarted.', 'success');
         await runPoll();
@@ -1118,7 +1125,6 @@ function renderRouting(routing) {
       const host = String(cfg.host || '');
       const port = Number(cfg.port || 0);
       const username = String(cfg.username || '');
-      const password = String(cfg.password || '');
 
       proxyHostLabel.textContent = upstreamType + ' host';
       proxyHost.placeholder = upstreamType === 'socks5' ? '127.0.0.1' : '127.0.0.1';
@@ -1130,7 +1136,7 @@ function renderRouting(routing) {
         proxyHost.value = host;
         proxyPort.value = port > 0 ? String(port) : '';
         proxyUser.value = username;
-        proxyPass.value = password;
+        proxyPass.placeholder = cfg.password_set ? 'Saved password — leave blank to keep' : 'Password';
       }
     } else {
       proxyCtl.style.display = 'none';
@@ -1266,7 +1272,7 @@ function renderEgress(egress, opts) {
   list.innerHTML = tunnels.map((tun) => {
     const iface = esc(tun.interface || '—');
     const isPrimary = tun.is_primary;
-    const quality = tun.quality || 'unknown';
+    const quality = ['good', 'degraded', 'poor', 'up', 'down', 'unknown'].includes(tun.quality) ? tun.quality : 'unknown';
     const rttText = tun.rtt_ms !== null && tun.rtt_ms !== undefined
       ? tun.rtt_ms.toFixed(1) + ' ms'
       : '—';
@@ -1336,15 +1342,16 @@ async function poll() {
   const r = await fetch('/api/stats', { cache: 'no-store' });
   if (!r.ok) throw new Error('stats request failed: ' + r.status);
   const d = await r.json();
+  if (d.errors && d.errors.length) throw new Error(d.errors.join('; '));
 
   lastData = d;
 
   // CPU
   setGauge('cpuArc', 'cpuPct', d.cpu);
-  $('cpuVal').innerHTML = d.cpu + '<span style="font-size:18px;font-weight:400">%</span>';
+  $('cpuVal').innerHTML = esc(d.cpu) + '<span style="font-size:18px;font-weight:400">%</span>';
   // Memory
   setGauge('memArc', 'memPct', d.mem_pct);
-  $('memVal').innerHTML = d.mem_used + '<span style="font-size:14px;font-weight:400"> MB</span>';
+  $('memVal').innerHTML = esc(d.mem_used) + '<span style="font-size:14px;font-weight:400"> MB</span>';
   $('memSub').textContent = d.mem_used + ' / ' + d.mem_total + ' MB';
 
   // Sparklines
@@ -1521,10 +1528,14 @@ async function runPoll() {
   try {
     await poll();
     hasPollError = false;
+    $('dataBadge').title = '';
     lastSuccessAt = Date.now();
     appRoot.classList.remove('is-loading');
   } catch (e) {
+    if ($('dataBadge').title !== e.message) showToast(e.message, 'error');
+    $('dataBadge').title = e.message;
     hasPollError = true;
+    appRoot.classList.remove('is-loading');
     console.error(e);
   } finally {
     pollInFlight = false;

--- a/src/ctl/dashboard_assets/static/index.html
+++ b/src/ctl/dashboard_assets/static/index.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>MTProto Proxy — Dashboard</title>
-  <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/style.css?v=20260610-paper12">
 </head>
 <body>
@@ -365,6 +364,7 @@
         <input id="routingProxyUser" class="ui-input routing-user" type="text" placeholder="optional" autocomplete="off">
         <label class="ctl-sublabel" for="routingProxyPass" data-i18n="routing.pass">Pass</label>
         <input id="routingProxyPass" class="ui-input routing-pass" type="password" placeholder="optional" autocomplete="off">
+        <label><input id="routingProxyClearPass" type="checkbox"> Clear saved password</label>
         <button class="ui-btn" id="routingProxyApply" type="button" data-i18n="btn.setTarget">Set target</button>
       </div>
     </div>
@@ -445,7 +445,7 @@
       <svg class="footer-zig" width="15" height="15" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><g fill="#F7A41D"><path d="M38.484 23.843l-15.06 18.405-7.529-11.712z"/><path d="M38.484 23.843l-10.876 9.203-4.183 9.202h-5.02v42.667h7.53l-9.203 4.183-6.693 14.222H0V23.843z"/><path d="M25.935 84.915L10.039 103.32l-6.693-9.202zM46.85 23.843l5.02 11.713-20.916 6.692z"/><path d="M46.85 23.843h46.013v18.405H30.954L46.85 32.21z"/><path d="M97.046 84.915L81.15 103.32l-5.856-10.875z"/><path d="M97.046 84.915l-13.386 7.53-2.51 10.875H35.137V84.915z"/><path d="M125.49 5.438L43.503 103.32 2.51 122.562l81.987-98.719zM117.96 23.843l-.836 15.06-15.059 4.182z"/><path d="M128 23.843v79.477H88.68l11.712-10.039 4.183-8.366h5.02v-41.83h-7.53l8.366-7.53 7.53-11.712z"/><path d="M104.575 84.915l4.183 12.55-20.078 5.855z"/></g></svg>
       <a class="footer-built-link" href="https://ziglang.org" target="_blank" rel="noopener">Zig</a>
     </div>
-    <div class="footer-host">proxy.sleep3r.ru</div>
+    <div class="footer-host">MTProto Proxy</div>
   </div>
 </div>
 

--- a/src/ctl/dashboard_assets/test_server.py
+++ b/src/ctl/dashboard_assets/test_server.py
@@ -10,6 +10,8 @@ The suite skips itself if the runtime deps aren't installed (e.g. minimal CI ima
 """
 
 import base64
+import os
+import tempfile
 import sys
 from pathlib import Path
 
@@ -23,6 +25,8 @@ pytest.importorskip("psutil")
 
 from fastapi.testclient import TestClient  # noqa: E402
 
+_token_dir = tempfile.TemporaryDirectory(prefix="dashboard-test-token-")
+os.environ["MTPROTO_DASHBOARD_TOKEN_FILE"] = str(Path(_token_dir.name) / "token")
 import server  # noqa: E402
 
 TOKEN = server.DASHBOARD_TOKEN
@@ -35,11 +39,17 @@ def _auth(token=TOKEN):
 @pytest.fixture(scope="module", autouse=True)
 def _cleanup_token():
     yield
-    # Importing server.py creates a dashboard.token in the assets dir; remove it.
-    try:
-        server._DASHBOARD_TOKEN_FILE.unlink()
-    except OSError:
-        pass
+    _token_dir.cleanup()
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_host(monkeypatch, tmp_path):
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('[server]\npublic_ip = "192.0.2.1"\n[access.users]\n', encoding="utf-8")
+    monkeypatch.setattr(server, "_proxy_config_candidates", lambda: [cfg])
+    monkeypatch.setattr(server.subprocess, "check_output", lambda *a, **kw: "")
+    monkeypatch.setattr(server.subprocess, "run", lambda *a, **kw: server.subprocess.CompletedProcess(a[0], 0, "", ""))
+    monkeypatch.setattr(server, "ensure_log_thread", lambda: None)
 
 
 @pytest.fixture
@@ -52,12 +62,33 @@ def test_unauthenticated_api_rejected(client):
     assert client.get("/api/stats").status_code == 401
 
 
-def test_authenticated_api_ok(client):
+def test_authenticated_api_ok(client, monkeypatch):
+    monkeypatch.setattr(server, "_unit_active", lambda unit: False)
+    monkeypatch.setattr(server, "_unit_enabled", lambda unit: False)
     assert client.get("/api/stats", headers=_auth()).status_code == 200
 
 
 def test_wrong_token_rejected(client):
     assert client.get("/api/stats", headers=_auth("not-the-token")).status_code == 401
+
+
+def test_unicode_wrong_token_rejected(client):
+    assert client.get("/api/stats", headers=_auth("неверный-пароль")).status_code == 401
+
+
+def test_originless_mutation_requires_custom_header(client):
+    assert client.post("/api/users/add", headers=_auth(), json={}).status_code == 403
+    response = client.post("/api/users/add", headers={**_auth(), "X-Requested-With": "mtbuddy"}, json={})
+    assert response.status_code not in (401, 403)
+
+
+def test_failed_restart_is_reported(monkeypatch):
+    def fail(*args, **kwargs):
+        raise server.subprocess.CalledProcessError(1, args[0])
+    monkeypatch.setattr(server.subprocess, "run", fail)
+    with pytest.raises(server.HTTPException) as exc:
+        server._restart_proxy()
+    assert exc.value.status_code == 503
 
 
 def test_dns_rebinding_host_rejected():
@@ -103,6 +134,90 @@ def test_ws_ticket_roundtrip():
     assert not server._ws_ticket_ok(forged)
 
 
+def test_expired_ticket_rejected(monkeypatch):
+    ticket = server._make_ws_ticket()
+    expiry = int(ticket.split(".")[0])
+    monkeypatch.setattr(server.time, "time", lambda: expiry + 1)
+    assert not server._ws_ticket_ok(ticket)
+
+
+def test_static_assets_require_auth(client):
+    assert client.get("/app.js").status_code == 401
+
+
+def test_cross_origin_websocket_rejected(client):
+    with pytest.raises(Exception):
+        with client.websocket_connect("/ws/logs", headers={**_auth(), "Origin": "http://evil.example"}):
+            pass
+
+
+def test_qr_rejects_unrelated_url(client):
+    assert client.get("/api/qr", params={"text": "https://evil.example"}, headers=_auth()).status_code == 400
+
+
+def test_omitted_upstream_password_is_preserved(tmp_path, monkeypatch):
+    cfg = tmp_path / "secret.toml"
+    cfg.write_text('[upstream.socks5]\nhost = "old"\npassword = "private"\n')
+    monkeypatch.setattr(server, "_find_config_path", lambda: cfg)
+    assert server._set_upstream_proxy_target("socks5", "new", 1080, "user", None)
+    assert 'password = "private"' in cfg.read_text()
+    assert server._set_upstream_proxy_target("socks5", "new", 1080, "user", "")
+    assert 'password = ""' in cfg.read_text()
+
+
+def test_toml_rewrite_preserves_comment_and_quoted_hash():
+    lines = ['[upstream.socks5]\n', 'password = "old#value"  # keep this\n']
+    result = server._set_toml_key(lines, "[upstream.socks5]", "password", '"new"')
+    assert result[1] == 'password = "new"  # keep this\n'
+
+
+def test_invalid_runtime_config_exposes_error(tmp_path, monkeypatch):
+    cfg = tmp_path / "broken.toml"
+    cfg.write_text('[server]\nport = "unterminated\n')
+    monkeypatch.setattr(server, "_proxy_config_candidates", lambda: [cfg])
+    assert server._load_proxy_runtime_config().get("error")
+
+
+def test_public_ip_rejects_invalid_literal(monkeypatch):
+    monkeypatch.setattr(server, "_public_ip_cache", {"ts": 0, "ip": ""})
+    monkeypatch.setattr(server.subprocess, "check_output", lambda *a, **kw: "999.999.999.999")
+    assert server._detect_public_ip() == ""
+
+
+def test_routing_status_never_contains_proxy_password(tmp_path, monkeypatch):
+    cfg = tmp_path / "routing.toml"
+    cfg.write_text('[upstream.socks5]\nhost = "127.0.0.1"\npassword = "never-export-this"\n')
+    monkeypatch.setattr(server, "_proxy_config_candidates", lambda: [cfg])
+    monkeypatch.setattr(server, "_routing_cache", {"ts": 0, "data": None})
+    status = server._routing_status()
+    assert status["upstream_socks5"]["password_set"] is True
+    assert "password" not in status["upstream_socks5"]
+    assert "never-export-this" not in server.json.dumps(status)
+
+
+def test_config_cache_invalidates_when_file_changes(tmp_path, monkeypatch):
+    cfg = tmp_path / "cached.toml"
+    cfg.write_text('[server]\nport = 443\n')
+    monkeypatch.setattr(server, "_proxy_config_candidates", lambda: [cfg])
+    assert server._load_proxy_runtime_config()["port"] == 443
+    cfg.write_text('[server]\nport = 8443\n')
+    assert server._load_proxy_runtime_config()["port"] == 8443
+
+
+def test_journal_shutdown_terminates_and_joins(monkeypatch):
+    from unittest.mock import Mock
+    proc = Mock()
+    thread = Mock()
+    monkeypatch.setattr(server, "_log_process", proc)
+    monkeypatch.setattr(server, "_log_thread", thread)
+    monkeypatch.setattr(server, "_log_thread_started", True)
+    server.stop_log_thread()
+    proc.terminate.assert_called_once()
+    proc.wait.assert_called_once_with(timeout=2)
+    thread.join.assert_called_once_with(timeout=3)
+    assert not server._log_thread_started
+
+
 def test_ws_ticket_endpoint_requires_auth(client):
     assert client.get("/api/ws-ticket").status_code == 401
     r = client.get("/api/ws-ticket", headers=_auth())
@@ -116,6 +231,61 @@ def test_ws_rejects_unauthenticated(client):
     with pytest.raises(Exception):
         with client.websocket_connect("/ws/logs"):
             pass
+
+
+def test_quoted_value_keeps_a_hash_and_a_semicolon(tmp_path, monkeypatch):
+    # '#'/';' start a comment only OUTSIDE a quoted string — src/config.zig parses it that way,
+    # so the proxy happily uses such a password while the dashboard used to truncate it at the
+    # '#' (leaving an unbalanced '"s3cr'), pre-fill that into the Routing card and write the
+    # mangled value back to config.toml on the next save.
+    cfg = tmp_path / "config.toml"
+    cfg.write_text(
+        '[upstream.socks5]\n'
+        'host = "10.0.0.1"  # the egress box\n'
+        'username = "u;1"\n'
+        'password = "s3cr#t"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(server, "_proxy_config_candidates", lambda: [cfg])
+
+    parsed = server._load_proxy_runtime_config()
+    assert parsed["upstream_socks5_password"] == "s3cr#t"
+    assert parsed["upstream_socks5_username"] == "u;1"
+    # A genuine trailing comment is still stripped.
+    assert parsed["upstream_socks5_host"] == "10.0.0.1"
+
+
+def test_config_write_replaces_atomically_and_keeps_a_backup(tmp_path):
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('[access.users]\nuser1 = "aa"\n', encoding="utf-8")
+    cfg.chmod(0o640)
+    before_ino = cfg.stat().st_ino
+
+    server._write_config_atomic(cfg, '[access.users]\nuser1 = "bb"\n')
+
+    # Renamed into place, never truncated in place: a crash mid-write can then only leave the
+    # old config, not a zero-length one whose user secrets exist nowhere else.
+    assert cfg.stat().st_ino != before_ino
+    assert cfg.read_text(encoding="utf-8") == '[access.users]\nuser1 = "bb"\n'
+    assert (tmp_path / "config.toml.bak").read_text(encoding="utf-8") == '[access.users]\nuser1 = "aa"\n'
+    assert not (tmp_path / "config.toml.tmp").exists()
+    # Both files hold every user secret, so neither may end up at the umask's mode.
+    assert cfg.stat().st_mode & 0o777 == 0o640
+    assert (tmp_path / "config.toml.bak").stat().st_mode & 0o777 == 0o640
+
+
+def test_config_mutator_uses_the_atomic_writer(tmp_path, monkeypatch):
+    cfg = tmp_path / "config.toml"
+    cfg.write_text("[general]\nuse_middle_proxy = false\n", encoding="utf-8")
+    monkeypatch.setattr(server, "_proxy_config_candidates", lambda: [cfg])
+
+    assert server._set_middle_proxy_enabled(True)
+    assert "use_middle_proxy = true" in cfg.read_text(encoding="utf-8")
+    # The .bak is what proves the mutator went through _write_config_atomic rather than the
+    # truncating Path.write_text it used to call.
+    assert (tmp_path / "config.toml.bak").read_text(encoding="utf-8") == (
+        "[general]\nuse_middle_proxy = false\n"
+    )
 
 
 def test_logs_fanout_is_per_client_cursor():

--- a/src/ctl/fronting_domain.zig
+++ b/src/ctl/fronting_domain.zig
@@ -51,12 +51,17 @@ pub fn classifyOpenSslOutput(output: []const u8) FrontingVerdict {
         else
             .not_reached;
     }
-    if (std.mem.indexOf(u8, output, "Server Temp Key") != null) {
-        if (std.mem.indexOf(u8, output, "MLKEM") != null) return .pq_capable;
-        return .single_round_x25519;
+    if (lineValue(output, "Server Temp Key:")) |group| {
+        if (std.mem.indexOf(u8, group, "MLKEM") != null) return .pq_capable;
+        if (std.ascii.indexOfIgnoreCase(group, "x25519") != null) return .single_round_x25519;
+        return .reachable_without_x25519;
     }
     if (std.mem.indexOf(u8, output, "CONNECTED") != null) return .reachable_without_x25519;
     return .not_reached;
+}
+
+test "legacy OpenSSL non-x25519 key is a mismatch" {
+    try std.testing.expectEqual(FrontingVerdict.reachable_without_x25519, classifyOpenSslOutput("CONNECTED\nServer Temp Key: ECDH, secp521r1, 521 bits\n"));
 }
 
 /// Text following `needle` up to the end of that line, trimmed. Null if absent.
@@ -94,8 +99,9 @@ pub fn warnIfPoorFrontingDomain(ui: *Tui, allocator: std.mem.Allocator, domain: 
     // x25519-only probe — the same check we shipped before PQ existed.
     const legacy = runOpensslProbe(allocator, domain, "X25519") orelse .not_reached;
     if (legacy == .not_reached) return warnFromVerdict(ui, domain, .not_reached);
+    if (legacy == .reachable_without_x25519) return warnFromVerdict(ui, domain, legacy);
 
-    var b: [360]u8 = undefined;
+    var b: [768]u8 = undefined;
     if (std.fmt.bufPrint(&b, "Couldn't test X25519MLKEM768 for '{s}' (the domain rejected the hybrid offer, or this host's OpenSSL predates 3.5). It does single-round x25519 — since June 2026 that alone can mark iOS. Verify PQ support with @Sni_checker_bot.", .{domain}) catch null) |m| ui.info(m);
     return .not_reached;
 }
@@ -103,7 +109,7 @@ pub fn warnIfPoorFrontingDomain(ui: *Tui, allocator: std.mem.Allocator, domain: 
 /// Run one `openssl s_client` probe with the given `-groups` list. Returns null only
 /// if the command couldn't be launched.
 fn runOpensslProbe(allocator: std.mem.Allocator, domain: []const u8, groups: []const u8) ?FrontingVerdict {
-    var cmd_buf: [512]u8 = undefined;
+    var cmd_buf: [768]u8 = undefined;
     const cmd = std.fmt.bufPrint(
         &cmd_buf,
         "echo | timeout 10 openssl s_client -connect {s}:443 -servername {s} -groups {s} -tls1_3 2>&1",
@@ -117,24 +123,24 @@ fn runOpensslProbe(allocator: std.mem.Allocator, domain: []const u8, groups: []c
 fn warnFromVerdict(ui: *Tui, domain: []const u8, verdict: FrontingVerdict) FrontingCheckResult {
     switch (verdict) {
         .pq_capable => {
-            var b: [256]u8 = undefined;
+            var b: [768]u8 = undefined;
             if (std.fmt.bufPrint(&b, "'{s}' negotiates X25519MLKEM768 (post-quantum) — a good fronting target, no iOS marker.", .{domain}) catch null) |m| ui.ok(m);
             return .ok;
         },
         .not_reached => {
-            var b: [320]u8 = undefined;
+            var b: [768]u8 = undefined;
             if (std.fmt.bufPrint(&b, "Couldn't reach '{s}:443' from here to verify its TLS — skipping (connectivity, not a bad domain).", .{domain}) catch null) |m| ui.info(m);
             return .not_reached;
         },
         .single_round_x25519 => {
             ui.warn("This fronting domain negotiates only classical x25519, not X25519MLKEM768.");
-            var msg_buf: [360]u8 = undefined;
+            var msg_buf: [768]u8 = undefined;
             if (std.fmt.bufPrint(&msg_buf, "  Since the June-2026 TSPU rollout a non-PQ domain is a passive marker: iOS clients (and everyone sharing their NAT IP) fronting '{s}' get blocked.", .{domain}) catch null) |m| ui.warn(m);
             ui.hint("  Prefer a domain that negotiates X25519MLKEM768 in one round. Verify: openssl s_client -groups X25519MLKEM768 -connect <domain>:443 (OpenSSL 3.5+), or @Sni_checker_bot. tls_domain is IMMUTABLE once links ship — choose now.");
             return .mismatch;
         },
         .reachable_without_x25519 => {
-            var msg_buf: [360]u8 = undefined;
+            var msg_buf: [768]u8 = undefined;
             if (std.fmt.bufPrint(&msg_buf, "  '{s}' does a HelloRetryRequest or prefers a non-x25519 group (like wb.ru/mail.ru → secp521r1) — our single-round FakeTLS ServerHello can't match it, so a passive observer sees a mismatch.", .{domain}) catch null) |m| ui.warn(m);
             ui.hint("  Prefer a domain that negotiates X25519MLKEM768 (or plain x25519) in one round. tls_domain is IMMUTABLE once links are shared — choose now.");
             return .mismatch;
@@ -142,12 +148,16 @@ fn warnFromVerdict(ui: *Tui, domain: []const u8, verdict: FrontingVerdict) Front
     }
 }
 
-fn isSafeFrontingDomain(domain: []const u8) bool {
+pub fn isSafeFrontingDomain(domain: []const u8) bool {
     if (domain.len == 0 or domain.len > 253) return false;
     for (domain) |c| {
         const ok = (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z') or
             (c >= '0' and c <= '9') or c == '.' or c == '-';
         if (!ok) return false;
+    }
+    var labels = std.mem.splitScalar(u8, domain, '.');
+    while (labels.next()) |label| {
+        if (label.len == 0 or label.len > 63 or label[0] == '-' or label[label.len - 1] == '-') return false;
     }
     return true;
 }

--- a/src/ctl/i18n.zig
+++ b/src/ctl/i18n.zig
@@ -11,13 +11,14 @@ pub const Lang = enum {
     ru,
 
     /// Resolve language from environment map.
-    /// Priority: LC_ALL -> LANG.
+    /// Priority: LANGUAGE preference list, then LC_ALL -> LC_MESSAGES -> LANG.
     pub fn fromEnvMap(env_map: *const std.process.Environ.Map) Lang {
-        if (env_map.get("LC_ALL")) |value| {
-            if (fromLocale(value)) |lang| return lang;
+        if (env_map.get("LANGUAGE")) |preferences| {
+            var languages = std.mem.splitScalar(u8, preferences, ':');
+            while (languages.next()) |value| if (fromLocale(value)) |lang| return lang;
         }
-        if (env_map.get("LANG")) |value| {
-            if (fromLocale(value)) |lang| return lang;
+        for ([_][]const u8{ "LC_ALL", "LC_MESSAGES", "LANG" }) |key| {
+            if (env_map.get(key)) |value| if (fromLocale(value)) |lang| return lang;
         }
         return .en;
     }
@@ -53,30 +54,21 @@ pub const S = enum(u16) {
     menu_setup_recovery,
     menu_setup_dashboard,
     menu_ipv6_hop,
-    menu_edit_config,
     menu_status,
     menu_restart,
     menu_uninstall,
     menu_exit,
 
     // ── Common ──
-    checking_root,
     error_not_root,
-    press_enter,
     yes,
-    no,
     done,
-    failed,
     skipped,
-    version_label,
     confirm_proceed,
     aborting,
     restart_success,
 
     // ── Monitor ──
-    monitor_header,
-    monitor_port_prompt,
-    monitor_port_help,
 
     // ── Tunnel ──
     tunnel_conf_prompt,
@@ -118,9 +110,7 @@ pub const S = enum(u16) {
     install_middle_proxy_warn,
     install_checking_deps,
     install_resolving_tag,
-    install_download_ok,
     install_downloading,
-    install_validating,
     install_binary_ok,
     install_config_generated,
     install_config_exists,
@@ -143,9 +133,7 @@ pub const S = enum(u16) {
     update_tag_resolved,
     update_downloading,
     update_download_ok,
-    update_validating,
     update_validation_ok,
-    update_validation_fail,
     update_backing_up,
     update_stopping,
     update_installing,
@@ -164,10 +152,8 @@ pub const S = enum(u16) {
     uninstall_success,
 
     // ── Errors ──
-    error_arch_unsupported,
     error_no_release,
     error_download_failed,
-    error_binary_not_found,
     error_service_failed,
     error_install_dir_missing,
 
@@ -223,8 +209,6 @@ const en_strings = [_][]const u8{
     "📊  Install Monitoring Dashboard",
     // menu_ipv6_hop
     "\xF0\x9F\x94\x84  IPv6 hopping",
-    // menu_edit_config
-    "\xE2\x9A\x99\xEF\xB8\x8F  Edit configuration",
     // menu_status
     "\xF0\x9F\x93\x8B  Show status",
     // menu_restart
@@ -235,24 +219,14 @@ const en_strings = [_][]const u8{
     "\xF0\x9F\x9A\xAA  Exit",
 
     // ── Common ──
-    // checking_root
-    "Checking root privileges...",
     // error_not_root
     "This command requires root. Run: sudo mtbuddy",
-    // press_enter
-    "Press Enter to continue...",
     // yes
     "yes",
-    // no
-    "no",
     // done
     "done",
-    // failed
-    "failed",
     // skipped
     "skipped",
-    // version_label
-    "version",
     // confirm_proceed
     "Proceed?",
     // aborting
@@ -261,12 +235,6 @@ const en_strings = [_][]const u8{
     "Proxy restarted successfully.",
 
     // ── Monitor ──
-    // monitor_header
-    "Configure Monitor API",
-    // monitor_port_prompt
-    "API port",
-    // monitor_port_help
-    "Port for Prometheus metrics / API.",
 
     // ── Tunnel ──
     // tunnel_conf_prompt
@@ -345,12 +313,8 @@ const en_strings = [_][]const u8{
     "Installing system dependencies...",
     // install_resolving_tag
     "Resolving latest release...",
-    // install_download_ok
-    "Binary downloaded",
     // install_downloading
     "Downloading proxy binary...",
-    // install_validating
-    "Validating binary compatibility...",
     // install_binary_ok
     "Binary installed",
     // install_config_generated
@@ -384,7 +348,7 @@ const en_strings = [_][]const u8{
     // update_version_prompt
     "Version",
     // update_version_help
-    "Leave empty for latest, or specify e.g. v0.11.0",
+    "Leave empty for latest, or specify a release tag (vX.Y.Z)",
     // update_resolving_tag
     "Resolving latest release...",
     // update_tag_resolved
@@ -393,12 +357,8 @@ const en_strings = [_][]const u8{
     "Downloading artifact...",
     // update_download_ok
     "Artifact downloaded",
-    // update_validating
-    "Validating binary compatibility...",
     // update_validation_ok
     "Binary compatible with this CPU",
-    // update_validation_fail
-    "Binary incompatible with this CPU (illegal instruction)",
     // update_backing_up
     "Backing up current binary...",
     // update_stopping
@@ -431,14 +391,10 @@ const en_strings = [_][]const u8{
     "mtproto-proxy and all its components have been removed.",
 
     // ── Errors ──
-    // error_arch_unsupported
-    "Unsupported architecture",
     // error_no_release
     "Couldn't reach GitHub to find the latest version. Check the server's internet and try again.",
     // error_download_failed
     "Failed to download artifact",
-    // error_binary_not_found
-    "Extracted binary not found in artifact",
     // error_service_failed
     "The proxy didn't start after the update — rolled back to the previous version. Check: journalctl -u mtproto-proxy -n 30",
     // error_install_dir_missing
@@ -488,8 +444,6 @@ const ru_strings = [_][]const u8{
     "📊  Установить дашборд мониторинга",
     // menu_ipv6_hop
     "\xF0\x9F\x94\x84  Ротация IPv6",
-    // menu_edit_config
-    "\xE2\x9A\x99\xEF\xB8\x8F  Настроить конфигурацию",
     // menu_status
     "\xF0\x9F\x93\x8B  Показать статус",
     // menu_restart
@@ -500,24 +454,14 @@ const ru_strings = [_][]const u8{
     "\xF0\x9F\x9A\xAA  Выход",
 
     // ── Common ──
-    // checking_root
-    "Проверка прав root...",
     // error_not_root
     "Требуются права root. Запустите: sudo mtbuddy",
-    // press_enter
-    "Нажмите Enter для продолжения...",
     // yes
     "да",
-    // no
-    "нет",
     // done
     "готово",
-    // failed
-    "ошибка",
     // skipped
     "пропущено",
-    // version_label
-    "версия",
     // confirm_proceed
     "Продолжить?",
     // aborting
@@ -526,12 +470,6 @@ const ru_strings = [_][]const u8{
     "Прокси успешно перезапущен.",
 
     // ── Monitor ──
-    // monitor_header
-    "Настройка API мониторинга",
-    // monitor_port_prompt
-    "Порт API",
-    // monitor_port_help
-    "Порт для отдачи метрик Prometheus / API.",
 
     // ── Tunnel ──
     // tunnel_conf_prompt
@@ -610,12 +548,8 @@ const ru_strings = [_][]const u8{
     "Установка системных зависимостей...",
     // install_resolving_tag
     "Определение последней версии...",
-    // install_download_ok
-    "Бинарник скачан",
     // install_downloading
     "Скачивание бинарника прокси...",
-    // install_validating
-    "Проверка совместимости бинарника...",
     // install_binary_ok
     "Бинарник установлен",
     // install_config_generated
@@ -649,7 +583,7 @@ const ru_strings = [_][]const u8{
     // update_version_prompt
     "Версия",
     // update_version_help
-    "Оставьте пустым для latest, или укажите (напр. v0.11.0)",
+    "Оставьте пустым для latest, или укажите тег релиза (vX.Y.Z)",
     // update_resolving_tag
     "Определение последней версии...",
     // update_tag_resolved
@@ -658,12 +592,8 @@ const ru_strings = [_][]const u8{
     "Скачивание артефакта...",
     // update_download_ok
     "Артефакт скачан",
-    // update_validating
-    "Проверка совместимости...",
     // update_validation_ok
     "Бинарник совместим с этим CPU",
-    // update_validation_fail
-    "Бинарник несовместим с этим CPU (недопустимая инструкция)",
     // update_backing_up
     "Резервная копия текущего бинарника...",
     // update_stopping
@@ -696,14 +626,10 @@ const ru_strings = [_][]const u8{
     "mtproto-proxy и все связанные компоненты успешно удалены.",
 
     // ── Errors ──
-    // error_arch_unsupported
-    "Неподдерживаемая архитектура",
     // error_no_release
     "Не удалось связаться с GitHub, чтобы найти последнюю версию. Проверьте интернет на сервере и повторите.",
     // error_download_failed
     "Не удалось скачать артефакт",
-    // error_binary_not_found
-    "Бинарник не найден в артефакте",
     // error_service_failed
     "Прокси не запустился после обновления — откатились к прежней версии. Подробности: journalctl -u mtproto-proxy -n 30",
     // error_install_dir_missing
@@ -770,6 +696,16 @@ test "Lang.fromEnvMap detects LANG ru locale" {
     try env.put("LANG", "ru_RU.UTF-8");
 
     try std.testing.expectEqual(Lang.ru, Lang.fromEnvMap(&env));
+}
+
+test "Lang.fromEnvMap respects message locale and language preferences" {
+    var env = std.process.Environ.Map.init(std.testing.allocator);
+    defer env.deinit();
+    try env.put("LANG", "en_US.UTF-8");
+    try env.put("LC_MESSAGES", "ru_RU.UTF-8");
+    try std.testing.expectEqual(Lang.ru, Lang.fromEnvMap(&env));
+    try env.put("LANGUAGE", "de:en:ru");
+    try std.testing.expectEqual(Lang.en, Lang.fromEnvMap(&env));
 }
 
 test "Lang.fromEnvMap falls back to en for C/POSIX and empty" {

--- a/src/ctl/install.zig
+++ b/src/ctl/install.zig
@@ -18,6 +18,7 @@ const masking = @import("masking.zig");
 const nfqws = @import("nfqws.zig");
 const fronting_domain = @import("fronting_domain.zig");
 const web = @import("web.zig");
+const update = @import("update.zig");
 const web_capability = @import("web_capability");
 
 const Tui = tui_mod.Tui;
@@ -48,7 +49,7 @@ pub const InstallOpts = struct {
     enable_masking: bool = true,
     enable_nfqws: bool = true,
     enable_ipv6_hop: bool = false,
-    enable_desync: bool = true,
+    enable_desync: bool = false,
     enable_drs: bool = false,
     /// Enable MiddleProxy (Telegram relay). Required for promo tags and
     /// non-Premium media loading.
@@ -168,7 +169,8 @@ pub fn printInstallHelp(ui: *Tui) void {
     ui.writeRaw("    --port, -p <port>          Listen port (default: 443)\n");
     ui.writeRaw("    --public-port <port>       Port shown in client links\n");
     ui.writeRaw("    --domain, -d <domain>      FakeTLS masking domain (default: rutube.ru)\n");
-    ui.writeRaw("    --secret, -s <32-hex>      Initial user secret for a new config\n");
+    ui.writeRaw("    --secret-file <path>      Read initial secret from a protected file (recommended)\n");
+    ui.writeRaw("    --secret, -s <32-hex>      Initial secret; visible in process arguments/history\n");
     ui.writeRaw("    --user, -u <name>          Initial user name for a new config\n");
     ui.writeRaw("    --config, -c <path>        Install using an existing config.toml\n");
     ui.writeRaw("    --max-connections <N>      Max concurrent client connections (default: 512)\n");
@@ -321,6 +323,15 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
             if (args.next()) |val| opts.config_path = val;
         } else if (std.mem.eql(u8, arg, "--max-connections")) {
             if (args.next()) |val| opts.max_connections = std.fmt.parseInt(u32, val, 10) catch 512;
+        } else if (std.mem.eql(u8, arg, "--secret-file")) {
+            const path = args.next() orelse return error.MissingSecretFile;
+            const data = try std.Io.Dir.cwd().readFileAlloc(std.Io.Threaded.global_single_threaded.io(), path, allocator, .limited(256));
+            defer allocator.free(data);
+            const secret = std.mem.trim(u8, data, " \r\n\t");
+            if (!isValidSecretHex(secret)) return error.InvalidSecret;
+            var sec: [32]u8 = undefined;
+            @memcpy(&sec, secret);
+            opts.secret = sec;
         } else if (std.mem.eql(u8, arg, "--secret") or std.mem.eql(u8, arg, "-s")) {
             if (args.next()) |val| {
                 if (isValidSecretHex(val)) {
@@ -369,6 +380,9 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
             opts.version = args.next();
         } else if (std.mem.eql(u8, arg, "--insecure")) {
             opts.insecure = true;
+        } else {
+            ui.print("Unknown option: {s}\n", .{arg});
+            return error.UnknownOption;
         }
     }
 
@@ -501,7 +515,7 @@ pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
         opts.enable_tcpmss = true;
         opts.enable_masking = true;
         opts.enable_nfqws = true;
-        opts.enable_desync = true;
+        opts.enable_desync = false;
         opts.enable_drs = false;
         opts.enable_ipv6_hop = false;
     } else {
@@ -524,7 +538,7 @@ pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
                 ui.str(.install_dpi_drs_help),
                 ui.str(.install_dpi_ipv6_help),
             },
-            &.{ true, true, true, true, false, false },
+            &.{ true, true, true, false, false, false },
         );
 
         opts.enable_tcpmss = (dpi_result & 1) != 0;
@@ -597,11 +611,43 @@ pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
 }
 
 /// Execute the installation steps.
-fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
+fn execute(ui: *Tui, allocator: std.mem.Allocator, requested_opts: InstallOpts) !void {
+    var opts = requested_opts;
     // ── Check root ──
     if (!sys.isRoot()) {
         ui.fail(ui.str(.error_not_root));
         return;
+    }
+
+    // A repeated install preserves the deployed identity, including its early QR.
+    const existing_path = opts.config_path orelse INSTALL_DIR ++ "/config.toml";
+    var existing_domain: ?[]u8 = null;
+    defer if (existing_domain) |domain| allocator.free(domain);
+    if (sys.fileExists(existing_path)) {
+        var existing = try toml.TomlDoc.load(allocator, existing_path);
+        defer existing.deinit();
+        if (existing.get("censorship", "tls_domain")) |domain| {
+            if (opts.domain_provided and !std.mem.eql(u8, domain, opts.tls_domain)) {
+                ui.fail("Existing tls_domain differs from --domain; install preserves existing client links");
+                return error.ConfigIdentityConflict;
+            }
+            existing_domain = try allocator.dupe(u8, domain);
+            opts.tls_domain = existing_domain.?;
+        }
+        if (existing.get("server", "port")) |value| {
+            const port = try std.fmt.parseInt(u16, value, 10);
+            if (opts.port_provided and opts.port != port) return error.ConfigIdentityConflict;
+            opts.port = port;
+        }
+        if (existing.get("server", "public_port")) |value| {
+            if (!opts.public_port_provided) opts.public_port = try std.fmt.parseInt(u16, value, 10);
+        }
+        if (existing.get("censorship", "mask_port")) |value| {
+            if (std.mem.eql(u8, value, "443")) {
+                ui.info("Preserving existing port-443 masking; local masking setup skipped");
+                opts.enable_masking = false;
+            }
+        }
     }
 
     // Warn NOW (before the link — which embeds tls_domain — is generated and frozen)
@@ -629,6 +675,15 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
     if (insecure_mode) {
         ui.warn("INSECURE mode enabled: release signature verification is disabled.");
     }
+
+    var completed = false;
+    defer if (!completed) {
+        ui.warn("Installation did not complete; partial state may remain. Existing files were not rolled back.");
+        for ([_][]const u8{ INSTALL_DIR, INSTALL_DIR ++ "/config.toml", release.SERVICE_FILE }) |path| {
+            if (sys.fileExists(path)) ui.print("  Present: {s}\n", .{path});
+        }
+        ui.warn("Inspect the paths above before retrying; for a fresh installation use mtbuddy uninstall --yes to remove managed state.");
+    };
 
     ui.writeRaw("\n");
     ui.rule();
@@ -740,7 +795,21 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
             ui.fail("Installing the mtproto-proxy binary failed (disk full / read-only " ++ INSTALL_DIR ++ "?)");
             return;
         }
-        release.writeServiceFile();
+        // Same guard `mtbuddy update` applies (update.zig): `setup tunnel` replaces this
+        // unit with one carrying AmbientCapabilities=…CAP_NET_ADMIN and
+        // ExecStartPre=+/usr/local/bin/setup_tunnel.sh. Stamping the stock unit over it
+        // leaves `[upstream] type = tunnel` in config.toml while the proxy can no longer
+        // SO_MARK its DC sockets — every upstream connect then fails EPERM on a service
+        // that still binds :443 and looks perfectly active.
+        if (update.isTunnelServiceUnit()) {
+            ui.info(localized(
+                ui,
+                "Keeping the existing tunnel-aware systemd unit (it carries CAP_NET_ADMIN). Use `mtbuddy update --force-service` to reset it.",
+                "Оставляю существующий systemd-юнит для туннеля (в нём CAP_NET_ADMIN). Чтобы перезаписать его, выполните `mtbuddy update --force-service`.",
+            ));
+        } else {
+            try release.writeServiceFile();
+        }
     }
     ui.ok(ui.str(.install_binary_ok));
 
@@ -833,7 +902,8 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
 
     // ── Create system user/group ──
     if (!ensureServiceUser(ui, allocator)) return;
-    if (!runRequired(ui, allocator, &.{ "chown", "-R", "mtproto:mtproto", INSTALL_DIR }, "Failed to chown install directory")) return;
+    if (!runRequired(ui, allocator, &.{ "chown", "root:root", INSTALL_DIR }, "Failed to secure install directory")) return;
+    if (!runRequired(ui, allocator, &.{ "chown", "mtproto:mtproto", INSTALL_DIR ++ "/config.toml" }, "Failed to chown config")) return;
 
     // ── Systemd service ──
     {
@@ -872,8 +942,26 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
     if (sys.commandExists("ufw")) {
         var port_str_buf: [8]u8 = undefined;
         const port_rule = std.fmt.bufPrint(&port_str_buf, "{d}/tcp", .{opts.port}) catch "443/tcp";
-        _ = sys.exec(allocator, &.{ "ufw", "allow", port_rule }) catch {};
-        ui.ok(ui.str(.install_firewall_ok));
+        // ufw lives in /usr/sbin. `commandExists` shells out and so sees dash's own default
+        // PATH, but the spawn does not — resolve the absolute path the way web.zig does.
+        // And report what actually happened: on a ufw-enabled default-deny host a swallowed
+        // failure here means every client SYN is dropped while the installer prints success
+        // and a working-looking link.
+        const ufw = sys.commandOrPath("ufw", &.{ "/usr/sbin/ufw", "/sbin/ufw" });
+        const ufw_result = sys.exec(allocator, &.{ ufw, "allow", port_rule }) catch null;
+        const ufw_ok = if (ufw_result) |r| blk: {
+            defer r.deinit();
+            break :blk r.exit_code == 0;
+        } else false;
+        if (ufw_ok) {
+            ui.ok(ui.str(.install_firewall_ok));
+        } else {
+            ui.warn(localized(
+                ui,
+                "Could not add the ufw rule for the proxy port — open it by hand (`ufw allow <port>/tcp`) or clients will be blocked.",
+                "Не удалось добавить правило ufw для порта прокси — откройте его вручную (`ufw allow <порт>/tcp`), иначе клиенты не подключатся.",
+            ));
+        }
     }
 
     // ── TCPMSS clamping ──
@@ -912,7 +1000,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
 
     // ── Masking (via Zig module) ──
     if (opts.enable_masking) {
-        masking.execute(ui, allocator, .{ .tls_domain = opts.tls_domain }) catch {
+        masking.execute(ui, allocator, .{ .tls_domain = opts.tls_domain, .domain_explicit = opts.domain_provided, .local_backend = true }) catch {
             ui.warn("Masking setup failed");
         };
         // Source of truth is the config (mask=true), not a local nginx site: the
@@ -951,7 +1039,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
     }
 
     // ── Final restart ──
-    if (!runRequired(ui, allocator, &.{ "chown", "-R", "mtproto:mtproto", INSTALL_DIR }, "Failed to chown install directory")) return;
+    if (!runRequired(ui, allocator, &.{ "chown", "root:root", INSTALL_DIR }, "Failed to secure install directory")) return;
     if (!runRequired(ui, allocator, &.{ "systemctl", "restart", SERVICE_NAME }, "Failed to restart mtproto-proxy after setup")) return;
     if (!sys.isServiceActive(SERVICE_NAME)) {
         ui.fail("mtproto-proxy service is not active after setup");
@@ -962,6 +1050,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
     ui.rule();
 
     // ── Print summary ──
+    completed = true;
     // The public server was already resolved once (resolved_server: configured
     // [server].public_ip preferred, else auto-detected) and reused here, so the
     // early link/QR and the summary agree and detection runs only once. The
@@ -1034,7 +1123,9 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: InstallOpts) !void {
     );
 }
 
-fn buildEeSecret(secret: []const u8, tls_domain: []const u8, ee_buf: *[512]u8) []const u8 {
+fn buildEeSecret(secret: []const u8, tls_domain: []const u8, ee_buf: []u8) ![]const u8 {
+    if (ee_buf.len < 34) return error.NoSpaceLeft;
+    if (tls_domain.len == 0 or tls_domain.len > 253) return error.InvalidDomain;
     var ee_pos: usize = 0;
 
     @memcpy(ee_buf[0..2], "ee");
@@ -1045,15 +1136,13 @@ fn buildEeSecret(secret: []const u8, tls_domain: []const u8, ee_buf: *[512]u8) [
         clean_secret = clean_secret[1 .. clean_secret.len - 1];
     }
 
-    const sec_len = @min(clean_secret.len, ee_buf.len - ee_pos);
+    if (clean_secret.len != 32) return error.InvalidSecret;
+    const sec_len = clean_secret.len;
     @memcpy(ee_buf[ee_pos..][0..sec_len], clean_secret[0..sec_len]);
     ee_pos += sec_len;
 
-    var domain_hex_buf: [512]u8 = undefined;
-    const domain_hex = sys.domainToHex(tls_domain, &domain_hex_buf);
-    const dh_len = @min(domain_hex.len, ee_buf.len - ee_pos);
-    @memcpy(ee_buf[ee_pos..][0..dh_len], domain_hex[0..dh_len]);
-    ee_pos += dh_len;
+    const domain_hex = try sys.domainToHex(tls_domain, ee_buf[ee_pos..]);
+    ee_pos += domain_hex.len;
 
     return ee_buf[0..ee_pos];
 }
@@ -1135,7 +1224,7 @@ fn encodeServerForProxyLink(server: []const u8, out: []u8) []const u8 {
 /// the link straight from an SSH session onto a phone — or show it to a relative.
 fn printQrCode(ui: *Tui, allocator: std.mem.Allocator, text: []const u8) void {
     if (!sys.commandExists("qrencode")) return;
-    const r = sys.exec(allocator, &.{ "qrencode", "-t", "UTF8", "-m", "1", text }) catch return;
+    const r = sys.execInput(allocator, &.{ "qrencode", "-t", "UTF8", "-m", "1", "-o", "-" }, text) catch return;
     defer r.deinit();
     if (r.stdout.len == 0) return;
     ui.writeRaw("\n");
@@ -1245,13 +1334,16 @@ fn printLinksFromConfig(
         }
         if (!isValidSecretHex(secret_hex)) continue;
 
-        var ee_buf: [512]u8 = undefined;
-        const ee_secret = buildEeSecret(secret_hex, tls_domain, &ee_buf);
+        var ee_buf: [576]u8 = undefined;
+        const ee_secret = buildEeSecret(secret_hex, tls_domain, &ee_buf) catch {
+            ui.warn("Cannot encode FakeTLS link: invalid or oversized secret/domain.");
+            continue;
+        };
 
         var encoded_ip_buf: [768]u8 = undefined;
         const safe_public_ip = encodeServerForProxyLink(public_ip, &encoded_ip_buf);
 
-        var ee_link_buf: [512]u8 = undefined;
+        var ee_link_buf: [2048]u8 = undefined;
         const ee_link = std.fmt.bufPrint(&ee_link_buf, "tg://proxy?server={s}&port={d}&secret={s}", .{
             safe_public_ip,
             port,
@@ -1260,7 +1352,7 @@ fn printLinksFromConfig(
         // The t.me link is the one to SHARE — it renders a tappable "Connect proxy"
         // card in Telegram and opens from any browser/messenger; tg:// is the direct
         // app link.
-        var tme_link_buf: [512]u8 = undefined;
+        var tme_link_buf: [2048]u8 = undefined;
         const tme_link = std.fmt.bufPrint(&tme_link_buf, "https://t.me/proxy?server={s}&port={d}&secret={s}", .{
             safe_public_ip,
             port,
@@ -1407,20 +1499,23 @@ fn printSummary(
         // secure TLS-only posture (fake_tls_only = true), so only the FakeTLS
         // (ee) link is printed here. dd links are surfaced by printLinksFromConfig
         // only when the operator has explicitly enabled the dd transport.
-        var ee_buf: [512]u8 = undefined;
-        const ee_secret = buildEeSecret(secret, tls_domain, &ee_buf);
+        var ee_buf: [576]u8 = undefined;
+        const ee_secret = buildEeSecret(secret, tls_domain, &ee_buf) catch {
+            ui.warn("Cannot encode FakeTLS link: invalid or oversized secret/domain.");
+            return;
+        };
 
         var encoded_ip_buf: [768]u8 = undefined;
         const safe_public_ip = encodeServerForProxyLink(public_ip, &encoded_ip_buf);
 
-        var ee_link_buf: [512]u8 = undefined;
+        var ee_link_buf: [2048]u8 = undefined;
         const ee_link = std.fmt.bufPrint(&ee_link_buf, "tg://proxy?server={s}&port={d}&secret={s}", .{
             safe_public_ip,
             public_port,
             ee_secret,
         }) catch "error building link";
 
-        var tme_link_buf: [512]u8 = undefined;
+        var tme_link_buf: [2048]u8 = undefined;
         const tme_link = std.fmt.bufPrint(&tme_link_buf, "https://t.me/proxy?server={s}&port={d}&secret={s}", .{
             safe_public_ip,
             public_port,
@@ -1478,9 +1573,13 @@ fn resolvePublicServer(ui: *Tui, allocator: std.mem.Allocator, config_path: []co
     } else |_| {}
     var ip_sp = ui.spinner("Detecting public IP");
     ip_sp.start();
-    const ip = sys.detectPublicIp(allocator) orelse "SERVER_IP";
+    const detected = sys.detectPublicIp(allocator);
+    defer if (detected) |owned| allocator.free(owned);
+    const ip = detected orelse "SERVER_IP";
     ip_sp.stop(true, ip);
-    return ip;
+    const n = @min(ip.len, out_buf.len);
+    @memcpy(out_buf[0..n], ip[0..n]);
+    return out_buf[0..n];
 }
 
 pub fn ensureServiceUser(ui: *Tui, allocator: std.mem.Allocator) bool {
@@ -1742,10 +1841,10 @@ fn removeTcpmssClamp(allocator: std.mem.Allocator) void {
 
 fn tcpmssRuleExists(allocator: std.mem.Allocator, cmd: []const u8, port_str: []const u8, mss_str: []const u8) bool {
     const result = sys.exec(allocator, &.{
-        cmd,       "-t",      "mangle",  "-C",     "OUTPUT",
-        "-p",      "tcp",     "--sport", port_str, "--tcp-flags",
-        "SYN,ACK", "SYN,ACK", "-j",      "TCPMSS", "--set-mss",
-        mss_str,
+        cmd,       "-t",     "mangle",      "-C",      "OUTPUT",
+        "!",       "-o",     "lo",          "-p",      "tcp",
+        "--sport", port_str, "--tcp-flags", "SYN,ACK", "SYN,ACK",
+        "-j",      "TCPMSS", "--set-mss",   mss_str,
     }) catch return false;
     defer result.deinit();
     return result.exit_code == 0;

--- a/src/ctl/ipv6hop.zig
+++ b/src/ctl/ipv6hop.zig
@@ -22,6 +22,10 @@ const CloudflareRecordType = enum {
     aaaa,
 };
 
+fn cloudflareDnsTtl() u16 {
+    return 60;
+}
+
 const CloudflareCredentials = struct {
     token: []const u8,
     zone: []const u8,
@@ -64,8 +68,26 @@ pub const Ipv6Opts = struct {
     ipv6_prefix: []const u8 = "",
     /// Hostname whose Cloudflare A/AAAA record to update. Empty = skip DNS updates.
     dns_name: []const u8 = "",
-    ban_threshold: u32 = 10,
+    // F15-18: hs_timeout fires for ANY handshake-in-progress slot that stalls
+    // handshake_timeout_sec after its first byte — scanners, dropped mobile clients, and
+    // (per proxy.zig's own comment) upstream-side stalls like a dead DC or a stale
+    // MiddleProxy secret, none of which are censorship. 10/60s is ordinary background
+    // noise on a public proxy; an order of magnitude fewer false positives still catches
+    // a real block (which holds the rate for the life of the ban, not one window).
+    ban_threshold: u32 = 100,
 };
+
+// F15-18: a single breaching 60s window is one scanner burst or one bad minute, not a
+// ban — a real TSPU block holds hs_timeout elevated continuously. Require several
+// consecutive breaching windows before treating a spike as a ban.
+const CONSECUTIVE_BREACHES_REQUIRED: u32 = 3;
+
+// F15-18: even a genuine, persistent false positive (dead upstream, stale MiddleProxy
+// secret) must not be allowed to tear the proxy down every ~75s forever — each rotation
+// deletes the live address (killing every connection on it) and rewrites the AAAA
+// record. Cap rotations to at most one per hour so the blast radius is bounded even when
+// the detector keeps firing.
+const ROTATION_COOLDOWN_SEC: i64 = 3600;
 
 pub const Mode = enum { manual, check, auto };
 
@@ -87,6 +109,9 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
             if (args.next()) |val| {
                 opts.ban_threshold = std.fmt.parseInt(u32, val, 10) catch 10;
             }
+        } else {
+            ui.print("Unknown option: {s}\n", .{arg});
+            return error.UnknownOption;
         }
     }
     try execute(ui, allocator, opts);
@@ -99,7 +124,7 @@ pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
     const mode_choice = try ui.menu("IPv6 hop mode", &.{
         "Manual — rotate now",
         "Check — show current status",
-        "Auto — loop, rotate on ban detection",
+        "Auto — monitor suspected blocking (rotation is manual)",
     });
 
     const mode: Mode = switch (mode_choice) {
@@ -117,7 +142,28 @@ pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
         &prefix_buf,
     );
 
-    try execute(ui, allocator, .{ .mode = mode, .ipv6_prefix = prefix });
+    const default_route = sys.exec(allocator, &.{ "ip", "-6", "route", "show", "default" }) catch null;
+    defer if (default_route) |result| result.deinit();
+    var detected_interface: []const u8 = "eth0";
+    if (default_route) |result| {
+        var tokens = std.mem.tokenizeAny(u8, result.stdout, " \t\r\n");
+        while (tokens.next()) |token| {
+            if (std.mem.eql(u8, token, "dev")) {
+                detected_interface = tokens.next() orelse "eth0";
+                break;
+            }
+        }
+    }
+    var interface_buf: [64]u8 = undefined;
+    const interface = try ui.input("Network interface", "Interface carrying the routed IPv6 prefix (for example ens3).", detected_interface, &interface_buf);
+    var dns_buf: [256]u8 = undefined;
+    const dns = try ui.input("DNS hostname (optional)", "Cloudflare hostname whose AAAA record should be updated.", "", &dns_buf);
+    var threshold_buf: [16]u8 = undefined;
+    const threshold = if (mode == .auto)
+        std.fmt.parseInt(u32, try ui.input("Timeout threshold", "Monitoring threshold per 60 seconds.", "100", &threshold_buf), 10) catch return error.InvalidThreshold
+    else
+        100;
+    try execute(ui, allocator, .{ .mode = mode, .ipv6_prefix = prefix, .interface = interface, .dns_name = dns, .ban_threshold = threshold });
 }
 
 fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: Ipv6Opts) !void {
@@ -130,6 +176,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: Ipv6Opts) !void {
         .check => {
             // Show current status
             const current = readStateFile(allocator);
+            defer if (current) |ip| allocator.free(ip);
             ui.print("\n  Current IPv6: {s}\n", .{current orelse "none"});
 
             const timeouts = countRecentTimeouts(allocator);
@@ -142,9 +189,11 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: Ipv6Opts) !void {
                 return;
             }
             ui.step("Manual IPv6 rotation...");
-            removeOldIpv6(allocator, opts.interface);
+            const old_ip = readStateFile(allocator);
+            defer if (old_ip) |ip| allocator.free(ip);
             const new_ip = addNewIpv6(allocator, opts.ipv6_prefix, opts.interface);
             if (new_ip) |ip| {
+                if (old_ip) |old| removeIpv6(allocator, opts.interface, old);
                 ui.ok("New IPv6 added");
                 updateDns(ui, allocator, ip, opts.dns_name);
                 ui.summaryBox("IPv6 Hop Complete", &.{
@@ -162,10 +211,17 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: Ipv6Opts) !void {
                 ui.fail("No IPv6 /64 prefix given — pass --prefix <your-/64> (e.g. 2001:db8:1234:5678)");
                 return;
             }
-            ui.info("Auto-hop mode started");
+            ui.info("IPv6 timeout monitor started (manual rotation only)");
             ui.print("  Ban threshold: {d} timeouts/60s\n", .{opts.ban_threshold});
             ui.info("Running in foreground. Ctrl+C to stop.");
             ui.writeRaw("\n");
+
+            // F15-18: consecutive_breaches turns one noisy window into a requirement for
+            // several in a row (see CONSECUTIVE_BREACHES_REQUIRED); last_rotation_unix
+            // enforces ROTATION_COOLDOWN_SEC between rotations regardless. Both live
+            // outside the loop body so they persist across iterations/arenas.
+            var consecutive_breaches: u32 = 0;
+            var last_rotation_unix: i64 = 0; // 0 == never rotated this run
 
             // Auto-hop loop — runs forever. Each iteration uses its own arena so the
             // journalctl/exec output captured for ban detection (and any rotation's dup'd
@@ -177,15 +233,13 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: Ipv6Opts) !void {
                 const a = it_arena.allocator();
 
                 const timeouts = countRecentTimeouts(a);
-                if (timeouts >= opts.ban_threshold) {
-                    ui.warn("Ban detected — rotating IPv6...");
-                    removeOldIpv6(a, opts.interface);
-                    const new_ip = addNewIpv6(a, opts.ipv6_prefix, opts.interface);
-                    if (new_ip) |ip| {
-                        ui.ok("Hopped to new IPv6");
-                        updateDns(ui, a, ip, opts.dns_name);
-                        ui.stepOk("Hop complete, sleeping 60s", ip);
-                    }
+                const now: i64 = @intCast(std.Io.Clock.real.now(std.Io.Threaded.global_single_threaded.io()).toSeconds());
+                const decision = evaluateBanWindow(timeouts, opts.ban_threshold, consecutive_breaches, now, last_rotation_unix);
+                consecutive_breaches = decision.consecutive_breaches;
+
+                if (decision.rotate) {
+                    ui.warn("Sustained handshake timeouts: check reachability externally before rotating IPv6 manually. Timeouts alone do not establish a ban.");
+                    last_rotation_unix = now;
                     sleepSeconds(60);
                 } else {
                     sleepSeconds(15);
@@ -206,30 +260,19 @@ const STATE_FILE = "/opt/mtproto-proxy/ipv6-current";
 /// `ip -6 addr del <content>` against a poisoned/garbage state file deleting the wrong
 /// address (e.g. the host's primary IPv6) — defense in depth atop the root-owned path.
 fn looksLikeIpv6(s: []const u8) bool {
-    if (s.len < 2 or s.len > 45) return false;
-    var colons: usize = 0;
-    for (s) |c| {
-        if (c == ':') {
-            colons += 1;
-        } else if (!std.ascii.isHex(c)) {
-            return false;
-        }
-    }
-    return colons >= 2;
+    _ = std.Io.net.IpAddress.parseIp6(s, 0) catch return false;
+    return !std.mem.eql(u8, s, "::");
 }
 
 fn readStateFile(allocator: std.mem.Allocator) ?[]const u8 {
-    const r = sys.exec(allocator, &.{ "cat", STATE_FILE }) catch return null;
-    defer r.deinit();
-    const trimmed = std.mem.trim(u8, r.stdout, &[_]u8{ ' ', '\t', '\r', '\n' });
+    const content = sys.readFileAllocAbsolute(allocator, STATE_FILE, 128) orelse return null;
+    defer allocator.free(content);
+    const trimmed = std.mem.trim(u8, content, &[_]u8{ ' ', '\t', '\r', '\n' });
     if (trimmed.len == 0) return null;
     return allocator.dupe(u8, trimmed) catch null;
 }
 
-fn removeOldIpv6(allocator: std.mem.Allocator, interface: []const u8) void {
-    const old_ip = readStateFile(allocator) orelse return;
-    defer allocator.free(old_ip);
-
+fn removeIpv6(allocator: std.mem.Allocator, interface: []const u8, old_ip: []const u8) void {
     // Never pass an unvalidated value to `ip -6 addr del` — a poisoned state file could
     // otherwise delete the host's primary IPv6 and cut connectivity.
     if (!looksLikeIpv6(old_ip)) return;
@@ -239,23 +282,33 @@ fn removeOldIpv6(allocator: std.mem.Allocator, interface: []const u8) void {
     _ = sys.exec(allocator, &.{ "ip", "-6", "addr", "del", addr, "dev", interface }) catch {};
 }
 
+fn hostAddress(buf: []u8, prefix: []const u8, rand_bytes: [8]u8) ![]const u8 {
+    var groups = std.mem.splitScalar(u8, prefix, ':');
+    var count: usize = 0;
+    while (groups.next()) |group| {
+        if (group.len == 0 or group.len > 4) return error.InvalidPrefix;
+        _ = std.fmt.parseInt(u16, group, 16) catch return error.InvalidPrefix;
+        count += 1;
+    }
+    if (count != 4) return error.InvalidPrefix;
+    return std.fmt.bufPrint(buf, "{s}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}", .{
+        prefix, rand_bytes[0], rand_bytes[1], rand_bytes[2], rand_bytes[3], rand_bytes[4], rand_bytes[5], rand_bytes[6], rand_bytes[7],
+    });
+}
+
 fn addNewIpv6(allocator: std.mem.Allocator, prefix: []const u8, interface: []const u8) ?[]const u8 {
+    if (interface.len == 0) return null;
+    for (interface) |c| {
+        if (!std.ascii.isAlphanumeric(c) and c != '_' and c != '-' and c != '.') return null;
+    }
     // Generate random suffix
     var rand_bytes: [8]u8 = undefined;
     if (!fillRandom(&rand_bytes)) return null;
 
     var ip_buf: [128]u8 = undefined;
-    const ip = std.fmt.bufPrint(&ip_buf, "{s}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}:{x:0>2}{x:0>2}", .{
-        prefix,
-        rand_bytes[0],
-        rand_bytes[1],
-        rand_bytes[2],
-        rand_bytes[3],
-        rand_bytes[4],
-        rand_bytes[5],
-        rand_bytes[6],
-        rand_bytes[7],
-    }) catch return null;
+    const ip = hostAddress(&ip_buf, prefix, rand_bytes) catch return null;
+
+    if (!looksLikeIpv6(ip)) return null;
 
     var addr_buf: [192]u8 = undefined;
     const addr = std.fmt.bufPrint(&addr_buf, "{s}/64", .{ip}) catch return null;
@@ -264,9 +317,22 @@ fn addNewIpv6(allocator: std.mem.Allocator, prefix: []const u8, interface: []con
     defer r.deinit();
     if (r.exit_code != 0) return null;
 
-    // Save state 0600 in the root-owned dir (no symlink-following hazard there).
-    sys.writeFileMode(STATE_FILE, ip, 0o600) catch {};
+    var saved = false;
+    defer if (!saved) removeIpv6(allocator, interface, ip);
+    // Restore the current address before the proxy starts after a reboot.
+    const unit = std.fmt.allocPrint(allocator, "[Unit]\nDescription=Restore mtbuddy IPv6 address\nWants=network-online.target\nAfter=network-online.target\nBefore=mtproto-proxy.service\n[Service]\nType=oneshot\nExecStart=/usr/sbin/ip -6 addr replace {s} dev {s}\nRemainAfterExit=yes\n[Install]\nWantedBy=multi-user.target\n", .{ addr, interface }) catch return null;
+    defer allocator.free(unit);
+    sys.writeFileMode("/etc/systemd/system/mtproto-ipv6.service", unit, 0o644) catch return null;
+    const reload = sys.exec(allocator, &.{ "systemctl", "daemon-reload" }) catch return null;
+    defer reload.deinit();
+    if (reload.exit_code != 0) return null;
+    const enable = sys.exec(allocator, &.{ "systemctl", "enable", "mtproto-ipv6.service" }) catch return null;
+    defer enable.deinit();
+    if (enable.exit_code != 0) return null;
 
+    // Save state 0600 in the root-owned dir (no symlink-following hazard there).
+    sys.writeFileMode(STATE_FILE, ip, 0o600) catch return null;
+    saved = true;
     return allocator.dupe(u8, ip) catch null;
 }
 
@@ -278,15 +344,49 @@ fn countRecentTimeouts(allocator: std.mem.Allocator) u32 {
         "--since",
         "60 seconds ago",
         "--no-pager",
+        "--lines=1000",
         "-q",
-    }) catch return 0;
+    }) catch |err| {
+        std.log.warn("Cannot read timeout journal: {s}; this window is unknown", .{@errorName(err)});
+        return 0;
+    };
     defer r.deinit();
+    if (r.exit_code != 0) {
+        std.log.warn("Cannot query timeout journal; this window is unknown", .{});
+        return 0;
+    }
 
     // The proxy never logs the literal "Handshake timeout"; per-event closes are at debug
     // level and filtered out by default. It DOES emit per-interval drop deltas at info,
     // e.g. "  drops: cap+=0 ... hs_timeout+=12 mp_fallback+=0 pool+=0". Sum the
     // hs_timeout deltas observed in the window — that's the real timeout count.
     return sumHandshakeTimeoutDeltas(r.stdout);
+}
+
+/// One auto-hop poll window's ban-detection outcome. Pure (no exec/journalctl/clock
+/// calls) so the consecutive-window + cooldown logic is testable without mocking the
+/// system — see F15-18. `consecutive_breaches` in the result replaces the caller's
+/// running counter for the next call.
+const BanDecision = struct {
+    consecutive_breaches: u32,
+    rotate: bool,
+};
+
+fn evaluateBanWindow(
+    timeouts: u32,
+    threshold: u32,
+    consecutive_breaches_in: u32,
+    now: i64,
+    last_rotation_unix: i64,
+) BanDecision {
+    const consecutive_breaches = if (timeouts >= threshold) consecutive_breaches_in +| 1 else 0;
+    const cooldown_elapsed = last_rotation_unix == 0 or now -| last_rotation_unix >= ROTATION_COOLDOWN_SEC;
+    const rotate = consecutive_breaches >= CONSECUTIVE_BREACHES_REQUIRED and cooldown_elapsed;
+    return .{
+        // Reset the streak once we've actually acted on it, same as a non-breaching window.
+        .consecutive_breaches = if (rotate) 0 else consecutive_breaches,
+        .rotate = rotate,
+    };
 }
 
 /// Sum every `hs_timeout+=N` delta in proxy journal output. Pure for testability.
@@ -308,7 +408,7 @@ fn sumHandshakeTimeoutDeltas(journal: []const u8) u32 {
 
 fn updateDns(ui: *Tui, allocator: std.mem.Allocator, new_ip: []const u8, dns_name: []const u8) void {
     if (dns_name.len == 0) return; // No hostname configured — nothing to update.
-    if (updateCloudflareRecord(ui, allocator, .aaaa, dns_name, new_ip, 30)) {
+    if (updateCloudflareRecord(ui, allocator, .aaaa, dns_name, new_ip, cloudflareDnsTtl())) {
         ui.ok("DNS AAAA record updated");
     }
 }
@@ -328,8 +428,13 @@ pub fn updateDnsA(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Arg
     };
 
     ui.step("Updating DNS A record...");
-    if (!updateCloudflareRecord(ui, allocator, .a, dns_name, new_ip, 60)) return;
+    if (!updateCloudflareRecord(ui, allocator, .a, dns_name, new_ip, cloudflareDnsTtl())) return;
     ui.ok("DNS A record updated successfully");
+}
+
+fn cloudflareRecordPayload(allocator: std.mem.Allocator, record_type: CloudflareRecordType, dns_name: []const u8, new_ip: []const u8, ttl: u16, existing: bool) ![]u8 {
+    if (existing) return std.json.Stringify.valueAlloc(allocator, .{ .content = new_ip }, .{});
+    return std.json.Stringify.valueAlloc(allocator, .{ .type = cloudflareRecordTypeText(record_type), .name = dns_name, .content = new_ip, .ttl = ttl, .proxied = false }, .{});
 }
 
 fn updateCloudflareRecord(
@@ -350,50 +455,60 @@ fn updateCloudflareRecord(
     defer allocator.free(header_file);
     defer deleteFileBestEffort(header_file);
 
-    const maybe_record_id = findCloudflareRecordId(allocator, creds.zone, dns_name, record_type, header_file) catch {
+    const maybe_record_ids = findCloudflareRecordId(allocator, creds.zone, dns_name, record_type, header_file) catch {
         ui.warn("Cloudflare DNS lookup failed");
         return false;
     };
-    defer if (maybe_record_id) |record_id| allocator.free(record_id);
+    defer if (maybe_record_ids) |record_ids| allocator.free(record_ids);
+    var records = std.mem.splitScalar(u8, maybe_record_ids orelse "", ',');
+    while (records.next()) |record_id_text| {
+        const maybe_record_id: ?[]const u8 = if (record_id_text.len == 0) null else record_id_text;
 
-    const payload = std.json.Stringify.valueAlloc(allocator, .{
-        .type = cloudflareRecordTypeText(record_type),
-        .name = dns_name,
-        .content = new_ip,
-        .ttl = ttl,
-        .proxied = false,
-    }, .{}) catch {
-        ui.warn("Failed to prepare Cloudflare DNS request body");
-        return false;
-    };
-    defer allocator.free(payload);
-
-    const url = if (maybe_record_id) |record_id|
-        std.fmt.allocPrint(allocator, "https://api.cloudflare.com/client/v4/zones/{s}/dns_records/{s}", .{ creds.zone, record_id }) catch {
-            ui.warn("Failed to prepare Cloudflare DNS request URL");
-            return false;
-        }
-    else
-        std.fmt.allocPrint(allocator, "https://api.cloudflare.com/client/v4/zones/{s}/dns_records", .{creds.zone}) catch {
-            ui.warn("Failed to prepare Cloudflare DNS request URL");
+        const payload = cloudflareRecordPayload(allocator, record_type, dns_name, new_ip, ttl, maybe_record_id != null) catch {
+            ui.warn("Failed to prepare Cloudflare DNS request body");
             return false;
         };
-    defer allocator.free(url);
+        defer allocator.free(payload);
 
-    const method = if (maybe_record_id != null) "PUT" else "POST";
-    var response = curlJsonRequest(allocator, method, url, header_file, payload) catch {
-        ui.warn("Cloudflare DNS update request failed");
-        return false;
-    };
-    defer response.deinit();
+        const url = if (maybe_record_id) |record_id|
+            std.fmt.allocPrint(allocator, "https://api.cloudflare.com/client/v4/zones/{s}/dns_records/{s}", .{ creds.zone, record_id }) catch {
+                ui.warn("Failed to prepare Cloudflare DNS request URL");
+                return false;
+            }
+        else
+            std.fmt.allocPrint(allocator, "https://api.cloudflare.com/client/v4/zones/{s}/dns_records", .{creds.zone}) catch {
+                ui.warn("Failed to prepare Cloudflare DNS request URL");
+                return false;
+            };
+        defer allocator.free(url);
 
-    if (response.exit_code != 0) {
-        ui.warn("Cloudflare DNS update command exited with non-zero status");
-        return false;
-    }
-    if (!cloudflareResponseSuccess(allocator, response.stdout)) {
-        ui.warn("Cloudflare API returned an unsuccessful response");
-        return false;
+        const method = if (maybe_record_id != null) "PATCH" else "POST";
+        var response = curlJsonRequest(allocator, method, url, header_file, payload) catch {
+            ui.warn("Cloudflare DNS update request failed");
+            return false;
+        };
+        defer response.deinit();
+
+        if (response.exit_code != 0) {
+            ui.warn("Cloudflare DNS update command exited with non-zero status");
+            return false;
+        }
+        if (!cloudflareResponseSuccess(allocator, response.stdout)) {
+            ui.warn("Cloudflare API returned an unsuccessful response");
+            if (std.json.parseFromSlice(std.json.Value, allocator, response.stdout, .{})) |parsed| {
+                defer parsed.deinit();
+                if (parsed.value == .object) {
+                    if (parsed.value.object.get("errors")) |errors| {
+                        if (errors == .array and errors.array.items.len > 0 and errors.array.items[0] == .object) {
+                            if (errors.array.items[0].object.get("message")) |message| {
+                                if (message == .string) ui.warn(message.string);
+                            }
+                        }
+                    }
+                }
+            } else |_| {}
+            return false;
+        }
     }
     return true;
 }
@@ -431,7 +546,7 @@ fn createCloudflareHeaderFile(allocator: std.mem.Allocator, token: []const u8) !
 
     const path = try std.fmt.allocPrint(
         allocator,
-        "/tmp/mtbuddy-cf-{x:0>2}{x:0>2}{x:0>2}{x:0>2}{x:0>2}{x:0>2}{x:0>2}{x:0>2}.headers",
+        "/run/mtbuddy-cf-{x:0>2}{x:0>2}{x:0>2}{x:0>2}{x:0>2}{x:0>2}{x:0>2}{x:0>2}.headers",
         .{
             rand_bytes[0],
             rand_bytes[1],
@@ -471,7 +586,7 @@ fn curlJsonRequest(
     defer allocator.free(header_arg);
     return sys.exec(allocator, &.{
         "curl",
-        "-fsS",
+        "-sS",
         "-X",
         method,
         url,
@@ -491,7 +606,7 @@ fn curlGetRequest(
     defer allocator.free(header_arg);
     return sys.exec(allocator, &.{
         "curl",
-        "-fsS",
+        "-sS",
         "-X",
         "GET",
         url,
@@ -507,18 +622,44 @@ fn findCloudflareRecordId(
     record_type: CloudflareRecordType,
     header_file: []const u8,
 ) !?[]u8 {
+    var encoded_name: std.ArrayList(u8) = .empty;
+    defer encoded_name.deinit(allocator);
+    for (dns_name) |c| {
+        if (std.ascii.isAlphanumeric(c) or c == '-' or c == '.') {
+            try encoded_name.append(allocator, c);
+        } else {
+            const hex = "0123456789ABCDEF";
+            try encoded_name.appendSlice(allocator, &.{ '%', hex[c >> 4], hex[c & 15] });
+        }
+    }
     const query_url = try std.fmt.allocPrint(
         allocator,
-        "https://api.cloudflare.com/client/v4/zones/{s}/dns_records?type={s}&name={s}",
-        .{ zone, cloudflareRecordTypeText(record_type), dns_name },
+        "https://api.cloudflare.com/client/v4/zones/{s}/dns_records?type={s}&name={s}&per_page=100",
+        .{ zone, cloudflareRecordTypeText(record_type), encoded_name.items },
     );
     defer allocator.free(query_url);
 
     var response = try curlGetRequest(allocator, query_url, header_file);
     defer response.deinit();
     if (response.exit_code != 0) return error.CloudflareRequestFailed;
+    if (!cloudflareResponseSuccess(allocator, response.stdout)) return error.CloudflareRequestFailed;
 
-    return cloudflareExtractRecordId(allocator, response.stdout);
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, response.stdout, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.CloudflareRequestFailed;
+    const results = parsed.value.object.get("result") orelse return error.CloudflareRequestFailed;
+    if (results != .array or results.array.items.len >= 100) return error.CloudflareRequestFailed;
+    var ids: std.ArrayList(u8) = .empty;
+    errdefer ids.deinit(allocator);
+    for (results.array.items) |record| {
+        if (record != .object) return error.CloudflareRequestFailed;
+        const id = record.object.get("id") orelse return error.CloudflareRequestFailed;
+        if (id != .string or id.string.len == 0 or std.mem.indexOfScalar(u8, id.string, ',') != null) return error.CloudflareRequestFailed;
+        if (ids.items.len > 0) try ids.append(allocator, ',');
+        try ids.appendSlice(allocator, id.string);
+    }
+    if (ids.items.len == 0) return null;
+    return try ids.toOwnedSlice(allocator);
 }
 
 fn cloudflareRecordTypeText(record_type: CloudflareRecordType) []const u8 {
@@ -580,6 +721,8 @@ fn cloudflareResponseSuccess(allocator: std.mem.Allocator, response_json: []cons
 // ── Tests ───────────────────────────────────────────────────────
 
 test "looksLikeIpv6 accepts valid literals and rejects junk" {
+    try std.testing.expect(!looksLikeIpv6("::::"));
+    try std.testing.expect(!looksLikeIpv6("::"));
     try std.testing.expect(looksLikeIpv6("2001:db8::1"));
     try std.testing.expect(looksLikeIpv6("2a01:48a0:4301:bf:1122:3344:5566:7788"));
     try std.testing.expect(!looksLikeIpv6(""));
@@ -626,4 +769,30 @@ test "cloudflareResponseSuccess parses the success flag" {
 test "cloudflareRecordTypeText" {
     try std.testing.expectEqualStrings("A", cloudflareRecordTypeText(.a));
     try std.testing.expectEqualStrings("AAAA", cloudflareRecordTypeText(.aaaa));
+}
+
+test "Cloudflare payloads preserve existing settings and use valid TTL on creation" {
+    for ([_]CloudflareRecordType{ .a, .aaaa }) |kind| {
+        const payload = try cloudflareRecordPayload(std.testing.allocator, kind, "proxy.example", "2001:db8::1", cloudflareDnsTtl(), false);
+        defer std.testing.allocator.free(payload);
+        const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, payload, .{});
+        defer parsed.deinit();
+        try std.testing.expectEqual(@as(i64, 60), parsed.value.object.get("ttl").?.integer);
+        try std.testing.expectEqualStrings(cloudflareRecordTypeText(kind), parsed.value.object.get("type").?.string);
+    }
+    const patch = try cloudflareRecordPayload(std.testing.allocator, .aaaa, "proxy.example", "2001:db8::1", 60, true);
+    defer std.testing.allocator.free(patch);
+    try std.testing.expectEqualStrings("{\"content\":\"2001:db8::1\"}", patch);
+}
+
+test "IPv6 host address requires four prefix groups and preserves the suffix" {
+    var buf: [128]u8 = undefined;
+    const suffix = [_]u8{ 0, 1, 2, 3, 4, 5, 6, 7 };
+    try std.testing.expectEqualStrings("2001:db8:1234:5678:0001:0203:0405:0607", try hostAddress(&buf, "2001:db8:1234:5678", suffix));
+    try std.testing.expectError(error.InvalidPrefix, hostAddress(&buf, "2001:db8::", suffix));
+    try std.testing.expectError(error.InvalidPrefix, hostAddress(&buf, "2001:db8:1234:xyz", suffix));
+}
+
+test "Cloudflare DNS TTL meets the provider minimum" {
+    try std.testing.expectEqual(@as(u16, 60), cloudflareDnsTtl());
 }

--- a/src/ctl/links.zig
+++ b/src/ctl/links.zig
@@ -90,7 +90,9 @@ fn printLinks(ui: *Tui, allocator: std.mem.Allocator, opts: LinkOpts) !void {
     // address is not part of any link it can hand out — and a host reached only through
     // a CDN may have none to detect. Not having one stops being fatal there.
     const web_only = cfg.web.onlyActive();
-    const server = opts.server orelse cfg.public_ip orelse sys.detectPublicIp(allocator) orelse blk: {
+    const detected = if (opts.server == null and cfg.public_ip == null) sys.detectPublicIp(allocator) else null;
+    defer if (detected) |owned| allocator.free(owned);
+    const server = opts.server orelse cfg.public_ip orelse detected orelse blk: {
         if (web_only) break :blk "";
         ui.fail("Could not determine public server address");
         ui.hint("Pass --server <ip-or-domain>, or set [server].public_ip in config.toml");
@@ -132,8 +134,11 @@ fn printLinks(ui: *Tui, allocator: std.mem.Allocator, opts: LinkOpts) !void {
         var secret_hex: [32]u8 = undefined;
         bytesToHex(entry.value_ptr.*, &secret_hex);
 
-        var ee_buf: [512]u8 = undefined;
-        const ee_secret = buildEeSecret(secret_hex[0..], domain, &ee_buf);
+        var ee_buf: [576]u8 = undefined;
+        const ee_secret = buildEeSecret(secret_hex[0..], domain, &ee_buf) catch {
+            ui.fail("Cannot encode FakeTLS link: secret or domain is invalid or too long.");
+            return;
+        };
 
         var encoded_server_buf: [768]u8 = undefined;
         const safe_server = encodeServerForProxyLink(server, &encoded_server_buf);
@@ -232,20 +237,19 @@ fn printLinksHelp(ui: *Tui) void {
     ui.writeRaw("  Prints a fresh 32-hex MTProto secret.\n\n");
 }
 
-fn buildEeSecret(secret: []const u8, tls_domain: []const u8, ee_buf: *[512]u8) []const u8 {
+fn buildEeSecret(secret: []const u8, tls_domain: []const u8, ee_buf: []u8) ![]const u8 {
+    if (secret.len != 32 or tls_domain.len == 0 or tls_domain.len > 253) return error.InvalidSecretOrDomain;
+    if (ee_buf.len < 34) return error.NoSpaceLeft;
     var pos: usize = 0;
     @memcpy(ee_buf[pos..][0..2], "ee");
     pos += 2;
 
-    const sec_len = @min(secret.len, ee_buf.len - pos);
+    const sec_len = secret.len;
     @memcpy(ee_buf[pos..][0..sec_len], secret[0..sec_len]);
     pos += sec_len;
 
-    var domain_hex_buf: [512]u8 = undefined;
-    const domain_hex = sys.domainToHex(tls_domain, &domain_hex_buf);
-    const domain_len = @min(domain_hex.len, ee_buf.len - pos);
-    @memcpy(ee_buf[pos..][0..domain_len], domain_hex[0..domain_len]);
-    pos += domain_len;
+    const domain_hex = try sys.domainToHex(tls_domain, ee_buf[pos..]);
+    pos += domain_hex.len;
 
     return ee_buf[0..pos];
 }
@@ -306,8 +310,18 @@ fn bytesToHex(bytes: [16]u8, out: *[32]u8) void {
 
 test "links - ee secret includes domain hex" {
     var buf: [512]u8 = undefined;
-    const ee = buildEeSecret("0123456789abcdef0123456789abcdef", "wb.ru", &buf);
+    const ee = try buildEeSecret("0123456789abcdef0123456789abcdef", "wb.ru", &buf);
     try std.testing.expectEqualStrings("ee0123456789abcdef0123456789abcdef77622e7275", ee);
+}
+
+test "links - long domains are complete or explicitly rejected" {
+    const secret = "0123456789abcdef0123456789abcdef";
+    const domain = [_]u8{'a'} ** 253;
+    var full: [576]u8 = undefined;
+    const result = try buildEeSecret(secret, &domain, &full);
+    try std.testing.expectEqual(@as(usize, 540), result.len);
+    var small: [512]u8 = undefined;
+    try std.testing.expectError(error.NoSpaceLeft, buildEeSecret(secret, &domain, &small));
 }
 
 test "links - dd secret uses secure transport prefix" {

--- a/src/ctl/main.zig
+++ b/src/ctl/main.zig
@@ -35,9 +35,16 @@ const Tui = tui_mod.Tui;
 const Color = tui_mod.Color;
 
 pub const version = version_mod.version;
+pub const std_options: std.Options = .{ .log_level = if (@import("builtin").is_test) .err else .info };
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.arena.allocator();
+    var command_runtime: std.Io.Threaded = .init(std.heap.page_allocator, .{
+        .environ = std.Io.Threaded.global_single_threaded.environ.process_environ,
+    });
+    defer command_runtime.deinit();
+    @import("sys.zig").command_io = command_runtime.io();
+    defer @import("sys.zig").command_io = null;
 
     var args = try init.minimal.args.iterateAllocator(allocator);
     defer args.deinit();
@@ -55,13 +62,13 @@ pub fn main(init: std.process.Init) !void {
         } else if (std.mem.eql(u8, arg, "--lang")) {
             const lang_val = args.next() orelse {
                 printLangFlagError("Missing value for --lang (expected: en|ru)\n");
-                return;
+                return error.BadUsage;
             };
             lang = parseLangFlag(lang_val) orelse {
                 var buf: [96]u8 = undefined;
                 const msg = std.fmt.bufPrint(&buf, "Unsupported language '{s}' (expected: en|ru)\n", .{lang_val}) catch "Unsupported language (expected: en|ru)\n";
                 printLangFlagError(msg);
-                return;
+                return error.BadUsage;
             };
         } else if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
             const help_lang = lang orelse i18n.Lang.fromEnvMap(init.environ_map);
@@ -113,6 +120,10 @@ pub fn main(init: std.process.Init) !void {
         // printing help (issue #310). Scan a copy so the real iterator stays intact.
         var help_scan = remaining_args;
         while (help_scan.next()) |a| {
+            if (std.mem.eql(u8, a, "--lang") or std.mem.eql(u8, a, "--interactive") or std.mem.eql(u8, a, "-i")) {
+                ui.fail("Global options --lang and --interactive must precede the command");
+                return error.BadUsage;
+            }
             if (std.mem.eql(u8, a, "--help") or std.mem.eql(u8, a, "-h")) {
                 if (std.mem.eql(u8, cmd, "install")) {
                     install.printInstallHelp(&ui);
@@ -155,11 +166,11 @@ pub fn main(init: std.process.Init) !void {
                         sub,
                     });
                     ui.hint(tr(ui.lang, "Available: masking, nfqws, syn-limit, tunnel, egress, recovery, dashboard, web", "Доступно: masking, nfqws, syn-limit, tunnel, egress, recovery, dashboard, web"));
-                    return;
+                    return error.BadUsage;
                 }
             } else {
                 ui.fail(tr(ui.lang, "Usage: mtbuddy setup <masking|nfqws|syn-limit|tunnel|egress|recovery|dashboard|web>", "Использование: mtbuddy setup <masking|nfqws|syn-limit|tunnel|egress|recovery|dashboard|web>"));
-                return;
+                return error.BadUsage;
             }
         } else if (std.mem.eql(u8, cmd, "ipv6-hop")) {
             return ipv6hop.run(&ui, allocator, &remaining_args);
@@ -186,7 +197,7 @@ pub fn main(init: std.process.Init) !void {
                 cmd,
             });
             printHelp(ui.lang);
-            return;
+            return error.BadUsage;
         }
     }
 
@@ -230,8 +241,11 @@ fn menuWebRemove(lang: i18n.Lang) []const u8 {
     return tr(lang, "🌐  Remove the WEB proxy relay", "🌐  Удалить релей WEB-прокси");
 }
 
-fn interactiveMain(ui: *Tui, allocator: std.mem.Allocator) !void {
+fn interactiveMain(ui: *Tui, backing_allocator: std.mem.Allocator) !void {
     while (true) {
+        var action_arena = std.heap.ArenaAllocator.init(backing_allocator);
+        defer action_arena.deinit();
+        const allocator = action_arena.allocator();
         const sys = @import("sys.zig");
         const is_installed = sys.fileExists("/opt/mtproto-proxy");
 
@@ -562,9 +576,9 @@ fn printHelp(lang: i18n.Lang) void {
     printCmd(&ui, "setup egress [--deps-only] <share-link...>", tr(lang, "Setup VPN share-link egress", "Настроить egress через VPN-ссылку"));
     printCmd(&ui, "setup dashboard", tr(lang, "Install web monitoring dashboard", "Установить веб-дашборд мониторинга"));
     printCmd(&ui, "setup recovery", tr(lang, "Install DPI auto-recovery", "Установить авто-восстановление DPI"));
-    printCmd(&ui, "setup web --domain <host> [--mode mask|behind] [--only] [--cert <pem> --key <pem>] [--remove]", tr(lang, "WEB proxy relay for Telegram Desktop 7.1+ (--only serves nothing else)", "Релей WEB-прокси для Telegram Desktop 7.1+ (--only отдаёт только его)"));
+    printCmd(&ui, "setup web --domain <host> [--mode mask|behind] [--only|--no-only] [--cert <pem> --key <pem>] [--remove]", tr(lang, "WEB proxy relay for Telegram Desktop 7.1+ (--only serves nothing else)", "Релей WEB-прокси для Telegram Desktop 7.1+ (--only отдаёт только его)"));
     printCmd(&ui, "ipv6-hop", tr(lang, "IPv6 address rotation", "Ротация IPv6 адреса"));
-    printCmd(&ui, "update-dns <ip>", tr(lang, "Update Cloudflare DNS A record", "Обновить A-запись Cloudflare DNS"));
+    printCmd(&ui, "update-dns <ip> <hostname>", tr(lang, "Update Cloudflare DNS A record", "Обновить A-запись Cloudflare DNS"));
     printCmd(&ui, "config <validate|doctor|print-effective>", tr(lang, "Config diagnostics and effective values", "Диагностика и эффективные значения конфига"));
     printCmd(&ui, "links", tr(lang, "Print tg:// links from config (sensitive)", "Показать tg:// ссылки из конфига (секретно)"));
     printCmd(&ui, "secret", tr(lang, "Generate a fresh 32-hex secret", "Сгенерировать новый 32-hex секрет"));
@@ -578,6 +592,7 @@ fn printHelp(lang: i18n.Lang) void {
     printOpt(&ui, "--public-port <port>", tr(lang, "Port advertised in Telegram links", "Порт для Telegram-ссылок"));
     printOpt(&ui, "--domain, -d <domain>", tr(lang, "TLS masking domain (default: rutube.ru)", "TLS-домен маскировки (по умолчанию: rutube.ru)"));
     printOpt(&ui, "--secret, -s <hex32>", tr(lang, "User secret (32 hex chars, auto-generated if omitted)", "Секрет пользователя (32 hex, если не задан — генерируется)"));
+    printOpt(&ui, "--secret-file <path>", tr(lang, "Read secret from a private file (avoids argv disclosure)", "Прочитать секрет из закрытого файла (не раскрывать в argv)"));
     printOpt(&ui, "--user,   -u <name>", tr(lang, "Username in config.toml (default: user)", "Имя пользователя в config.toml (по умолчанию: user)"));
     printOpt(&ui, "--config, -c <path>", tr(lang, "Use existing config.toml file", "Использовать существующий config.toml"));
     printOpt(&ui, "--yes,    -y", tr(lang, "Skip confirmation prompt (non-interactive)", "Пропустить подтверждение (non-interactive)"));
@@ -590,7 +605,7 @@ fn printHelp(lang: i18n.Lang) void {
     printOpt(&ui, "--bind,   -b <ip>", tr(lang, "Bind to specific IP (default: all interfaces)", "Слушать конкретный IP (по умолчанию: все интерфейсы)"));
     printOpt(&ui, "--middle-proxy", tr(lang, "Enable Telegram MiddleProxy relay", "Включить Telegram MiddleProxy relay"));
     printOpt(&ui, "--web <domain>", tr(lang, "Also set up the WEB proxy relay (Desktop 7.1+)", "Дополнительно поднять релей WEB-прокси (Desktop 7.1+)"));
-    printOpt(&ui, "--ipv6-hop", tr(lang, "Enable IPv6 auto-hopping", "Включить автоматическую ротацию IPv6"));
+    printOpt(&ui, "--ipv6-hop", tr(lang, "Print reminder to configure IPv6 hopping separately", "Напомнить об отдельной настройке ротации IPv6"));
     printOpt(&ui, "--version, -v <tag>", tr(lang, "Release version to install (default: latest)", "Версия релиза для установки (по умолчанию: latest)"));
     printOpt(&ui, "--insecure", tr(lang, "Allow unsigned assets (disables minisign verification)", "Разрешить неподписанные артефакты (отключает minisign verification)"));
     ui.writeRaw("\n");
@@ -599,12 +614,15 @@ fn printHelp(lang: i18n.Lang) void {
     ui.print("  {s}{s}:{s}\n\n", .{ Color.accent, tr(lang, "Update options", "Опции обновления"), Color.reset });
     printOpt(&ui, "--version, -v <tag>", tr(lang, "Pin to specific release tag", "Зафиксировать конкретный тег релиза"));
     printOpt(&ui, "--force-service", tr(lang, "Force systemd unit update", "Принудительно обновить systemd unit"));
+    printOpt(&ui, "--force", tr(lang, "Reapply the same release and host repairs", "Повторно применить релиз и настройки хоста"));
+    printOpt(&ui, "--allow-downgrade", tr(lang, "Explicitly allow an older release", "Явно разрешить более старый релиз"));
     printOpt(&ui, "--insecure", tr(lang, "Allow unsigned assets (disables minisign verification)", "Разрешить неподписанные артефакты (отключает minisign verification)"));
     ui.writeRaw("\n");
 
     // ── Setup options ──
     ui.print("  {s}{s}:{s}\n\n", .{ Color.accent, tr(lang, "Setup options", "Опции setup"), Color.reset });
     printOpt(&ui, "--domain <domain>", tr(lang, "TLS masking domain", "TLS-домен маскировки"));
+    printOpt(&ui, "--local", tr(lang, "Masking: explicitly replace remote cover with local nginx", "Маскировка: явно заменить удалённый сайт локальным nginx"));
     printOpt(&ui, "--ttl <N>", tr(lang, "nfqws fake packet TTL (default: 6)", "TTL фейковых пакетов nfqws (по умолчанию: 6)"));
     printOpt(&ui, "--remove", tr(lang, "Remove nfqws installation", "Удалить установленный nfqws"));
     ui.writeRaw("\n");
@@ -669,6 +687,7 @@ fn tr(lang: i18n.Lang, en: []const u8, ru: []const u8) []const u8 {
 }
 
 test {
+    std.testing.log_level = .err;
     // Zig only collects tests from files reachable through analyzed test code. The root
     // test previously referenced only `tunnel`, so 25+ tests in modules reached solely
     // from main() (sharelink, links, config_cmd, fronting_domain, install, ipv6hop, …)
@@ -693,6 +712,7 @@ test {
     _ = @import("uninstall.zig");
     _ = @import("update.zig");
     _ = @import("web.zig");
+    _ = @import("dashboard.zig");
 }
 
 test "every main-menu entry is decorated with an emoji" {

--- a/src/ctl/masking.zig
+++ b/src/ctl/masking.zig
@@ -28,6 +28,7 @@ pub const MaskingOpts = struct {
     /// Allow changing an already-configured tls_domain even though it breaks every
     /// distributed share link.
     force: bool = false,
+    local_backend: bool = false,
 };
 
 const config_path = INSTALL_DIR ++ "/config.toml";
@@ -59,9 +60,14 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
             opts.skip_monitor = true;
         } else if (std.mem.eql(u8, arg, "--force")) {
             opts.force = true;
+        } else if (std.mem.eql(u8, arg, "--local")) {
+            opts.local_backend = true;
         } else if (arg.len > 0 and arg[0] != '-') {
             opts.tls_domain = arg;
             opts.domain_explicit = true;
+        } else {
+            ui.print("Unknown option: {s}\n", .{arg});
+            return error.UnknownOption;
         }
     }
     try execute(ui, allocator, opts);
@@ -129,6 +135,7 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts_in: MaskingOpts) !vo
         }
     }
 
+    if (!fronting_domain.isSafeFrontingDomain(opts.tls_domain)) return error.InvalidFrontingDomain;
     _ = fronting_domain.warnIfPoorFrontingDomain(ui, allocator, opts.tls_domain);
 
     // ── Install Nginx ──
@@ -157,41 +164,26 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts_in: MaskingOpts) !vo
     // ── Generate certificates ──
     _ = sys.exec(allocator, &.{ "mkdir", "-p", CERT_DIR }) catch {};
 
-    var cert_ok = false;
-    if (sys.commandExists("certbot")) {
-        ui.step("Attempting Let's Encrypt certificate...");
-        const r = sys.exec(allocator, &.{
-            "certbot",           "certonly",    "--nginx",                           "-d", opts.tls_domain,
-            "--non-interactive", "--agree-tos", "--register-unsafely-without-email",
-        }) catch null;
-        if (r) |result| {
-            defer result.deinit();
-            if (result.exit_code == 0) {
-                var symlink_buf: [256]u8 = undefined;
-                const fullchain = std.fmt.bufPrint(&symlink_buf, "/etc/letsencrypt/live/{s}/fullchain.pem", .{opts.tls_domain}) catch "";
-                if (fullchain.len > 0) {
-                    _ = sys.exec(allocator, &.{ "ln", "-sf", fullchain, CERT_DIR ++ "/cert.pem" }) catch {};
-                    var key_buf: [256]u8 = undefined;
-                    const privkey = std.fmt.bufPrint(&key_buf, "/etc/letsencrypt/live/{s}/privkey.pem", .{opts.tls_domain}) catch "";
-                    if (privkey.len > 0) {
-                        _ = sys.exec(allocator, &.{ "ln", "-sf", privkey, CERT_DIR ++ "/key.pem" }) catch {};
-                    }
-                }
-                ui.ok("Let's Encrypt certificate obtained");
-                cert_ok = true;
-            }
-        }
-    }
+    // A borrowed fronting hostname cannot pass ACME ownership validation. Reuse
+    // operator-provided certificates; certificate issuance belongs to setup web.
+    const cert_ok = sys.fileExists(CERT_DIR ++ "/cert.pem") and sys.fileExists(CERT_DIR ++ "/key.pem");
 
     if (!cert_ok) {
         ui.step("Generating self-signed certificate...");
-        var subj_buf: [128]u8 = undefined;
-        const subj = std.fmt.bufPrint(&subj_buf, "/CN={s}", .{opts.tls_domain}) catch "/CN=rutube.ru";
-        _ = sys.execForward(&.{
-            "openssl", "req",                  "-x509", "-newkey",               "ec",    "-pkeyopt", "ec_paramgen_curve:prime256v1",
-            "-keyout", CERT_DIR ++ "/key.pem", "-out",  CERT_DIR ++ "/cert.pem", "-days", "3650",     "-nodes",
+        var subj_buf: [280]u8 = undefined;
+        const subj = try std.fmt.bufPrint(&subj_buf, "/CN={s}", .{opts.tls_domain});
+        const generated = sys.execForward(&.{
+            "openssl", "req",                             "-x509", "-newkey",                          "ec",    "-pkeyopt", "ec_paramgen_curve:prime256v1",
+            "-keyout", CERT_DIR ++ "/selfsigned-key.pem", "-out",  CERT_DIR ++ "/selfsigned-cert.pem", "-days", "3650",     "-nodes",
             "-subj",   subj,
-        }) catch {};
+        }) catch return;
+        if (generated != 0) {
+            ui.fail("Certificate generation failed");
+            return;
+        }
+        // Replace directory entries, never write through Let's Encrypt symlinks.
+        std.Io.Dir.renameAbsolute(CERT_DIR ++ "/selfsigned-key.pem", CERT_DIR ++ "/key.pem", std.Io.Threaded.global_single_threaded.io()) catch return;
+        std.Io.Dir.renameAbsolute(CERT_DIR ++ "/selfsigned-cert.pem", CERT_DIR ++ "/cert.pem", std.Io.Threaded.global_single_threaded.io()) catch return;
         ui.ok("Self-signed certificate generated");
     }
 
@@ -205,13 +197,72 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts_in: MaskingOpts) !vo
     // ── Configure Nginx ──
     ui.step("Configuring Nginx...");
     sys.execSilent(allocator, &.{ "mkdir", "-p", "/var/www/masking" });
-    sys.writeFile("/var/www/masking/index.html", "<!DOCTYPE html><html><head><title>Welcome</title></head><body><h1>It works!</h1></body></html>\n") catch {};
+    const old_cover = sys.readFileAllocAbsolute(allocator, "/var/www/masking/index.html", 64 * 1024);
+    defer if (old_cover) |p| allocator.free(p);
+    const legacy_cover = "<!DOCTYPE html><html><head><title>Welcome</title></head><body><h1>It works!</h1></body></html>\n";
+    // Replace the known shipped placeholder, preserving operator content.
+    if (old_cover == null or std.mem.eql(u8, old_cover.?, legacy_cover)) {
+        var nonce: [16]u8 = undefined;
+        std.Io.Threaded.global_single_threaded.io().random(&nonce);
+        const page = try @import("cover_page").renderCover(allocator, &nonce);
+        defer allocator.free(page);
+        try sys.writeFile("/var/www/masking/index.html", page);
+    }
 
-    var nginx_cfg_buf: [2048]u8 = undefined;
-    const nginx_cfg = std.fmt.bufPrint(&nginx_cfg_buf,
+    const nginx_cfg = try renderNginxConfig(allocator, opts.tls_domain);
+    defer allocator.free(nginx_cfg);
+
+    try sys.writeFile("/etc/nginx/sites-available/mtproto-masking", nginx_cfg);
+
+    _ = sys.exec(allocator, &.{ "ln", "-sf", "/etc/nginx/sites-available/mtproto-masking", "/etc/nginx/sites-enabled/" }) catch {};
+    const nginx_bin = sys.commandOrPath("nginx", &.{ "/usr/sbin/nginx", "/sbin/nginx" });
+    const nginx_test = sys.exec(allocator, &.{ nginx_bin, "-t" }) catch {
+        ui.fail("Could not run nginx -t; leaving the default site enabled");
+        return error.NginxTestFailed;
+    };
+    defer nginx_test.deinit();
+    if (nginx_test.exit_code != 0) {
+        _ = sys.exec(allocator, &.{ "rm", "-f", "/etc/nginx/sites-enabled/mtproto-masking" }) catch {};
+        return error.NginxTestFailed;
+    }
+
+    // Config is valid — now it is safe to disable the default site and reload.
+    _ = sys.exec(allocator, &.{ "rm", "-f", "/etc/nginx/sites-enabled/default" }) catch {};
+    _ = sys.execForward(&.{ "systemctl", "restart", "nginx" }) catch {};
+    _ = sys.exec(allocator, &.{ "systemctl", "enable", "nginx" }) catch {};
+    ui.ok("Nginx configured on 127.0.0.1:" ++ NGINX_PORT);
+
+    var config_written = false;
+    if (sys.fileExists(config_path)) {
+        var doc = try toml.TomlDoc.load(allocator, config_path);
+        defer doc.deinit();
+        const domain_value = try std.fmt.allocPrint(allocator, "\"{s}\"", .{opts.tls_domain});
+        defer allocator.free(domain_value);
+        try doc.set("censorship", "tls_domain", domain_value);
+        const previous_port = doc.get("censorship", "mask_port") orelse "443";
+        if (opts.local_backend or !std.mem.eql(u8, std.mem.trim(u8, previous_port, " \t\""), "443")) {
+            try doc.set("censorship", "mask_port", NGINX_PORT);
+        } else ui.warn("Keeping remote-origin masking on port 443. Use setup masking --local to explicitly switch to the local cover site.");
+        try doc.set("censorship", "mask", "true");
+        try doc.save(config_path);
+        config_written = true;
+    }
+
+    if (config_written and sys.isServiceActive("mtproto-proxy")) {
+        const restarted = try sys.exec(allocator, &.{ "systemctl", "restart", "mtproto-proxy" });
+        defer restarted.deinit();
+        if (restarted.exit_code != 0) return error.ProxyRestartFailed;
+    }
+    if (!opts.skip_monitor) try @import("recovery.zig").execute(ui, allocator, .{ .quiet = true });
+    ui.ok("Local Nginx cover site configured; remote-origin and local-cover masking have different fingerprint tradeoffs.");
+}
+
+fn renderNginxConfig(allocator: std.mem.Allocator, domain: []const u8) ![]u8 {
+    if (!fronting_domain.isSafeFrontingDomain(domain)) return error.InvalidFrontingDomain;
+    return std.fmt.allocPrint(allocator,
         \\# MTProto proxy masking server — local only
         \\server {{
-        \\    listen 127.0.0.1:{[port]s} ssl;
+        \\    listen 127.0.0.1:{[port]s} ssl default_server;
         \\
         \\    server_name {[domain]s};
         \\
@@ -233,114 +284,19 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts_in: MaskingOpts) !vo
         \\}}
     , .{
         .port = NGINX_PORT,
-        .domain = opts.tls_domain,
+        .domain = domain,
         .cert_dir = CERT_DIR,
-    }) catch "";
-
-    if (nginx_cfg.len > 0) {
-        // Write config using native Zig I/O (no shell injection risk)
-        sys.writeFile("/etc/nginx/sites-available/mtproto-masking", nginx_cfg) catch {
-            ui.fail("Failed to write Nginx config");
-            return;
-        };
-    }
-
-    // Enable our vhost and validate BEFORE removing the default site, so a failed test
-    // never leaves nginx with a broken config and no default vhost (which would take
-    // nginx fully down on its next restart — reboot, certbot hook, mask-health timer).
-    _ = sys.exec(allocator, &.{ "ln", "-sf", "/etc/nginx/sites-available/mtproto-masking", "/etc/nginx/sites-enabled/" }) catch {};
-
-    // nginx lives in /usr/sbin, which std.process.run's PATH expansion does not find even
-    // when PATH lists it; resolve by absolute path like the other sbin tools, otherwise
-    // the spawn fails and `catch null` below would treat that as a PASSED test.
-    const nginx_bin = sys.commandOrPath("nginx", &.{ "/usr/sbin/nginx", "/sbin/nginx" });
-    const nginx_test = sys.exec(allocator, &.{ nginx_bin, "-t" }) catch null;
-    if (nginx_test) |r| {
-        defer r.deinit();
-        if (r.exit_code != 0) {
-            // Roll back: drop only our vhost, leaving the existing config (incl. default).
-            _ = sys.exec(allocator, &.{ "rm", "-f", "/etc/nginx/sites-enabled/mtproto-masking" }) catch {};
-            ui.fail("Nginx config test failed — masking vhost rolled back, nginx left unchanged");
-            return;
-        }
-    }
-
-    // Config is valid — now it is safe to disable the default site and reload.
-    _ = sys.exec(allocator, &.{ "rm", "-f", "/etc/nginx/sites-enabled/default" }) catch {};
-    _ = sys.execForward(&.{ "systemctl", "restart", "nginx" }) catch {};
-    _ = sys.exec(allocator, &.{ "systemctl", "enable", "nginx" }) catch {};
-    ui.ok("Nginx configured on 127.0.0.1:" ++ NGINX_PORT);
-
-    // ── Verify Nginx ──
-    {
-        const check = sys.exec(allocator, &.{ "curl", "-sk", "--max-time", "3", "https://127.0.0.1:" ++ NGINX_PORT ++ "/" }) catch null;
-        if (check) |r| {
-            defer r.deinit();
-            if (r.exit_code == 0) {
-                ui.ok("Nginx responding on https://127.0.0.1:" ++ NGINX_PORT);
-            } else {
-                ui.warn("Nginx not responding yet");
-            }
-        }
-    }
-
-    // ── Update mtproto config ──
-    var config_written = false;
-    if (sys.fileExists(config_path)) {
-        var doc = toml.TomlDoc.load(allocator, config_path) catch {
-            ui.warn("Could not read config.toml");
-            return;
-        };
-        defer doc.deinit();
-
-        var tls_domain_val_buf: [320]u8 = undefined;
-        const tls_domain_val = std.fmt.bufPrint(&tls_domain_val_buf, "\"{s}\"", .{opts.tls_domain}) catch {
-            ui.warn("Could not update tls_domain in config.toml");
-            return;
-        };
-
-        try doc.set("censorship", "tls_domain", tls_domain_val);
-        try doc.set("censorship", "mask_port", NGINX_PORT);
-        try doc.set("censorship", "mask", "true");
-        doc.save(config_path) catch {};
-        _ = sys.exec(allocator, &.{ "chown", "mtproto:mtproto", config_path }) catch {};
-        ui.ok("Updated config.toml with tls_domain, mask=true, mask_port = " ++ NGINX_PORT);
-        config_written = true;
-    }
-
-    // The running proxy only re-reads config on reload/restart. Apply it now so masking
-    // actually takes effect instead of waiting for some arbitrary later restart (the
-    // fresh-install path is covered by install.zig's final restart; this is the standalone
-    // `mtbuddy setup-masking` path).
-    if (config_written and sys.isServiceActive("mtproto-proxy")) {
-        var reloaded = false;
-        if (sys.exec(allocator, &.{ "systemctl", "reload", "mtproto-proxy" }) catch null) |r| {
-            defer r.deinit();
-            reloaded = r.exit_code == 0;
-        }
-        if (!reloaded) _ = sys.execForward(&.{ "systemctl", "restart", "mtproto-proxy" }) catch {};
-        ui.ok("Reloaded mtproto-proxy to apply masking");
-    }
-
-    // ── Install masking monitor ──
-    if (!opts.skip_monitor) {
-        const recovery = @import("recovery.zig");
-        recovery.execute(ui, allocator, .{ .quiet = true }) catch |err| {
-            ui.warn("Failed to install auto-recovery module");
-            std.log.debug("Recovery install error: {any}", .{err});
-        };
-    }
-
-    // ── Summary ──
-    ui.summaryBox("Local Nginx Masking Configured", &.{
-        .{ .label = "Nginx:", .value = "127.0.0.1:" ++ NGINX_PORT ++ " (TLS)" },
-        .{ .label = "Domain:", .value = opts.tls_domain },
-        .{ .label = "Cert:", .value = CERT_DIR ++ "/cert.pem" },
-        .{ .label = "Monitor:", .value = "systemctl status mtproto-mask-health.timer" },
-        .{ .label = "", .style = .blank },
-        .{ .label = "Bad clients are now forwarded to local Nginx (<1ms RTT)", .style = .success },
-        .{ .label = "Timing side-channel eliminated", .style = .success },
     });
+}
+
+test "masking renderer selects explicit default vhost and rejects injected domains" {
+    const allocator = std.testing.allocator;
+    const rendered = try renderNginxConfig(allocator, "example.com");
+    defer allocator.free(rendered);
+    try std.testing.expect(std.mem.indexOf(u8, rendered, "listen 127.0.0.1:8443 ssl default_server;") != null);
+    try std.testing.expect(std.mem.indexOf(u8, rendered, "server_name example.com;") != null);
+    try std.testing.expectError(error.InvalidFrontingDomain, renderNginxConfig(allocator, "example.com;return 200"));
+    try std.testing.expectError(error.InvalidFrontingDomain, renderNginxConfig(allocator, "bad..example"));
 }
 
 fn runLogged(ui: *Tui, allocator: std.mem.Allocator, argv: []const []const u8, failure_msg: []const u8) bool {

--- a/src/ctl/nfqws.zig
+++ b/src/ctl/nfqws.zig
@@ -38,6 +38,9 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
             if (args.next()) |val| opts.ttl = val;
         } else if (std.mem.eql(u8, arg, "--remove") or std.mem.eql(u8, arg, "--uninstall")) {
             opts.remove = true;
+        } else {
+            ui.print("Unknown option: {s}\n", .{arg});
+            return error.UnknownOption;
         }
     }
     try execute(ui, allocator, opts);
@@ -79,9 +82,8 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: NfqwsOpts) !void {
         if (doc) |*d| {
             defer d.deinit();
             const raw = d.get("server", "port") orelse "443";
-            const n = @min(raw.len, port_buf.len);
-            @memcpy(port_buf[0..n], raw[0..n]);
-            port = port_buf[0..n];
+            const number = try parsePort(raw);
+            port = try std.fmt.bufPrint(&port_buf, "{d}", .{number});
         }
     }
 
@@ -140,59 +142,7 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: NfqwsOpts) !void {
 
     const ipt = iptablesCommands();
 
-    // ── Clone and build zapret ──
-    if (sys.fileExists(ZAPRET_DIR ++ "/nfq/nfqws")) {
-        ui.ok("nfqws already built");
-    } else {
-        const cc = chooseWorkingCCompiler(ui, allocator) orelse return;
-
-        // Clone the newest release tag (falls back to a known-good one offline) so
-        // the bypass engine stays current with DPI changes, while avoiding raw HEAD.
-        var tag_buf: [64]u8 = undefined;
-        var sha_buf: [64]u8 = undefined;
-        const ref = resolveLatestZapretTag(allocator, &tag_buf, &sha_buf);
-        const tag = if (ref) |rf| rf.tag else ZAPRET_FALLBACK_TAG;
-
-        var step_buf: [96]u8 = undefined;
-        ui.step(std.fmt.bufPrint(&step_buf, "Cloning and building zapret ({s})...", .{tag}) catch "Cloning and building zapret...");
-        _ = sys.exec(allocator, &.{ "rm", "-rf", ZAPRET_DIR }) catch {};
-        if (!runLogged(ui, allocator, &.{
-            "git", "clone", "--branch", tag, "--depth", "1", "https://github.com/bol-van/zapret.git", ZAPRET_DIR,
-        }, "Failed to clone zapret")) return;
-
-        // When we resolved the tag from the remote, verify the clone landed on the
-        // exact commit that remote advertised for it (guards against the clone
-        // returning a different commit than ls-remote saw). Built+run root-side, so
-        // refuse to build on mismatch. The offline fallback path has no SHA to check.
-        if (ref) |rf| {
-            const rev = sys.exec(allocator, &.{ "git", "-C", ZAPRET_DIR, "rev-parse", "HEAD" }) catch null;
-            if (rev) |rv| {
-                defer rv.deinit();
-                const got = std.mem.trim(u8, rv.stdout, " \t\r\n");
-                if (!std.mem.eql(u8, got, rf.sha)) {
-                    ui.fail("zapret clone commit does not match the resolved release tag — refusing to build");
-                    return;
-                }
-            }
-        }
-
-        _ = sys.exec(allocator, &.{ "bash", "-c", "cd " ++ ZAPRET_DIR ++ "/nfq && make clean" }) catch {};
-        var make_cmd_buf: [128]u8 = undefined;
-        const make_cmd = std.fmt.bufPrint(
-            &make_cmd_buf,
-            "cd " ++ ZAPRET_DIR ++ "/nfq && PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make CC={s}",
-            .{cc},
-        ) catch "cd " ++ ZAPRET_DIR ++ "/nfq && make";
-        if (!runLogged(ui, allocator, &.{
-            "bash", "-c", make_cmd,
-        }, "nfqws build failed")) return;
-
-        if (!sys.fileExists(ZAPRET_DIR ++ "/nfq/nfqws")) {
-            ui.fail("nfqws build finished but /opt/zapret/nfq/nfqws was not created");
-            return;
-        }
-        ui.ok("nfqws built successfully");
-    }
+    if (!try ensureZapret(ui, allocator)) return;
 
     // ── Configure iptables NFQUEUE ──
     ui.step("Setting up NFQUEUE rules...");
@@ -208,28 +158,30 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: NfqwsOpts) !void {
     // there, so without this exclusion every relayed byte takes a userspace round trip
     // through nfqws and the relay's streams crawl.
     if (!runLogged(ui, allocator, &.{
-        ipt.iptables, "-t",          "mangle",    "-A",             "OUTPUT",
-        "!",          "-o",          "lo",
-        "-p",         "tcp",         "--sport",   port,             "-j",
-        "NFQUEUE",    "--queue-num", NFQUEUE_NUM, "--queue-bypass",
+        ipt.iptables, "-t",             "mangle", "-A",      "OUTPUT",
+        "!",          "-o",             "lo",     "-p",      "tcp",
+        "--sport",    port,             "-j",     "NFQUEUE", "--queue-num",
+        NFQUEUE_NUM,  "--queue-bypass",
     }, "Failed to apply IPv4 NFQUEUE rule")) return;
-    _ = sys.exec(allocator, &.{
-        ipt.ip6tables, "-t",          "mangle",    "-A",             "OUTPUT",
-        "!",           "-o",          "lo",
-        "-p",          "tcp",         "--sport",   port,             "-j",
-        "NFQUEUE",     "--queue-num", NFQUEUE_NUM, "--queue-bypass",
-    }) catch {};
+    if (!runLogged(ui, allocator, &.{
+        ipt.ip6tables, "-t",             "mangle", "-A",      "OUTPUT",
+        "!",           "-o",             "lo",     "-p",      "tcp",
+        "--sport",     port,             "-j",     "NFQUEUE", "--queue-num",
+        NFQUEUE_NUM,   "--queue-bypass",
+    }, "IPv6 NFQUEUE rule unavailable; IPv6 desync is not enabled")) ui.warn("IPv4 may work, but IPv6 protection needs repair.");
 
-    if (!outputRuleContains(allocator, ipt.iptables, "NFQUEUE")) {
+    if (!nfqueueRuleExists(allocator, ipt.iptables, port)) {
         ui.fail("IPv4 NFQUEUE rule was not installed");
         return;
     }
+    const ipv6_active = nfqueueRuleExists(allocator, ipt.ip6tables, port);
+    if (!ipv6_active) ui.warn("IPv6 NFQUEUE verification failed; do not assume IPv6 traffic is protected.");
 
     // NOTE: we intentionally do NOT `iptables-save > /etc/iptables/rules.v4` here. The
     // systemd unit's ExecStartPre re-adds the NFQUEUE rule on every boot, so persisting it
     // is redundant — and a full-firewall snapshot would clobber any operator-curated
     // rules.v4 and freeze transient chains (Docker, fail2ban) into the boot ruleset.
-    ui.ok("NFQUEUE rules applied (queue " ++ NFQUEUE_NUM ++ ")");
+    ui.ok(if (ipv6_active) "IPv4 and IPv6 NFQUEUE rules verified (queue " ++ NFQUEUE_NUM ++ ")" else "IPv4 NFQUEUE rule verified (IPv6 unavailable)");
 
     // ── Create systemd service ──
     ui.step("Creating systemd service...");
@@ -292,6 +244,7 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: NfqwsOpts) !void {
     }
 
     // ── Summary ──
+    ui.hint("After changing [server].port, rerun: sudo mtbuddy setup nfqws (the unit records the current port).");
     ui.summaryBox("nfqws TCP Desync Configured", &.{
         .{ .label = "Binary:", .value = ZAPRET_DIR ++ "/nfq/nfqws" },
         .{ .label = "Service:", .value = SERVICE_NAME },
@@ -308,20 +261,75 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: NfqwsOpts) !void {
 const IptablesCommands = struct {
     iptables: []const u8,
     ip6tables: []const u8,
-    iptables_save: []const u8,
-    ip6tables_save: []const u8,
 };
 
 fn iptablesCommands() IptablesCommands {
     return .{
         .iptables = sys.commandOrPath("iptables", &.{ "/usr/sbin/iptables", "/sbin/iptables" }),
         .ip6tables = sys.commandOrPath("ip6tables", &.{ "/usr/sbin/ip6tables", "/sbin/ip6tables" }),
-        .iptables_save = sys.commandOrPath("iptables-save", &.{ "/usr/sbin/iptables-save", "/sbin/iptables-save" }),
-        .ip6tables_save = sys.commandOrPath("ip6tables-save", &.{ "/usr/sbin/ip6tables-save", "/sbin/ip6tables-save" }),
     };
 }
 
 const ZapretRef = struct { tag: []const u8, sha: []const u8 };
+
+fn parsePort(raw: []const u8) !u16 {
+    if (raw.len == 0) return error.InvalidPort;
+    for (raw) |c| if (!std.ascii.isDigit(c)) return error.InvalidPort;
+    const port = std.fmt.parseInt(u16, raw, 10) catch return error.InvalidPort;
+    if (port == 0) return error.InvalidPort;
+    return port;
+}
+
+test "nfqws port validation rejects truncation and command tokens" {
+    try std.testing.expectEqual(@as(u16, 443), try parsePort("00443"));
+    for ([_][]const u8{ "", "0", "65536", "443 --jump ACCEPT", "12345678901234567890", "+443" }) |text| try std.testing.expectError(error.InvalidPort, parsePort(text));
+}
+
+fn ensureZapret(ui: *Tui, allocator: std.mem.Allocator) !bool {
+    var tag_buf: [64]u8 = undefined;
+    var sha_buf: [64]u8 = undefined;
+    const ref = resolveLatestZapretTag(allocator, &tag_buf, &sha_buf);
+    const installed = sys.fileExists(ZAPRET_DIR ++ "/nfq/nfqws");
+    if (installed and ref == null) {
+        ui.warn("Could not resolve the current zapret release; keeping the installed binary.");
+        return true;
+    }
+    const tag = if (ref) |r| r.tag else ZAPRET_FALLBACK_TAG;
+    const version = if (ref) |r| r.sha else tag;
+    const previous = sys.readFileAllocAbsolute(allocator, ZAPRET_DIR ++ "/nfq/nfqws.version", 128);
+    defer if (previous) |v| allocator.free(v);
+    if (installed and previous != null and std.mem.eql(u8, std.mem.trim(u8, previous.?, " \r\n"), version)) return true;
+
+    const cc = chooseWorkingCCompiler(ui, allocator) orelse return false;
+    const temporary = try sys.exec(allocator, &.{ "mktemp", "-d", "/opt/zapret-build.XXXXXXXX" });
+    defer temporary.deinit();
+    if (temporary.exit_code != 0) return error.StagingDirectoryFailed;
+    const stage = std.mem.trim(u8, temporary.stdout, " \r\n");
+    if (!std.mem.startsWith(u8, stage, "/opt/zapret-build.") or std.mem.indexOfScalar(u8, stage[18..], '/') != null) return error.InvalidStagingDirectory;
+    defer sys.execSilent(allocator, &.{ "rm", "-rf", "--", stage });
+    if (!runLogged(ui, allocator, &.{ "git", "clone", "--branch", tag, "--depth", "1", "https://github.com/bol-van/zapret.git", stage }, "Failed to clone zapret release")) return false;
+    if (ref) |r| {
+        // Compare tag objects, not HEAD: annotated tag objects have their own SHA.
+        const tag_ref = try std.fmt.allocPrint(allocator, "refs/tags/{s}", .{tag});
+        defer allocator.free(tag_ref);
+        const rev = try sys.exec(allocator, &.{ "git", "-C", stage, "rev-parse", tag_ref });
+        defer rev.deinit();
+        if (rev.exit_code != 0 or !std.mem.eql(u8, std.mem.trim(u8, rev.stdout, " \r\n"), r.sha)) return error.ReleaseTagMismatch;
+    }
+    const source = try std.fmt.allocPrint(allocator, "{s}/nfq", .{stage});
+    defer allocator.free(source);
+    const compiler = try std.fmt.allocPrint(allocator, "CC={s}", .{cc});
+    defer allocator.free(compiler);
+    if (!runLogged(ui, allocator, &.{ "make", "-C", source, compiler }, "nfqws build failed; installed binary retained")) return false;
+    const binary = try std.fmt.allocPrint(allocator, "{s}/nfqws", .{source});
+    defer allocator.free(binary);
+    if (!runLogged(ui, allocator, &.{ "mkdir", "-p", ZAPRET_DIR ++ "/nfq" }, "Could not create nfqws install directory")) return false;
+    if (!runLogged(ui, allocator, &.{ "install", "-m", "755", binary, ZAPRET_DIR ++ "/nfq/nfqws.new" }, "Could not stage nfqws binary")) return false;
+    try std.Io.Dir.renameAbsolute(ZAPRET_DIR ++ "/nfq/nfqws.new", ZAPRET_DIR ++ "/nfq/nfqws", std.Io.Threaded.global_single_threaded.io());
+    try sys.writeFile(ZAPRET_DIR ++ "/nfq/nfqws.version", version);
+    ui.ok("nfqws release built and installed atomically");
+    return true;
+}
 
 /// Resolve the newest zapret release tag (highest vX.Y) AND the commit it points
 /// to, from the remote without the GitHub API (works wherever `git clone` does).
@@ -450,11 +458,10 @@ fn removeNfqwsRules(allocator: std.mem.Allocator, ipt: []const u8) void {
     _ = sys.exec(allocator, &.{ "bash", "-c", cmd }) catch {};
 }
 
-fn outputRuleContains(allocator: std.mem.Allocator, ipt: []const u8, needle: []const u8) bool {
-    const result = sys.exec(allocator, &.{ ipt, "-t", "mangle", "-S", "OUTPUT" }) catch return false;
+fn nfqueueRuleExists(allocator: std.mem.Allocator, ipt: []const u8, port: []const u8) bool {
+    const result = sys.exec(allocator, &.{ ipt, "-t", "mangle", "-C", "OUTPUT", "!", "-o", "lo", "-p", "tcp", "--sport", port, "-j", "NFQUEUE", "--queue-num", NFQUEUE_NUM, "--queue-bypass" }) catch return false;
     defer result.deinit();
-    if (result.exit_code != 0) return false;
-    return std.mem.indexOf(u8, result.stdout, needle) != null;
+    return result.exit_code == 0;
 }
 
 fn runLogged(ui: *Tui, allocator: std.mem.Allocator, argv: []const []const u8, failure_msg: []const u8) bool {

--- a/src/ctl/recovery.zig
+++ b/src/ctl/recovery.zig
@@ -20,9 +20,135 @@ const MASK_HEALTH_TIMER = "/etc/systemd/system/mtproto-mask-health.timer";
 const NGINX_DROPIN_DIR = "/etc/systemd/system/nginx.service.d";
 const PROXY_DROPIN_DIR = "/etc/systemd/system/mtproto-proxy.service.d";
 
+/// Health-check script installed at MASK_HEALTH_SCRIPT and run by the systemd timer.
+///
+/// read_censorship_value()'s awk uses `[[:space:]]` (POSIX bracket expression), never
+/// `\s` — `\s` is a gawk-only regex extension. Debian/Ubuntu ship mawk as /usr/bin/awk
+/// (gawk is not installed by default) and mawk/BWK awk treat `\s` as a literal `s`, so
+/// the old pattern degraded to `^s*mask_ports*=` and never matched `mask_port = 8443`
+/// (TomlDoc.formatKv always writes `key = value` with spaces). That silently returned
+/// the "443" fallback, and the `[[ "$mask_port" == "443" ]] && exit 0` guard below then
+/// skipped every probe — nginx could be dead for hours with the timer reporting active
+/// and this "Auto-restart" summary box claiming coverage.
+const HEALTH_SCRIPT =
+    \\#!/usr/bin/env bash
+    \\set -euo pipefail
+    \\
+    \\CONFIG_FILE="/opt/mtproto-proxy/config.toml"
+    \\LOCAL_HOST_IP="127.0.0.1"
+    \\
+    \\read_censorship_value() {
+    \\    local key="$1"
+    \\    local default_value="$2"
+    \\    [[ -f "$CONFIG_FILE" ]] || { printf '%s\n' "$default_value"; return; }
+    \\    awk -v want_key="$key" -v fallback="$default_value" '
+    \\        BEGIN { in_section=0; value="" }
+    \\        /^[[:space:]]*\[censorship\][[:space:]]*$/ { in_section=1; next }
+    \\        /^[[:space:]]*\[[^\]]+\][[:space:]]*$/ { in_section=0; next }
+    \\        in_section { line=$0; sub(/#.*/,"",line)
+    \\            if (line ~ "^[[:space:]]*" want_key "[[:space:]]*=") {
+    \\                split(line,parts,"="); value=parts[2]
+    \\                gsub(/^[[:space:]]+|[[:space:]]+$/,"",value); gsub(/^"|"$/,"",value)
+    \\            }
+    \\        }
+    \\        END { print (value=="" ? fallback : value) }
+    \\    ' "$CONFIG_FILE"
+    \\}
+    \\
+    \\probe_endpoint() {
+    \\    local host="$1" port="$2"
+    \\    curl -sk --max-time 3 "https://${host}:${port}/" >/dev/null 2>&1
+    \\}
+    \\
+    \\command -v systemctl >/dev/null 2>&1 || exit 0
+    \\command -v curl >/dev/null 2>&1 || { logger -t mtproto-mask-health "curl not found"; exit 1; }
+    \\systemctl list-unit-files --type=service --no-legend 2>/dev/null | grep -q '^nginx\.service\s' || exit 0
+    \\
+    \\mask_enabled=$(read_censorship_value "mask" "true" | tr '[:upper:]' '[:lower:]')
+    \\case "$mask_enabled" in true|1|yes|on) ;; *) exit 0 ;; esac
+    \\
+    \\mask_port=$(read_censorship_value "mask_port" "443" | tr -cd '0-9')
+    \\mask_port="${mask_port:-443}"
+    \\[[ "$mask_port" == "443" ]] && exit 0
+    \\
+    \\target_host="$LOCAL_HOST_IP"
+    \\
+    \\if ! systemctl is-active --quiet nginx; then
+    \\    logger -t mtproto-mask-health "nginx inactive, restarting"
+    \\    systemctl restart nginx || true; sleep 1
+    \\fi
+    \\
+    \\probe_endpoint "$target_host" "$mask_port" && exit 0
+    \\
+    \\logger -t mtproto-mask-health "endpoint ${target_host}:${mask_port} unreachable; restarting nginx"
+    \\systemctl restart nginx || true; sleep 1
+    \\probe_endpoint "$target_host" "$mask_port" && { logger -t mtproto-mask-health "recovered after nginx restart"; exit 0; }
+    \\
+    \\logger -t mtproto-mask-health "critical: endpoint still unreachable"
+    \\exit 1
+;
+
 pub const RecoveryOpts = struct {
     quiet: bool = false,
 };
+
+const WEB_HEALTH_SCRIPT =
+    \\#!/usr/bin/env bash
+    \\set -euo pipefail
+    \\read_web() {
+    \\  awk -v key="$1" -v fallback="$2" '
+    \\    /^\[web\]$/ { inside=1; next }
+    \\    /^\[/ { inside=0 }
+    \\    inside && $0 ~ "^[[:space:]]*" key "[[:space:]]*=" {
+    \\      sub(/^[^=]*=[[:space:]]*/, ""); sub(/[[:space:]]*#.*/, ""); gsub(/"/, ""); value=$0
+    \\    }
+    \\    END { print value == "" ? fallback : value }
+    \\  ' /opt/mtproto-proxy/config.toml
+    \\}
+    \\[[ "$(read_web enabled false)" == true ]] || exit 0
+    \\port=$(read_web port 8081)
+    \\host=$(read_web host 127.0.0.1)
+    \\domain=$(read_web domain '')
+    \\[[ "$port" =~ ^[0-9]{1,5}$ ]] && ((10#$port > 0 && 10#$port < 65536)) || exit 1
+    \\[[ "$host" =~ ^[0-9a-fA-F:.]+$ ]] || exit 1
+    \\[[ "$domain" =~ ^[a-zA-Z0-9.-]+$ ]] || exit 1
+    \\[[ "$host" == 0.0.0.0 ]] && host=127.0.0.1
+    \\[[ "$host" == :: ]] && host=::1
+    \\[[ "$host" == *:* ]] && host="[$host]"
+    \\healthy=false
+    \\for attempt in 1 2 3; do
+    \\  if curl --noproxy '*' -fsS --max-time 5 "http://${host}:${port}/" >/dev/null; then healthy=true; break; fi
+    \\  sleep 1
+    \\done
+    \\if [[ "$healthy" != true ]]; then
+    \\  logger -t mtproto-web-health 'relay failed three local probes; restarting relay only'
+    \\  systemctl restart mtproto-web-relay.service
+    \\  exit 1
+    \\fi
+    \\if ! curl --noproxy '*' -fsS --max-time 8 "https://${domain}/" >/dev/null; then
+    \\  logger -t mtproto-web-health 'public HTTPS path failed; check DNS, certificate and terminator'
+    \\  exit 1
+    \\fi
+;
+
+pub fn installWebHealth(allocator: std.mem.Allocator) !void {
+    try sys.writeFileMode("/usr/local/bin/mtproto-web-health.sh", WEB_HEALTH_SCRIPT, 0o755);
+    try sys.writeFile("/etc/systemd/system/mtproto-web-health.service", "[Unit]\nDescription=MTProto WEB relay health check\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStart=/usr/local/bin/mtproto-web-health.sh\nTimeoutStartSec=30\n");
+    try sys.writeFile("/etc/systemd/system/mtproto-web-health.timer", "[Unit]\nDescription=Check the MTProto WEB path every minute\n\n[Timer]\nOnBootSec=2min\nOnUnitActiveSec=1min\nRandomizedDelaySec=10s\n\n[Install]\nWantedBy=timers.target\n");
+    const reload = try sys.exec(allocator, &.{ "systemctl", "daemon-reload" });
+    defer reload.deinit();
+    if (reload.exit_code != 0) return error.SystemdReloadFailed;
+    const enable = try sys.exec(allocator, &.{ "systemctl", "enable", "--now", "mtproto-web-health.timer" });
+    defer enable.deinit();
+    if (enable.exit_code != 0) return error.WebHealthEnableFailed;
+}
+
+test "health recovery never restarts the data plane for an endpoint failure" {
+    try std.testing.expect(std.mem.indexOf(u8, HEALTH_SCRIPT, "restart mtproto-proxy") == null);
+    try std.testing.expect(std.mem.indexOf(u8, WEB_HEALTH_SCRIPT, "for attempt in 1 2 3") != null);
+    try std.testing.expect(std.mem.indexOf(u8, WEB_HEALTH_SCRIPT, "restart mtproto-web-relay.service") != null);
+    try std.testing.expect(std.mem.indexOf(u8, WEB_HEALTH_SCRIPT, "restart mtproto-proxy") == null);
+}
 
 /// Run in CLI mode.
 pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) !void {
@@ -30,6 +156,9 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
     while (args.next()) |arg| {
         if (std.mem.eql(u8, arg, "--quiet")) {
             opts.quiet = true;
+        } else {
+            ui.print("Unknown option: {s}\n", .{arg});
+            return error.UnknownOption;
         }
     }
     try execute(ui, allocator, opts);
@@ -56,90 +185,25 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: RecoveryOpts) !void
     // ── Create drop-in for nginx auto-restart ──
     _ = sys.exec(allocator, &.{ "mkdir", "-p", NGINX_DROPIN_DIR, PROXY_DROPIN_DIR }) catch {};
 
-    sys.writeFile(NGINX_DROPIN_DIR ++ "/restart.conf", "[Service]\nRestart=on-failure\nRestartSec=2s\n") catch {};
+    try sys.writeFile(NGINX_DROPIN_DIR ++ "/restart.conf", "[Service]\nRestart=on-failure\nRestartSec=2s\n");
 
-    sys.writeFile(PROXY_DROPIN_DIR ++ "/10-nginx.conf", "[Unit]\nWants=nginx.service\nAfter=nginx.service\n") catch {};
-
-    // ── Create health check script ──
-    const health_script =
-        \\#!/usr/bin/env bash
-        \\set -euo pipefail
-        \\
-        \\CONFIG_FILE="/opt/mtproto-proxy/config.toml"
-        \\LOCAL_HOST_IP="127.0.0.1"
-        \\
-        \\read_censorship_value() {
-        \\    local key="$1"
-        \\    local default_value="$2"
-        \\    [[ -f "$CONFIG_FILE" ]] || { printf '%s\n' "$default_value"; return; }
-        \\    awk -v want_key="$key" -v fallback="$default_value" '
-        \\        BEGIN { in_section=0; value="" }
-        \\        /^\s*\[censorship\]\s*$/ { in_section=1; next }
-        \\        /^\s*\[[^\]]+\]\s*$/ { in_section=0; next }
-        \\        in_section { line=$0; sub(/#.*/,"",line)
-        \\            if (line ~ "^\\s*" want_key "\\s*=") {
-        \\                split(line,parts,"="); value=parts[2]
-        \\                gsub(/^\s+|\s+$/,"",value); gsub(/^"|"$/,"",value)
-        \\            }
-        \\        }
-        \\        END { print (value=="" ? fallback : value) }
-        \\    ' "$CONFIG_FILE"
-        \\}
-        \\
-        \\probe_endpoint() {
-        \\    local host="$1" port="$2"
-        \\    curl -sk --max-time 3 "https://${host}:${port}/" >/dev/null 2>&1
-        \\}
-        \\
-        \\command -v systemctl >/dev/null 2>&1 || exit 0
-        \\command -v curl >/dev/null 2>&1 || { logger -t mtproto-mask-health "curl not found"; exit 1; }
-        \\systemctl list-unit-files --type=service --no-legend 2>/dev/null | grep -q '^nginx\.service\s' || exit 0
-        \\
-        \\mask_enabled=$(read_censorship_value "mask" "true" | tr '[:upper:]' '[:lower:]')
-        \\case "$mask_enabled" in true|1|yes|on) ;; *) exit 0 ;; esac
-        \\
-        \\mask_port=$(read_censorship_value "mask_port" "443" | tr -cd '0-9')
-        \\mask_port="${mask_port:-443}"
-        \\[[ "$mask_port" == "443" ]] && exit 0
-        \\
-        \\target_host="$LOCAL_HOST_IP"
-        \\
-        \\if ! systemctl is-active --quiet nginx; then
-        \\    logger -t mtproto-mask-health "nginx inactive, restarting"
-        \\    systemctl restart nginx || true; sleep 1
-        \\fi
-        \\
-        \\probe_endpoint "$target_host" "$mask_port" && exit 0
-        \\
-        \\logger -t mtproto-mask-health "endpoint ${target_host}:${mask_port} unreachable; restarting nginx"
-        \\systemctl restart nginx || true; sleep 1
-        \\probe_endpoint "$target_host" "$mask_port" && { logger -t mtproto-mask-health "recovered after nginx restart"; exit 0; }
-        \\
-        \\if systemctl is-active --quiet mtproto-proxy; then
-        \\    logger -t mtproto-mask-health "still unreachable; restarting mtproto-proxy"
-        \\    systemctl restart mtproto-proxy || true; sleep 1
-        \\fi
-        \\
-        \\probe_endpoint "$target_host" "$mask_port" && { logger -t mtproto-mask-health "recovered after proxy restart"; exit 0; }
-        \\logger -t mtproto-mask-health "critical: endpoint still unreachable"
-        \\exit 1
-    ;
+    try sys.writeFile(PROXY_DROPIN_DIR ++ "/10-nginx.conf", "[Unit]\nWants=nginx.service\nAfter=nginx.service\n");
 
     {
         // Write using native Zig I/O (no shell needed)
-        sys.writeFileMode(MASK_HEALTH_SCRIPT, health_script, 0o755) catch {
+        sys.writeFileMode(MASK_HEALTH_SCRIPT, HEALTH_SCRIPT, 0o755) catch {
             ui.fail("Failed to write health check script");
             return;
         };
     }
 
-    sys.writeFile(MASK_HEALTH_SERVICE, "[Unit]\nDescription=MTProto masking endpoint health check\n\n" ++
-        "[Service]\nType=oneshot\nExecStart=" ++ MASK_HEALTH_SCRIPT ++ "\n") catch {};
+    try sys.writeFile(MASK_HEALTH_SERVICE, "[Unit]\nDescription=MTProto masking endpoint health check\n\n" ++
+        "[Service]\nType=oneshot\nExecStart=" ++ MASK_HEALTH_SCRIPT ++ "\n");
 
     // ── Create timer unit ──
-    sys.writeFile(MASK_HEALTH_TIMER, "[Unit]\nDescription=Run MTProto masking health check every minute\n\n" ++
-        "[Timer]\nOnBootSec=2min\nOnUnitActiveSec=1min\nRandomizedDelaySec=10s\nPersistent=true\n\n" ++
-        "[Install]\nWantedBy=timers.target\n") catch {};
+    try sys.writeFile(MASK_HEALTH_TIMER, "[Unit]\nDescription=Run MTProto masking health check every minute\n\n" ++
+        "[Timer]\nOnBootSec=2min\nOnUnitActiveSec=1min\nRandomizedDelaySec=10s\n\n" ++
+        "[Install]\nWantedBy=timers.target\n");
 
     // ── Enable and start ──
     _ = sys.execForward(&.{ "systemctl", "daemon-reload" }) catch {};
@@ -171,7 +235,7 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: RecoveryOpts) !void
             .{ .label = "Logs:", .value = "journalctl -t mtproto-mask-health -n 50" },
             .{ .label = "", .style = .blank },
             .{ .label = "Auto-restart nginx on failure", .style = .success },
-            .{ .label = "Auto-restart mtproto-proxy if nginx recovery insufficient", .style = .success },
+            .{ .label = "Unhealthy masking is reported without restarting the data plane", .style = .success },
             .{ .label = "Checks every 60 seconds", .style = .success },
         });
     }

--- a/src/ctl/release.zig
+++ b/src/ctl/release.zig
@@ -105,6 +105,7 @@ pub fn resolveTag(
 ) bool {
     if (version) |v| {
         if (v.len == 0 or std.mem.eql(u8, v, "latest")) return resolveLatest(allocator, tag);
+        if (v.len > tag.buf.len - @intFromBool(v[0] != 'v')) return false;
         if (v[0] != 'v') {
             tag.buf[0] = 'v';
             const n = @min(v.len, tag.buf.len - 1);
@@ -122,9 +123,10 @@ pub fn resolveTag(
 
 /// Download, extract, and validate a proxy binary from GitHub Releases.
 ///
-/// Detects CPU architecture and tries optimised builds first (x86_64_v3),
-/// falling back to the base build. Validates the downloaded binary can
-/// execute on this CPU (catches SIGILL from unsupported instructions).
+/// Detects CPU architecture and tries optimised builds first (x86_64_v3 on x86_64,
+/// aarch64_crypto on ARM64), falling back to the base build. Validates the downloaded
+/// binary can execute on this CPU (catches SIGILL from unsupported instructions), which
+/// is also the safety net if crypto detection above ever mispredicts.
 ///
 /// `label` is used in the temp directory name (e.g. "install", "update").
 /// Returns true on success (artifact is populated), false on failure.
@@ -138,14 +140,10 @@ pub fn downloadProxyArtifact(
     // ── Detect architecture ──
     const arch = sys.getArch() catch return false;
     const supports_v3 = if (arch == .x86_64) sys.supportsV3(allocator) else false;
+    const supports_aarch64_crypto = if (arch == .aarch64) supportsAarch64Aes(allocator) else false;
 
     // ── Build candidate list ──
-    const candidates: []const []const u8 = if (supports_v3)
-        &[_][]const u8{ "mtproto-proxy-linux-x86_64_v3", "mtproto-proxy-linux-x86_64" }
-    else if (arch == .aarch64)
-        &[_][]const u8{"mtproto-proxy-linux-aarch64"}
-    else
-        &[_][]const u8{"mtproto-proxy-linux-x86_64"};
+    const candidates = proxyCandidates(arch, supports_v3, supports_aarch64_crypto);
 
     // ── Prepare extraction directory ──
     // Unpredictable name + create-exclusive 0700 (mkdir without -p): a local unprivileged
@@ -201,7 +199,7 @@ pub fn downloadProxyArtifact(
         // Validate — run with a nonexistent config to check for SIGILL (exit 132)
         const check = sys.exec(allocator, &.{
             bin_path,
-            "/tmp/.mtproto-release-check-nonexistent.toml",
+            "--help",
         }) catch continue;
         defer check.deinit();
 
@@ -213,6 +211,88 @@ pub fn downloadProxyArtifact(
     }
 
     return false;
+}
+
+/// Ordered candidate proxy asset names: best-available first, generic baseline last as the
+/// guaranteed-to-work fallback if the post-download SIGILL exec check rejects everything
+/// ahead of it. `downloadBuddyArtifact` derives the buddy asset name from whichever of
+/// these wins, so a new tuned rung here needs a matching artifact published in
+/// release-please.yml or mtbuddy's own self-update finds no download.
+fn proxyCandidates(arch: sys.Arch, supports_v3: bool, supports_aarch64_crypto: bool) []const []const u8 {
+    if (arch == .x86_64 and supports_v3)
+        return &[_][]const u8{ "mtproto-proxy-linux-x86_64_v3", "mtproto-proxy-linux-x86_64" };
+    if (arch == .aarch64 and supports_aarch64_crypto)
+        return &[_][]const u8{ "mtproto-proxy-linux-aarch64_crypto", "mtproto-proxy-linux-aarch64" };
+    if (arch == .aarch64)
+        return &[_][]const u8{"mtproto-proxy-linux-aarch64"};
+    return &[_][]const u8{"mtproto-proxy-linux-x86_64"};
+}
+
+test "proxyCandidates prefers aarch64_crypto with the plain build as fallback" {
+    const with_crypto = proxyCandidates(.aarch64, false, true);
+    try std.testing.expectEqual(@as(usize, 2), with_crypto.len);
+    try std.testing.expectEqualStrings("mtproto-proxy-linux-aarch64_crypto", with_crypto[0]);
+    try std.testing.expectEqualStrings("mtproto-proxy-linux-aarch64", with_crypto[1]);
+}
+
+test "proxyCandidates has no aarch64_crypto candidate without the aes feature" {
+    const without_crypto = proxyCandidates(.aarch64, false, false);
+    try std.testing.expectEqual(@as(usize, 1), without_crypto.len);
+    try std.testing.expectEqualStrings("mtproto-proxy-linux-aarch64", without_crypto[0]);
+}
+
+test "proxyCandidates leaves x86_64 selection untouched" {
+    const v3 = proxyCandidates(.x86_64, true, false);
+    try std.testing.expectEqual(@as(usize, 2), v3.len);
+    try std.testing.expectEqualStrings("mtproto-proxy-linux-x86_64_v3", v3[0]);
+
+    const baseline = proxyCandidates(.x86_64, false, false);
+    try std.testing.expectEqual(@as(usize, 1), baseline.len);
+    try std.testing.expectEqualStrings("mtproto-proxy-linux-x86_64", baseline[0]);
+}
+
+/// True if this ARM64 host exposes the ARMv8-A crypto extension's AES instructions.
+/// Mirrors sys.supportsV3's shape but reads a different key: aarch64 /proc/cpuinfo
+/// publishes "Features", not x86's "flags", and the token set is unrelated, so this
+/// can't reuse that parser directly. `generic` (what an unpinned aarch64-linux target
+/// builds against) carries `fuse_aes`, a scheduling hint, but not the `aes` feature
+/// itself — without this check every ARM host, crypto-capable or not, kept downloading
+/// the software-AES baseline artifact forever.
+fn supportsAarch64Aes(allocator: std.mem.Allocator) bool {
+    if (@import("builtin").os.tag != .linux) return false;
+
+    const content = sys.readFileAllocAbsolute(allocator, "/proc/cpuinfo", 4 * 1024 * 1024) orelse return false;
+    defer allocator.free(content);
+
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line| {
+        if (!std.mem.startsWith(u8, line, "Features")) continue;
+        return containsFeatureWord(line, "aes");
+    }
+    return false;
+}
+
+fn containsFeatureWord(haystack: []const u8, word: []const u8) bool {
+    var i: usize = 0;
+    while (i + word.len <= haystack.len) {
+        if (std.mem.eql(u8, haystack[i..][0..word.len], word)) {
+            const before_ok = (i == 0) or (haystack[i - 1] == ' ' or haystack[i - 1] == '\t' or haystack[i - 1] == ':');
+            const after_idx = i + word.len;
+            const after_ok = (after_idx >= haystack.len) or (haystack[after_idx] == ' ' or haystack[after_idx] == '\t' or haystack[after_idx] == '\n' or haystack[after_idx] == '\r');
+            if (before_ok and after_ok) return true;
+        }
+        i += 1;
+    }
+    return false;
+}
+
+test "containsFeatureWord matches aes as a whole Features token only" {
+    const line = "Features\t\t: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid";
+    try std.testing.expect(containsFeatureWord(line, "aes"));
+    // A feature name that merely contains "aes" as a substring must not match
+    // (guards against false positives from unrelated future feature names).
+    try std.testing.expect(!containsFeatureWord("Features\t\t: fp asimd aesx", "aes"));
+    try std.testing.expect(!containsFeatureWord("Features\t\t: fp asimd evtstrm", "aes"));
 }
 
 /// Download the mtbuddy binary for the same platform as a proxy artifact.
@@ -253,75 +333,8 @@ pub fn downloadBuddyArtifact(
 /// Write the systemd service file from embedded content.
 /// Avoids network dependency on raw.githubusercontent.com which may be
 /// throttled or blocked on some hosting providers.
-pub fn writeServiceFile() void {
-    const content =
-        \\[Unit]
-        \\Description=MTProto Proxy (Zig)
-        \\Documentation=https://github.com/sleep3r/mtproto.zig
-        \\After=network-online.target
-        \\Wants=network-online.target
-        \\
-        \\[Service]
-        \\# Type=simple (not notify): the proxy's sd_notify READY works on bare-metal
-        \\# systemd, but containerized systemd (Docker/LXC) frequently fails to deliver
-        \\# the notify datagram, which would restart-loop a perfectly healthy proxy.
-        \\# simple is robust everywhere; Restart=always still recovers crashes. Re-enable
-        \\# Type=notify + WatchdogSec only behind container detection + ping validation.
-        \\Type=simple
-        \\User=mtproto
-        \\Group=mtproto
-        \\WorkingDirectory=/opt/mtproto-proxy
-        \\ExecStart=/opt/mtproto-proxy/mtproto-proxy /opt/mtproto-proxy/config.toml
-        \\ExecReload=/bin/kill -HUP $MAINPID
-        \\KillSignal=SIGTERM
-        \\TimeoutStopSec=25
-        \\Restart=always
-        \\RestartSec=3
-        \\
-        \\# Security hardening
-        \\NoNewPrivileges=yes
-        \\ProtectSystem=strict
-        \\ProtectHome=yes
-        \\PrivateTmp=yes
-        \\ReadOnlyPaths=/opt/mtproto-proxy
-        \\
-        \\# Syscall + kernel surface reduction (@system-service baseline; AF_NETLINK
-        \\# for glibc getaddrinfo, AF_UNIX for sd_notify). Validate egress modes on a
-        \\# real host before tightening further.
-        \\SystemCallFilter=@system-service
-        \\SystemCallArchitectures=native
-        \\SystemCallErrorNumber=EPERM
-        \\RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
-        \\MemoryDenyWriteExecute=yes
-        \\RestrictNamespaces=yes
-        \\LockPersonality=yes
-        \\RestrictRealtime=yes
-        \\RestrictSUIDSGID=yes
-        \\ProtectKernelTunables=yes
-        \\ProtectKernelModules=yes
-        \\ProtectKernelLogs=yes
-        \\ProtectControlGroups=yes
-        \\ProtectClock=yes
-        \\ProtectHostname=yes
-        \\ProtectProc=invisible
-        \\ProcSubset=pid
-        \\PrivateDevices=yes
-        \\RemoveIPC=yes
-        \\UMask=0077
-        \\
-        \\# Allow binding to privileged ports (443)
-        \\AmbientCapabilities=CAP_NET_BIND_SERVICE
-        \\CapabilityBoundingSet=CAP_NET_BIND_SERVICE
-        \\
-        \\# Limits
-        \\LimitNOFILE=131582
-        \\TasksMax=65535
-        \\
-        \\[Install]
-        \\WantedBy=multi-user.target
-        \\
-    ;
-    sys.writeFile(SERVICE_FILE, content) catch {};
+pub fn writeServiceFile() !void {
+    try sys.writeFile(SERVICE_FILE, @import("build_options").proxy_service);
 }
 
 /// Remove temporary files created during download.

--- a/src/ctl/sharelink.zig
+++ b/src/ctl/sharelink.zig
@@ -73,6 +73,17 @@ fn rawFieldChecked(s: []const u8) ![]const u8 {
     return s;
 }
 
+/// True when a WHOLE share-link is safe to record verbatim. `setup egress` writes the
+/// pasted text into `[upstream.xray] links` in the root-owned config.toml as a bare quoted
+/// array, so a newline in the link emits extra physical lines into a file the proxy parses
+/// back: an injected `[access.users]` entry hands the proxy to whoever wrote the link, and
+/// an injected `[general] tls_domain` invalidates every distributed tg:// link. A
+/// share-link is a single URI, so a control byte or a `"` in it is never legitimate.
+pub fn linkTextIsSafe(s: []const u8) bool {
+    if (hasControlBytes(s)) return false;
+    return std.mem.indexOfScalar(u8, s, '"') == null;
+}
+
 /// Return the (raw, undecoded) value of `key` in a `k=v&k2=v2` query string, or null.
 pub fn queryParam(query: []const u8, key: []const u8) ?[]const u8 {
     var it = std.mem.splitScalar(u8, query, '&');
@@ -127,6 +138,7 @@ pub const XrayLink = struct {
     id: ?[]const u8 = null, // uuid (vless/vmess)
     password: ?[]const u8 = null, // trojan / ss
     method: ?[]const u8 = null, // ss cipher
+    plugin: ?[]const u8 = null, // ss SIP002 `plugin=` (v2ray-plugin/obfs/shadow-tls)
     alter_id: u16 = 0, // vmess aid
     cipher: []const u8 = "auto", // vmess scy (auto|none|zero|aes-128-gcm|chacha20-poly1305)
     // transport / security
@@ -142,9 +154,12 @@ pub const XrayLink = struct {
     // hysteria2
     obfs: ?[]const u8 = null, // only "salamander" exists
     obfs_password: ?[]const u8 = null,
-    /// hysteria2 `insecure=1`: skip certificate verification. Hysteria servers are
-    /// commonly self-signed, and unlike the Xray family the scheme has no Reality-style
-    /// pinning we can emit faithfully, so the link has to say so explicitly.
+    /// `insecure=1` (hysteria2) / `allowInsecure=1` (vless/trojan): skip certificate
+    /// verification. Hysteria servers are commonly self-signed, and unlike the Xray family
+    /// the scheme has no Reality-style pinning we can emit faithfully, so the link has to
+    /// say so explicitly. 3x-ui hands out `allowInsecure=1` on tls links for the same
+    /// reason: dropping the flag built an outbound that verifies strictly, so `sing-box
+    /// check` passed and every dial then failed on x509 behind a green "egress up".
     insecure: bool = false,
 };
 
@@ -183,6 +198,11 @@ fn parseUriCred(a: std.mem.Allocator, link: []const u8, scheme: Scheme, prefix: 
 
     var l = XrayLink{ .scheme = scheme, .name = name, .address = try a.dupe(u8, hp.host), .port = hp.port };
     if (scheme == .vless) l.id = cred else l.password = cred;
+    // trojan is TLS by definition — the original trojan-gfw URI carries no `security=` at
+    // all. Left at the "none" default it generated a PLAINTEXT trojan outbound that ships
+    // the password in the clear on the first packet and can never connect, while
+    // `sing-box check` passed and setup reported the egress up.
+    if (scheme == .trojan) l.security = "tls";
 
     if (queryParam(query, "type")) |v| l.network = try percentDecodeAlloc(a, v);
     if (queryParam(query, "security")) |v| l.security = try percentDecodeAlloc(a, v);
@@ -194,6 +214,11 @@ fn parseUriCred(a: std.mem.Allocator, link: []const u8, scheme: Scheme, prefix: 
     if (queryParam(query, "fp")) |v| l.fingerprint = try percentDecodeAlloc(a, v);
     if (queryParam(query, "pbk")) |v| l.public_key = try percentDecodeAlloc(a, v);
     if (queryParam(query, "sid")) |v| l.short_id = try percentDecodeAlloc(a, v);
+    // Panels (3x-ui) emit `allowInsecure=1` for endpoints with a self-signed certificate;
+    // `insecure=1` is the same flag under the hysteria2 spelling. See XrayLink.insecure.
+    if (queryParam(query, "allowInsecure") orelse queryParam(query, "insecure")) |v| {
+        l.insecure = std.mem.eql(u8, v, "1") or std.ascii.eqlIgnoreCase(v, "true");
+    }
     return l;
 }
 
@@ -212,7 +237,9 @@ fn jsonStr(a: std.mem.Allocator, obj: std.json.Value, key: []const u8) ?[]const 
 /// Parse vmess:// (base64-encoded JSON object).
 fn parseVmess(a: std.mem.Allocator, link: []const u8) !XrayLink {
     const decoded = try base64Decode(a, link["vmess://".len..]);
+    defer a.free(decoded);
     const parsed = std.json.parseFromSlice(std.json.Value, a, decoded, .{}) catch return error.BadLink;
+    defer parsed.deinit();
     const o = parsed.value;
     if (o != .object) return error.BadLink;
     const add = jsonStr(a, o, "add") orelse return error.BadLink;
@@ -247,7 +274,16 @@ fn parseSs(a: std.mem.Allocator, link: []const u8) !XrayLink {
         name = try percentDecodeAlloc(a, rest[h + 1 ..]);
         rest = rest[0..h];
     }
-    if (std.mem.indexOfScalar(u8, rest, '?')) |q| rest = rest[0..q]; // drop plugin params
+    // The query is not part of the credential/authority, but `plugin=` is KEPT: it names
+    // the transport (v2ray-plugin, obfs-local, shadow-tls) the server actually speaks, and
+    // our generator emits a bare shadowsocks outbound. Dropped, the link looked ordinary,
+    // `sing-box check` passed, and every connection to such a server died — so it is
+    // carried into validateLink as a rejection instead.
+    var plugin: ?[]const u8 = null;
+    if (std.mem.indexOfScalar(u8, rest, '?')) |q| {
+        if (queryParam(rest[q + 1 ..], "plugin")) |v| plugin = try percentDecodeAlloc(a, v);
+        rest = rest[0..q];
+    }
     var method: []const u8 = undefined;
     var password: []const u8 = undefined;
     var hostport: []const u8 = undefined;
@@ -275,6 +311,7 @@ fn parseSs(a: std.mem.Allocator, link: []const u8) !XrayLink {
         .port = hp.port,
         .method = try a.dupe(u8, method),
         .password = try a.dupe(u8, password),
+        .plugin = plugin,
     };
 }
 
@@ -401,6 +438,22 @@ pub fn validateLink(l: XrayLink, buf: []u8) ?[]const u8 {
     if (!(net.len == 0 or std.mem.eql(u8, net, "tcp") or std.mem.eql(u8, net, "ws") or std.mem.eql(u8, net, "grpc"))) {
         return std.fmt.bufPrint(buf, "unsupported transport '{s}' for {s} — only tcp/ws/grpc are supported", .{ net, l.address }) catch "unsupported transport";
     }
+    // The generator emits a TLS block for exactly "tls" and "reality"; every other value
+    // (legacy `security=xtls`, a typo) falls through to a PLAINTEXT outbound that
+    // `sing-box check` accepts and whose every dial then fails. `none` is deliberately
+    // legal — vless+ws behind a CDN is a real plaintext-to-the-edge shape.
+    const sec = l.security;
+    if (!(sec.len == 0 or std.mem.eql(u8, sec, "none") or std.mem.eql(u8, sec, "tls") or std.mem.eql(u8, sec, "reality"))) {
+        return std.fmt.bufPrint(buf, "unsupported security '{s}' for {s} — only tls/reality/none are supported", .{ sec, l.address }) catch "unsupported security";
+    }
+    // A flow (xtls-rprx-vision) without TLS is the same trap one level down: sing-box's
+    // vless outbound only rejects an UNKNOWN flow name, so `check` exits 0 and the failure
+    // appears per-dial inside NewVisionConn ("not a valid supported TLS connection").
+    if (l.flow) |flow| {
+        if (flow.len > 0 and !(std.mem.eql(u8, sec, "tls") or std.mem.eql(u8, sec, "reality"))) {
+            return std.fmt.bufPrint(buf, "flow '{s}' needs security=tls or reality ({s})", .{ flow, l.address }) catch "flow without tls";
+        }
+    }
     if (l.scheme == .hysteria2) {
         // pinSHA256 pins sha256 of the whole DER certificate, colon-hex. sing-box's
         // nearest field pins the SPKI, base64 — a different preimage AND a different
@@ -425,6 +478,15 @@ pub fn validateLink(l: XrayLink, buf: []u8) ?[]const u8 {
         return null;
     }
     if (l.scheme == .shadowsocks) {
+        // sing-box does support `plugin`/`plugin_opts`, but our generator emits neither, so
+        // a v2ray-plugin/obfs/shadow-tls endpoint would get a plain shadowsocks outbound
+        // and drop every connection behind a config that checks clean.
+        if (l.plugin) |p| {
+            if (p.len > 0) {
+                const name = p[0 .. std.mem.indexOfScalar(u8, p, ';') orelse p.len];
+                return std.fmt.bufPrint(buf, "shadowsocks plugin '{s}' is not supported ({s})", .{ name, l.address }) catch "shadowsocks plugin unsupported";
+            }
+        }
         const m = l.method orelse "";
         for (supported_ss_methods) |sm| {
             if (std.mem.eql(u8, m, sm)) return null;
@@ -436,9 +498,13 @@ pub fn validateLink(l: XrayLink, buf: []u8) ?[]const u8 {
 
 // ── wireguard:// -> .conf transform ──────────────────────────────────────────────
 
-/// Convert a `wireguard://<privkey>@<host>:<port>?publickey=&address=&mtu=...#name`
-/// share-link into a WireGuard/AmneziaWG `.conf`. AmneziaWG obfuscation params
-/// (jc/jmin/jmax/s1/s2/h1..h4) and presharedkey are carried through when present.
+test "wireguard requires an explicit tunnel address" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    try std.testing.expectError(error.BadLink, convertWireguardLink(arena.allocator(), "wireguard://PRIVATE@example.com:51820?publickey=PUBLIC"));
+}
+
+/// Convert a wireguard share-link into a WireGuard/AmneziaWG config.
 pub fn convertWireguardLink(a: std.mem.Allocator, link_in: []const u8) ![]const u8 {
     const link = std.mem.trim(u8, link_in, " \t\r\n");
     const after = if (std.mem.startsWith(u8, link, "wireguard://"))
@@ -461,10 +527,12 @@ pub fn convertWireguardLink(a: std.mem.Allocator, link_in: []const u8) ![]const 
     const host = try rawFieldChecked(hp.host);
 
     const pub_key = try percentDecodeChecked(a, queryParam(query, "publickey") orelse queryParam(query, "public_key") orelse return error.BadLink);
-    const address = try percentDecodeChecked(a, queryParam(query, "address") orelse "10.0.0.2/32");
+    const address = try percentDecodeChecked(a, queryParam(query, "address") orelse return error.BadLink);
+    if (address.len == 0) return error.BadLink;
     const mtu = try rawFieldChecked(queryParam(query, "mtu") orelse "1420");
 
     var aw: std.Io.Writer.Allocating = .init(a);
+    errdefer aw.deinit();
     const w = &aw.writer;
     try w.print("[Interface]\nPrivateKey = {s}\nAddress = {s}\nMTU = {s}\n", .{ private_key, address, mtu });
     if (queryParam(query, "dns")) |dns| try w.print("DNS = {s}\n", .{try percentDecodeChecked(a, dns)});
@@ -478,7 +546,7 @@ pub fn convertWireguardLink(a: std.mem.Allocator, link_in: []const u8) ![]const 
     }
     try w.print("\n[Peer]\nPublicKey = {s}\nEndpoint = {s}:{d}\nAllowedIPs = 0.0.0.0/0, ::/0\nPersistentKeepalive = 25\n", .{ pub_key, host, hp.port });
     if (queryParam(query, "presharedkey")) |psk| try w.print("PresharedKey = {s}\n", .{try percentDecodeChecked(a, psk)});
-    return aw.written();
+    return try aw.toOwnedSlice();
 }
 
 test "parse vless reality link" {
@@ -538,6 +606,75 @@ test "validateLink rejects unsupported transport and ss cipher" {
     try std.testing.expect(validateLink(.{ .scheme = .shadowsocks, .address = "h", .port = 1, .method = "aes-256-gcm" }, &buf) == null);
     try std.testing.expect(validateLink(.{ .scheme = .vless, .address = "h", .port = 1, .network = "quic" }, &buf) != null);
     try std.testing.expect(validateLink(.{ .scheme = .shadowsocks, .address = "h", .port = 1, .method = "rc4-md5-is-unsupported" }, &buf) != null);
+}
+
+test "a share link that would inject TOML is refused before it is recorded" {
+    // `setup egress` writes the pasted argv verbatim into `[upstream.xray] links`, so a
+    // newline in the link adds physical lines to the root-owned config.toml — an
+    // `[access.users]` entry the proxy honours, or a `tls_domain` that kills every link.
+    try std.testing.expect(linkTextIsSafe("vless://u@1.2.3.4:443?security=tls#name"));
+    try std.testing.expect(!linkTextIsSafe("vless://u@1.2.3.4:443?security=tls#x\n[access.users]\nattacker = \"00\""));
+    try std.testing.expect(!linkTextIsSafe("vless://u@1.2.3.4:443#x\r\nfoo"));
+    // A bare quote alone already closes the TOML array element.
+    try std.testing.expect(!linkTextIsSafe("vless://u@1.2.3.4:443#x\",\"y"));
+}
+
+test "trojan is TLS by default and an unusable security/flow combination is rejected" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    var buf: [256]u8 = undefined;
+
+    // The original trojan-gfw URI has no `security=`: at the "none" default the generator
+    // emitted a PLAINTEXT trojan outbound (password in the clear, never connects).
+    const trojan = try parseXrayLink(a, "trojan://pw@vpn.example:443?sni=vpn.example#t");
+    try std.testing.expectEqualStrings("tls", trojan.security);
+    try std.testing.expect(validateLink(trojan, &buf) == null);
+
+    // Legacy/typo'd security values must be refused, not silently degraded to plaintext.
+    const xtls = try parseXrayLink(a, "vless://u@h:443?type=tcp&security=xtls&sni=s#x");
+    try std.testing.expect(validateLink(xtls, &buf) != null);
+
+    // A flow with no TLS builds fine (`sing-box check` exits 0) and fails every dial.
+    const flow_no_tls = try parseXrayLink(a, "vless://u@h:443?type=tcp&flow=xtls-rprx-vision&sni=s&fp=chrome#x");
+    try std.testing.expect(validateLink(flow_no_tls, &buf) != null);
+    // ...while the same flow over reality stays supported.
+    const flow_reality = try parseXrayLink(a, "vless://u@h:443?type=tcp&security=reality&pbk=P&sid=S&flow=xtls-rprx-vision#x");
+    try std.testing.expect(validateLink(flow_reality, &buf) == null);
+    // security=none remains legal: vless+ws behind a CDN is a real deployment shape.
+    const ws_plain = try parseXrayLink(a, "vless://u@h:443?type=ws&path=%2Fx#x");
+    try std.testing.expect(validateLink(ws_plain, &buf) == null);
+}
+
+test "allowInsecure survives parsing instead of being dropped" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const l = try parseXrayLink(a, "trojan://pw@vpn.example:443?security=tls&sni=vpn.example&allowInsecure=1#t");
+    try std.testing.expect(l.insecure);
+    const strict = try parseXrayLink(a, "trojan://pw@vpn.example:443?security=tls&sni=vpn.example#t");
+    try std.testing.expect(!strict.insecure);
+}
+
+test "ss plugin params are rejected, not silently dropped" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    var buf: [256]u8 = undefined;
+
+    // A v2ray-plugin (websocket+TLS) server against a bare shadowsocks outbound drops
+    // every connection while `sing-box check` passes.
+    const plugged = try parseXrayLink(a, "ss://YWVzLTI1Ni1nY206cHc=@vpn.example:443?plugin=v2ray-plugin%3Btls%3Bhost%3Dvpn.example#EU");
+    try std.testing.expectEqualStrings("v2ray-plugin;tls;host=vpn.example", plugged.plugin.?);
+    const msg = validateLink(plugged, &buf) orelse return error.TestExpectedEqual;
+    try std.testing.expect(std.mem.indexOf(u8, msg, "v2ray-plugin") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, ";tls") == null); // name only, not the opts
+
+    // A plain SIP002 link is untouched.
+    const plain = try parseXrayLink(a, "ss://YWVzLTI1Ni1nY206cHc=@vpn.example:443#EU");
+    try std.testing.expect(plain.plugin == null);
+    try std.testing.expect(validateLink(plain, &buf) == null);
 }
 
 test "detectScheme" {

--- a/src/ctl/synlimit.zig
+++ b/src/ctl/synlimit.zig
@@ -35,6 +35,21 @@ const SCRIPT_PATH = "/usr/local/sbin/mtproto-syn-limit.sh";
 const UNIT_PATH = "/etc/systemd/system/" ++ SERVICE_NAME ++ ".service";
 const CHAIN = "MTPROTO_SYNLIMIT";
 
+/// Upgrade the previously generated script while preserving its chosen rate/burst.
+pub fn repairInstalled(allocator: std.mem.Allocator) void {
+    const old = sys.readFileAllocAbsolute(allocator, SCRIPT_PATH, 64 * 1024) orelse return;
+    defer allocator.free(old);
+    const loopback = std.mem.replaceOwned(u8, allocator, old, "-I INPUT -p tcp", "-I INPUT ! -i lo -p tcp") catch return;
+    defer allocator.free(loopback);
+    const reset = std.mem.replaceOwned(u8, allocator, loopback, "\"$T\" $W -F \"$CHAIN\"", "\"$T\" $W -D INPUT ! -i lo -p tcp --dport \"$PORT\" --syn -j \"$CHAIN\" 2>/dev/null || true\n    \"$T\" $W -F \"$CHAIN\"") catch return;
+    defer allocator.free(reset);
+    const ipv6 = std.mem.replaceOwned(u8, allocator, reset, "\"$IP6T\" $W -A \"$CHAIN\" -p tcp -m hashlimit --hashlimit-name mtproto_syn --hashlimit-mode srcip --hashlimit-above", "\"$IP6T\" $W -A \"$CHAIN\" -p tcp -m hashlimit --hashlimit-name mtproto_syn --hashlimit-mode srcip --hashlimit-srcmask 64 --hashlimit-above") catch return;
+    defer allocator.free(ipv6);
+    if (std.mem.eql(u8, old, loopback) and std.mem.indexOf(u8, old, "--hashlimit-srcmask 64") != null) return;
+    sys.writeFileMode(SCRIPT_PATH, ipv6, 0o755) catch return;
+    sys.execSilent(allocator, &.{ "systemctl", "try-restart", SERVICE_NAME });
+}
+
 /// Token-bucket presets, mirroring MTproxy-reanimation's hard/medium/soft. Rates use
 /// the iptables `<n>/second` syntax. `soft` is the default when enabling because the
 /// stricter presets false-positive behind carrier-grade NAT / shared VPN egress.
@@ -117,6 +132,9 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
             opts.reject = true;
         } else if (std.mem.eql(u8, arg, "--drop")) {
             opts.reject = false;
+        } else {
+            ui.print("Unknown option: {s}\n", .{arg});
+            return error.UnknownOption;
         }
     }
     try execute(ui, allocator, opts);
@@ -126,20 +144,12 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
 pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
     ui.section(tr(ui, "Kernel SYN rate-limit (anti-flood)", "Ограничение SYN на уровне ядра (анти-флуд)"));
 
-    ui.print("  {s}{s}{s}\n", .{ Color.dim, tr(ui,
-        "Drops abusive first-SYN bursts per source IP in the kernel, before they",
-        "Дропает абьюзные SYN-всплески по каждому IP-источнику в ядре, до того как они"), Color.reset });
-    ui.print("  {s}{s}{s}\n\n", .{ Color.dim, tr(ui,
-        "ever reach the proxy. Complements the in-proxy guards (which run after accept).",
-        "достигнут прокси. Дополняет защиту внутри прокси (которая работает после accept)."), Color.reset });
+    ui.print("  {s}{s}{s}\n", .{ Color.dim, tr(ui, "Drops abusive first-SYN bursts per source IP in the kernel, before they", "Дропает абьюзные SYN-всплески по каждому IP-источнику в ядре, до того как они"), Color.reset });
+    ui.print("  {s}{s}{s}\n\n", .{ Color.dim, tr(ui, "ever reach the proxy. Complements the in-proxy guards (which run after accept).", "достигнут прокси. Дополняет защиту внутри прокси (которая работает после accept)."), Color.reset });
 
     // The same NAT/VPN false-positive that keeps the in-proxy flood guard OFF by default.
-    ui.warn(tr(ui,
-        "Per-IP limit: behind carrier-NAT / shared VPN egress many real users share one IP",
-        "Лимит на IP: за carrier-NAT / общим VPN-выходом много реальных пользователей делят один IP"));
-    ui.print("  {s}{s}{s}\n\n", .{ Color.dim, tr(ui,
-        "and can be throttled together. Leave it off unless you see a SYN flood.",
-        "и могут быть зарезаны вместе. Оставьте выключенным, если нет SYN-флуда."), Color.reset });
+    ui.warn(tr(ui, "Per-IP limit: behind carrier-NAT / shared VPN egress many real users share one IP", "Лимит на IP: за carrier-NAT / общим VPN-выходом много реальных пользователей делят один IP"));
+    ui.print("  {s}{s}{s}\n\n", .{ Color.dim, tr(ui, "and can be throttled together. Leave it off unless you see a SYN flood.", "и могут быть зарезаны вместе. Оставьте выключенным, если нет SYN-флуда."), Color.reset });
 
     printStatus(ui, allocator);
     ui.writeRaw("\n");
@@ -235,12 +245,8 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: SynLimitOpts) !void
     // client's — the limiter would throttle the LB. Warn loudly (don't refuse: for a
     // single trusted LB the operator may still want a global cap).
     if (proxy_protocol) {
-        ui.warn(tr(ui,
-            "accept_proxy_protocol is ON: the kernel sees your load balancer's IP, not real clients.",
-            "accept_proxy_protocol включён: ядро видит IP балансировщика, а не реальных клиентов."));
-        ui.print("  {s}{s}{s}\n", .{ Color.dim, tr(ui,
-            "The per-IP SYN limiter will throttle the LB. Only enable if you understand this.",
-            "Лимитер SYN per-IP будет резать балансировщик. Включайте, только если понимаете это."), Color.reset });
+        ui.warn(tr(ui, "accept_proxy_protocol is ON: the kernel sees your load balancer's IP, not real clients.", "accept_proxy_protocol включён: ядро видит IP балансировщика, а не реальных клиентов."));
+        ui.print("  {s}{s}{s}\n", .{ Color.dim, tr(ui, "The per-IP SYN limiter will throttle the LB. Only enable if you understand this.", "Лимитер SYN per-IP будет резать балансировщик. Включайте, только если понимаете это."), Color.reset });
     }
 
     ui.step(tr(ui, "Installing kernel SYN rate-limit...", "Установка ограничения SYN на уровне ядра..."));
@@ -297,6 +303,11 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: SynLimitOpts) !void
 /// and by `mtbuddy status`.
 pub fn printStatus(ui: *Tui, allocator: std.mem.Allocator) void {
     if (sys.isServiceActive(SERVICE_NAME)) {
+        const ipt = iptablesCommands().iptables;
+        if (!chainHasLimitRule(allocator, ipt) or !inputHasJump(allocator, ipt)) {
+            ui.warn(tr(ui, "SYN limiter unit is active, but its live firewall rules are missing; rerun setup syn-limit.", "Сервис SYN-limit активен, но правила firewall отсутствуют; повторите setup syn-limit."));
+            return;
+        }
         const drops = limitedCount(allocator);
         if (drops) |d| {
             var buf: [96]u8 = undefined;
@@ -361,7 +372,11 @@ pub fn renderScript(buf: []u8, p: ScriptParams) ![]const u8 {
         \\
         \\# Idempotent reset: drop the jump, flush + delete the chain (both families).
         \\for T in "$IPT" "$IP6T"; do
-        \\    "$T" $W -D INPUT -p tcp --dport "$PORT" --syn -j "$CHAIN" 2>/dev/null || true
+        \\    "$T" $W -S INPUT 2>/dev/null | while read -r op rule; do
+        \\        case "$rule" in
+        \\            *"-j $CHAIN") "$T" $W -D $rule 2>/dev/null || true ;;
+        \\        esac
+        \\    done
         \\    "$T" $W -F "$CHAIN" 2>/dev/null || true
         \\    "$T" $W -X "$CHAIN" 2>/dev/null || true
         \\done
@@ -372,13 +387,13 @@ pub fn renderScript(buf: []u8, p: ScriptParams) ![]const u8 {
         \\"$IPT" $W -N "$CHAIN" 2>/dev/null || true
         \\"$IPT" $W -A "$CHAIN" -p tcp -m hashlimit --hashlimit-name mtproto_syn --hashlimit-mode srcip --hashlimit-above "$RATE" --hashlimit-burst "$BURST" --hashlimit-htable-expire 60000 -j $ACTION
         \\"$IPT" $W -A "$CHAIN" -j RETURN
-        \\"$IPT" $W -I INPUT -p tcp --dport "$PORT" --syn -j "$CHAIN"
+        \\"$IPT" $W -I INPUT ! -i lo -p tcp --dport "$PORT" --syn -j "$CHAIN"
         \\
         \\# IPv6 (best-effort — hosts without IPv6 must not fail the unit).
         \\"$IP6T" $W -N "$CHAIN" 2>/dev/null || true
-        \\"$IP6T" $W -A "$CHAIN" -p tcp -m hashlimit --hashlimit-name mtproto_syn --hashlimit-mode srcip --hashlimit-above "$RATE" --hashlimit-burst "$BURST" --hashlimit-htable-expire 60000 -j $ACTION 2>/dev/null || true
+        \\"$IP6T" $W -A "$CHAIN" -p tcp -m hashlimit --hashlimit-name mtproto_syn --hashlimit-mode srcip --hashlimit-srcmask 64 --hashlimit-above "$RATE" --hashlimit-burst "$BURST" --hashlimit-htable-expire 60000 -j $ACTION 2>/dev/null || true
         \\"$IP6T" $W -A "$CHAIN" -j RETURN 2>/dev/null || true
-        \\"$IP6T" $W -I INPUT -p tcp --dport "$PORT" --syn -j "$CHAIN" 2>/dev/null || true
+        \\"$IP6T" $W -I INPUT ! -i lo -p tcp --dport "$PORT" --syn -j "$CHAIN" 2>/dev/null || true
         \\exit 0
         \\
     , .{
@@ -402,6 +417,9 @@ fn unitContent() []const u8 {
         "[Service]\n" ++
         "Type=oneshot\n" ++
         "RemainAfterExit=yes\n" ++
+        "NoNewPrivileges=yes\nProtectSystem=strict\nProtectHome=yes\nPrivateTmp=yes\n" ++
+        "CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW\nRestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK\n" ++
+        "ProtectKernelTunables=yes\nProtectControlGroups=yes\nRestrictSUIDSGID=yes\nLockPersonality=yes\n" ++
         "ExecStart=/bin/sh " ++ SCRIPT_PATH ++ " apply\n" ++
         "ExecStop=/bin/sh " ++ SCRIPT_PATH ++ " flush\n" ++
         "\n" ++
@@ -442,6 +460,17 @@ fn chainHasLimitRule(allocator: std.mem.Allocator, ipt: []const u8) bool {
     defer result.deinit();
     if (result.exit_code != 0) return false;
     return lineHasLimitTarget(result.stdout);
+}
+
+fn inputHasJump(allocator: std.mem.Allocator, ipt: []const u8) bool {
+    const result = sys.exec(allocator, &.{ ipt, "-S", "INPUT" }) catch return false;
+    defer result.deinit();
+    if (result.exit_code != 0) return false;
+    var lines = std.mem.splitScalar(u8, result.stdout, '\n');
+    while (lines.next()) |line| {
+        if (std.mem.endsWith(u8, std.mem.trim(u8, line, " \r"), "-j " ++ CHAIN)) return true;
+    }
+    return false;
 }
 
 /// Sum the limit rule's packet counter from `iptables -nvxL CHAIN`. Returns an owned
@@ -532,7 +561,8 @@ test "renderScript bakes params and stays brace-free for std.fmt" {
     try std.testing.expect(std.mem.indexOf(u8, out, "RATE=2/second") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "BURST=5") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "CHAIN=MTPROTO_SYNLIMIT") != null);
-    try std.testing.expect(std.mem.indexOf(u8, out, "-I INPUT -p tcp --dport \"$PORT\" --syn -j \"$CHAIN\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "-I INPUT ! -i lo -p tcp --dport \"$PORT\" --syn -j \"$CHAIN\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "--hashlimit-srcmask 64") != null);
     // Default over-limit target is DROP.
     try std.testing.expect(std.mem.indexOf(u8, out, "ACTION=\"DROP\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "-j $ACTION") != null);

--- a/src/ctl/sys.zig
+++ b/src/ctl/sys.zig
@@ -7,6 +7,9 @@
 const std = @import("std");
 const tui_mod = @import("tui.zig");
 
+/// Set once by main before dispatch; tests may use the per-call fallback.
+pub var command_io: ?std.Io = null;
+
 fn io() std.Io {
     return std.Io.Threaded.global_single_threaded.io();
 }
@@ -81,14 +84,29 @@ pub const Arch = enum {
     }
 };
 
+/// The environment this process was started with.
+///
+/// `std.Io.Threaded.InitOptions.environ` defaults to `.empty`, and an empty block makes
+/// `Threaded` skip its environment scan entirely: every child then got an EMPTY environment
+/// (no HOME, no LANG, no http(s)_proxy, no SSL_CERT_FILE) and argv[0] was resolved against
+/// the hardcoded `default_PATH` "/usr/local/bin:/bin/:/usr/bin". That is the real reason a
+/// bare `ufw`/`ip` from /usr/sbin came back FileNotFound while `commandExists` — which shells
+/// out and so gets dash's own compiled-in PATH — said the tool was there. `start.zig` records
+/// the real environment on this singleton before main() runs, so it is available without
+/// threading `std.process.Init` through every call site.
+fn processEnviron() std.process.Environ {
+    return std.Io.Threaded.global_single_threaded.environ.process_environ;
+}
+
 /// Run a command, capture stdout/stderr, return result.
 pub fn exec(allocator: std.mem.Allocator, argv: []const []const u8) !ExecResult {
-    var io_instance: std.Io.Threaded = .init(std.heap.page_allocator, .{});
+    var io_instance: std.Io.Threaded = .init(std.heap.page_allocator, .{ .environ = processEnviron() });
     defer io_instance.deinit();
 
-    const result = try std.process.run(allocator, io_instance.io(), .{
+    const result = try std.process.run(allocator, command_io orelse io_instance.io(), .{
         .argv = argv,
         .expand_arg0 = .expand,
+        .timeout = .{ .duration = .{ .raw = .fromSeconds(900), .clock = .awake } },
         .stdout_limit = std.Io.Limit.limited(1024 * 1024),
         .stderr_limit = std.Io.Limit.limited(1024 * 1024),
     });
@@ -109,8 +127,54 @@ pub fn exec(allocator: std.mem.Allocator, argv: []const []const u8) !ExecResult 
 }
 
 /// Run a command with output forwarded directly to the terminal (no capture).
+/// Small stdin payloads stay off argv. Limit input to PIPE_BUF so writing it
+/// before collecting output cannot fill the pipe on our Linux runtime.
+pub fn execInput(allocator: std.mem.Allocator, argv: []const []const u8, input: []const u8) !ExecResult {
+    if (input.len > 4096) return error.InputTooLong;
+    var io_instance: std.Io.Threaded = .init(std.heap.page_allocator, .{ .environ = processEnviron() });
+    defer io_instance.deinit();
+    const child_io = command_io orelse io_instance.io();
+    var child = try std.process.spawn(child_io, .{
+        .argv = argv,
+        .expand_arg0 = .expand,
+        .stdin = .pipe,
+        .stdout = .pipe,
+        .stderr = .pipe,
+    });
+    defer child.kill(child_io);
+    try child.stdin.?.writeStreamingAll(child_io, input);
+    child.stdin.?.close(child_io);
+    child.stdin = null;
+    var buffers: std.Io.File.MultiReader.Buffer(2) = undefined;
+    var reader: std.Io.File.MultiReader = undefined;
+    reader.init(allocator, child_io, buffers.toStreams(), &.{ child.stdout.?, child.stderr.? });
+    defer reader.deinit();
+    while (reader.fill(256, .{ .duration = .{ .raw = .fromSeconds(10), .clock = .awake } })) |_| {
+        if (reader.reader(0).buffered().len > 1024 * 1024 or reader.reader(1).buffered().len > 1024 * 1024)
+            return error.StreamTooLong;
+    } else |err| switch (err) {
+        error.EndOfStream => {},
+        else => return err,
+    }
+    try reader.checkAnyError();
+    const term = try child.wait(child_io);
+    const stdout = try reader.toOwnedSlice(0);
+    errdefer allocator.free(stdout);
+    const stderr = try reader.toOwnedSlice(1);
+    return .{
+        .allocator = allocator,
+        .stdout = stdout,
+        .stderr = stderr,
+        .exit_code = switch (term) {
+            .exited => |code| code,
+            else => 1,
+        },
+    };
+}
+
+/// Run a command with output forwarded directly to the terminal (no capture).
 pub fn execForward(argv: []const []const u8) !u8 {
-    var io_instance: std.Io.Threaded = .init(std.heap.page_allocator, .{});
+    var io_instance: std.Io.Threaded = .init(std.heap.page_allocator, .{ .environ = processEnviron() });
     defer io_instance.deinit();
 
     const io_ctx = io_instance.io();
@@ -205,7 +269,7 @@ fn containsWord(haystack: []const u8, word: []const u8) bool {
             // Check word boundaries
             const before_ok = (i == 0) or (haystack[i - 1] == ' ' or haystack[i - 1] == '\t' or haystack[i - 1] == ':');
             const after_idx = i + word.len;
-            const after_ok = (after_idx >= haystack.len) or (haystack[after_idx] == ' ' or haystack[after_idx] == '\t' or haystack[after_idx] == '\n');
+            const after_ok = (after_idx >= haystack.len) or (haystack[after_idx] == ' ' or haystack[after_idx] == '\t' or haystack[after_idx] == '\n' or haystack[after_idx] == '\r');
             if (before_ok and after_ok) return true;
         }
         i += 1;
@@ -215,18 +279,19 @@ fn containsWord(haystack: []const u8, word: []const u8) bool {
 
 /// Check if a command exists on PATH.
 pub fn commandExists(name: []const u8) bool {
-    if (std.mem.indexOfScalar(u8, name, '/') != null) return fileExists(name);
-
-    const shell = if (fileExists("/bin/sh")) "/bin/sh" else "sh";
-    const result = exec(std.heap.page_allocator, &.{
-        shell,
-        "-c",
-        "command -v \"$1\" >/dev/null 2>&1",
-        "sh",
-        name,
-    }) catch return false;
-    defer result.deinit();
-    return result.exit_code == 0;
+    if (std.mem.indexOfScalar(u8, name, '/') != null) {
+        std.Io.Dir.cwd().access(io(), name, .{ .execute = true }) catch return false;
+        return true;
+    }
+    const path = processEnviron().getPosix("PATH") orelse "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+    var directories = std.mem.splitScalar(u8, path, ':');
+    var buffer: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    while (directories.next()) |directory| {
+        const candidate = std.fmt.bufPrint(&buffer, "{s}/{s}", .{ if (directory.len == 0) "." else directory, name }) catch continue;
+        std.Io.Dir.cwd().access(io(), candidate, .{ .execute = true }) catch continue;
+        return true;
+    }
+    return false;
 }
 
 /// Resolve a command by known absolute-path fallbacks first, then PATH.
@@ -277,6 +342,9 @@ pub fn writeFileMode(path: []const u8, content: []const u8, mode: u9) !void {
             .permissions = std.Io.File.Permissions.fromMode(mode),
         },
     });
+    var file = try std.Io.Dir.cwd().openFile(io(), path, .{ .mode = .read_write });
+    defer file.close(io());
+    try file.setPermissions(io(), std.Io.File.Permissions.fromMode(mode));
 }
 
 /// Parse a simple KEY=VALUE .env file, return value for given key.
@@ -305,11 +373,8 @@ pub fn readEnvFile(allocator: std.mem.Allocator, path: []const u8, key: []const 
 /// Read a boolean-like env flag from the current process environment.
 /// Returns true for: 1, true, yes, on (case-insensitive).
 pub fn envFlagSet(name: []const u8) bool {
-    const result = exec(std.heap.page_allocator, &.{ "printenv", name }) catch return false;
-    defer result.deinit();
-    if (result.exit_code != 0) return false;
-
-    const trimmed = std.mem.trim(u8, result.stdout, &[_]u8{ ' ', '\t', '\r', '\n' });
+    const value = processEnviron().getPosix(name) orelse return false;
+    const trimmed = std.mem.trim(u8, value, &[_]u8{ ' ', '\t', '\r', '\n' });
     return std.ascii.eqlIgnoreCase(trimmed, "1") or
         std.ascii.eqlIgnoreCase(trimmed, "true") or
         std.ascii.eqlIgnoreCase(trimmed, "yes") or
@@ -344,11 +409,11 @@ pub fn generateSecret(buf: *[32]u8) error{NoEntropy}!void {
 }
 
 /// Convert a domain string to hex encoding (for ee-secret).
-pub fn domainToHex(domain: []const u8, buf: []u8) []const u8 {
+pub fn domainToHex(domain: []const u8, buf: []u8) error{NoSpaceLeft}![]const u8 {
+    if (domain.len > buf.len / 2) return error.NoSpaceLeft;
     const hex = "0123456789abcdef";
     var pos: usize = 0;
     for (domain) |byte| {
-        if (pos + 2 > buf.len) break;
         buf[pos] = hex[byte >> 4];
         buf[pos + 1] = hex[byte & 0x0f];
         pos += 2;
@@ -415,4 +480,64 @@ fn detectPublicIpFromServices(
     }
 
     return null;
+}
+
+test "exec hands the child the process environment" {
+    // Regression: `Threaded.init(.., .{})` defaults `environ` to `.empty`, which both gave
+    // every child a zero-entry environment and pinned argv[0] resolution to the hardcoded
+    // "/usr/local/bin:/bin/:/usr/bin". `env` with an empty environment prints nothing at all.
+    const result = exec(std.testing.allocator, &.{"/usr/bin/env"}) catch return error.SkipZigTest;
+    defer result.deinit();
+    try std.testing.expectEqual(@as(u8, 0), result.exit_code);
+    try std.testing.expect(result.stdout.len > 0);
+}
+
+test "execInput feeds stdin and captures output without argument disclosure" {
+    const result = try execInput(std.testing.allocator, &.{"/bin/cat"}, "private payload\n");
+    defer result.deinit();
+    try std.testing.expectEqual(@as(u8, 0), result.exit_code);
+    try std.testing.expectEqualStrings("private payload\n", result.stdout);
+}
+
+test "CPU feature word boundaries do not accept substring matches" {
+    try std.testing.expect(containsWord("flags:aes\r", "aes"));
+    try std.testing.expect(containsWord("flags:\tavx2 aes\n", "avx2"));
+    try std.testing.expect(!containsWord("vaes noavx2 avx512", "aes"));
+    try std.testing.expect(!containsWord("avx512", "avx"));
+}
+
+test "domain hex conversion stays inside odd-sized output buffers" {
+    var buf: [7]u8 = @splat(0xaa);
+    try std.testing.expectEqualStrings("612e62", try domainToHex("a.b", &buf));
+    try std.testing.expectEqual(@as(u8, 0xaa), buf[6]);
+    try std.testing.expectError(error.NoSpaceLeft, domainToHex("x", buf[0..1]));
+}
+
+test "exec maps normal failure and signal termination to failure" {
+    const normal = try exec(std.testing.allocator, &.{ "/bin/sh", "-c", "exit 7" });
+    defer normal.deinit();
+    try std.testing.expectEqual(@as(u8, 7), normal.exit_code);
+    const signaled = try exec(std.testing.allocator, &.{ "/bin/sh", "-c", "kill -TERM $$" });
+    defer signaled.deinit();
+    try std.testing.expect(signaled.exit_code != 0);
+}
+
+test "secret generator fills exactly a hexadecimal secret" {
+    if (@import("builtin").os.tag != .linux) return error.SkipZigTest;
+    var secret: [32]u8 = undefined;
+    try generateSecret(&secret);
+    for (secret) |c| try std.testing.expect(std.ascii.isHex(c));
+}
+
+test "environment file reads exports quoted values and ignores comment lines" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const io_ctx = std.Io.Threaded.global_single_threaded.io();
+    try tmp.dir.writeFile(io_ctx, .{ .sub_path = "vars.env", .data = "# ignored=yes\nexport TOKEN = \"value#inside\"\r\nTAG=v1\n" });
+    var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}/vars.env", .{tmp.sub_path});
+    const token = readEnvFile(std.testing.allocator, path, "TOKEN") orelse return error.MissingToken;
+    defer std.testing.allocator.free(token);
+    try std.testing.expectEqualStrings("value#inside", token);
+    try std.testing.expect(readEnvFile(std.testing.allocator, path, "ignored") == null);
 }

--- a/src/ctl/toml.zig
+++ b/src/ctl/toml.zig
@@ -42,26 +42,80 @@ pub const TomlDoc = struct {
     }
 
     /// Save the document back to a file.
+    ///
+    /// Staged through `<path>.tmp` + rename(2) rather than written in place: `createFile`
+    /// truncates the destination before the first byte lands, so an ENOSPC, an EIO or a
+    /// kill mid-write left config.toml empty or half-written. That file is the ONLY copy of
+    /// the `[access.users]` secrets — losing it kills every distributed link. rename is
+    /// atomic within a filesystem, so a reader (or a crash) sees either the whole old file
+    /// or the whole new one, a failed write leaves the original untouched, and the previous
+    /// contents are kept one deep in `<path>.bak`.
     pub fn save(self: *Self, path: []const u8) !void {
         const io = std.Io.Threaded.global_single_threaded.io();
-        // config.toml carries [access.users] secrets and the FakeTLS identity.
-        // Create it 0640 (owner+group only) so unprivileged local accounts
-        // (e.g. the www-data user this tool installs for masking) cannot read
-        // the proxy secrets. createFile only sets the mode on creation, so also
-        // fchmod to tighten an already-existing world-readable config in place.
-        var file = try std.Io.Dir.cwd().createFile(io, path, .{
-            .permissions = std.Io.File.Permissions.fromMode(0o640),
-        });
-        defer file.close(io);
-        file.setPermissions(io, std.Io.File.Permissions.fromMode(0o640)) catch {};
+        const dir = std.Io.Dir.cwd();
 
-        for (self.lines.items) |line| {
-            try file.writeStreamingAll(io, line);
-            try file.writeStreamingAll(io, "\n");
+        // Render before touching the filesystem: an allocation failure must not be able to
+        // happen with the destination already replaced.
+        var rendered: std.ArrayListUnmanaged(u8) = .empty;
+        defer rendered.deinit(self.allocator);
+        var last = self.lines.items.len;
+        while (last > 0 and self.lines.items[last - 1].len == 0) last -= 1;
+        for (self.lines.items[0..last]) |line| {
+            try rendered.appendSlice(self.allocator, line);
+            try rendered.append(self.allocator, '\n');
+        }
+
+        const tmp_path = try std.fmt.allocPrint(self.allocator, "{s}.tmp", .{path});
+        defer self.allocator.free(tmp_path);
+
+        // Read the current contents now, while they still exist, so the .bak below is the
+        // document this save replaces and not the one it wrote.
+        const previous: ?[]u8 = dir.readFileAlloc(io, path, self.allocator, .limited(1024 * 1024)) catch null;
+        defer if (previous) |old| self.allocator.free(old);
+
+        {
+            errdefer dir.deleteFile(io, tmp_path) catch {};
+
+            var file = try dir.createFile(io, tmp_path, .{
+                .permissions = std.Io.File.Permissions.fromMode(0o640),
+            });
+            defer file.close(io);
+            // config.toml carries [access.users] secrets and the FakeTLS identity.
+            // Keep it 0640 (owner+group only) so unprivileged local accounts (e.g. the
+            // www-data user this tool installs for masking) cannot read the proxy secrets.
+            // createFile only sets the mode on creation, so also fchmod in case a stale
+            // world-readable .tmp was left behind by an older build.
+            file.setPermissions(io, std.Io.File.Permissions.fromMode(0o640)) catch {};
+            // rename() installs a NEW inode, so the destination's owner has to be carried
+            // over explicitly. The proxy runs as User=mtproto and reads config.toml 0640 —
+            // a root:root replacement would make the service fail to start, and most
+            // save() call sites do not chown afterwards.
+            if (fileOwner(path)) |owner| file.setOwner(io, owner.uid, owner.gid) catch {};
+
+            try file.writeStreamingAll(io, rendered.items);
+            // Durability before the rename: without the fsync the directory entry can be
+            // committed while the data is still in the page cache, and a host reset then
+            // leaves a 0-length config.toml — exactly the loss the rename is here to avoid.
+            try file.sync(io);
+        }
+
+        try dir.rename(tmp_path, dir, path, io);
+
+        // Best-effort second copy. rename() rules out a torn write, but not mtbuddy itself
+        // writing a document that dropped a user; one undo is cheap.
+        if (previous) |old| {
+            var bak_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+            const bak_path = std.fmt.bufPrint(&bak_buf, "{s}.bak", .{path}) catch return;
+            dir.writeFile(io, .{
+                .sub_path = bak_path,
+                .data = old,
+                .flags = .{ .permissions = std.Io.File.Permissions.fromMode(0o640) },
+            }) catch {};
         }
     }
 
     /// Get a value by [section].key. Returns null if not found.
+    /// Borrowed value: copy it before changing this document. Surrounding quotes are removed.
     pub fn get(self: *Self, section_name: []const u8, key: []const u8) ?[]const u8 {
         var in_section = false;
         var hdr_buf: [128]u8 = undefined;
@@ -90,7 +144,15 @@ pub const TomlDoc = struct {
         return null;
     }
 
-    /// Set a value in [section].key, creating section/key if needed.
+    /// Write a raw TOML literal. Use setString for text. Invalidates borrowed get() values.
+    pub fn setString(self: *Self, section_name: []const u8, key: []const u8, value: []const u8) !void {
+        var encoded: std.Io.Writer.Allocating = .init(self.allocator);
+        defer encoded.deinit();
+        try std.json.Stringify.value(value, .{}, &encoded.writer);
+        try self.set(section_name, key, encoded.written());
+    }
+
+    /// Set a raw TOML literal in [section].key, creating section/key if needed.
     pub fn set(self: *Self, section_name: []const u8, key: []const u8, value: []const u8) !void {
         var hdr_buf: [128]u8 = undefined;
         const target_header = sectionHeader(section_name, &hdr_buf);
@@ -116,8 +178,9 @@ pub const TomlDoc = struct {
             if (parseKeyValue(trimmed)) |kv| {
                 if (std.mem.eql(u8, kv.key, key)) {
                     // Replace existing line
+                    const replacement = try formatKv(self.allocator, key, value);
                     self.allocator.free(self.lines.items[idx]);
-                    self.lines.items[idx] = try formatKv(self.allocator, key, value);
+                    self.lines.items[idx] = replacement;
                     return;
                 }
             }
@@ -161,9 +224,14 @@ pub const TomlDoc = struct {
 
     /// Add a key-value pair with a quoted string value.
     pub fn addKvStr(self: *Self, key: []const u8, value: []const u8) !void {
-        var buf: [512]u8 = undefined;
-        const formatted = std.fmt.bufPrint(&buf, "{s} = \"{s}\"", .{ key, value }) catch return;
-        try self.lines.append(self.allocator, try self.allocator.dupe(u8, formatted));
+        var output: std.Io.Writer.Allocating = .init(self.allocator);
+        defer output.deinit();
+        try output.writer.print("{s} = ", .{key});
+        // JSON string escaping is also valid for TOML basic strings.
+        try std.json.Stringify.value(value, .{}, &output.writer);
+        const owned = try self.allocator.dupe(u8, output.written());
+        errdefer self.allocator.free(owned);
+        try self.lines.append(self.allocator, owned);
     }
 
     /// Render the full document as a string.
@@ -198,6 +266,25 @@ pub const TomlDoc = struct {
 fn sectionHeader(name: []const u8, buf: []u8) []const u8 {
     if (name.len > 0 and name[0] == '[') return name;
     return std.fmt.bufPrint(buf, "[{s}]", .{name}) catch name;
+}
+
+const Owner = struct {
+    uid: std.posix.uid_t,
+    gid: std.posix.gid_t,
+};
+
+/// Owner of an existing file, so `save()` can put it back on the replacement it renames
+/// into place. Linux is mtbuddy's runtime target; on a dev host the owner is left alone
+/// (everything there already belongs to the developer).
+fn fileOwner(path: []const u8) ?Owner {
+    if (@import("builtin").os.tag != .linux) return null;
+
+    const path_z = std.posix.toPosixPath(path) catch return null;
+    var stx: std.os.linux.Statx = undefined;
+    const rc = std.os.linux.statx(std.os.linux.AT.FDCWD, &path_z, 0, .{ .UID = true, .GID = true }, &stx);
+    if (std.os.linux.errno(rc) != .SUCCESS) return null;
+    if (!stx.mask.UID or !stx.mask.GID) return null;
+    return .{ .uid = stx.uid, .gid = stx.gid };
 }
 
 const KeyValue = struct {
@@ -276,6 +363,17 @@ test "parseKeyValue: quoted '#' preserved" {
     try std.testing.expectEqualStrings("abc#def", kv.value);
 }
 
+test "setString writes escaped TOML literals and set accepts an aliased value" {
+    var doc = TomlDoc{ .allocator = std.testing.allocator };
+    defer doc.deinit();
+    try doc.setString("upstream", "type", "tunnel");
+    try std.testing.expectEqualStrings("type = \"tunnel\"", doc.lines.items[2]);
+    try doc.setString("upstream", "password", "quote\" and newline\n");
+    try std.testing.expectEqualStrings("password = \"quote\\\" and newline\\n\"", doc.lines.items[3]);
+    try doc.setString("upstream", "type", doc.get("upstream", "type").?);
+    try std.testing.expectEqualStrings("tunnel", doc.get("upstream", "type").?);
+}
+
 test "set/get round-trips a dotted (non-allowlisted) section with brackets" {
     var doc = TomlDoc.initEmpty(std.testing.allocator);
     defer doc.deinit();
@@ -329,4 +427,68 @@ test "TomlDoc.set survives a value longer than the old fixed buffer" {
     // And it is readable back in one piece.
     const read_back = doc.get("upstream.xray", "links") orelse return error.TestExpectedEqual;
     try std.testing.expectEqualStrings(long.items, read_back);
+}
+
+test "TomlDoc.save keeps the replaced document in <path>.bak" {
+    const a = std.testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}/config.toml", .{tmp.sub_path});
+
+    const original = "[server]\nport = 443\n";
+    try tmp.dir.writeFile(io, .{ .sub_path = "config.toml", .data = original });
+
+    var doc = try TomlDoc.load(a, path);
+    defer doc.deinit();
+    try doc.set("server", "port", "8443");
+    try doc.save(path);
+
+    const saved = try tmp.dir.readFileAlloc(io, "config.toml", a, .limited(4096));
+    defer a.free(saved);
+    try std.testing.expect(std.mem.indexOf(u8, saved, "port = 8443") != null);
+
+    const bak = try tmp.dir.readFileAlloc(io, "config.toml.bak", a, .limited(4096));
+    defer a.free(bak);
+    try std.testing.expectEqualStrings(original, bak);
+
+    // A successful save must not leave the staging file behind.
+    if (tmp.dir.access(io, "config.toml.tmp", .{})) |_| {
+        return error.TestUnexpectedResult;
+    } else |_| {}
+}
+
+test "TomlDoc.save leaves the destination intact when the staged write fails" {
+    // Regression: save() opened the destination itself with createFile, which truncates it
+    // to zero before a single byte of the new document is written — an ENOSPC or a kill in
+    // that window destroyed the only copy of the [access.users] secrets.
+    const a = std.testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}/config.toml", .{tmp.sub_path});
+
+    const original = "[access.users]\nalice = \"deadbeef\"\n";
+    try tmp.dir.writeFile(io, .{ .sub_path = "config.toml", .data = original });
+
+    var doc = try TomlDoc.load(a, path);
+    defer doc.deinit();
+    try doc.set("access.users", "alice", "\"c0ffee\"");
+
+    // A directory sitting on the staging path makes the write fail at exactly the point
+    // where the old code had already emptied config.toml.
+    try tmp.dir.createDir(io, "config.toml.tmp", .default_dir);
+    if (doc.save(path)) |_| {
+        return error.TestUnexpectedResult;
+    } else |_| {}
+
+    const survived = try tmp.dir.readFileAlloc(io, "config.toml", a, .limited(4096));
+    defer a.free(survived);
+    try std.testing.expectEqualStrings(original, survived);
 }

--- a/src/ctl/tui.zig
+++ b/src/ctl/tui.zig
@@ -257,6 +257,8 @@ fn installTerminalSignalHandlers() void {
     };
     std.posix.sigaction(std.posix.SIG.TERM, &act, null);
     std.posix.sigaction(std.posix.SIG.HUP, &act, null);
+    std.posix.sigaction(std.posix.SIG.INT, &act, null);
+    std.posix.sigaction(std.posix.SIG.QUIT, &act, null);
 }
 
 pub const Tui = struct {
@@ -392,8 +394,13 @@ pub const Tui = struct {
     /// Write formatted output to stdout.
     pub fn print(self: *Self, comptime fmt: []const u8, args: anytype) void {
         var buf: [8192]u8 = undefined;
-        const slice = std.fmt.bufPrint(&buf, fmt, args) catch return;
-        self.writeRaw(slice);
+        var writer: std.Io.Writer = .fixed(&buf);
+        writer.print(fmt, args) catch {
+            self.writeRaw(writer.buffered());
+            self.writeRaw("… [output truncated]\n");
+            return;
+        };
+        self.writeRaw(writer.buffered());
     }
 
     // ── Localized helpers ──────────────────────────────────────────────────
@@ -499,6 +506,7 @@ pub const Tui = struct {
 
     /// Show a numbered menu, return the 0-based index of the selected item.
     pub fn menu(self: *Self, title: []const u8, items: []const []const u8) !usize {
+        if (items.len == 0) return error.EmptyMenu;
         self.print("\n  {s}╭─ {s}{s}{s}\n", .{ Color.gray, Color.bold, title, Color.reset });
         self.print("  {s}│{s}\n", .{ Color.gray, Color.reset });
 
@@ -644,13 +652,15 @@ pub const Tui = struct {
 
         if (trimmed.len == 0) {
             if (default) |d| {
+                if (d.len > buf.len) return error.InputTooLong;
                 @memcpy(buf[0..d.len], d);
                 return buf[0..d.len];
             }
             return error.InputError;
         }
 
-        const len = @min(trimmed.len, buf.len);
+        if (trimmed.len > buf.len) return error.InputTooLong;
+        const len = trimmed.len;
         @memcpy(buf[0..len], trimmed[0..len]);
         return buf[0..len];
     }
@@ -665,6 +675,8 @@ pub const Tui = struct {
         helps: []const []const u8,
         defaults: []const bool,
     ) !u32 {
+        if (items.len == 0 or items.len > 32 or defaults.len > items.len or helps.len != items.len)
+            return error.InvalidCheckboxItems;
         var state: u32 = 0;
         for (defaults, 0..) |d, idx| {
             if (d) state |= @as(u32, 1) << @intCast(idx);
@@ -787,7 +799,7 @@ pub const Tui = struct {
         const title_len = std.unicode.utf8CountCodepoints(title) catch title.len;
         const box_interior = 66;
         const title_pad = if (title_len + 1 < box_interior) box_interior - title_len - 1 else 0;
-        var title_pad_buf: [64]u8 = undefined;
+        var title_pad_buf: [66]u8 = undefined;
         @memset(title_pad_buf[0..title_pad], ' ');
 
         self.print("  {s}│{s} {s}{s}{s}{s}{s}│{s}\n", .{
@@ -979,6 +991,8 @@ pub const Tui = struct {
                 },
                 .enter => {
                     self.writeRaw("\n");
+                    // A pasted second line must not silently answer the next prompt.
+                    while (self.readByteTimeout(0) != null) {}
                     return self.line_buf[0..pos];
                 },
                 .char => {
@@ -1031,7 +1045,6 @@ pub const SummaryLine = struct {
 };
 
 test "visibleLen counts display columns: ASCII=1, emoji/CJK=2, combining/VS=0" {
-
     try std.testing.expectEqual(@as(usize, 5), visibleLen("hello"));
 
     // Emoji is double-width.
@@ -1049,6 +1062,10 @@ test "visibleLen counts display columns: ASCII=1, emoji/CJK=2, combining/VS=0" {
 }
 
 fn expectRawPromptInput(input: []const u8, expected: []const u8) !void {
+    return expectPromptInteraction(input, expected, .line);
+}
+
+fn expectPromptInteraction(input: []const u8, expected: []const u8, kind: enum { line, menu, checkboxes, default_too_long }) !void {
     const input_pipe = try std.Io.Threaded.pipe2(.{});
     defer std.Io.Threaded.closeFd(input_pipe[0]);
     defer std.Io.Threaded.closeFd(input_pipe[1]);
@@ -1073,8 +1090,33 @@ fn expectRawPromptInput(input: []const u8, expected: []const u8) !void {
         .lang = .en,
         .is_tty = true,
     };
-    const line = try ui.readLineOrBack();
-    try std.testing.expectEqualStrings(expected, line);
+    switch (kind) {
+        .line => try std.testing.expectEqualStrings(expected, try ui.readLineOrBack()),
+        .menu => try std.testing.expectEqual(@as(usize, 1), try ui.menu("Choose", &.{ "First", "Second" })),
+        .checkboxes => try std.testing.expectEqual(@as(u32, 1), try ui.checkboxes("Choose", &.{ "First", "Second" }, &.{ "", "" }, &.{ false, false })),
+        .default_too_long => {
+            var small: [2]u8 = undefined;
+            try std.testing.expectError(error.InputTooLong, ui.input("Value", null, "long", &small));
+        },
+    }
+}
+
+test "menu keyboard navigation selects second item" {
+    if (@import("builtin").os.tag != .linux) return error.SkipZigTest; // terminal width uses Linux ioctl.
+    try expectPromptInteraction("\x1b[B\n", "", .menu);
+}
+
+test "checkbox keyboard toggles selected item" {
+    if (@import("builtin").os.tag != .linux) return error.SkipZigTest;
+    try expectPromptInteraction(" \n", "", .checkboxes);
+}
+
+test "prompt default does not truncate into the destination" {
+    try expectPromptInteraction("\n", "", .default_too_long);
+}
+
+test "raw prompt returns only the first line of a CRLF paste" {
+    try expectRawPromptInput("first\r\nsecond\n", "first");
 }
 
 test "raw prompt backspace can erase the first pasted byte" {

--- a/src/ctl/tunnel.zig
+++ b/src/ctl/tunnel.zig
@@ -10,7 +10,6 @@ const sys = @import("sys.zig");
 const toml = @import("toml.zig");
 const release = @import("release.zig");
 const tunnel_wg = @import("tunnel_wg.zig");
-const Tunnel = @import("tunnel").Tunnel;
 
 const Tui = tui_mod.Tui;
 const Color = tui_mod.Color;
@@ -45,6 +44,8 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
 
         if (arg.len > 0 and arg[0] != '-') {
             opts.awg_source = arg;
+        } else {
+            return error.UnknownOption;
         }
     }
 
@@ -71,7 +72,7 @@ pub fn freeInterfaceList(allocator: std.mem.Allocator, list: []const []const u8)
 }
 
 /// Create (iface_opt == null → next free interface) or replace (iface_opt set) an AmneziaWG /
-/// WireGuard tunnel from a pasted config or vpn:// share link. The management/type menus that
+/// WireGuard tunnel from a config file path or vpn:// share link. The management/type menus that
 /// reach this live in main.zig; this is just the AmneziaWG create wizard. Esc steps back one
 /// field (confirm → config), and Esc at the config prompt returns error.GoBack to the caller.
 pub fn runCreateAmnezia(ui: *Tui, allocator: std.mem.Allocator, iface_opt: ?[]const u8) !void {
@@ -181,6 +182,7 @@ fn tunnelRuntimeStatus(allocator: std.mem.Allocator, iface: []const u8) []const 
     const link = sys.exec(allocator, &.{ "ip", "link", "show", "dev", iface }) catch return "unknown";
     defer link.deinit();
     if (link.exit_code != 0) return "down";
+    if (std.mem.startsWith(u8, iface, "sbx")) return "up";
 
     const tool = tunnelShowTool(iface) orelse return "up, no tool";
     const show = sys.exec(allocator, &.{ tool, "show", iface }) catch return "up, show failed";
@@ -294,6 +296,12 @@ fn deleteTunnelPoolMember(allocator: std.mem.Allocator, iface: []const u8) !Tunn
         try doc.save(INSTALL_DIR ++ "/config.toml");
     }
 
+    if (removed_last) {
+        sys.execSilent(allocator, &.{ "ip", "-4", "route", "replace", "blackhole", "default", "table", "200" });
+    } else {
+        refreshTunnelPoolRuntime(allocator);
+    }
+
     // Only bring the interface down when no config behind it is somebody else's. An
     // adopted interface was up before mtbuddy touched it and is theirs to run; the pool
     // entry is gone either way, so nothing of ours routes through it any more.
@@ -302,10 +310,8 @@ fn deleteTunnelPoolMember(allocator: std.mem.Allocator, iface: []const u8) !Tunn
 
     if (removed_last) {
         disableTunnelPoolRuntime(allocator);
-        release.writeServiceFile();
+        try release.writeServiceFile();
         _ = sys.exec(allocator, &.{ "systemctl", "daemon-reload" }) catch null;
-    } else {
-        refreshTunnelPoolRuntime(allocator);
     }
 
     _ = sys.exec(allocator, &.{ "systemctl", "restart", "mtproto-proxy" }) catch null;
@@ -398,6 +404,7 @@ fn disableTunnelPoolRuntime(allocator: std.mem.Allocator) void {
     sys.execSilent(allocator, &.{ "systemctl", "disable", "--now", "mtproto-tunnel-pool.timer" });
     sys.execSilent(allocator, &.{ "systemctl", "stop", "mtproto-tunnel-pool.service" });
     sys.execSilent(allocator, &.{ "sh", "-c", "while ip -4 rule del priority 1200 fwmark 200 table 200 2>/dev/null; do :; done; while ip -4 rule del fwmark 200 table 200 2>/dev/null; do :; done; ip -4 route flush table 200 2>/dev/null || true" });
+    sys.execSilent(allocator, &.{ "sh", "-c", "while ip -6 rule del fwmark 200 table 200 2>/dev/null; do :; done; ip -6 route flush table 200 2>/dev/null || true" });
     sys.execSilent(allocator, &.{ "rm", "-f", TUNNEL_SCRIPT, TUNNEL_POOL_STATE, TUNNEL_POOL_SERVICE, TUNNEL_POOL_TIMER });
 }
 
@@ -525,50 +532,6 @@ fn clearTunnelConfigInDoc(doc: *toml.TomlDoc) !void {
     try doc.set("upstream.tunnel", "interface", "\"\"");
     try doc.set("upstream.tunnel", "interfaces", "[]");
     try doc.set("upstream.tunnel", "pinned_interface", "\"\"");
-}
-
-fn nextAwgInterfaceNameFromPool(allocator: std.mem.Allocator, used: []const []const u8) ![]const u8 {
-    var i: usize = 0;
-    while (i < 64) : (i += 1) {
-        var buf: [16]u8 = undefined;
-        const candidate = try std.fmt.bufPrint(&buf, "awg{d}", .{i});
-        if (!tunnel_wg.containsInterface(used, candidate)) return try allocator.dupe(u8, candidate);
-    }
-    return error.NoFreeInterface;
-}
-
-/// Strip legacy netns listen directives (e.g. `listen 10.200.200.1:8443 ssl;`)
-/// from the nginx masking config. Returns true if any lines were removed.
-/// Detect the currently active tunnel by inspecting runtime state.
-/// Returns the `Tunnel.Tag` corresponding to the detected tunnel,
-/// or `.none` if no known tunnel is active.
-pub fn detectActiveTunnel(allocator: std.mem.Allocator) Tunnel.Tag {
-    const route_result = sys.exec(allocator, &.{ "ip", "-4", "route", "show", "table", "200", "default" }) catch null;
-    if (route_result) |r| {
-        defer r.deinit();
-        if (r.exit_code == 0 and std.mem.indexOf(u8, r.stdout, " dev ") != null) return .tunnel;
-    }
-
-    const awg_result = sys.exec(allocator, &.{ "awg", "show", "awg0" }) catch null;
-    if (awg_result) |r| {
-        defer r.deinit();
-        if (r.exit_code == 0) return .tunnel;
-    }
-
-    const wg_result = sys.exec(allocator, &.{ "wg", "show", "wg0" }) catch null;
-    if (wg_result) |r| {
-        defer r.deinit();
-        if (r.exit_code == 0) return .tunnel;
-    }
-
-    return .none;
-}
-
-test "tunnel pool - next awg interface skips used names" {
-    const used = [_][]const u8{ "awg0", "awg1" };
-    const next = try nextAwgInterfaceNameFromPool(std.testing.allocator, &used);
-    defer std.testing.allocator.free(next);
-    try std.testing.expectEqualStrings("awg2", next);
 }
 
 test "tunnel pool - append interface avoids duplicates" {

--- a/src/ctl/tunnel_singbox.zig
+++ b/src/ctl/tunnel_singbox.zig
@@ -49,6 +49,8 @@ const INSTALL_DIR = "/opt/mtproto-proxy";
 const CONFIG_PATH = INSTALL_DIR ++ "/config.toml";
 const SB_CONFIG_DIR = "/etc/mtproto-proxy";
 const SB_CONFIG_PATH = SB_CONFIG_DIR ++ "/singbox-egress.json";
+/// Where a generated config waits while `sing-box check` judges it — see setupSingboxTunnel.
+const SB_CANDIDATE_PATH = SB_CONFIG_PATH ++ ".new";
 const SB_SERVICE_NAME = "mtproto-singbox-egress.service";
 const SB_SERVICE_PATH = "/etc/systemd/system/" ++ SB_SERVICE_NAME;
 const SB_ROUTE_SCRIPT = "/usr/local/bin/mtproto-singbox-route.sh";
@@ -137,13 +139,73 @@ const PROXY_EGRESS_DROPIN = "[Unit]\nAfter=" ++ SB_SERVICE_NAME ++ "\nWants=" ++
 const TUN_TABLE = "200"; // same policy-routing table the AmneziaWG tunnel uses
 const TUN_FWMARK = "200"; // proxy SO_MARK for tunnel egress
 
+/// Policy-routing helper: the sing-box unit runs it after start (`ExecStartPost`) and,
+/// with `down`, after stop (`ExecStopPost`).
+///
+/// It fails CLOSED, and that is the whole point of the blackhole. A policy rule that
+/// matches but resolves nothing does NOT drop the packet — the kernel walks on to the next
+/// rule — so an EMPTY table 200 sends the proxy's SO_MARK'd DC sockets out of the host's
+/// real uplink: the origin the egress exists to hide, leaked with no log line, no metric
+/// and no user-visible symptom. sbx0's route is `dev`-bound, so the kernel purges it the
+/// instant sing-box stops or crashes. The blackhole is therefore installed BEFORE we wait
+/// for the tun and restored when the unit stops; `ip route replace default dev sbx0`
+/// simply overwrites it while the tun is up. The AmneziaWG pool script fails closed the
+/// same way (tunnel_wg.zig, "Fail CLOSED").
+const SB_ROUTE_SCRIPT_BODY = "#!/bin/bash\n" ++
+    "blackhole() {\n" ++
+    "    ip route replace blackhole default table " ++ TUN_TABLE ++ " 2>/dev/null || true\n" ++
+    "    ip -6 route replace blackhole default table " ++ TUN_TABLE ++ " 2>/dev/null || true\n" ++
+    "}\n" ++
+    // `down` only restores the blackhole: re-adding the rule on every stop would stack
+    // duplicate `fwmark 200 lookup 200` entries for the life of the boot.
+    "if [ \"${1:-up}\" = \"down\" ]; then blackhole; exit 0; fi\n" ++
+    "for family in -4 -6; do\n" ++
+    "  while ip $family rule del fwmark " ++ TUN_FWMARK ++ " lookup " ++ TUN_TABLE ++ " 2>/dev/null; do :; done\n" ++
+    "  ip $family rule add fwmark " ++ TUN_FWMARK ++ " lookup " ++ TUN_TABLE ++ " || exit 1\n" ++
+    "done\n" ++
+    "blackhole\n" ++
+    "for i in $(seq 1 60); do ip link show " ++ TUN_IFACE ++ " >/dev/null 2>&1 && break; sleep 0.25; done\n" ++
+    "ip link show " ++ TUN_IFACE ++ " >/dev/null 2>&1 || { echo 'mtproto egress: " ++ TUN_IFACE ++ " never appeared (sing-box failed to start the tun?)' >&2; exit 1; }\n" ++
+    "ip route replace default dev " ++ TUN_IFACE ++ " table " ++ TUN_TABLE ++ "\n";
+
+/// The sing-box unit. Rendered rather than a const because ExecStart names the binary we
+/// actually found; `refreshFailClosedRouting` re-renders it to add the ExecStopPost that a
+/// pre-fail-closed host is missing.
+fn renderEgressUnit(a: std.mem.Allocator, sb_bin: []const u8) ![]const u8 {
+    if (!std.fs.path.isAbsolute(sb_bin)) return error.InvalidBinaryPath;
+    return std.fmt.allocPrint(a,
+        \\[Unit]
+        \\Description=mtproto-proxy sing-box tunnel egress
+        \\After=network-online.target
+        \\Wants=network-online.target
+        \\
+        \\[Service]
+        \\ExecStart={s} run -c {s}
+        \\ExecStartPost=+{s}
+        \\ExecStopPost=+{s} down
+        \\Restart=on-failure
+        \\RestartSec=3
+        \\AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW
+        \\
+        \\[Install]
+        \\WantedBy=multi-user.target
+        \\
+    , .{ sb_bin, SB_CONFIG_PATH, SB_ROUTE_SCRIPT, SB_ROUTE_SCRIPT });
+}
+
+fn sleepSeconds(seconds: u64) void {
+    const req: std.posix.timespec = .{ .sec = @intCast(seconds), .nsec = 0 };
+    _ = std.os.linux.nanosleep(&req, null);
+}
+
 // ── Xray client config generation ───────────────────────────────────────────────
 
 /// JSON-escape + quote a string (returns including the surrounding quotes). Control
 /// characters below 0x20 are emitted as \u00XX — a raw control byte (reachable via a
 /// percent-decoded link field) would otherwise produce JSON sing-box rejects.
-fn js(a: std.mem.Allocator, s: []const u8) []const u8 {
-    var buf = a.alloc(u8, s.len * 6 + 2) catch return "\"\"";
+fn js(a: std.mem.Allocator, s: []const u8) ![]const u8 {
+    if (!std.unicode.utf8ValidateSlice(s)) return error.InvalidUtf8;
+    var buf = try a.alloc(u8, s.len * 6 + 2);
     var w: usize = 0;
     buf[w] = '"';
     w += 1;
@@ -188,13 +250,26 @@ fn js(a: std.mem.Allocator, s: []const u8) []const u8 {
     return buf[0..w];
 }
 
+test "egress generation rejects missing links and invalid JSON text" {
+    try std.testing.expectError(error.NoLinks, genSingboxConfig(std.testing.allocator, &.{}));
+    try std.testing.expectError(error.InvalidUtf8, js(std.testing.allocator, "\xff"));
+}
+
+test "endpoint comparison distinguishes port prefixes" {
+    try std.testing.expect(!sameEgressEndpoints("{\"server\":\"host\",\"server_port\":44,\"uuid\":\"x\"}", "{\"server\":\"host\",\"server_port\":443,\"uuid\":\"x\"}"));
+}
+
 fn sbTls(a: std.mem.Allocator, l: XrayLink) ![]const u8 {
     const sni = l.sni orelse l.host orelse l.address;
     const fp = l.fingerprint orelse "chrome";
     if (std.mem.eql(u8, l.security, "reality")) {
-        return std.fmt.allocPrint(a, ",\"tls\":{{\"enabled\":true,\"server_name\":{s},\"utls\":{{\"enabled\":true,\"fingerprint\":{s}}},\"reality\":{{\"enabled\":true,\"public_key\":{s},\"short_id\":{s}}}}}", .{ js(a, sni), js(a, fp), js(a, l.public_key orelse ""), js(a, l.short_id orelse "") });
+        return std.fmt.allocPrint(a, ",\"tls\":{{\"enabled\":true,\"server_name\":{s},\"utls\":{{\"enabled\":true,\"fingerprint\":{s}}},\"reality\":{{\"enabled\":true,\"public_key\":{s},\"short_id\":{s}}}}}", .{ try js(a, sni), try js(a, fp), try js(a, l.public_key orelse ""), try js(a, l.short_id orelse "") });
     } else if (std.mem.eql(u8, l.security, "tls")) {
-        return std.fmt.allocPrint(a, ",\"tls\":{{\"enabled\":true,\"server_name\":{s},\"utls\":{{\"enabled\":true,\"fingerprint\":{s}}}}}", .{ js(a, sni), js(a, fp) });
+        // `allowInsecure=1` rides through as sing-box's `insecure`, and ONLY when the link
+        // asked for it. Dropped, a self-signed 3x-ui endpoint got an outbound that verifies
+        // strictly: `sing-box check` passes, the unit starts, and every dial dies on x509.
+        const insecure = if (l.insecure) ",\"insecure\":true" else "";
+        return std.fmt.allocPrint(a, ",\"tls\":{{\"enabled\":true,\"server_name\":{s}{s},\"utls\":{{\"enabled\":true,\"fingerprint\":{s}}}}}", .{ try js(a, sni), insecure, try js(a, fp) });
     }
     return "";
 }
@@ -213,16 +288,16 @@ fn sbTlsHy2(a: std.mem.Allocator, l: XrayLink) ![]const u8 {
     return std.fmt.allocPrint(
         a,
         ",\"tls\":{{\"enabled\":true,\"server_name\":{s},\"insecure\":{s}}}",
-        .{ js(a, sni), if (l.insecure) "true" else "false" },
+        .{ try js(a, sni), if (l.insecure) "true" else "false" },
     );
 }
 
 fn sbTransport(a: std.mem.Allocator, l: XrayLink) ![]const u8 {
     const sni = l.sni orelse l.host orelse l.address;
     if (std.mem.eql(u8, l.network, "ws")) {
-        return std.fmt.allocPrint(a, ",\"transport\":{{\"type\":\"ws\",\"path\":{s},\"headers\":{{\"Host\":{s}}}}}", .{ js(a, l.path orelse "/"), js(a, l.host orelse sni) });
+        return std.fmt.allocPrint(a, ",\"transport\":{{\"type\":\"ws\",\"path\":{s},\"headers\":{{\"Host\":{s}}}}}", .{ try js(a, l.path orelse "/"), try js(a, l.host orelse sni) });
     } else if (std.mem.eql(u8, l.network, "grpc")) {
-        return std.fmt.allocPrint(a, ",\"transport\":{{\"type\":\"grpc\",\"service_name\":{s}}}", .{js(a, l.path orelse "")});
+        return std.fmt.allocPrint(a, ",\"transport\":{{\"type\":\"grpc\",\"service_name\":{s}}}", .{try js(a, l.path orelse "")});
     }
     return "";
 }
@@ -230,25 +305,26 @@ fn sbTransport(a: std.mem.Allocator, l: XrayLink) ![]const u8 {
 fn sbOutbound(a: std.mem.Allocator, l: XrayLink, tag: []const u8) ![]const u8 {
     // The Xray-family TLS/transport blocks. The hysteria2 arm below uses neither — it
     // builds its own TLS and has no transport concept.
-    const tls = try sbTls(a, l);
-    const tr = try sbTransport(a, l);
+    const uses_xray_transport = l.scheme == .vless or l.scheme == .vmess or l.scheme == .trojan;
+    const tls = if (uses_xray_transport) try sbTls(a, l) else "";
+    const tr = if (uses_xray_transport) try sbTransport(a, l) else "";
     return switch (l.scheme) {
         .vless => blk: {
-            const flow = if (l.flow) |f| try std.fmt.allocPrint(a, ",\"flow\":{s}", .{js(a, f)}) else "";
-            break :blk std.fmt.allocPrint(a, "{{\"type\":\"vless\",\"tag\":{s},\"server\":{s},\"server_port\":{d},\"uuid\":{s}{s}{s}{s}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.id.?), flow, tls, tr });
+            const flow = if (l.flow) |f| try std.fmt.allocPrint(a, ",\"flow\":{s}", .{try js(a, f)}) else "";
+            break :blk std.fmt.allocPrint(a, "{{\"type\":\"vless\",\"tag\":{s},\"server\":{s},\"server_port\":{d},\"uuid\":{s}{s}{s}{s}}}", .{ try js(a, tag), try js(a, l.address), l.port, try js(a, l.id.?), flow, tls, tr });
         },
-        .vmess => std.fmt.allocPrint(a, "{{\"type\":\"vmess\",\"tag\":{s},\"server\":{s},\"server_port\":{d},\"uuid\":{s},\"alter_id\":{d},\"security\":{s}{s}{s}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.id.?), l.alter_id, js(a, l.cipher), tls, tr }),
-        .trojan => std.fmt.allocPrint(a, "{{\"type\":\"trojan\",\"tag\":{s},\"server\":{s},\"server_port\":{d},\"password\":{s}{s}{s}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.password.?), tls, tr }),
-        .shadowsocks => std.fmt.allocPrint(a, "{{\"type\":\"shadowsocks\",\"tag\":{s},\"server\":{s},\"server_port\":{d},\"method\":{s},\"password\":{s}}}", .{ js(a, tag), js(a, l.address), l.port, js(a, l.method.?), js(a, l.password.?) }),
+        .vmess => std.fmt.allocPrint(a, "{{\"type\":\"vmess\",\"tag\":{s},\"server\":{s},\"server_port\":{d},\"uuid\":{s},\"alter_id\":{d},\"security\":{s}{s}{s}}}", .{ try js(a, tag), try js(a, l.address), l.port, try js(a, l.id.?), l.alter_id, try js(a, l.cipher), tls, tr }),
+        .trojan => std.fmt.allocPrint(a, "{{\"type\":\"trojan\",\"tag\":{s},\"server\":{s},\"server_port\":{d},\"password\":{s}{s}{s}}}", .{ try js(a, tag), try js(a, l.address), l.port, try js(a, l.password.?), tls, tr }),
+        .shadowsocks => std.fmt.allocPrint(a, "{{\"type\":\"shadowsocks\",\"tag\":{s},\"server\":{s},\"server_port\":{d},\"method\":{s},\"password\":{s}}}", .{ try js(a, tag), try js(a, l.address), l.port, try js(a, l.method.?), try js(a, l.password.?) }),
         .hysteria2 => blk: {
             // No `tr`: hysteria2 is QUIC end to end, it has no ws/grpc transport to carry.
             const hy_tls = try sbTlsHy2(a, l);
-            const pw = if (l.password) |p| try std.fmt.allocPrint(a, ",\"password\":{s}", .{js(a, p)}) else "";
+            const pw = if (l.password) |p| try std.fmt.allocPrint(a, ",\"password\":{s}", .{try js(a, p)}) else "";
             const obfs = if (l.obfs) |o|
-                try std.fmt.allocPrint(a, ",\"obfs\":{{\"type\":{s},\"password\":{s}}}", .{ js(a, o), js(a, l.obfs_password orelse "") })
+                try std.fmt.allocPrint(a, ",\"obfs\":{{\"type\":{s},\"password\":{s}}}", .{ try js(a, o), try js(a, l.obfs_password orelse "") })
             else
                 "";
-            break :blk std.fmt.allocPrint(a, "{{\"type\":\"hysteria2\",\"tag\":{s},\"server\":{s},\"server_port\":{d}{s}{s}{s}}}", .{ js(a, tag), js(a, l.address), l.port, pw, obfs, hy_tls });
+            break :blk std.fmt.allocPrint(a, "{{\"type\":\"hysteria2\",\"tag\":{s},\"server\":{s},\"server_port\":{d}{s}{s}{s}}}", .{ try js(a, tag), try js(a, l.address), l.port, pw, obfs, hy_tls });
         },
         else => error.UnsupportedScheme,
     };
@@ -259,6 +335,7 @@ fn sbOutbound(a: std.mem.Allocator, l: XrayLink, tag: []const u8) ![]const u8 {
 /// one outbound per link. >1 link adds a `urltest` selector (health-based failover — the
 /// analogue of the tunnel pool). VLESS-Reality camouflages the egress hop as real TLS.
 pub fn genSingboxConfig(a: std.mem.Allocator, links: []const XrayLink) ![]const u8 {
+    if (links.len == 0) return error.NoLinks;
     var outs: std.ArrayListUnmanaged(u8) = .empty;
     for (links, 0..) |l, i| {
         const tag = try std.fmt.allocPrint(a, "egress-{d}", .{i});
@@ -273,7 +350,7 @@ pub fn genSingboxConfig(a: std.mem.Allocator, links: []const XrayLink) ![]const 
             if (i != 0) try tags.append(a, ',');
             try tags.appendSlice(a, try std.fmt.allocPrint(a, "\"egress-{d}\"", .{i}));
         }
-        selector = try std.fmt.allocPrint(a, ",{{\"type\":\"urltest\",\"tag\":\"egress\",\"outbounds\":[{s}],\"url\":\"https://www.gstatic.com/generate_204\",\"interval\":\"10s\"}}", .{tags.items});
+        selector = try std.fmt.allocPrint(a, ",{{\"type\":\"urltest\",\"tag\":\"egress\",\"outbounds\":[{s}],\"url\":\"https://www.gstatic.com/generate_204\",\"interval\":\"60s\",\"tolerance\":50}}", .{tags.items});
         final_tag = "egress";
     }
     return std.fmt.allocPrint(a, "{{\"log\":{{\"level\":\"warn\"}},\"inbounds\":[{{\"type\":\"tun\",\"tag\":\"tun-in\",\"interface_name\":\"{s}\",\"address\":[\"{s}\"],\"auto_route\":false,\"stack\":\"{s}\",\"mtu\":{s}}}],\"outbounds\":[{s},{{\"type\":\"direct\",\"tag\":\"direct\"}}{s}],\"route\":{{\"auto_detect_interface\":true,\"final\":\"{s}\"}}}}", .{ TUN_IFACE, TUN_ADDR, TUN_STACK, TUN_MTU, outs.items, selector, final_tag });
@@ -291,6 +368,13 @@ fn dispatchLinks(ui: *Tui, allocator: std.mem.Allocator, link_list: []const []co
     // One egress = one provider family. Reject a mix of wireguard:// and Xray links.
     const fam0 = schemeFamily(detectScheme(link_list[0]));
     for (link_list) |l| {
+        // Before anything else: the pasted text is recorded verbatim in the root-owned
+        // config.toml (`[upstream.xray] links`), so a newline in it injects TOML the proxy
+        // then honours — e.g. an extra [access.users] entry. See sharelink.linkTextIsSafe.
+        if (!sharelink.linkTextIsSafe(l)) {
+            ui.fail("Refusing a share-link containing a newline, control byte or quote — it would inject config into config.toml");
+            return;
+        }
         const s = detectScheme(l);
         if (s == .unknown) {
             ui.fail("Unrecognized share-link scheme (want vless/vmess/trojan/ss/hysteria2/wireguard)");
@@ -316,7 +400,11 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
             deps_only = true;
             continue;
         }
-        if (arg.len > 0 and arg[0] != '-') links.append(allocator, arg) catch {};
+        if (arg.len > 0 and arg[0] != '-') {
+            try links.append(allocator, arg);
+        } else {
+            return error.UnknownOption;
+        }
     }
     if (deps_only) {
         ui.step("Checking sing-box dependency...");
@@ -400,14 +488,16 @@ fn setupWireguard(ui: *Tui, allocator: std.mem.Allocator, links: []const []const
         // so a predictable /tmp/mtbuddy-wg-<idx>.conf let a local user pre-create a symlink
         // and have root's write land on an arbitrary file (CWE-59 overwrite-as-root). /etc
         // and /etc/amnezia are root-owned, so no unprivileged user can plant a symlink here.
-        _ = sys.exec(allocator, &.{ "mkdir", "-p", "/etc/amnezia" }) catch {};
+        try std.Io.Dir.cwd().createDirPath(std.Io.Threaded.global_single_threaded.io(), "/etc/amnezia");
         const tmp = try std.fmt.allocPrint(a, "/etc/amnezia/.mtbuddy-stage-{d}.conf", .{idx});
         sys.writeFileMode(tmp, conf, 0o600) catch {
             ui.fail("Failed to stage the WireGuard config");
             return;
         };
+        defer std.Io.Dir.deleteFileAbsolute(std.Io.Threaded.global_single_threaded.io(), tmp) catch {
+            ui.warn("Failed to remove staged WireGuard credentials");
+        };
         try tunnel_wg.setupFromConf(ui, allocator, tmp);
-        _ = sys.exec(allocator, &.{ "rm", "-f", tmp }) catch {};
     }
 }
 
@@ -428,6 +518,10 @@ fn setupSingboxTunnel(ui: *Tui, allocator: std.mem.Allocator, link_texts: []cons
             return;
         }
         ui.stepOk("Parsed egress", parsed[i].address);
+        if (parsed[i].insecure) {
+            // Faithful to the link, but never silent: the egress hop is then unauthenticated.
+            ui.warn("Certificate verification is DISABLED for this endpoint (the link carries allowInsecure=1)");
+        }
     }
 
     // A sing-box tunnel and the AmneziaWG tunnel pool both own fwmark 200 / table 200 —
@@ -442,64 +536,77 @@ fn setupSingboxTunnel(ui: *Tui, allocator: std.mem.Allocator, link_texts: []cons
     }
 
     if (!ensureSingboxInstalled(ui, allocator)) return;
-    const sb_bin: []const u8 = if (sys.fileExists(SB_BIN)) SB_BIN else "sing-box";
+    const sb_bin = resolveSingboxBinary(allocator) catch {
+        ui.fail("Unable to resolve an absolute sing-box executable path");
+        return;
+    };
+    defer allocator.free(sb_bin);
 
     const cfg = genSingboxConfig(a, parsed) catch {
         ui.fail("Failed to generate sing-box config");
         return;
     };
-    _ = sys.exec(allocator, &.{ "mkdir", "-p", SB_CONFIG_DIR }) catch {};
-    sys.writeFileMode(SB_CONFIG_PATH, cfg, 0o600) catch {
-        ui.fail("Failed to write " ++ SB_CONFIG_PATH);
+    try std.Io.Dir.cwd().createDirPath(std.Io.Threaded.global_single_threaded.io(), SB_CONFIG_DIR);
+
+    // Check the CANDIDATE, then rename it into place. Writing first and checking after
+    // destroyed a working config the moment this sing-box rejected the new one: the
+    // running egress kept serving from memory, so nothing looked broken until the next
+    // reboot, when the unit failed, sbx0 never appeared and table 200 stayed empty.
+    sys.writeFileMode(SB_CANDIDATE_PATH, cfg, 0o600) catch {
+        ui.fail("Failed to write " ++ SB_CANDIDATE_PATH);
         return;
     };
+    if (!singboxConfigLoads(allocator, sb_bin, SB_CANDIDATE_PATH)) {
+        ui.fail("The installed sing-box rejects the generated config — the egress was NOT started");
+        ui.info("The rejected config is at " ++ SB_CANDIDATE_PATH ++ " (the running one is untouched); run it through `sing-box check -c` for the reason. An outbound type this build does not know (hysteria2 needs sing-box 1.5.0+) rejects the whole file, including the other endpoints in a pool.");
+        return;
+    }
+    var installed_config = false;
+    if (sys.exec(allocator, &.{ "mv", "-f", SB_CANDIDATE_PATH, SB_CONFIG_PATH })) |r| {
+        defer r.deinit();
+        installed_config = r.exit_code == 0;
+    } else |_| {}
+    if (!installed_config) {
+        ui.fail("Failed to install " ++ SB_CONFIG_PATH);
+        return;
+    }
 
-    // Policy-routing helper: wait for the tun, then route the proxy's SO_MARK'd egress
-    // (fwmark 200 → table 200 → sbx0) — the same mechanism the AmneziaWG tunnel uses.
-    const route_script = "#!/bin/bash\n" ++
-        "for i in $(seq 1 60); do ip link show " ++ TUN_IFACE ++ " >/dev/null 2>&1 && break; sleep 0.25; done\n" ++
-        "ip link show " ++ TUN_IFACE ++ " >/dev/null 2>&1 || { echo 'mtproto egress: " ++ TUN_IFACE ++ " never appeared (sing-box failed to start the tun?)' >&2; exit 1; }\n" ++
-        "ip rule add fwmark " ++ TUN_FWMARK ++ " lookup " ++ TUN_TABLE ++ " 2>/dev/null || true\n" ++
-        "ip route replace default dev " ++ TUN_IFACE ++ " table " ++ TUN_TABLE ++ "\n";
-    sys.writeFileMode(SB_ROUTE_SCRIPT, route_script, 0o755) catch {
+    sys.writeFileMode(SB_ROUTE_SCRIPT, SB_ROUTE_SCRIPT_BODY, 0o755) catch {
         ui.fail("Failed to write the routing helper");
         return;
     };
 
-    const unit = try std.fmt.allocPrint(a,
-        \\[Unit]
-        \\Description=mtproto-proxy sing-box tunnel egress
-        \\After=network-online.target
-        \\Wants=network-online.target
-        \\
-        \\[Service]
-        \\ExecStart={s} run -c {s}
-        \\ExecStartPost=+{s}
-        \\Restart=on-failure
-        \\RestartSec=3
-        \\AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW
-        \\
-        \\[Install]
-        \\WantedBy=multi-user.target
-        \\
-    , .{ sb_bin, SB_CONFIG_PATH, SB_ROUTE_SCRIPT });
+    const unit = try renderEgressUnit(a, sb_bin);
     sys.writeFile(SB_SERVICE_PATH, unit) catch {
         ui.fail("Failed to write the systemd unit");
         return;
     };
-    if (!singboxConfigLoads(allocator, sb_bin, SB_CONFIG_PATH)) {
-        ui.fail("The installed sing-box rejects the generated config — the egress was NOT started");
-        ui.info("Run `" ++ SB_CONFIG_PATH ++ "` through `sing-box check -c` for the reason. An outbound type this build does not know (hysteria2 needs sing-box 1.5.0+) rejects the whole file, including the other endpoints in a pool.");
+    _ = sys.exec(allocator, &.{ "systemctl", "daemon-reload" }) catch {};
+    var start_ok = false;
+    if (sys.exec(allocator, &.{ "systemctl", "enable", "--now", SB_SERVICE_NAME })) |r| {
+        defer r.deinit();
+        start_ok = r.exit_code == 0;
+    } else |_| {}
+    if (!start_ok or !egressTunIsUp(allocator)) {
+        // Never rewire the proxy onto an egress that did not come up: `sing-box check`
+        // validates the config's SHAPE only, and the run reported "egress up" while every
+        // DC connection failed.
+        ui.fail("sing-box egress did not come up — the proxy was NOT rewired to it");
+        ui.hint("journalctl -u " ++ SB_SERVICE_NAME ++ " -n 50 --no-pager");
+        ui.info("Usual causes: no /dev/net/tun (LXC/OpenVZ container), no CAP_NET_ADMIN, or an option sing-box only validates at Start().");
         return;
     }
-    _ = sys.exec(allocator, &.{ "systemctl", "daemon-reload" }) catch {};
-    _ = sys.exec(allocator, &.{ "systemctl", "enable", "--now", SB_SERVICE_NAME }) catch {};
     ui.ok("sing-box tunnel egress up (tun " ++ TUN_IFACE ++ ")");
+    ui.info(trL(
+        ui,
+        "If the egress ever stops, marked traffic is dropped, not sent out the host's real IP — DC connections fail loudly instead of silently leaking the origin.",
+        "Если egress остановится, помеченный трафик будет отброшен, а не выпущен через реальный IP хоста — соединения с DC упадут, но origin не утечёт.",
+    ));
 
     if (sys.fileExists(CONFIG_PATH)) {
         // Order mtproto-proxy after the egress so sbx0 + its route exist before the proxy
         // marks DC sockets — otherwise a reboot races and DC connects fail until retry.
-        _ = sys.exec(allocator, &.{ "mkdir", "-p", PROXY_DROPIN_DIR }) catch {};
+        try std.Io.Dir.cwd().createDirPath(std.Io.Threaded.global_single_threaded.io(), PROXY_DROPIN_DIR);
         sys.writeFile(PROXY_DROPIN_PATH, PROXY_EGRESS_DROPIN) catch {};
         _ = sys.exec(allocator, &.{ "systemctl", "daemon-reload" }) catch {};
         wireUpstreamTunnel(allocator, link_texts) catch {
@@ -507,11 +614,35 @@ fn setupSingboxTunnel(ui: *Tui, allocator: std.mem.Allocator, link_texts: []cons
             return;
         };
         _ = sys.exec(allocator, &.{ "systemctl", "restart", "mtproto-proxy" }) catch {};
-        ui.ok("upstream set to tunnel via " ++ TUN_IFACE ++ "; mtproto-proxy restarted");
+        if (sys.isServiceActive("mtproto-proxy")) {
+            ui.ok("upstream set to tunnel via " ++ TUN_IFACE ++ "; mtproto-proxy restarted");
+        } else {
+            ui.fail("config.toml was updated but mtproto-proxy did not come back");
+            ui.hint("journalctl -u mtproto-proxy -n 30 --no-pager");
+        }
         warnMiddleProxyOverTun(ui, allocator);
     } else {
         ui.warn("mtproto-proxy not installed here — the sing-box tunnel is up on " ++ TUN_IFACE ++ "; set [upstream] type=tunnel, [upstream.tunnel] interface=" ++ TUN_IFACE);
     }
+}
+
+/// Did the egress actually come up? A zero exit from `enable --now` does not say so: the
+/// unit is Type=simple, so systemd is satisfied once sing-box has been exec'd and its
+/// ExecStartPost returned, and a sing-box that dies at Start() (no /dev/net/tun in an LXC
+/// container, an option only validated at Start()) leaves a fully green run over a proxy
+/// about to be rewired onto an egress that does not exist. Ask the two questions that do
+/// answer it — the unit is still active, and sbx0 is present — with a few seconds of grace
+/// for a process that exits a moment after being started.
+fn egressTunIsUp(allocator: std.mem.Allocator) bool {
+    var attempt: usize = 0;
+    while (attempt < 5) : (attempt += 1) {
+        if (attempt > 0) sleepSeconds(1);
+        if (!sys.isServiceActive(SB_SERVICE_NAME)) continue;
+        const r = sys.exec(allocator, &.{ "ip", "link", "show", TUN_IFACE }) catch continue;
+        defer r.deinit();
+        if (r.exit_code == 0) return true;
+    }
+    return false;
 }
 
 /// A sing-box TUN egress and MiddleProxy do not work together, and the failure is silent
@@ -556,12 +687,12 @@ fn warnMiddleProxyOverTun(ui: *Tui, allocator: std.mem.Allocator) void {
 fn wireUpstreamTunnel(allocator: std.mem.Allocator, link_texts: []const []const u8) !void {
     var doc = try toml.TomlDoc.load(allocator, CONFIG_PATH);
     defer doc.deinit();
-    try doc.set("upstream", "type", "tunnel");
+    try doc.setString("upstream", "type", "tunnel");
     // Point both the plural pool list (which the proxy reads first) and the singular key
     // at sbx0, and clear any pinned awg interface, so no stale awg name shadows sbx0.
     try doc.set("upstream.tunnel", "interfaces", "[\"" ++ TUN_IFACE ++ "\"]");
-    try doc.set("upstream.tunnel", "pinned_interface", "");
-    try doc.set("upstream.tunnel", "interface", TUN_IFACE);
+    try doc.setString("upstream.tunnel", "pinned_interface", "");
+    try doc.setString("upstream.tunnel", "interface", TUN_IFACE);
     // Persist the links so a reinstall reproduces the egress (config is 0600).
     var arr: std.ArrayListUnmanaged(u8) = .empty;
     defer arr.deinit(allocator);
@@ -608,7 +739,8 @@ fn egressEndpointAt(cfg: []const u8, start: usize) ?[]const u8 {
     var end = port_at + SB_PORT_KEY.len;
     while (end < cfg.len and std.ascii.isDigit(cfg[end])) end += 1;
     if (end == port_at + SB_PORT_KEY.len) return null;
-    return cfg[start..end];
+    if (end == cfg.len or (cfg[end] != ',' and cfg[end] != '}')) return null;
+    return cfg[start .. end + 1];
 }
 
 fn countEgressEndpoints(cfg: []const u8) usize {
@@ -685,7 +817,41 @@ fn egressManualHint(ui: *Tui) void {
 pub fn refreshEgress(ui: *Tui, allocator: std.mem.Allocator) void {
     if (!sys.fileExists(SB_SERVICE_PATH)) return;
     refreshProxyDropin(ui, allocator);
+    refreshFailClosedRouting(ui, allocator);
     refreshSingboxConfig(ui, allocator);
+}
+
+/// Repair an egress provisioned before the routing failed closed. Its helper only ever
+/// installed `default dev sbx0`, so the moment sing-box stopped, table 200 went empty, the
+/// fwmark rule fell through to `main` and every SO_MARK'd DC socket left via the host's
+/// real uplink. Both halves (the helper and the unit's ExecStopPost) take effect on the
+/// next start/stop, so nothing is restarted here.
+fn refreshFailClosedRouting(ui: *Tui, allocator: std.mem.Allocator) void {
+    const script = sys.readFileAllocAbsolute(allocator, SB_ROUTE_SCRIPT, 64 * 1024) orelse return;
+    defer allocator.free(script);
+    const unit = sys.readFileAllocAbsolute(allocator, SB_SERVICE_PATH, 64 * 1024) orelse return;
+    defer allocator.free(unit);
+
+    const script_current = std.mem.eql(u8, script, SB_ROUTE_SCRIPT_BODY);
+    const unit_current = std.mem.indexOf(u8, unit, "ExecStopPost=") != null;
+    if (script_current and unit_current) return;
+
+    if (!script_current) {
+        sys.writeFileMode(SB_ROUTE_SCRIPT, SB_ROUTE_SCRIPT_BODY, 0o755) catch return;
+    }
+    if (!unit_current) {
+        const sb_bin = resolveSingboxBinary(allocator) catch return;
+        defer allocator.free(sb_bin);
+        const rendered = renderEgressUnit(allocator, sb_bin) catch return;
+        defer allocator.free(rendered);
+        sys.writeFile(SB_SERVICE_PATH, rendered) catch return;
+        _ = sys.exec(allocator, &.{ "systemctl", "daemon-reload" }) catch {};
+    }
+    ui.ok(trL(
+        ui,
+        "egress routing now fails closed — a stopped tunnel drops marked traffic instead of leaking the host's real IP",
+        "маршрутизация egress теперь fail-closed — остановленный туннель отбрасывает помеченный трафик, а не выпускает его с реального IP хоста",
+    ));
 }
 
 /// Repairs an EXISTING drop-in only. A host whose egress predates this never had the
@@ -770,7 +936,10 @@ fn refreshSingboxConfig(ui: *Tui, allocator: std.mem.Allocator) void {
 
     // Keep the file we are about to replace. The endpoints match, so this should never be
     // needed — but it is one copy of the only on-disk record of a working egress.
-    _ = sys.exec(allocator, &.{ "cp", "-f", SB_CONFIG_PATH, SB_CONFIG_PATH ++ ".bak" }) catch {};
+    sys.writeFileMode(SB_CONFIG_PATH ++ ".bak", existing, 0o600) catch {
+        ui.warn("Failed to back up sing-box credentials; repair aborted");
+        return;
+    };
 
     sys.writeFileMode(SB_CONFIG_PATH, cfg, 0o600) catch {
         egressManualHint(ui);
@@ -778,9 +947,13 @@ fn refreshSingboxConfig(ui: *Tui, allocator: std.mem.Allocator) void {
     };
 
     // Never restart into a config this sing-box cannot load: put the old one back first.
-    const sb_bin: []const u8 = if (sys.fileExists(SB_BIN)) SB_BIN else "sing-box";
+    const sb_bin = resolveSingboxBinary(allocator) catch return;
+    defer allocator.free(sb_bin);
     if (!singboxConfigLoads(allocator, sb_bin, SB_CONFIG_PATH)) {
-        _ = sys.exec(allocator, &.{ "cp", "-f", SB_CONFIG_PATH ++ ".bak", SB_CONFIG_PATH }) catch {};
+        sys.writeFileMode(SB_CONFIG_PATH, existing, 0o600) catch {
+            ui.fail("Failed to restore sing-box config from backup");
+            return;
+        };
         ui.warn(trL(
             ui,
             "The installed sing-box rejects the repaired egress config — restored the previous one and left the egress running.",
@@ -793,6 +966,13 @@ fn refreshSingboxConfig(ui: *Tui, allocator: std.mem.Allocator) void {
     // `--now` is a no-op on a unit that is already running — which is exactly the host
     // this repair exists for.
     _ = sys.execForward(&.{ "systemctl", "restart", SB_SERVICE_NAME }) catch {};
+    if (!sys.isServiceActive(SB_SERVICE_NAME)) {
+        ui.fail("sing-box restart failed; the previous credentials remain in the .bak file for recovery");
+        return;
+    }
+    std.Io.Dir.deleteFileAbsolute(std.Io.Threaded.global_single_threaded.io(), SB_CONFIG_PATH ++ ".bak") catch {
+        ui.warn("Failed to remove the sing-box credentials backup");
+    };
     ui.ok(trL(
         ui,
         "sing-box egress tun repaired (" ++ TUN_ADDR ++ ", stack " ++ TUN_STACK ++ ", mtu " ++ TUN_MTU ++ ")",
@@ -828,8 +1008,17 @@ fn ensureSingboxInstalled(ui: *Tui, allocator: std.mem.Allocator) bool {
     return true;
 }
 
+fn resolveSingboxBinary(allocator: std.mem.Allocator) ![]u8 {
+    if (sys.fileExists(SB_BIN)) return allocator.dupe(u8, SB_BIN);
+    const result = try sys.exec(allocator, &.{ "sh", "-c", "command -v sing-box" });
+    defer result.deinit();
+    const path = std.mem.trim(u8, result.stdout, " \t\r\n");
+    if (result.exit_code != 0 or !std.fs.path.isAbsolute(path) or std.mem.indexOfAny(u8, path, " \t\r\n\"%") != null) return error.InvalidBinaryPath;
+    return allocator.dupe(u8, path);
+}
+
 /// Download + install the static sing-box binary for this arch. The release asset name
-/// carries the version, so resolve the latest tag from the API first. Private temp dir.
+/// and SHA-256 digest are pinned; extraction uses a private temporary directory.
 fn installSingbox(allocator: std.mem.Allocator) bool {
     const arch: []const u8 = switch (builtin.cpu.arch) {
         .x86_64 => "amd64",
@@ -840,21 +1029,12 @@ fn installSingbox(allocator: std.mem.Allocator) bool {
         _ = sys.exec(allocator, &.{ "env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "-o", "DPkg::Lock::Timeout=600", "update", "-qq" }) catch {};
         _ = sys.exec(allocator, &.{ "env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "install", "-y", "--no-install-recommends", "curl", "tar" }) catch {};
     }
-    const ver = blk: {
-        const r = sys.exec(allocator, &.{ "curl", "-fsSL", "--connect-timeout", "30", "https://api.github.com/repos/SagerNet/sing-box/releases/latest" }) catch return false;
-        defer r.deinit();
-        if (r.exit_code != 0) break :blk null;
-        // Tolerate whitespace + the optional leading 'v': `"tag_name": "v1.13.13"`.
-        const key = "\"tag_name\"";
-        const ki = std.mem.indexOf(u8, r.stdout, key) orelse break :blk null;
-        const after = r.stdout[ki + key.len ..];
-        const q1 = std.mem.indexOfScalar(u8, after, '"') orelse break :blk null;
-        var vstart = q1 + 1;
-        if (vstart < after.len and after[vstart] == 'v') vstart += 1;
-        const q2 = std.mem.indexOfScalarPos(u8, after, vstart, '"') orelse break :blk null;
-        break :blk allocator.dupe(u8, after[vstart..q2]) catch null;
-    } orelse return false;
-    defer allocator.free(ver);
+    // Official release asset digests: https://api.github.com/repos/SagerNet/sing-box/releases/tags/v1.13.13
+    const ver = "1.13.13";
+    const expected_sha256 = if (std.mem.eql(u8, arch, "amd64"))
+        "bb99cabf47694625db421ee17898f36cdc1f9c2cb5decf65b12bac8d8437e842"
+    else
+        "d7fab87b921933eb281d8ee7bd5377cdd8228089f1f7c807c9363a6a2329286c";
     const td = blk: {
         const r = sys.exec(allocator, &.{ "mktemp", "-d", "/tmp/mtbuddy-singbox.XXXXXX" }) catch return false;
         defer r.deinit();
@@ -877,15 +1057,19 @@ fn installSingbox(allocator: std.mem.Allocator) bool {
         if (r.exit_code != 0) return false;
     }
     {
+        const r = sys.exec(allocator, &.{ "sha256sum", tgz }) catch return false;
+        defer r.deinit();
+        if (r.exit_code != 0 or r.stdout.len < 64 or !std.mem.eql(u8, r.stdout[0..64], expected_sha256)) return false;
+    }
+    {
         const r = sys.exec(allocator, &.{ "tar", "xzf", tgz, "-C", td, "--no-same-owner" }) catch return false;
         defer r.deinit();
         if (r.exit_code != 0) return false;
     }
     const extracted = std.fmt.allocPrint(allocator, "{s}/sing-box-{s}-linux-{s}/sing-box", .{ td, ver, arch }) catch return false;
     defer allocator.free(extracted);
-    // Verify the downloaded artifact actually runs as sing-box before installing it. The
-    // transport is TLS (authenticity); this catches a corrupt/truncated download or a
-    // wrong-arch binary. sing-box publishes no checksums/signatures to verify against.
+    // The archive hash is pinned above and checked before extraction or execution.
+    // Verify that the authenticated binary also runs on this host.
     {
         const r = sys.exec(allocator, &.{ extracted, "version" }) catch return false;
         defer r.deinit();

--- a/src/ctl/tunnel_wg.zig
+++ b/src/ctl/tunnel_wg.zig
@@ -109,6 +109,7 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
     if (sys.fileExists("/etc/systemd/system/mtproto-singbox-egress.service")) {
         ui.warn("Retiring the existing sing-box egress — it can't share table 200 with a WG tunnel.");
         sys.execSilent(allocator, &.{ "systemctl", "disable", "--now", "mtproto-singbox-egress.service" });
+        sys.execSilent(allocator, &.{ "rm", "-f", "/etc/mtproto-proxy/singbox-egress.json.bak" });
         sys.execSilent(allocator, &.{ "rm", "-f", "/etc/systemd/system/mtproto-singbox-egress.service", "/etc/mtproto-proxy/singbox-egress.json", "/usr/local/bin/mtproto-singbox-route.sh", "/etc/systemd/system/mtproto-proxy.service.d/egress.conf" });
         sys.execSilent(allocator, &.{ "systemctl", "daemon-reload" });
     }
@@ -151,6 +152,10 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
     // Decided BEFORE the write, because the write is what makes the two paths
     // indistinguishable afterwards. See `sourceIsDestination`.
     const adopted_in_place = sourceIsDestination(awg_source, awg_config_path);
+    if (!adopted_in_place and sys.fileExists(awg_config_path) and !configIsOwned(allocator, awg_config_path)) {
+        ui.fail("Refusing to overwrite an existing tunnel config owned by the operator");
+        return;
+    }
 
     const config_kind = installAwgConfigSource(allocator, awg_source, awg_config_path) catch |err| {
         switch (err) {
@@ -248,8 +253,8 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
         \\ExecReload=/bin/kill -HUP $MAINPID
         \\KillSignal=SIGTERM
         \\TimeoutStopSec=25
-        \\Restart=on-failure
-        \\RestartSec=5
+        \\Restart=always
+        \\RestartSec=3
         \\
         \\# Security hardening — mirrors the default unit so tunnel mode does NOT
         \\# silently run the internet-facing proxy as unsandboxed root. CAP_NET_ADMIN
@@ -269,6 +274,14 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
         \\ProtectClock=yes
         \\ProtectHostname=yes
         \\ProtectKernelLogs=yes
+        \\SystemCallArchitectures=native
+        \\MemoryDenyWriteExecute=yes
+        \\RestrictNamespaces=yes
+        \\ProtectControlGroups=yes
+        \\ProtectKernelTunables=yes
+        \\ProtectProc=invisible
+        \\ProcSubset=pid
+        \\RemoveIPC=yes
         \\UMask=0077
         \\AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_ADMIN
         \\CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_ADMIN
@@ -290,7 +303,10 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
     installTunnelPoolUnits(ui, allocator);
 
     // ── Configure proxy egress mode ──
-    setTunnelPoolConfig(allocator, iface);
+    setTunnelPoolConfig(allocator, iface) catch {
+        ui.fail("Failed to save tunnel pool configuration");
+        return;
+    };
     ui.stepOk("Set [upstream].type", "tunnel");
     ui.stepOk("Added tunnel pool interface", iface);
     ui.stepOk("Preserved [general].use_middle_proxy", "unchanged");
@@ -369,7 +385,8 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: TunnelOpts) !void {
 
     _ = sys.execForward(&.{TUNNEL_SCRIPT}) catch {};
 
-    const awg_status = sys.exec(allocator, &.{ "awg", "show", iface }) catch null;
+    const show_tool = if (std.mem.startsWith(u8, iface, "wg") and sys.commandExists("wg")) "wg" else if (sys.commandExists("awg")) "awg" else "wg";
+    const awg_status = sys.exec(allocator, &.{ show_tool, "show", iface }) catch null;
     if (awg_status) |result| {
         defer result.deinit();
         if (result.exit_code == 0) {
@@ -423,19 +440,29 @@ fn installAwgConfigSource(allocator: std.mem.Allocator, source: []const u8, dest
     const trimmed = std.mem.trim(u8, source, &[_]u8{ ' ', '\t', '\r', '\n' });
     if (trimmed.len == 0) return error.ConfigSourceNotFound;
 
-    if (isAmneziaVpnLinkSource(trimmed)) {
-        try sys.writeFileMode(dest_path, trimmed, 0o600);
-    } else {
-        const content = readFileAllocCwd(allocator, trimmed, 1024 * 1024) catch |err| switch (err) {
+    const content = if (isAmneziaVpnLinkSource(trimmed))
+        try allocator.dupe(u8, trimmed)
+    else
+        readFileAllocCwd(allocator, trimmed, 1024 * 1024) catch |err| switch (err) {
             error.FileNotFound => return error.ConfigSourceNotFound,
             else => return err,
         };
-        defer allocator.free(content);
-
-        try sys.writeFileMode(dest_path, content, 0o600);
+    defer allocator.free(content);
+    const source_text = std.mem.trim(u8, content, " \t\r\n");
+    if (isAmneziaVpnLinkSource(source_text)) {
+        const converted = convertAmneziaVpnLink(allocator, source_text) catch |err| switch (err) {
+            error.AwgConfigNotFound => return error.AwgConfigNotFound,
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return error.InvalidAmneziaVpnLink,
+        };
+        defer allocator.free(converted);
+        try sys.writeFileMode(dest_path, converted, 0o600);
+        return .amnezia_vpn_link;
     }
-
-    return normalizeAwgConfig(allocator, dest_path);
+    if (!looksLikeAwgConfig(source_text)) return error.UnsupportedConfigFormat;
+    try validateImportedAwgConfig(source_text);
+    try sys.writeFileMode(dest_path, content, 0o600);
+    return .native_conf;
 }
 fn normalizeAwgConfig(allocator: std.mem.Allocator, path: []const u8) !AwgConfigKind {
     const content = try readFileAllocCwd(allocator, path, 1024 * 1024);
@@ -467,16 +494,15 @@ fn convertAmneziaVpnLink(allocator: std.mem.Allocator, link: []const u8) ![]u8 {
     };
     defer allocator.free(decoded);
     if (decoded.len <= 4) return error.InvalidAmneziaVpnLink;
+    if (std.mem.readInt(u32, decoded[0..4], .big) > 1024 * 1024) return error.InvalidAmneziaVpnLink;
 
     var compressed_reader: std.Io.Reader = .fixed(decoded[4..]);
-    var json_writer: std.Io.Writer.Allocating = .init(allocator);
-    defer json_writer.deinit();
-
     var decompress_buffer: [std.compress.flate.max_window_len]u8 = undefined;
     var decompressor: std.compress.flate.Decompress = .init(&compressed_reader, .zlib, &decompress_buffer);
-    _ = decompressor.reader.streamRemaining(&json_writer.writer) catch return error.InvalidAmneziaVpnLink;
+    const json_bytes = decompressor.reader.allocRemaining(allocator, .limited(1024 * 1024)) catch return error.InvalidAmneziaVpnLink;
+    defer allocator.free(json_bytes);
 
-    var parsed = std.json.parseFromSlice(std.json.Value, allocator, json_writer.written(), .{}) catch return error.InvalidAmneziaVpnLink;
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, json_bytes, .{}) catch return error.InvalidAmneziaVpnLink;
     defer parsed.deinit();
 
     const root = switch (parsed.value) {
@@ -561,7 +587,66 @@ fn convertAmneziaLastConfig(
         prepared = updated;
     }
 
+    try validateImportedAwgConfig(prepared);
     return prepared;
+}
+
+// Share links are untrusted data; wg-quick hook directives execute as root.
+// Validate the final text, including every substituted JSON value.
+fn validateImportedAwgConfig(content: []const u8) !void {
+    if (!looksLikeAwgConfig(content)) return error.InvalidAmneziaVpnLink;
+    var in_interface = false;
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |raw| {
+        const line = std.mem.trim(u8, raw, " \t\r");
+        if (line.len == 0 or line[0] == '#' or line[0] == ';') continue;
+        if (std.mem.eql(u8, line, "[Interface]")) {
+            in_interface = true;
+            continue;
+        }
+        if (std.mem.eql(u8, line, "[Peer]")) {
+            in_interface = false;
+            continue;
+        }
+        const eq = std.mem.indexOfScalar(u8, line, '=') orelse return error.InvalidAmneziaVpnLink;
+        const key = std.mem.trim(u8, line[0..eq], " \t");
+        // Our own installed configs carry this directive. Permit only the safe
+        // value we generate, so adopting/re-importing them remains idempotent.
+        if (in_interface and std.mem.eql(u8, key, "Table")) {
+            if (!std.mem.eql(u8, std.mem.trim(u8, line[eq + 1 ..], " \t"), "off")) return error.InvalidAmneziaVpnLink;
+            continue;
+        }
+        const allowed = if (in_interface)
+            &[_][]const u8{ "PrivateKey", "Address", "DNS", "MTU", "ListenPort", "Jc", "Jmin", "Jmax", "S1", "S2", "S3", "S4", "H1", "H2", "H3", "H4", "I1", "I2", "I3", "I4", "I5", "HeaderProtectionKey", "ContentPaddingAddition", "RekeyAfterTime", "RekeyTimeout", "RejectAfterTime", "KeepaliveTimeout", "MaxHandshakeAttempts", "RandomTrailers", "DisableCookies" }
+        else
+            &[_][]const u8{ "PublicKey", "PresharedKey", "AllowedIPs", "Endpoint", "PersistentKeepalive" };
+        var known = false;
+        for (allowed) |candidate| {
+            if (std.mem.eql(u8, key, candidate)) {
+                known = true;
+                break;
+            }
+        }
+        if (!known) return error.InvalidAmneziaVpnLink;
+        for (line[eq + 1 ..]) |c| {
+            if (c < 32 and c != '\t') return error.InvalidAmneziaVpnLink;
+        }
+    }
+}
+
+test "vpn import rejects root hooks and substituted hooks" {
+    try validateImportedAwgConfig("[Interface]\nPrivateKey = abc\n[Peer]\nPublicKey = def");
+    try std.testing.expectError(error.InvalidAmneziaVpnLink, validateImportedAwgConfig("[Interface]\nPostUp = touch /tmp/pwn\n[Peer]"));
+    try std.testing.expectError(error.InvalidAmneziaVpnLink, convertAmneziaLastConfig(std.testing.allocator, "{\"config\":\"[Interface]\\nDNS = $PRIMARY_DNS\\n[Peer]\"}", "1.1.1.1\nPostUp = id", ""));
+}
+
+test "vpn import accepts AWG 3.1 protocol fields but never quick hooks" {
+    const conf = "[Interface]\nPrivateKey=abc\nHeaderProtectionKey=abc\nContentPaddingAddition=10-100\nRekeyAfterTime=120\nRekeyTimeout=5\nRejectAfterTime=180\nKeepaliveTimeout=10\nMaxHandshakeAttempts=18\nRandomTrailers=on\nDisableCookies=on\n[Peer]\nPublicKey=def\n";
+    try validateImportedAwgConfig(conf);
+    try validateImportedAwgConfig("[Interface]\nTable = off\nPrivateKey=abc\n[Peer]\nPublicKey=def\n");
+    try std.testing.expectError(error.InvalidAmneziaVpnLink, validateImportedAwgConfig("[Interface]\nTable=200\n"));
+    try std.testing.expectError(error.InvalidAmneziaVpnLink, validateImportedAwgConfig(conf ++ "PostUp=id\n"));
+    try std.testing.expectError(error.InvalidAmneziaVpnLink, validateImportedAwgConfig("[Interface]\nSaveConfig=true\n"));
 }
 fn jsonObjectString(object: std.json.ObjectMap, key: []const u8) ?[]const u8 {
     const value = object.get(key) orelse return null;
@@ -827,6 +912,8 @@ fn debianAmneziaRepositorySetupScript() []const u8 {
     \\tmp="$(mktemp)"
     \\trap 'rm -f "$tmp"' EXIT
     \\curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x75C9DD72C799870E310542E24166F2C257290828" -o "$tmp"
+    \\fingerprints="$(gpg --batch --with-colons --import-options show-only --import "$tmp" | awk -F: '$1=="pub" { want=1; next } want && $1=="fpr" { print $10; want=0 }')"
+    \\[ "$fingerprints" = 75C9DD72C799870E310542E24166F2C257290828 ] || exit 1
     \\gpg --batch --yes --dearmor -o /usr/share/keyrings/amnezia-ppa.gpg "$tmp"
     \\cat >/etc/apt/sources.list.d/amnezia-ppa.list <<'AMNEZIA_PPA'
     \\deb [signed-by=/usr/share/keyrings/amnezia-ppa.gpg] https://ppa.launchpadcontent.net/amnezia/ppa/ubuntu focal main
@@ -1066,6 +1153,13 @@ pub fn selectTunnelInterface(allocator: std.mem.Allocator, requested: []const u8
         const candidate = try std.fmt.bufPrint(&name_buf, "awg{d}", .{i});
         var path_buf: [256]u8 = undefined;
         const path = awgConfigPath(&path_buf, candidate) catch continue;
+        var wg_path_buf: [256]u8 = undefined;
+        const wg_path = try std.fmt.bufPrint(&wg_path_buf, "/etc/wireguard/{s}.conf", .{candidate});
+        if (sys.fileExists(wg_path)) continue;
+        if (sys.exec(allocator, &.{ "ip", "link", "show", "dev", candidate })) |r| {
+            defer r.deinit();
+            if (r.exit_code == 0) continue;
+        } else |_| {}
         if (!containsInterface(pool, candidate) and !sys.fileExists(path)) {
             return try allocator.dupe(u8, candidate);
         }
@@ -1087,29 +1181,29 @@ pub fn formatInterfaceArrayLiteral(allocator: std.mem.Allocator, values: []const
     try out.append(allocator, ']');
     return try out.toOwnedSlice(allocator);
 }
-fn setTunnelPoolConfig(allocator: std.mem.Allocator, iface: []const u8) void {
-    var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch return;
+fn setTunnelPoolConfig(allocator: std.mem.Allocator, iface: []const u8) !void {
+    var doc = toml.TomlDoc.load(allocator, INSTALL_DIR ++ "/config.toml") catch |err| return err;
     defer doc.deinit();
 
-    doc.set("upstream", "type", "\"tunnel\"") catch return;
+    doc.set("upstream", "type", "\"tunnel\"") catch |err| return err;
 
-    const existing = loadTunnelPoolFromDoc(allocator, &doc) catch &.{};
+    const existing = loadTunnelPoolFromDoc(allocator, &doc) catch |err| return err;
     defer freeOwnedStringSlice(allocator, existing);
 
-    const pool = appendInterfaceIfMissing(allocator, existing, iface) catch return;
+    const pool = appendInterfaceIfMissing(allocator, existing, iface) catch |err| return err;
     defer freeOwnedStringSlice(allocator, pool);
 
     if (pool.len > 0) {
         var first_buf: [64]u8 = undefined;
-        const first = std.fmt.bufPrint(&first_buf, "\"{s}\"", .{pool[0]}) catch return;
-        doc.set("upstream.tunnel", "interface", first) catch return;
+        const first = std.fmt.bufPrint(&first_buf, "\"{s}\"", .{pool[0]}) catch |err| return err;
+        doc.set("upstream.tunnel", "interface", first) catch |err| return err;
     }
 
-    const array_literal = formatInterfaceArrayLiteral(allocator, pool) catch return;
+    const array_literal = formatInterfaceArrayLiteral(allocator, pool) catch |err| return err;
     defer allocator.free(array_literal);
-    doc.set("upstream.tunnel", "interfaces", array_literal) catch return;
+    doc.set("upstream.tunnel", "interfaces", array_literal) catch |err| return err;
 
-    doc.save(INSTALL_DIR ++ "/config.toml") catch {};
+    try doc.save(INSTALL_DIR ++ "/config.toml");
 }
 fn installTunnelPoolUnits(ui: *Tui, allocator: std.mem.Allocator) void {
     const service =
@@ -1178,6 +1272,8 @@ fn renderTunnelPoolScript(allocator: std.mem.Allocator) ![]const u8 {
         \\BOUNCE_AFTER_DEGRADED_CHECKS=2
         \\
         \\mkdir -p "$STATE_DIR"
+        \\exec 9>"$STATE_DIR/pool.lock"
+        \\flock -w 60 9 || exit 1
         \\
         \\log() {
         \\    logger -t mtproto-tunnel-pool "$*" 2>/dev/null || true
@@ -1325,6 +1421,9 @@ fn renderTunnelPoolScript(allocator: std.mem.Allocator) ![]const u8 {
         \\}
         \\
         \\ensure_policy_rule() {
+        \\    while ip -6 rule del fwmark "$MARK" table "$TABLE" 2>/dev/null; do :; done
+        \\    ip -6 route replace blackhole default table "$TABLE"
+        \\    ip -6 rule add fwmark "$MARK" table "$TABLE" priority "$RULE_PRIORITY" || return 1
         \\    while ip -4 rule del priority "$RULE_PRIORITY" fwmark "$MARK" table "$TABLE" 2>/dev/null; do :; done
         \\    while ip -4 rule del fwmark "$MARK" table "$TABLE" 2>/dev/null; do :; done
         \\    ip -4 rule add fwmark "$MARK" table "$TABLE" priority "$RULE_PRIORITY" 2>/dev/null || true
@@ -1333,7 +1432,6 @@ fn renderTunnelPoolScript(allocator: std.mem.Allocator) ![]const u8 {
         \\
         \\route_table_to_iface() {
         \\    local iface="$1"
-        \\    ip -4 route flush table "$TABLE" 2>/dev/null || true
         \\    ip -4 route replace default dev "$iface" table "$TABLE"
         \\}
         \\
@@ -1370,14 +1468,13 @@ fn renderTunnelPoolScript(allocator: std.mem.Allocator) ![]const u8 {
         \\    local streak
         \\    streak="$(( $(read_degraded_streak "$iface") + 1 ))"
         \\    write_degraded_streak "$iface" "$streak"
-        \\    if [[ "$streak" -ge "$BOUNCE_AFTER_DEGRADED_CHECKS" ]]; then
+        \\    if [[ "$streak" -ge "$BOUNCE_AFTER_DEGRADED_CHECKS" ]] && { [[ "$streak" -eq "$BOUNCE_AFTER_DEGRADED_CHECKS" ]] || (( streak % 20 == 0 )); }; then
         \\        if bounce_iface "$iface" && telegram_probe_iface "$iface"; then
         \\            write_degraded_streak "$iface" 0
         \\            reason="healthy (recovered after bounce)"
         \\            return 0
         \\        fi
         \\        log "tunnel $iface still unreachable after bounce"
-        \\        write_degraded_streak "$iface" 0
         \\    fi
         \\    # Usable (up + policy route installed) but can't reach Telegram through it.
         \\    # Return 2 ("degraded-usable") so pool selection PREFERS a tunnel that can
@@ -1408,7 +1505,8 @@ fn renderTunnelPoolScript(allocator: std.mem.Allocator) ![]const u8 {
         \\        printf 'pool=%s\n' "${pool[*]}"
         \\        printf 'last_switch=%s\n' "$last_switch"
         \\        printf 'checked_at=%s\n' "$now"
-        \\    } > "$STATE_FILE"
+        \\    } > "$STATE_FILE.tmp"
+        \\    mv -f "$STATE_FILE.tmp" "$STATE_FILE"
         \\}
         \\
         \\mapfile -t pool < <(
@@ -1676,6 +1774,60 @@ fn cleanupNetnsNginxListen(allocator: std.mem.Allocator) bool {
 }
 const test_amnezia_vpn_link =
     "vpn://AAABPXicLY9Ra8IwFIX_Srn4WGoSHZSCD6I-lDEX9Gm0IrG5jkKbliSdG6X_fTdWTiA53wn3JCNo4zhkwJOnIA5AEEiTpwhUnfGqNmgdZMUI6vEN2QiNcv5K0b0mC2MJ87mELCqhyI1He1cVXsrSbLW26Fy0iThLgsRyJYhLW_8oj-_4R1FPhtj-eCazkKf8Y3v6upKNo8X5sPs87l-eLuUi2tBGq5CINnTI4dbU1WvUcAutTdM9UOcyFM-9bMkoOBjdd7XxhPFXtX2DSdW12Xq9CjMhpve3fpg_wkXKZtR31gf2xlPBJpimy_QPWglhtw";
+test "tunnel pool executes bounce backoff and recovery" {
+    const a = std.testing.allocator;
+    const script = try renderTunnelPoolScript(a);
+    defer a.free(script);
+    const start = std.mem.indexOf(u8, script, "probe_iface() {\n") orelse unreachable;
+    const end = std.mem.indexOfPos(u8, script, start, "\nstate_value() {") orelse unreachable;
+    const harness = try std.mem.concat(a, u8, &.{
+        script[start..end],
+        \\
+        \\set -eu
+        \\stored_streak=0; bounces=0; healthy=0; BOUNCE_AFTER_DEGRADED_CHECKS=2
+        \\ensure_iface_up() { :; }
+        \\ip() { :; }
+        \\show_tool_for() { echo true; }
+        \\route_table_to_iface() { :; }
+        \\policy_route_matches_iface() { :; }
+        \\telegram_probe_iface() { [[ "$healthy" == 1 ]]; }
+        \\write_degraded_streak() { stored_streak="$2"; }
+        \\read_degraded_streak() { echo "$stored_streak"; }
+        \\bounce_iface() { bounces=$((bounces + 1)); }
+        \\log() { :; }
+        \\for ((n=1;n<=19;n++)); do
+        \\  if probe_iface awg0; then exit 10; else [[ "$?" == 2 ]]; fi
+        \\done
+        \\[[ "$bounces" == 1 && "$stored_streak" == 19 ]]
+        \\if probe_iface awg0; then exit 11; else [[ "$?" == 2 ]]; fi
+        \\[[ "$bounces" == 2 && "$stored_streak" == 20 ]]
+        \\healthy=1
+        \\probe_iface awg0
+        \\[[ "$stored_streak" == 0 && "$bounces" == 2 ]]
+    });
+    defer a.free(harness);
+    const result = try sys.exec(a, &.{ "bash", "-c", harness });
+    defer result.deinit();
+    try std.testing.expectEqual(@as(u8, 0), result.exit_code);
+}
+
+test "tunnel pool executes both fail closed routes when no tunnel is usable" {
+    const a = std.testing.allocator;
+    const script = try renderTunnelPoolScript(a);
+    defer a.free(script);
+    const start = std.mem.indexOf(u8, script, "if [[ -z \"$selected\" ]]; then") orelse unreachable;
+    const end = std.mem.indexOfPos(u8, script, start, "\nroute_table_to_iface \"$selected\"") orelse unreachable;
+    const harness = try std.mem.concat(a, u8, &.{
+        "selected=''; TABLE=200; candidates=(awg0); ip() { printf '%s\\n' \"$*\"; }; write_state() { :; };\n",
+        script[start..end],
+    });
+    defer a.free(harness);
+    const result = try sys.exec(a, &.{ "bash", "-c", harness });
+    defer result.deinit();
+    try std.testing.expectEqual(@as(u8, 1), result.exit_code);
+    try std.testing.expectEqualStrings("-4 route replace blackhole default table 200\n-6 route replace blackhole default table 200\n", result.stdout);
+}
+
 test "tunnel pool - script renders failover (prefer reachable, fall back to usable)" {
     const script = try renderTunnelPoolScript(std.testing.allocator);
     defer std.testing.allocator.free(script);
@@ -1708,6 +1860,8 @@ test "tunnel pool script - degraded tunnel bounces after consecutive-failure thr
     try std.testing.expect(std.mem.indexOf(u8, script, "\"$quick\" up \"$conf\"") != null);
     // Streak resets on success so only CONSECUTIVE failures trigger a bounce.
     try std.testing.expect(std.mem.indexOf(u8, script, "write_degraded_streak \"$iface\" 0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "streak % 20 == 0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, script, "still unreachable after bounce\"\n        write_degraded_streak") == null);
     try std.testing.expect(std.mem.indexOf(u8, script, "recovered after bounce") != null);
 }
 

--- a/src/ctl/uninstall.zig
+++ b/src/ctl/uninstall.zig
@@ -22,7 +22,7 @@ pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
     try execute(ui, allocator);
 }
 
-pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) void {
+pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Iterator) !void {
     var yes_flag = false;
 
     while (args.next()) |arg| {
@@ -30,7 +30,7 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
             yes_flag = true;
         } else {
             ui.fail("Unknown flag for uninstall. See mtbuddy --help");
-            return;
+            return error.UnknownOption;
         }
     }
 
@@ -89,7 +89,10 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
         "mtproto-tunnel-pool.timer",
         "mtproto-tunnel-pool.service",
         "mtproto-singbox-egress.service",
+        "mtproto-ipv6.service",
         "mtproto-web-relay",
+        "mtproto-web-health.timer",
+        "mtproto-web-health.service",
     };
     for (services) |svc| {
         // Quiet: this runs under a spinner and most of these units aren't present in any
@@ -117,7 +120,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
     // uninstall leaves credentials on disk.
     _ = sys.execForward(&.{ "rm", "-f", "/etc/mtproto-proxy/singbox-egress.json", "/etc/mtproto-proxy/singbox-egress.json.bak" }) catch {};
     _ = sys.execForward(&.{ "rm", "-f", "/usr/local/bin/mtproto-singbox-route.sh" }) catch {};
-    _ = sys.execForward(&.{ "rm", "-f", "/usr/local/bin/sing-box" }) catch {};
+    // The binary may predate mtbuddy; without an ownership marker retain it.
     // rmdir, not rm -rf: it removes the directory only once it is empty, so anything an
     // operator put there of their own is left alone rather than silently deleted.
     // Wrapped like the nginx drop-in rmdir below, because a deploy that never created
@@ -129,6 +132,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
     // is installed" and silently re-enables the whole timer stack. Remove it on uninstall
     // so a later reinstall+update doesn't resurrect recovery.
     _ = sys.execForward(&.{ "rm", "-f", "/usr/local/bin/mtproto-mask-health.sh" }) catch {};
+    _ = sys.execForward(&.{ "rm", "-f", "/usr/local/bin/mtproto-web-health.sh" }) catch {};
     _ = sys.execForward(&.{ "rm", "-f", "/etc/systemd/system/mtproto-tunnel-pool.timer" }) catch {};
     _ = sys.execForward(&.{ "rm", "-f", "/etc/systemd/system/mtproto-tunnel-pool.service" }) catch {};
 
@@ -143,7 +147,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
 
     // 2. Remove directories
     _ = sys.execForward(&.{ "rm", "-rf", "/opt/mtproto-proxy" }) catch {};
-    _ = sys.execForward(&.{ "rm", "-rf", "/opt/zapret" }) catch {};
+    // Retain unmarked third-party software: it may serve another application.
 
     // 3. Remove user
     const userdel = sys.commandOrPath("userdel", &.{ "/usr/sbin/userdel", "/sbin/userdel" });
@@ -156,6 +160,8 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
     // Quiet: an empty/absent table 200 or netns makes these print "FIB table does not
     // exist" / "Cannot remove namespace" even though there's simply nothing to clean.
     sys.execSilent(allocator, &.{ "ip", "-4", "route", "flush", "table", "200" });
+    sys.execSilent(allocator, &.{ "sh", "-c", "while ip -6 rule del fwmark 200 table 200 2>/dev/null; do :; done" });
+    sys.execSilent(allocator, &.{ "ip", "-6", "route", "flush", "table", "200" });
     _ = sys.execForward(&.{ "rm", "-f", "/usr/local/bin/setup_tunnel.sh" }) catch {};
     _ = sys.execForward(&.{ "rm", "-f", "/usr/local/bin/setup_netns.sh" }) catch {};
     sys.execSilent(allocator, &.{ "ip", "netns", "del", "tg_proxy_ns" });
@@ -285,10 +291,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
         \\  done
         \\done
         \\rm -f /usr/local/sbin/mtproto-tcpmss.sh
-        \\if [ -d /etc/iptables ]; then
-        \\  command -v iptables-save >/dev/null 2>&1 && iptables-save > /etc/iptables/rules.v4 2>/dev/null || true
-        \\  command -v ip6tables-save >/dev/null 2>&1 && ip6tables-save > /etc/iptables/rules.v6 2>/dev/null || true
-        \\fi
+        \\# Do not overwrite the operator's persisted firewall with a live snapshot.
     ;
     _ = sys.execForward(&.{ "bash", "-c", tcpmss_cleanup }) catch {};
 
@@ -325,6 +328,7 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator) !void {
 
     ui.writeRaw("\n");
     ui.print("  {s}{s} {s}{s}\n", .{ Color.ok, "✔", ui.str(.uninstall_success), Color.reset });
+    ui.hint("Shared resources retained if present: mtproto group; /usr/local/bin/{uv,uvx,minisign,sing-box}; /opt/zapret; /etc/apt/sources.list.d/amnezia-ppa.list; /usr/share/keyrings/amnezia-ppa.gpg. Remove them manually only after checking that no other service uses them. The Amnezia apt source remains enabled until removed.");
 
     // Said after the spinner, not under it, and deliberately not phrased as a failure:
     // these files are still there because mtbuddy is not sure it created them, which is

--- a/src/ctl/update.zig
+++ b/src/ctl/update.zig
@@ -27,6 +27,8 @@ pub const UpdateOpts = struct {
     version: ?[]const u8 = null,
     force_service_update: bool = false,
     insecure: bool = false,
+    force: bool = false,
+    allow_downgrade: bool = false,
 };
 
 /// Run update in CLI (non-interactive) mode.
@@ -38,8 +40,15 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
             opts.version = args.next();
         } else if (std.mem.eql(u8, arg, "--force-service")) {
             opts.force_service_update = true;
+        } else if (std.mem.eql(u8, arg, "--force")) {
+            opts.force = true;
+        } else if (std.mem.eql(u8, arg, "--allow-downgrade")) {
+            opts.allow_downgrade = true;
         } else if (std.mem.eql(u8, arg, "--insecure")) {
             opts.insecure = true;
+        } else {
+            ui.print("Unknown option: {s}\n", .{arg});
+            return error.UnknownOption;
         }
     }
 
@@ -147,6 +156,26 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: UpdateOpts) !void {
     }
 
     // ── Download + validate proxy binary ──
+    if (sys.fileExists(INSTALL_DIR ++ "/mtproto-proxy")) {
+        const current = try sys.exec(allocator, &.{ INSTALL_DIR ++ "/mtproto-proxy", "--version" });
+        defer current.deinit();
+        if (current.exit_code != 0) return error.InstalledVersionUnavailable;
+        const installed = installedVersion(current.stdout, current.stderr) orelse return error.InstalledVersionUnavailable;
+        const desired = versionFromOutput(tag.slice()) orelse return error.InvalidReleaseVersion;
+        switch (desired.order(installed)) {
+            .eq => if (!opts.force and !opts.force_service_update) {
+                ui.ok("Already up to date (use update --force to reapply host repairs)");
+                return;
+            },
+            .lt => if (!opts.allow_downgrade) {
+                ui.fail("Refusing downgrade; pass --allow-downgrade explicitly");
+                return error.DowngradeRefused;
+            },
+            .gt => {},
+        }
+    }
+
+    // ── Download + validate proxy binary ──
     var artifact = release.Artifact{};
     defer release.cleanup(allocator, &artifact);
     {
@@ -198,28 +227,21 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: UpdateOpts) !void {
 
     // ── Backup current binary ──
     ui.step(ui.str(.update_backing_up));
-    var backup_path_buf: [256]u8 = undefined;
     var backup_path: ?[]const u8 = null;
+    const previous_unit = sys.readFileAllocAbsolute(allocator, SERVICE_FILE, 128 * 1024);
+    defer if (previous_unit) |content| allocator.free(content);
+    if (previous_unit == null and sys.fileExists(SERVICE_FILE)) return error.ServiceBackupFailed;
 
     if (sys.fileExists(INSTALL_DIR ++ "/mtproto-proxy")) {
-        const timestamp = sys.exec(allocator, &.{ "date", "+%Y%m%d%H%M%S" }) catch null;
-        if (timestamp) |t| {
-            const ts = std.mem.trim(u8, t.stdout, &[_]u8{ ' ', '\t', '\r', '\n' });
-            backup_path = std.fmt.bufPrint(&backup_path_buf, "{s}/mtproto-proxy.backup.{s}", .{ INSTALL_DIR, ts }) catch null;
-            // Don't deinit t here — with ArenaAllocator it's freed at exit
-        } else {
-            backup_path = std.fmt.bufPrint(&backup_path_buf, "{s}/mtproto-proxy.backup", .{INSTALL_DIR}) catch null;
-        }
-
-        if (backup_path) |bp| {
-            _ = sys.execForward(&.{ "cp", INSTALL_DIR ++ "/mtproto-proxy", bp }) catch {};
-            ui.stepOk(ui.str(.update_backing_up), bp);
-        }
+        const bp = INSTALL_DIR ++ "/mtproto-proxy.backup.prev";
+        if (try sys.execForward(&.{ "cp", INSTALL_DIR ++ "/mtproto-proxy", bp }) != 0) return error.BackupFailed;
+        backup_path = bp;
+        ui.stepOk(ui.str(.update_backing_up), bp);
     }
 
     // ── Stop service ──
     ui.step(ui.str(.update_stopping));
-    _ = sys.execForward(&.{ "systemctl", "stop", SERVICE_NAME }) catch {};
+    if (try sys.execForward(&.{ "systemctl", "stop", SERVICE_NAME }) != 0) return error.StopFailed;
 
     // ── Install new binary ──
     ui.step(ui.str(.update_installing));
@@ -229,38 +251,60 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: UpdateOpts) !void {
     // so the proxy comes back up, and abort.
     const proxy_install_rc = sys.execForward(&.{ "install", "-m", "0755", artifact.binaryPath(), INSTALL_DIR ++ "/mtproto-proxy" }) catch 1;
     if (proxy_install_rc != 0) {
-        ui.fail("Failed to install the new mtproto-proxy binary — keeping the current version");
-        _ = sys.execForward(&.{ "systemctl", "restart", SERVICE_NAME }) catch {};
-        return;
+        ui.fail("Failed to install the new mtproto-proxy binary — restoring backup");
+        if (backup_path) |bp| {
+            if (try sys.execForward(&.{ "install", "-m", "0755", bp, INSTALL_DIR ++ "/mtproto-proxy" }) != 0) return error.RollbackRestoreFailed;
+        }
+        if (try sys.execForward(&.{ "systemctl", "restart", SERVICE_NAME }) != 0) return error.RollbackRestartFailed;
+        return error.UpdateFailed;
     }
 
     if (buddy_path) |bp| {
         const buddy_rc = sys.execForward(&.{ "install", "-m", "0755", bp, "/usr/local/bin/mtbuddy" }) catch 1;
-        if (buddy_rc != 0) ui.warn("Failed to update the mtbuddy CLI (proxy binary was updated)");
+        if (buddy_rc != 0) {
+            ui.warn("Failed to update the mtbuddy CLI (proxy binary was updated)");
+        } else {
+            ui.info("This run finishes with the previous updater logic; run mtbuddy update --force once to apply the new updater's host repairs");
+        }
     }
 
     // Fix ownership
-    _ = sys.exec(allocator, &.{ "chown", "-R", "mtproto:mtproto", INSTALL_DIR }) catch {};
+    // The dashboard runs as root: never give its code, interpreter or token to
+    // the network-facing service account.
+    _ = sys.exec(allocator, &.{ "chown", "root:root", INSTALL_DIR }) catch {};
+    if (sys.fileExists(INSTALL_DIR ++ "/monitor")) {
+        _ = sys.exec(allocator, &.{ "chown", "-R", "root:root", INSTALL_DIR ++ "/monitor" }) catch {};
+    }
+    _ = sys.exec(allocator, &.{ "chown", "mtproto:mtproto", INSTALL_DIR ++ "/config.toml" }) catch {};
 
     // ── Update service file (unless tunnel-aware) ──
+    var preparation_failed = false;
     if (opts.force_service_update or !isTunnelServiceUnit()) {
-        release.writeServiceFile();
+        release.writeServiceFile() catch |err| {
+            ui.print("Failed to write proxy service: {any}; restoring the previous installation\n", .{err});
+            preparation_failed = true;
+        };
     }
-    _ = sys.execForward(&.{ "systemctl", "daemon-reload" }) catch {};
+    if ((sys.execForward(&.{ "systemctl", "daemon-reload" }) catch 1) != 0) preparation_failed = true;
+    @import("synlimit.zig").repairInstalled(allocator);
 
     // ── Start service ──
     ui.step(ui.str(.update_starting));
-    const start_result = sys.execForward(&.{ "systemctl", "restart", SERVICE_NAME }) catch 1;
+    const start_result = if (preparation_failed) 1 else sys.execForward(&.{ "systemctl", "restart", SERVICE_NAME }) catch 1;
 
     if (start_result != 0 or !sys.isServiceActive(SERVICE_NAME)) {
         ui.fail(ui.str(.error_service_failed));
         // Rollback
         if (backup_path) |bp| {
             ui.step(ui.str(.update_rollback));
-            _ = sys.execForward(&.{ "cp", bp, INSTALL_DIR ++ "/mtproto-proxy" }) catch {};
-            _ = sys.execForward(&.{ "systemctl", "restart", SERVICE_NAME }) catch {};
+            if (try sys.execForward(&.{ "systemctl", "stop", SERVICE_NAME }) != 0) return error.RollbackStopFailed;
+            if (try sys.execForward(&.{ "install", "-m", "0755", bp, INSTALL_DIR ++ "/mtproto-proxy" }) != 0) return error.RollbackRestoreFailed;
+            if (previous_unit) |content| try sys.writeFile(SERVICE_FILE, content);
+            if (try sys.execForward(&.{ "systemctl", "daemon-reload" }) != 0) return error.RollbackReloadFailed;
+            if (try sys.execForward(&.{ "systemctl", "restart", SERVICE_NAME }) != 0 or !sys.isServiceActive(SERVICE_NAME)) return error.RollbackRestartFailed;
+            ui.warn("Update failed; previous binary and service unit restored");
         }
-        return;
+        return error.UpdateFailed;
     }
 
     ui.ok(ui.str(.update_starting));
@@ -310,13 +354,37 @@ fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: UpdateOpts) !void {
 // ── Helpers ─────────────────────────────────────────────────────
 
 /// Check if the current service file is a tunnel-aware unit.
-fn isTunnelServiceUnit() bool {
+/// Also consulted by `install`, which must not stamp the stock unit (no CAP_NET_ADMIN,
+/// no ExecStartPre) over a tunnel egress on a re-run.
+pub fn isTunnelServiceUnit() bool {
     if (!sys.fileExists(SERVICE_FILE)) return false;
-    const result = sys.exec(std.heap.page_allocator, &.{
-        "grep", "-Eq", "setup_(netns|tunnel)\\.sh|ip[[:space:]]+netns[[:space:]]+exec|AmneziaWG[[:space:]]+Tunnel|Tunnel[[:space:]]+Policy[[:space:]]+Routing", SERVICE_FILE,
-    }) catch return false;
-    defer result.deinit();
-    return result.exit_code == 0;
+    const content = sys.readFileAllocAbsolute(std.heap.page_allocator, SERVICE_FILE, 128 * 1024) orelse return true;
+    defer std.heap.page_allocator.free(content);
+    for ([_][]const u8{ "setup_netns.sh", "setup_tunnel.sh", "netns", "AmneziaWG", "Tunnel Policy Routing", "CAP_NET_ADMIN", "SO_MARK" }) |marker| {
+        if (std.mem.indexOf(u8, content, marker) != null) return true;
+    }
+    return false;
+}
+
+fn versionFromOutput(output: []const u8) ?std.SemanticVersion {
+    var words = std.mem.tokenizeAny(u8, output, " \r\n\t");
+    while (words.next()) |word| {
+        const value = if (std.mem.startsWith(u8, word, "v")) word[1..] else word;
+        return std.SemanticVersion.parse(value) catch continue;
+    }
+    return null;
+}
+
+fn installedVersion(stdout: []const u8, stderr: []const u8) ?std.SemanticVersion {
+    // Released proxies before this audit printed --version to stderr.
+    return versionFromOutput(stdout) orelse versionFromOutput(stderr);
+}
+
+test "release version parsing handles binary output and v-prefixed tags" {
+    try std.testing.expectEqual(std.math.Order.gt, versionFromOutput("v1.13.1").?.order(versionFromOutput("mtproto-proxy 1.13.0\n").?));
+    try std.testing.expect(versionFromOutput("garbage") == null);
+    try std.testing.expectEqual(std.math.Order.eq, installedVersion("", "mtproto-proxy v1.13.0\n").?.order(try std.SemanticVersion.parse("1.13.0")));
+    try std.testing.expectEqual(std.math.Order.eq, installedVersion("mtproto-proxy v1.13.1\n", "").?.order(try std.SemanticVersion.parse("1.13.1")));
 }
 
 fn localized(ui: *const Tui, en: []const u8, ru: []const u8) []const u8 {

--- a/src/ctl/web.zig
+++ b/src/ctl/web.zig
@@ -25,10 +25,16 @@
 //!
 //! ## Order of operations
 //!
-//! nginx-touching steps follow `masking.zig`'s discipline exactly: symlink first, then
-//! `nginx -t`, and on failure remove **only our own** symlink and leave nginx untouched.
-//! A vhost that breaks nginx would otherwise be caught by the mask-health timer, which
-//! restarts `mtproto-proxy` every minute while the masking probe fails.
+//! nginx-touching steps follow `masking.zig`'s discipline: symlink first, then `nginx -t`,
+//! and on failure roll back rather than leave nginx broken. `writeVhost` goes one step
+//! further than a fresh install needs to, because it is also how `mtbuddy update`
+//! re-renders an already-live relay vhost: it takes an `nginx -t` baseline *before*
+//! touching the file, so a tree that was already broken for an unrelated reason is
+//! reported as such instead of blamed on us, and on failure it restores the previous
+//! vhost content (not just the symlink) so a previously working relay actually comes
+//! back up rather than staying disabled with the new, bad file still on disk. A vhost
+//! that breaks nginx would otherwise be caught by the mask-health timer, which restarts
+//! `mtproto-proxy` every minute while the masking probe fails.
 
 const std = @import("std");
 const tui_mod = @import("tui.zig");
@@ -78,6 +84,9 @@ pub const WebOpts = struct {
     /// the pre-upgrade binary.
     mode_explicit: bool = false,
     port: []const u8 = DEFAULT_PORT,
+    /// Explicit bind address for a remote TLS terminator; defaults to loopback.
+    host: ?[]const u8 = null,
+    lets_encrypt: bool = false,
     /// Contact address for the ACME account; empty registers without one.
     email: []const u8 = "",
     /// Skip ACME issuance and keep whatever certificate is already on disk.
@@ -92,10 +101,40 @@ pub const WebOpts = struct {
     only: ?bool = null,
     quiet: bool = false,
     yes: bool = false,
+    /// Allow changing an already-configured [web].domain even though it breaks every
+    /// distributed WEB link (same gate as masking.zig's tls_domain --force).
+    force: bool = false,
 };
 
 fn tr(ui: *Tui, en: []const u8, ru: []const u8) []const u8 {
     return if (ui.lang == .ru) ru else en;
+}
+
+fn safeCertificatePath(path: []const u8) bool {
+    if (path.len == 0 or path[0] != '/' or path.len > 512) return false;
+    for (path) |c| {
+        if (!(std.ascii.isAlphanumeric(c) or std.mem.indexOfScalar(u8, "/._-", c) != null)) return false;
+    }
+    return true;
+}
+
+fn dnsHasAddress(output: []const u8, address: []const u8) bool {
+    var lines = std.mem.splitScalar(u8, output, '\n');
+    while (lines.next()) |line| {
+        var fields = std.mem.tokenizeAny(u8, line, " \t\r");
+        if (std.mem.eql(u8, fields.next() orelse continue, address)) return true;
+    }
+    return false;
+}
+
+test "certificate paths reject directive and TOML injection" {
+    try std.testing.expect(safeCertificatePath("/etc/ssl/relay/fullchain.pem"));
+    for ([_][]const u8{ "relative.pem", "/tmp/cert;", "/tmp/cert\n", "/tmp/a\"b", "/tmp/a b" }) |path| try std.testing.expect(!safeCertificatePath(path));
+}
+
+test "DNS check compares the first complete address field" {
+    try std.testing.expect(dnsHasAddress("1.2.3.40 STREAM name\n1.2.3.4 DGRAM name\n", "1.2.3.4"));
+    try std.testing.expect(!dnsHasAddress("1.2.3.40 STREAM name\n", "1.2.3.4"));
 }
 
 // ── entry points ──────────────────────────────────────────────────────────────
@@ -128,6 +167,10 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
             opts.only = false;
         } else if (std.mem.eql(u8, arg, "--port")) {
             opts.port = args.next() orelse DEFAULT_PORT;
+        } else if (std.mem.eql(u8, arg, "--host")) {
+            opts.host = args.next() orelse return error.MissingHost;
+        } else if (std.mem.eql(u8, arg, "--lets-encrypt")) {
+            opts.lets_encrypt = true;
         } else if (std.mem.eql(u8, arg, "--email")) {
             opts.email = args.next() orelse "";
         } else if (std.mem.eql(u8, arg, "--skip-cert")) {
@@ -136,10 +179,15 @@ pub fn run(ui: *Tui, allocator: std.mem.Allocator, args: *std.process.Args.Itera
             opts.quiet = true;
         } else if (std.mem.eql(u8, arg, "--yes") or std.mem.eql(u8, arg, "-y")) {
             opts.yes = true;
+        } else if (std.mem.eql(u8, arg, "--force")) {
+            opts.force = true;
         } else if (std.mem.eql(u8, arg, "--remove") or std.mem.eql(u8, arg, "--uninstall")) {
             do_remove = true;
         } else if (arg.len > 0 and arg[0] != '-') {
             opts.domain = arg;
+        } else {
+            ui.print("Unknown option: {s}\n", .{arg});
+            return error.UnknownOption;
         }
     }
 
@@ -201,12 +249,35 @@ pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
         return;
     }
 
+    // If the operator typed a domain different from the live one, require informed
+    // consent before clobbering it — same gate as masking.zig's tls_domain.
+    var force = false;
+    if (existing) |e| {
+        if (!std.mem.eql(u8, e, domain)) {
+            var warn_buf: [512]u8 = undefined;
+            const msg = std.fmt.bufPrint(&warn_buf, "{s} '{s}' {s} '{s}' {s}", .{
+                tr(ui, "Changing the relay domain from", "Смена домена релея с"),
+                e,
+                tr(ui, "to", "на"),
+                domain,
+                tr(ui, "INVALIDATES every WEB link already distributed.", "СДЕЛАЕТ НЕРАБОЧИМИ все уже выданные WEB-ссылки."),
+            }) catch tr(ui, "Changing the relay domain invalidates every distributed WEB link.", "Смена домена релея сделает нерабочими все выданные WEB-ссылки.");
+            ui.warn(msg);
+            if (!try ui.confirm(tr(ui, "Change the relay domain anyway?", "Всё равно сменить домен релея?"), false)) {
+                ui.info(i18n.get(ui.lang, .aborting));
+                return;
+            }
+            force = true;
+        }
+    }
+
     try execute(ui, allocator, .{
         .domain = domain,
         .mode = if (mode_choice == 1) .behind else .mask,
         .mode_explicit = true,
         .only = only,
         .yes = true,
+        .force = force,
     });
 }
 
@@ -225,6 +296,24 @@ fn readConfigured(allocator: std.mem.Allocator, key: []const u8, buf: []u8) ?[]c
     return buf[0..trimmed.len];
 }
 
+/// Whether `[web].domain` may move from `existing` to `new`. Same rule as
+/// [censorship].tls_domain in masking.zig: a live deploy's domain is baked into every
+/// distributed link, so only an unchanged value or an explicit `--force` may pass.
+fn domainChangeAllowed(existing: []const u8, new: []const u8, force: bool) bool {
+    return std.mem.eql(u8, existing, new) or force;
+}
+
+fn configuredPort(allocator: std.mem.Allocator, section: []const u8, key: []const u8, fallback: u16) u16 {
+    var doc = toml.TomlDoc.load(allocator, config_path) catch return fallback;
+    defer doc.deinit();
+    const text = doc.get(section, key) orelse return fallback;
+    return std.fmt.parseInt(u16, std.mem.trim(u8, text, " \t\""), 10) catch fallback;
+}
+
+fn relayPortConflicts(port: u16, proxy_port: u16, mask_port: u16) bool {
+    return port == 0 or port == proxy_port or port == mask_port or port == 8443 or port == 8444;
+}
+
 // ── the work ──────────────────────────────────────────────────────────────────
 
 pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts_in: WebOpts) !void {
@@ -240,11 +329,28 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts_in: WebOpts) !void {
     // the domain is baked into every WEB link's bridge capability, so changing it
     // silently would break links exactly the way changing tls_domain does.
     var existing_buf: [256]u8 = undefined;
+    const existing_domain = readConfigured(allocator, "domain", &existing_buf);
     if (opts.domain.len == 0) {
-        opts.domain = readConfigured(allocator, "domain", &existing_buf) orelse {
+        opts.domain = existing_domain orelse {
             ui.fail(tr(ui, "No relay domain configured. Pass --domain <hostname>.", "Домен релея не задан. Укажите --domain <hostname>."));
             return;
         };
+    } else if (existing_domain) |cur| {
+        // Mirrors masking.zig's tls_domain gate: the caller named a domain that differs
+        // from the one already configured. Every distributed tg://webproxy link's bridge
+        // capability is HMAC'd over the OLD host (web_capability.deriveForPaddedSecret),
+        // so writing this through unguarded breaks every one of them the moment the
+        // relay restarts — refuse unless the operator explicitly overrides it.
+        if (!domainChangeAllowed(cur, opts.domain, opts.force)) {
+            var msg_buf: [512]u8 = undefined;
+            const msg = std.fmt.bufPrint(
+                &msg_buf,
+                "Refusing to change [web].domain from '{s}' to '{s}' — this invalidates every distributed WEB link. Re-run with --force to override.",
+                .{ cur, opts.domain },
+            ) catch "Refusing to change [web].domain (would break WEB links); re-run with --force.";
+            ui.fail(msg);
+            return;
+        }
     }
     var port_buf: [16]u8 = undefined;
     if (std.mem.eql(u8, opts.port, DEFAULT_PORT)) {
@@ -255,11 +361,11 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts_in: WebOpts) !void {
     // not name it. `mtbuddy update` calls us with bare defaults, and defaults are
     // `--mode mask` with a Let's Encrypt certificate — re-running a `behind` host or a
     // bring-your-own-cert host that way rewrote it into a topology it never asked for.
-    if (!opts.mode_explicit and isInstalled()) {
+    if (!opts.mode_explicit) {
         var mode_buf: [16]u8 = undefined;
         if (readConfigured(allocator, "mode", &mode_buf)) |persisted| {
             opts.mode = if (std.ascii.eqlIgnoreCase(persisted, "behind")) .behind else .mask;
-        } else {
+        } else if (isInstalled()) {
             // A relay installed before `[web].mode` existed. Only mode "mask" has a
             // PROXY-protocol terminator to point at, so the presence of `mask_backend`
             // is the best record of what it was set up as.
@@ -276,7 +382,10 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts_in: WebOpts) !void {
     }
     var cert_buf: [512]u8 = undefined;
     var key_buf: [512]u8 = undefined;
-    if (opts.cert.len == 0 and opts.key.len == 0) {
+    if (opts.lets_encrypt) {
+        opts.cert = "";
+        opts.key = "";
+    } else if (opts.cert.len == 0 and opts.key.len == 0) {
         opts.cert = readConfigured(allocator, "cert", &cert_buf) orelse "";
         opts.key = readConfigured(allocator, "key", &key_buf) orelse "";
         // A config carrying only one of the two is not a pair either; ignore both and
@@ -285,6 +394,12 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts_in: WebOpts) !void {
             opts.cert = "";
             opts.key = "";
         }
+    }
+
+    if ((opts.cert.len > 0 and !safeCertificatePath(opts.cert)) or (opts.key.len > 0 and !safeCertificatePath(opts.key))) return error.InvalidCertificatePath;
+    if (opts.host) |host| {
+        _ = std.Io.net.IpAddress.parse(host, 0) catch return error.InvalidListenHost;
+        if (opts.mode == .mask and !std.mem.eql(u8, host, "127.0.0.1")) return error.MaskRequiresLoopback;
     }
 
     // Validate exactly the way the client does, so a domain that would be silently
@@ -311,7 +426,7 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts_in: WebOpts) !void {
         ui.fail(tr(ui, "--port must be a number", "--port должен быть числом"));
         return;
     };
-    if (port == 443 or std.mem.eql(u8, opts.port, masking.NGINX_PORT)) {
+    if (relayPortConflicts(port, configuredPort(allocator, "server", "port", 443), configuredPort(allocator, "censorship", "mask_port", 8443))) {
         ui.fail(tr(
             ui,
             "The relay port must not collide with the proxy (443) or the masking backend (8443).",
@@ -332,7 +447,7 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts_in: WebOpts) !void {
         return;
     }
 
-    checkDns(ui, allocator, domain);
+    if (!opts.quiet and opts.mode == .mask) checkDns(ui, allocator, domain);
 
     if (opts.mode == .mask) {
         if (!try prepareMaskTopology(ui, allocator, domain, opts)) {
@@ -357,23 +472,29 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts_in: WebOpts) !void {
     // same breath as failing to open the WEB one, leaving a box that serves nobody.
     var staged = opts;
     staged.only = if (opts.only == true) null else opts.only;
-    try writeConfig(ui, allocator, domain, staged);
+    var config_changed = try writeConfig(ui, allocator, domain, staged);
     try installService(ui, allocator);
     if (opts.only == true) {
-        if (!sys.isServiceActive(SERVICE_NAME)) {
+        if (!sys.isServiceActive(SERVICE_NAME) or !verifyEndToEnd(ui, allocator, domain)) {
             ui.fail(tr(
                 ui,
-                "The relay is not running, so WEB-only was NOT enabled — it would have left this proxy with no working links at all.",
-                "Релей не запущен, поэтому WEB-only НЕ включён — иначе у прокси не осталось бы ни одной рабочей ссылки.",
+                "The relay HTTPS path could not be verified; the existing WEB-only setting was left unchanged.",
+                "Не удалось проверить HTTPS-путь релея; прежнее значение WEB-only оставлено без изменений.",
             ));
             ui.hint("journalctl -u " ++ SERVICE_NAME ++ " -n 50 --no-pager");
-            opts.only = false;
+            opts.only = null;
         } else {
-            try writeConfig(ui, allocator, domain, opts);
+            config_changed = try writeConfig(ui, allocator, domain, opts) or config_changed;
         }
     }
+    if (config_changed) {
+        ui.step(tr(ui, "Restarting the proxy to apply [web]...", "Перезапускаю прокси, чтобы применить [web]..."));
+        const restart = try sys.exec(allocator, &.{ "systemctl", "restart", "mtproto-proxy" });
+        defer restart.deinit();
+        if (restart.exit_code != 0) return error.ProxyRestartFailed;
+    }
 
-    if (opts.mode == .mask and !opts.quiet) verifyEndToEnd(ui, allocator, domain);
+    if (opts.only != true and opts.mode == .mask and !opts.quiet) _ = verifyEndToEnd(ui, allocator, domain);
     if (!opts.quiet) printSummary(ui, allocator, domain, opts);
 }
 
@@ -448,7 +569,7 @@ fn checkDns(ui: *Tui, allocator: std.mem.Allocator, domain: []const u8) void {
         ui.hint(tr(ui, "Add an A record pointing at this server before handing out links.", "Добавьте A-запись на этот сервер до раздачи ссылок."));
         return;
     }
-    if (std.mem.indexOf(u8, result.stdout, public_ip) == null) {
+    if (!dnsHasAddress(result.stdout, public_ip)) {
         var buf: [384]u8 = undefined;
         const msg = std.fmt.bufPrint(&buf, "{s} '{s}' {s} {s}.", .{
             tr(ui, "DNS for", "DNS для"),
@@ -495,14 +616,29 @@ fn aptInstall(allocator: std.mem.Allocator, packages: []const []const u8) bool {
 /// fronting domain (`rutube.ru`) that could never validate. The relay domain is one the
 /// operator actually owns, so issuance is both possible and required — a self-signed
 /// certificate would make every client's WebView refuse the bridge.
+fn prepareAcmeRoot(allocator: std.mem.Allocator) !void {
+    const mkdir = try sys.exec(allocator, &.{ "mkdir", "-p", ACME_ROOT ++ "/.well-known/acme-challenge" });
+    defer mkdir.deinit();
+    if (mkdir.exit_code != 0) return error.AcmeDirectoryFailed;
+    const chmod = try sys.exec(allocator, &.{ "chmod", "755", ACME_ROOT, ACME_ROOT ++ "/.well-known", ACME_ROOT ++ "/.well-known/acme-challenge" });
+    defer chmod.deinit();
+    if (chmod.exit_code != 0) return error.AcmeDirectoryFailed;
+}
+
 fn ensureCertificate(ui: *Tui, allocator: std.mem.Allocator, domain: []const u8, email: []const u8) !bool {
     var live_buf: [512]u8 = undefined;
     const fullchain = std.fmt.bufPrint(&live_buf, "/etc/letsencrypt/live/{s}/fullchain.pem", .{domain}) catch return false;
-    if (sys.fileExists(fullchain)) {
+    const valid_certificate = blk: {
+        if (!sys.fileExists(fullchain)) break :blk false;
+        const result = sys.exec(allocator, &.{ "openssl", "x509", "-checkend", "86400", "-noout", "-in", fullchain }) catch break :blk false;
+        defer result.deinit();
+        break :blk result.exit_code == 0;
+    };
+    if (valid_certificate) {
         ui.ok(tr(ui, "Certificate already present", "Сертификат уже есть"));
         // The lineage renews over HTTP-01 through our port-80 responder; (re)create it
         // so a re-setup after `--remove`, or a lineage issued by hand, keeps renewing.
-        _ = sys.exec(allocator, &.{ "mkdir", "-p", ACME_ROOT ++ "/.well-known/acme-challenge" }) catch {};
+        try prepareAcmeRoot(allocator);
         if (!sys.fileExists("/etc/nginx/sites-enabled/mtproto-web-acme")) {
             _ = try writeAcmeVhost(ui, allocator, domain);
         }
@@ -521,7 +657,7 @@ fn ensureCertificate(ui: *Tui, allocator: std.mem.Allocator, domain: []const u8,
 
     // HTTP-01 needs port 80. It also makes the cover story better: a host that serves
     // HTTPS but refuses port 80 is unusual.
-    _ = sys.exec(allocator, &.{ "mkdir", "-p", ACME_ROOT ++ "/.well-known/acme-challenge" }) catch {};
+    try prepareAcmeRoot(allocator);
     if (!try writeAcmeVhost(ui, allocator, domain)) return false;
     if (sys.commandExists("ufw")) {
         sys.execSilent(allocator, &.{ sys.commandOrPath("ufw", &.{ "/usr/sbin/ufw", "/sbin/ufw" }), "allow", "80/tcp" });
@@ -565,13 +701,13 @@ fn writeAcmeVhost(ui: *Tui, allocator: std.mem.Allocator, domain: []const u8) !b
         \\    }}
         \\
         \\    location / {{
-        \\        return 301 https://$host$request_uri;
+        \\        return 301 https://{s}$request_uri;
         \\    }}
         \\
         \\    access_log off;
         \\}}
         \\
-    , .{ domain, ACME_ROOT });
+    , .{ domain, ACME_ROOT, domain });
     defer allocator.free(content);
 
     sys.writeFile("/etc/nginx/sites-available/mtproto-web-acme", content) catch {
@@ -714,6 +850,36 @@ fn writeVhost(ui: *Tui, allocator: std.mem.Allocator, domain: []const u8, opts: 
     };
     defer allocator.free(content);
 
+    // `nginx -t` validates the WHOLE /etc/nginx tree, not just this vhost. Take a
+    // baseline BEFORE touching anything: if the tree is already broken (an unrelated
+    // half-written vhost, a missing cert for some other site), that is not this vhost's
+    // fault to fix, and clobbering the live file first would make a pre-existing
+    // problem look like ours to roll back.
+    if (!nginxTestPasses(allocator)) {
+        ui.fail(tr(
+            ui,
+            "nginx's config was already broken before this change (unrelated to the relay vhost) — fix that first, then re-run.",
+            "конфигурация nginx была сломана ещё до этого изменения (не из-за vhost релея) — сначала исправьте её, затем повторите.",
+        ));
+        return false;
+    }
+
+    // Back up whatever is live now, so a test failure below can restore the exact prior
+    // state — which the check just above proved passes `nginx -t` — instead of leaving
+    // the clobbered file on disk with only the symlink removed (the old rollback deleted
+    // the symlink but left the overwritten file, so the previously working vhost stayed
+    // both clobbered and disabled). Only a currently-ENABLED vhost was actually exercised
+    // by that baseline test — nginx reads sites-enabled, not sites-available — so a stale
+    // NGINX_SITE left over from an earlier failed run (not linked) is not "proven valid"
+    // and must not be restored as if it were.
+    const was_enabled = sys.fileExists(NGINX_LINK);
+    const previous = if (was_enabled) sys.readFileAllocAbsolute(allocator, NGINX_SITE, 64 * 1024) else null;
+    defer if (previous) |p| allocator.free(p);
+    if (was_enabled and previous == null) {
+        ui.fail("Cannot back up the active relay vhost; leaving it unchanged");
+        return false;
+    }
+
     sys.writeFile(NGINX_SITE, content) catch {
         ui.fail(tr(ui, "Could not write the relay vhost", "Не удалось записать vhost релея"));
         return false;
@@ -723,7 +889,15 @@ fn writeVhost(ui: *Tui, allocator: std.mem.Allocator, domain: []const u8, opts: 
     // order masking.zig uses, and for the same reason.
     _ = sys.exec(allocator, &.{ "ln", "-sf", NGINX_SITE, NGINX_LINK }) catch {};
     if (!nginxTestPasses(allocator)) {
-        _ = sys.exec(allocator, &.{ "rm", "-f", NGINX_LINK }) catch {};
+        if (previous) |p| {
+            // A previous vhost existed and the baseline above proved it valid — put it
+            // back verbatim rather than just dropping the symlink, so the reload below
+            // actually restores the working relay instead of leaving the bad content on
+            // disk for the next reload/reboot to pick up.
+            sys.writeFile(NGINX_SITE, p) catch {};
+        } else {
+            _ = sys.exec(allocator, &.{ "rm", "-f", NGINX_LINK, NGINX_SITE }) catch {};
+        }
         _ = sys.exec(allocator, &.{ "systemctl", "reload", "nginx" }) catch {};
         ui.fail(tr(ui, "nginx rejected the relay vhost — rolled back, nginx left unchanged", "nginx отверг vhost релея — откатил, nginx не тронут"));
         return false;
@@ -756,26 +930,39 @@ fn nginxTestPasses(allocator: std.mem.Allocator) bool {
 /// `TomlDoc` round-trips add a trailing newline every time it saves, and
 /// `test/installer-e2e` asserts `mtbuddy update` leaves config.toml byte-identical. This
 /// module is re-run from `update`, so an unconditional save would fail that.
-fn writeConfig(ui: *Tui, allocator: std.mem.Allocator, domain: []const u8, opts: WebOpts) !void {
-    const mask_mode = opts.mode == .mask;
+fn writeConfig(ui: *Tui, allocator: std.mem.Allocator, domain: []const u8, opts: WebOpts) !bool {
     if (!sys.fileExists(config_path)) {
         ui.warn(tr(ui, "config.toml not found — skipping [web] update", "config.toml не найден — пропускаю обновление [web]"));
-        return;
+        return error.ConfigNotFound;
     }
     var doc = toml.TomlDoc.load(allocator, config_path) catch {
         ui.warn(tr(ui, "Could not read config.toml", "Не удалось прочитать config.toml"));
-        return;
+        return error.ConfigReadFailed;
     };
     defer doc.deinit();
 
+    const changed = try applyConfigDoc(&doc, domain, opts);
+    if (!changed) {
+        ui.ok(tr(ui, "[web] already up to date", "[web] уже актуален"));
+        return false;
+    }
+    try doc.save(config_path);
+    const owner = try sys.exec(allocator, &.{ "chown", "mtproto:mtproto", config_path });
+    defer owner.deinit();
+    if (owner.exit_code != 0) return error.ConfigOwnershipFailed;
+    return true;
+}
+
+fn applyConfigDoc(doc: *toml.TomlDoc, domain: []const u8, opts: WebOpts) !bool {
+    const mask_mode = opts.mode == .mask;
     var quoted_domain_buf: [300]u8 = undefined;
-    const quoted_domain = std.fmt.bufPrint(&quoted_domain_buf, "\"{s}\"", .{domain}) catch return;
+    const quoted_domain = try std.fmt.bufPrint(&quoted_domain_buf, "\"{s}\"", .{domain});
     const quoted_mask_backend = "\"127.0.0.1:" ++ PROXY_PROTOCOL_PORT ++ "\"";
     var quoted_cert_buf: [560]u8 = undefined;
     var quoted_key_buf: [560]u8 = undefined;
     const byo_cert = opts.cert.len > 0 and opts.key.len > 0;
-    const quoted_cert = if (byo_cert) std.fmt.bufPrint(&quoted_cert_buf, "\"{s}\"", .{opts.cert}) catch return else "";
-    const quoted_key = if (byo_cert) std.fmt.bufPrint(&quoted_key_buf, "\"{s}\"", .{opts.key}) catch return else "";
+    const quoted_cert = if (byo_cert) try std.fmt.bufPrint(&quoted_cert_buf, "\"{s}\"", .{opts.cert}) else "";
+    const quoted_key = if (byo_cert) try std.fmt.bufPrint(&quoted_key_buf, "\"{s}\"", .{opts.key}) else "";
     // `only` is tri-state on the way in: null means "leave whatever is there", so an
     // `mtbuddy update` (which passes no flags) never flips a WEB-only deploy back.
     const only_text: ?[]const u8 = if (opts.only) |v| (if (v) "true" else "false") else null;
@@ -784,49 +971,49 @@ fn writeConfig(ui: *Tui, allocator: std.mem.Allocator, domain: []const u8, opts:
     // is already there. An `mtbuddy update` names none, and introducing a key on its own
     // would rewrite config.toml (and restart the proxy) on every update — which
     // test/installer-e2e asserts against.
-    const write_mode = opts.mode_explicit or hasValue(&doc, "mode");
+    const write_mode = opts.mode_explicit or hasValue(doc, "mode");
     const mode_text: []const u8 = if (mask_mode) "\"mask\"" else "\"behind\"";
 
     var changed = false;
-    changed = needsSet(&doc, "enabled", "true") or changed;
-    changed = needsSet(&doc, "domain", quoted_domain) or changed;
-    changed = needsSet(&doc, "port", opts.port) or changed;
-    if (mask_mode) changed = needsSet(&doc, "mask_backend", quoted_mask_backend) or changed;
-    if (write_mode) changed = needsSet(&doc, "mode", mode_text) or changed;
+    var host_buf: [128]u8 = undefined;
+    const quoted_host = if (opts.host) |host| try std.fmt.bufPrint(&host_buf, "\"{s}\"", .{host}) else null;
+    if (quoted_host) |host| changed = needsSet(doc, "host", host) or changed;
+    if (opts.lets_encrypt) changed = hasValue(doc, "cert") or hasValue(doc, "key") or changed;
+    changed = needsSet(doc, "enabled", "true") or changed;
+    changed = needsSet(doc, "domain", quoted_domain) or changed;
+    changed = needsSet(doc, "port", opts.port) or changed;
+    if (mask_mode) changed = needsSet(doc, "mask_backend", quoted_mask_backend) or changed;
+    if (!mask_mode) changed = hasValue(doc, "mask_backend") or changed;
+    if (write_mode) changed = needsSet(doc, "mode", mode_text) or changed;
     if (byo_cert) {
-        changed = needsSet(&doc, "cert", quoted_cert) or changed;
-        changed = needsSet(&doc, "key", quoted_key) or changed;
+        changed = needsSet(doc, "cert", quoted_cert) or changed;
+        changed = needsSet(doc, "key", quoted_key) or changed;
     }
-    if (only_text) |v| changed = needsSet(&doc, "only", v) or changed;
-    if (!changed) {
-        ui.ok(tr(ui, "[web] already up to date", "[web] уже актуален"));
-        return;
-    }
+    if (only_text) |v| changed = needsSet(doc, "only", v) or changed;
+    if (!changed) return false;
 
     try doc.set("web", "enabled", "true");
+    if (quoted_host) |host| try doc.set("web", "host", host);
+    if (opts.lets_encrypt) {
+        try doc.set("web", "cert", "\"\"");
+        try doc.set("web", "key", "\"\"");
+    }
     try doc.set("web", "domain", quoted_domain);
     try doc.set("web", "port", opts.port);
     // Only mode "mask" routes through the proxy, so only it has a PROXY-protocol
     // terminator to point at.
     if (mask_mode) try doc.set("web", "mask_backend", quoted_mask_backend);
+    if (!mask_mode and hasValue(doc, "mask_backend")) try doc.set("web", "mask_backend", "\"\"");
     if (write_mode) try doc.set("web", "mode", mode_text);
     if (byo_cert) {
         try doc.set("web", "cert", quoted_cert);
         try doc.set("web", "key", quoted_key);
     }
     if (only_text) |v| try doc.set("web", "only", v);
-    doc.save(config_path) catch {};
-    _ = sys.exec(allocator, &.{ "chown", "mtproto:mtproto", config_path }) catch {};
 
-    // `[web].enabled` decides at startup whether the data plane trusts the relay, and
-    // it is not part of the SIGHUP reload set — the proxy has to restart.
-    ui.step(tr(ui, "Restarting the proxy to apply [web]...", "Перезапускаю прокси, чтобы применить [web]..."));
-    _ = sys.exec(allocator, &.{ "systemctl", "restart", "mtproto-proxy" }) catch {};
+    return true;
 }
 
-/// True when `[web].key` differs from `value`, comparing without surrounding quotes on
-/// either side — `doc.get` may or may not return them, and a false "changed" here
-/// means an unnecessary config rewrite plus a proxy restart on every `mtbuddy update`.
 /// True when `[web].key` is present with a non-empty value. An empty string is how this
 /// module expresses "unset" (TomlDoc cannot delete a key), so it must not read as set.
 fn hasValue(doc: *toml.TomlDoc, key: []const u8) bool {
@@ -834,6 +1021,7 @@ fn hasValue(doc: *toml.TomlDoc, key: []const u8) bool {
     return std.mem.trim(u8, current, " \t\"").len > 0;
 }
 
+/// Compare a persisted value without surrounding TOML quotes.
 fn needsSet(doc: *toml.TomlDoc, key: []const u8, value: []const u8) bool {
     const current = doc.get("web", key) orelse return true;
     const cur = std.mem.trim(u8, current, " \t\"");
@@ -848,6 +1036,14 @@ fn unitContent() []const u8 {
     \\Documentation=https://github.com/sleep3r/mtproto.zig
     \\After=network-online.target mtproto-proxy.service
     \\Wants=network-online.target
+    \\StartLimitIntervalSec=0
+    \\# The relay reads [access.users] once, at startup, and derives one bridge capability
+    \\# per user from it — so a user added or removed later never reaches it and its WEB
+    \\# link answers with the cover page instead of the bridge. Every path that changes
+    \\# users (the dashboard, mtbuddy, install) restarts mtproto-proxy, and PartOf= makes
+    \\# systemd propagate that restart here. It costs nothing: a proxy restart already
+    \\# drops every relayed stream, since each one is a connection to the proxy.
+    \\PartOf=mtproto-proxy.service
     \\
     \\[Service]
     \\Type=simple
@@ -905,8 +1101,9 @@ fn installService(ui: *Tui, allocator: std.mem.Allocator) !void {
         return;
     };
     _ = sys.exec(allocator, &.{ "systemctl", "daemon-reload" }) catch {};
-    _ = sys.exec(allocator, &.{ "systemctl", "enable", "--now", SERVICE_NAME }) catch {};
+    _ = sys.exec(allocator, &.{ "systemctl", "enable", SERVICE_NAME }) catch {};
     _ = sys.exec(allocator, &.{ "systemctl", "restart", SERVICE_NAME }) catch {};
+    try @import("recovery.zig").installWebHealth(allocator);
 
     // Type=simple is "active" the instant it is exec'd; a relay that exits on a bad
     // config does so within the first second. Look after that, not before.
@@ -921,10 +1118,10 @@ fn installService(ui: *Tui, allocator: std.mem.Allocator) !void {
 
 /// Fetch the relay's own domain over the public path: browser → proxy :443 → masking →
 /// nginx → relay. Anything less than that does not prove the topology works.
-fn verifyEndToEnd(ui: *Tui, allocator: std.mem.Allocator, domain: []const u8) void {
-    if (!sys.commandExists("curl")) return;
+fn verifyEndToEnd(ui: *Tui, allocator: std.mem.Allocator, domain: []const u8) bool {
+    if (!sys.commandExists("curl")) return false;
     var url_buf: [320]u8 = undefined;
-    const url = std.fmt.bufPrint(&url_buf, "https://{s}/", .{domain}) catch return;
+    const url = std.fmt.bufPrint(&url_buf, "https://{s}/", .{domain}) catch return false;
     // The proxy was restarted and the relay started moments ago; `is-active` on a
     // Type=simple unit says nothing about the listener being bound yet. Give the
     // chain a few seconds before declaring it broken.
@@ -943,9 +1140,11 @@ fn verifyEndToEnd(ui: *Tui, allocator: std.mem.Allocator, domain: []const u8) vo
     }
     if (std.mem.eql(u8, code, "200")) {
         ui.ok(tr(ui, "The relay site answers over the public HTTPS path", "Сайт релея отвечает по публичному HTTPS"));
+        return true;
     } else {
         ui.warn(tr(ui, "Could not fetch the relay site from this host", "Не удалось получить сайт релея с этого хоста"));
         ui.hint(tr(ui, "Check DNS, the certificate, and that [censorship].mask is on.", "Проверьте DNS, сертификат и что [censorship].mask включён."));
+        return false;
     }
 }
 
@@ -975,7 +1174,11 @@ fn printSummary(ui: *Tui, allocator: std.mem.Allocator, domain: []const u8, opts
         lines_buf[n] = .{ .label = tr(ui, "Certificate", "Сертификат"), .value = opts.cert };
         n += 1;
     }
-    lines_buf[n] = .{ .label = tr(ui, "Listener", "Слушает"), .value = "127.0.0.1:" ++ DEFAULT_PORT };
+    var listener_buf: [64]u8 = undefined;
+    var configured_host: [64]u8 = undefined;
+    const host = opts.host orelse readConfigured(allocator, "host", &configured_host) orelse "127.0.0.1";
+    const listener = std.fmt.bufPrint(&listener_buf, "{s}:{s}", .{ host, opts.port }) catch "";
+    lines_buf[n] = .{ .label = tr(ui, "Listener", "Слушает"), .value = listener };
     n += 1;
     lines_buf[n] = .{ .label = tr(ui, "Service", "Сервис"), .value = SERVICE_NAME };
     n += 1;
@@ -993,11 +1196,8 @@ fn printSummary(ui: *Tui, allocator: std.mem.Allocator, domain: []const u8, opts
         ));
     }
     if (opts.mode == .behind) {
-        ui.hint(tr(
-            ui,
-            "Point your terminator at 127.0.0.1:" ++ DEFAULT_PORT ++ ", forward Upgrade/Connection, and pass X-Forwarded-For.",
-            "Направьте терминатор на 127.0.0.1:" ++ DEFAULT_PORT ++ ", пробросьте Upgrade/Connection и X-Forwarded-For.",
-        ));
+        var hint_buf: [256]u8 = undefined;
+        ui.hint(std.fmt.bufPrint(&hint_buf, "Point your terminator at {s}; forward Upgrade/Connection. Use --host <IP> for a remote terminator and restrict access with your firewall.", .{listener}) catch "Configure your TLS terminator to forward Upgrade/Connection.");
     }
     ui.hint(if (only_now)
         tr(
@@ -1035,6 +1235,8 @@ pub fn remove(ui: *Tui, allocator: std.mem.Allocator) void {
     ui.section(tr(ui, "Remove the WEB proxy relay", "Удаление релея WEB-прокси"));
 
     ui.step(tr(ui, "Stopping the relay service...", "Останавливаю сервис релея..."));
+    sys.execSilent(allocator, &.{ "systemctl", "disable", "--now", "mtproto-web-health.timer", "mtproto-web-health.service" });
+    sys.execSilent(allocator, &.{ "rm", "-f", "/usr/local/bin/mtproto-web-health.sh", "/etc/systemd/system/mtproto-web-health.service", "/etc/systemd/system/mtproto-web-health.timer" });
     _ = sys.exec(allocator, &.{ "systemctl", "disable", "--now", SERVICE_NAME }) catch {};
     _ = sys.exec(allocator, &.{ "rm", "-f", SERVICE_FILE }) catch {};
     _ = sys.exec(allocator, &.{ "systemctl", "daemon-reload" }) catch {};
@@ -1068,8 +1270,8 @@ pub fn remove(ui: *Tui, allocator: std.mem.Allocator) void {
     ui.ok(tr(ui, "WEB proxy relay removed. The proxy keeps running.", "Релей WEB-прокси удалён. Прокси продолжает работать."));
     ui.hint(tr(
         ui,
-        "The Let's Encrypt certificate, its port-80 challenge responder and renewal hook were left in place (certbot delete --cert-name <domain> to drop them).",
-        "Сертификат Let's Encrypt, ACME-ответчик на порту 80 и hook продления оставлены (certbot delete --cert-name <domain>, чтобы убрать).",
+        "Retained shared resources: the Let's Encrypt certificate, mtproto-web-acme nginx site, /var/www/acme, certbot renewal hook, and firewall port 80. If no other service needs them, delete the certificate with certbot delete --cert-name <domain>, remove the ACME site/hook/root, reload nginx, and close port 80 manually.",
+        "Сохранены общие ресурсы: сертификат Let's Encrypt, сайт nginx mtproto-web-acme, /var/www/acme, hook certbot и порт 80 в firewall. Если они больше не нужны, удалите сертификат через certbot delete --cert-name <domain>, сайт/hook/каталог ACME, перезагрузите nginx и вручную закройте порт 80.",
     ));
 }
 
@@ -1133,6 +1335,12 @@ test "the systemd unit runs the relay mode of the proxy binary and drops all cap
     try std.testing.expect(std.mem.containsAtLeast(u8, unit, 1, "After=network-online.target mtproto-proxy.service"));
 }
 
+test "the relay unit restarts with the proxy, so user changes reach its capabilities" {
+    // Capabilities are built once from [access.users]; without this line adding a user
+    // restarts only mtproto-proxy and the new WEB link keeps getting the cover page.
+    try std.testing.expect(std.mem.containsAtLeast(u8, unitContent(), 1, "\nPartOf=mtproto-proxy.service\n"));
+}
+
 test "the relay vhost carries both listeners and never appends to X-Forwarded-For" {
     const rendered = try writeVhostContent(
         std.testing.allocator,
@@ -1152,9 +1360,42 @@ test "the relay vhost carries both listeners and never appends to X-Forwarded-Fo
 }
 
 test "the relay port may not collide with the proxy or the masking backend" {
-    // Guard rail encoded in execute(); assert the constants it compares are distinct.
-    try std.testing.expect(!std.mem.eql(u8, DEFAULT_PORT, masking.NGINX_PORT));
-    try std.testing.expect(!std.mem.eql(u8, DEFAULT_PORT, "443"));
+    for ([_]u16{ 0, 443, 9443, 8443, 8444 }) |port| try std.testing.expect(relayPortConflicts(port, 443, 9443));
+    try std.testing.expect(relayPortConflicts(try std.fmt.parseInt(u16, "08443", 10), 443, 9443));
+    try std.testing.expect(!relayPortConflicts(8081, 443, 9443));
+}
+
+test "WEB provisioning preserves only on update and clears stale mask and certificate keys" {
+    var doc = toml.TomlDoc.initEmpty(std.testing.allocator);
+    defer doc.deinit();
+    var opts: WebOpts = .{ .mode = .mask, .port = "8081", .only = true, .cert = "/cert.pem", .key = "/key.pem" };
+    try std.testing.expect(try applyConfigDoc(&doc, "relay.example.com", opts));
+    opts.only = null;
+    try std.testing.expect(!try applyConfigDoc(&doc, "relay.example.com", opts));
+    try std.testing.expect(!needsSet(&doc, "only", "true"));
+    opts.mode = .behind;
+    opts.mode_explicit = true;
+    opts.lets_encrypt = true;
+    opts.cert = "";
+    opts.key = "";
+    opts.only = false;
+    try std.testing.expect(try applyConfigDoc(&doc, "relay.example.com", opts));
+    try std.testing.expect(!hasValue(&doc, "mask_backend"));
+    try std.testing.expect(!hasValue(&doc, "cert"));
+    try std.testing.expect(!hasValue(&doc, "key"));
+    try std.testing.expect(!needsSet(&doc, "only", "false"));
+    try std.testing.expect(!try applyConfigDoc(&doc, "relay.example.com", opts));
+}
+
+test "changing [web].domain is refused without --force, same as tls_domain" {
+    // Same domain (or none configured yet, which execute() never routes through this
+    // helper): no gate needed either way.
+    try std.testing.expect(domainChangeAllowed("relay.example.com", "relay.example.com", false));
+    // A different domain silently written through would break every distributed
+    // tg://webproxy link's HMAC'd bridge capability the moment the relay restarts.
+    try std.testing.expect(!domainChangeAllowed("relay.example.com", "relay2.example.com", false));
+    // --force is the operator's informed override, same as masking.zig's tls_domain gate.
+    try std.testing.expect(domainChangeAllowed("relay.example.com", "relay2.example.com", true));
 }
 
 test "domain validation matches the client's own rules" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -26,7 +26,7 @@ const web_relay = @import("web/relay.zig");
 pub const std_options = std.Options{
     // Set comptime level to .debug so all log calls are compiled in.
     // Runtime filtering is done in lockFreeLog via runtime_log.level.
-    .log_level = .debug,
+    .log_level = if (builtin.is_test) .err else .debug,
     .logFn = lockFreeLog,
 };
 
@@ -37,7 +37,7 @@ fn lockFreeLog(
     args: anytype,
 ) void {
     // Runtime filter: skip messages below configured level
-    if (@intFromEnum(message_level) > @intFromEnum(runtime_log.level)) return;
+    if (@intFromEnum(message_level) > @intFromEnum(runtime_log.level.load(.monotonic))) return;
 
     const level_txt = comptime message_level.asText();
     const prefix2 = comptime if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
@@ -83,32 +83,7 @@ fn writeRaw(s: []const u8) void {
 
 // ============= Public IP Detection =============
 
-fn fetchUrlBytes(allocator: std.mem.Allocator, url: []const u8) ![]u8 {
-    const uri = try std.Uri.parse(url);
-    const io = std.Io.Threaded.global_single_threaded.io();
-
-    var client: std.http.Client = .{ .allocator = allocator, .io = io };
-    defer client.deinit();
-
-    var req = try client.request(.GET, uri, .{
-        .redirect_behavior = @enumFromInt(3),
-        .keep_alive = false,
-        .headers = .{
-            .accept_encoding = .{ .override = "identity" },
-        },
-    });
-    defer req.deinit();
-
-    try req.sendBodiless();
-
-    var redirect_buf: [8 * 1024]u8 = undefined;
-    var response = try req.receiveHead(&redirect_buf);
-    if (response.head.status.class() != .success) return error.HttpRequestFailed;
-
-    var transfer_buf: [4 * 1024]u8 = undefined;
-    const reader = response.reader(&transfer_buf);
-    return reader.allocRemaining(allocator, .limited(64 * 1024));
-}
+const fetchUrlBytes = @import("proxy/http_fetch.zig").fetchUrlBytes;
 
 /// Try to detect the server's public IP address via external services.
 /// Returns the IP string (caller owns memory) or null on failure.
@@ -240,17 +215,17 @@ fn estimateCapacity(cfg: *const config.Config, total_ram_bytes: u64) CapacityEst
     // - optional middle-proxy stream buffers (2 per-connection buffers)
     // - allocator/socket bookkeeping cushion
     const tls_working_bytes: u64 = @intCast(6 * 1024);
-    const middleproxy_per_conn_bytes: u64 = if (cfg.use_middle_proxy)
+    const middleproxy_per_conn_bytes: u64 = if (cfg.use_middle_proxy or cfg.force_media_middle_proxy or cfg.tag != null)
         @intCast(cfg.middleProxyBufferBytes() * 2)
     else
         0;
     // Event loop also keeps 2 shared scratch buffers for middle-proxy
     // encapsulate/decapsulate temporary output.
-    const middleproxy_shared_bytes: u64 = if (cfg.use_middle_proxy)
-        @intCast(cfg.middleProxyBufferBytes() * 2)
+    const middleproxy_shared_bytes: u64 = if (cfg.use_middle_proxy or cfg.force_media_middle_proxy or cfg.tag != null)
+        @intCast(cfg.middleProxySharedBytes())
     else
         0;
-    const overhead_bytes: u64 = 2 * 1024;
+    const overhead_bytes: u64 = 2 * 1024 + 2 * 32 * 1024; // two bounded queue block caches
     const per_conn_bytes = tls_working_bytes + middleproxy_per_conn_bytes + overhead_bytes;
 
     // Keep safety headroom for kernel TCP memory, page cache, and baseline process state.
@@ -297,13 +272,7 @@ fn enforceCapacitySafety(cfg: *config.Config, capacity_estimate: ?CapacityEstima
     const configured_limit = cfg.max_connections;
     cfg.max_connections = est.safe_connections;
 
-    if (cfg.max_connections > est.safe_connections) {
-        log_main.err(
-            "failed to enforce RAM safety limit: max_connections={d}, safe={d}; refusing startup",
-            .{ cfg.max_connections, est.safe_connections },
-        );
-        return error.CapacitySafetyEnforcementFailed;
-    }
+    std.debug.assert(cfg.max_connections <= est.safe_connections);
 
     log_main.warn(
         "auto-clamping max_connections from {d} to {d} " ++
@@ -421,7 +390,7 @@ fn runWebRelay(allocator: std.mem.Allocator, config_path: []const u8) !void {
         std.process.exit(1);
     };
     defer cfg.deinit(allocator);
-    runtime_log.level = cfg.log_level;
+    runtime_log.level.store(cfg.log_level, .monotonic);
 
     // `opts.domain` borrows this frame, which outlives the relay.
     var domain_buf: [web_capability.max_host_len]u8 = undefined;
@@ -456,9 +425,10 @@ pub fn main(init: std.process.Init) !void {
 
     if (first_arg) |arg| {
         if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
-            writeStderr(
+            writeStdout(
                 \\
                 \\  Usage: mtproto-proxy [config.toml]
+                \\         mtproto-proxy web-relay <config.toml>
                 \\
                 \\  Starts the MTProto proxy using the given config file.
                 \\  Defaults to 'config.toml' in the current directory.
@@ -473,7 +443,7 @@ pub fn main(init: std.process.Init) !void {
             return;
         }
         if (std.mem.eql(u8, arg, "--version") or std.mem.eql(u8, arg, "-v")) {
-            writeStderr("mtproto-proxy v" ++ version ++ "\n", .{});
+            writeStdout("mtproto-proxy v" ++ version ++ "\n", .{});
             return;
         }
         // Config dry-run (like `nginx -t`): parse + validate, then exit with a
@@ -485,7 +455,7 @@ pub fn main(init: std.process.Init) !void {
                 std.process.exit(1);
             };
             defer check_cfg.deinit(allocator);
-            runtime_log.level = check_cfg.log_level;
+            runtime_log.level.store(check_cfg.log_level, .monotonic);
             check_cfg.emitWarnings();
             writeStdout("  \x1b[32m✓\x1b[0m config '{s}' is valid ({d} user(s))\n", .{ path, check_cfg.users.count() });
             std.process.exit(0);
@@ -506,13 +476,13 @@ pub fn main(init: std.process.Init) !void {
     var cfg = config.Config.loadFromFile(allocator, config_path) catch |err| {
         writeStderr("\x1b[1m\x1b[31m  ✗ Failed to load config '{s}': {}\x1b[0m\n", .{ config_path, err });
         writeStderr("\n  Usage: mtproto-proxy [config.toml]\n\n", .{});
-        return;
+        return err;
     };
     var cfg_owned_by_main = true;
     defer if (cfg_owned_by_main) cfg.deinit(allocator);
 
     // Apply runtime log level from config
-    runtime_log.level = cfg.log_level;
+    runtime_log.level.store(cfg.log_level, .monotonic);
 
     if (!std.crypto.core.aes.has_hardware_support and (builtin.cpu.arch == .x86_64 or builtin.cpu.arch == .aarch64)) {
         const log_main = std.log.scoped(.config);
@@ -537,22 +507,29 @@ pub fn main(init: std.process.Init) !void {
     cfg.emitWarnings();
 
     // Create shared state (DI — no globals)
-    var state = try proxy.ProxyState.init(allocator, cfg, config_path);
+    const state = try allocator.create(proxy.ProxyState);
+    defer allocator.destroy(state);
+    state.* = try proxy.ProxyState.init(allocator, cfg, config_path);
     cfg_owned_by_main = false;
     defer state.deinit();
 
     // systemd notify/watchdog wiring (no-op when not run under systemd). The env
     // strings are owned by the process environ and live for the whole run.
     state.notify_socket = init.environ_map.get("NOTIFY_SOCKET");
-    if (init.environ_map.get("WATCHDOG_USEC")) |w| {
-        state.watchdog_usec = std.fmt.parseInt(u64, w, 10) catch 0;
-    }
+    state.watchdog_usec = @import("proxy/sd_notify.zig").watchdogInterval(
+        init.environ_map.get("WATCHDOG_USEC"),
+        init.environ_map.get("WATCHDOG_PID"),
+        @intCast(std.os.linux.getpid()),
+    );
 
     // Run the proxy
     try state.run();
 }
 
 test {
+    // Zig's server-mode test runner reports any warning output as "failed command"
+    // even on exit 0. Expected warning-path regressions should remain quiet.
+    std.testing.log_level = .err;
     _ = constants;
     _ = crypto;
     _ = obfuscation;
@@ -585,6 +562,21 @@ test "capacity safety clamp enforces safe cap when override disabled" {
 
     try enforceCapacitySafety(&cfg, est);
     try std.testing.expectEqual(@as(u32, 585), cfg.max_connections);
+}
+
+test "capacity estimate includes forced media MiddleProxy buffers" {
+    var cfg = config.Config{
+        .users = std.StringHashMap([16]u8).init(std.testing.allocator),
+        .direct_users = std.StringHashMap(void).init(std.testing.allocator),
+        .use_middle_proxy = false,
+        .force_media_middle_proxy = false,
+    };
+    defer cfg.deinit(std.testing.allocator);
+    const direct = estimateCapacity(&cfg, 2 * 1024 * 1024 * 1024);
+    cfg.force_media_middle_proxy = true;
+    const media = estimateCapacity(&cfg, 2 * 1024 * 1024 * 1024);
+    try std.testing.expectEqual(direct.per_conn_bytes + cfg.middleProxyBufferBytes() * 2, media.per_conn_bytes);
+    try std.testing.expect(media.safe_connections < direct.safe_connections);
 }
 
 test "capacity safety clamp keeps configured limit when override enabled" {

--- a/src/monitoring.zig
+++ b/src/monitoring.zig
@@ -20,7 +20,26 @@ const ProcessMetrics = struct {
     cgroup_memory_limit_bytes: ?u64 = null,
 };
 
-pub fn start(state: *proxy.ProxyState) !void {
+pub const Handle = struct {
+    context: *Context,
+    threads: [4]std.Thread,
+
+    pub fn stop(self: Handle) void {
+        self.context.stopping.store(true, .release);
+        _ = linux.shutdown(self.context.server.socket.handle, linux.SHUT.RD);
+        for (self.threads) |thread| thread.join();
+        self.context.server.deinit(std.Io.Threaded.global_single_threaded.io());
+        self.context.state.allocator.destroy(self.context);
+    }
+};
+
+const Context = struct {
+    state: *proxy.ProxyState,
+    server: net.Server,
+    stopping: std.atomic.Value(bool) = .init(false),
+};
+
+pub fn start(state: *proxy.ProxyState) !Handle {
     if (builtin.os.tag != .linux) return error.UnsupportedOperatingSystem;
 
     const host = state.config.metrics.effectiveHost();
@@ -36,22 +55,34 @@ pub fn start(state: *proxy.ProxyState) !void {
 
     log.info("metrics endpoint listening on {s}:{d}", .{ host, port });
 
-    const thread = try std.Thread.spawn(.{}, acceptLoop, .{ state, server });
-    thread.detach();
+    const context = try state.allocator.create(Context);
+    errdefer state.allocator.destroy(context);
+    context.* = .{ .state = state, .server = server };
+    var threads: [4]std.Thread = undefined;
+    var count: usize = 0;
+    errdefer {
+        context.stopping.store(true, .release);
+        _ = linux.shutdown(server.socket.handle, linux.SHUT.RD);
+        for (threads[0..count]) |thread| thread.join();
+    }
+    for (&threads) |*thread| {
+        thread.* = try std.Thread.spawn(.{}, acceptLoop, .{context});
+        count += 1;
+    }
+    return .{ .context = context, .threads = threads };
 }
 
-fn acceptLoop(state: *proxy.ProxyState, server: net.Server) void {
-    var local_server = server;
+fn acceptLoop(context: *Context) void {
     const io_ctx = std.Io.Threaded.global_single_threaded.io();
-    defer local_server.deinit(io_ctx);
 
-    while (true) {
-        const conn = local_server.accept(io_ctx) catch |err| {
+    while (!context.stopping.load(.acquire)) {
+        const conn = context.server.accept(io_ctx) catch |err| {
+            if (context.stopping.load(.acquire)) return;
             log.warn("metrics accept failed: {any}", .{err});
             sleepNs(200 * std.time.ns_per_ms);
             continue;
         };
-        handleConnection(state, conn.socket.handle);
+        handleConnection(context.state, conn.socket.handle);
     }
 }
 
@@ -61,7 +92,7 @@ fn resolveFirstAddress(host: []const u8, port: u16) !net.IpAddress {
     const host_name = try net.HostName.init(host);
     const io_ctx = std.Io.Threaded.global_single_threaded.io();
 
-    var results_buf: [8]net.HostName.LookupResult = undefined;
+    var results_buf: [32]net.HostName.LookupResult = undefined;
     var results: std.Io.Queue(net.HostName.LookupResult) = .init(&results_buf);
     try host_name.lookup(io_ctx, &results, .{ .port = port });
 
@@ -104,7 +135,17 @@ fn handleConnection(state: *proxy.ProxyState, fd: posix.fd_t) void {
     }
 
     var req_buf: [2048]u8 = undefined;
-    const req_len = posix.read(fd, &req_buf) catch return;
+    var req_len: usize = 0;
+    const deadline = @import("proxy/socket_utils.zig").nowMs() + 5000;
+    while (req_len < req_buf.len and std.mem.indexOf(u8, req_buf[0..req_len], "\r\n") == null) {
+        const remaining = deadline - @import("proxy/socket_utils.zig").nowMs();
+        if (remaining <= 0) return;
+        const timeout = posix.timeval{ .sec = @intCast(@divTrunc(remaining, 1000)), .usec = @intCast(@mod(remaining, 1000) * 1000) };
+        posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.RCVTIMEO, std.mem.asBytes(&timeout)) catch return;
+        const n = posix.read(fd, req_buf[req_len..]) catch return;
+        if (n == 0) return;
+        req_len += n;
+    }
     if (req_len == 0) return;
 
     const request = req_buf[0..req_len];
@@ -134,9 +175,8 @@ fn handleConnection(state: *proxy.ProxyState, fd: posix.fd_t) void {
         writeSimpleResponse(fd, "404 Not Found", "text/plain", "not found\n");
         return;
     }
-    writeMetricsResponse(fd, state) catch {
-        writeSimpleResponse(fd, "500 Internal Server Error", "text/plain", "internal error\n");
-    };
+    // Once the response starts, a write failure must only close the connection.
+    writeMetricsResponse(fd, state) catch {};
 }
 
 fn closeFd(fd: posix.fd_t) void {
@@ -153,10 +193,10 @@ fn writeMetricsResponse(fd: posix.fd_t, state: *proxy.ProxyState) !void {
     // Sized for the per-user families, which dominate: every configured user costs
     // ~165 bytes, and a user with an [access.user_max_ips] quota ~145 more. A fixed
     // writer that runs out fails the whole scrape, so keep the headroom generous.
-    var body_buf: [64 * 1024]u8 = undefined;
-    var body_writer: std.Io.Writer = .fixed(&body_buf);
-    try writeMetrics(&body_writer, state, collectProcessMetrics());
-    const body = body_writer.buffered();
+    var body_writer: std.Io.Writer.Allocating = .init(state.allocator);
+    defer body_writer.deinit();
+    try writeMetrics(&body_writer.writer, state, collectProcessMetrics());
+    const body = body_writer.written();
 
     var header_buf: [256]u8 = undefined;
     var header_writer: std.Io.Writer = .fixed(&header_buf);
@@ -360,10 +400,24 @@ fn writePrometheusLabelValue(writer: anytype, value: []const u8) !void {
         switch (ch) {
             '\\' => try writer.writeAll("\\\\"),
             '"' => try writer.writeAll("\\\""),
-            '\n' => try writer.writeAll("\\n"),
+            '\n', '\r' => try writer.writeAll("\\n"), // Prometheus has no \\r escape.
             else => try writer.writeByte(ch),
         }
     }
+}
+
+test "labels normalize carriage returns using valid Prometheus escapes" {
+    var buf: [128]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    try writePrometheusLabelValue(&writer, "a\rb\n\"\\");
+    try std.testing.expectEqualStrings("a\\nb\\n\\\"\\\\", writer.buffered());
+}
+
+test "process status parses both gauges from one snapshot and rejects overflow" {
+    const status = "Name: proxy\nVmRSS:\t12 kB\nVmSize:\t34 kB\n";
+    try std.testing.expectEqual(@as(?u64, 12 * 1024), parseStatusValueBytes(status, "VmRSS:"));
+    try std.testing.expectEqual(@as(?u64, 34 * 1024), parseStatusValueBytes(status, "VmSize:"));
+    try std.testing.expectEqual(@as(?u64, null), parseStatusValueBytes("VmRSS: 18446744073709551615 kB", "VmRSS:"));
 }
 
 fn writeGauge(writer: anytype, name: []const u8, help: []const u8, value: anytype) !void {
@@ -381,15 +435,31 @@ fn boolToInt(value: bool) u8 {
 }
 
 fn collectProcessMetrics() ProcessMetrics {
-    return .{
-        .resident_memory_bytes = readStatusValueBytes("VmRSS:"),
-        .virtual_memory_bytes = readStatusValueBytes("VmSize:"),
+    // Four scrape workers share one one-second snapshot, including the O(fd-count)
+    // directory walk. A burst of scrapes must not multiply procfs work.
+    const Cache = struct {
+        var mutex: std.Io.Mutex = .init;
+        var at_ms: i64 = -1;
+        var value: ProcessMetrics = .{};
+    };
+    const io = std.Io.Threaded.global_single_threaded.io();
+    Cache.mutex.lockUncancelable(io);
+    defer Cache.mutex.unlock(io);
+    const now: i64 = @intCast(std.Io.Clock.awake.now(io).toMilliseconds());
+    if (Cache.at_ms >= 0 and now - Cache.at_ms < 1000) return Cache.value;
+    var status_buf: [16 * 1024]u8 = undefined;
+    const status = readFileAbsolute("/proc/self/status", &status_buf) orelse "";
+    Cache.value = .{
+        .resident_memory_bytes = parseStatusValueBytes(status, "VmRSS:"),
+        .virtual_memory_bytes = parseStatusValueBytes(status, "VmSize:"),
         .cpu_seconds_total = readCpuSecondsTotal(),
         .open_fds = countOpenFds(),
         .max_fds = readMaxFds(),
         .cgroup_memory_usage_bytes = readCgroupMemoryCurrent(),
         .cgroup_memory_limit_bytes = readCgroupMemoryLimit(),
     };
+    Cache.at_ms = now;
+    return Cache.value;
 }
 
 fn readCgroupMemoryCurrent() ?u64 {
@@ -418,17 +488,14 @@ fn readNumericFileAbsolute(path: []const u8) ?u64 {
     return std.fmt.parseInt(u64, trimmed, 10) catch null;
 }
 
-fn readStatusValueBytes(label: []const u8) ?u64 {
-    var buf: [16 * 1024]u8 = undefined;
-    const text = readFileAbsolute("/proc/self/status", &buf) orelse return null;
-
+fn parseStatusValueBytes(text: []const u8, label: []const u8) ?u64 {
     var lines = std.mem.splitScalar(u8, text, '\n');
     while (lines.next()) |line| {
         if (!std.mem.startsWith(u8, line, label)) continue;
         var it = std.mem.tokenizeAny(u8, line[label.len..], " \t");
         const value_txt = it.next() orelse return null;
         const kib = std.fmt.parseInt(u64, value_txt, 10) catch return null;
-        return kib * 1024;
+        return std.math.mul(u64, kib, 1024) catch null;
     }
     return null;
 }

--- a/src/protocol/constants.zig
+++ b/src/protocol/constants.zig
@@ -23,6 +23,7 @@ pub const tg_datacenters_v4 = [5]net.IpAddress{
     ip4(.{ 149, 154, 171, 5 }, tg_datacenter_port),
 };
 
+/// Reference addresses only: current direct and MiddleProxy routing requires IPv4 egress.
 pub const tg_datacenters_v6 = [5]net.IpAddress{
     ip6(.{ 0x20, 0x01, 0x0b, 0x28, 0xf2, 0x3d, 0xf0, 0x01, 0, 0, 0, 0, 0, 0, 0, 0x0a }, tg_datacenter_port),
     ip6(.{ 0x20, 0x01, 0x06, 0x7c, 0x04, 0xe8, 0xf0, 0x02, 0, 0, 0, 0, 0, 0, 0, 0x0a }, tg_datacenter_port),
@@ -57,7 +58,7 @@ pub const tg_media_middle_proxies_v4 = [5]net.IpAddress{
 };
 
 /// Resolves physical Datacenter IP by its index, handling special media DCs.
-pub fn getDcAddressV4(abs_dc: usize) net.IpAddress {
+pub fn getDcAddressV4(abs_dc: usize) ?net.IpAddress {
     if (abs_dc == 203) {
         // Media DC 203 has a dedicated network, resolving to MiddleProxy IP
         return ip4(.{ 91, 105, 192, 110 }, tg_datacenter_port);
@@ -65,9 +66,15 @@ pub fn getDcAddressV4(abs_dc: usize) net.IpAddress {
     if (abs_dc >= 1 and abs_dc <= tg_datacenters_v4.len) {
         return tg_datacenters_v4[abs_dc - 1];
     }
-    // Fallback to modulo arithmetic for unknown DC indices
-    const fallback_idx = (abs_dc - 1) % tg_datacenters_v4.len;
-    return tg_datacenters_v4[fallback_idx];
+    return null;
+}
+
+test "unknown datacenters never alias a production endpoint" {
+    try std.testing.expect(getDcAddressV4(0) == null);
+    try std.testing.expect(getDcAddressV4(6) == null);
+    try std.testing.expect(getDcAddressV4(std.math.maxInt(usize)) == null);
+    for (1..6) |dc| try std.testing.expect(getDcAddressV4(dc) != null);
+    try std.testing.expect(getDcAddressV4(203) != null);
 }
 
 // ============= Protocol Tags =============
@@ -128,18 +135,12 @@ pub const min_tls_client_hello_size: usize = 100;
 
 // ============= Message Limits =============
 
-pub const min_msg_len: usize = 12;
-pub const max_msg_len: usize = 1 << 24; // 16 MB
-
 // ============= Buffer Sizes =============
-
-pub const default_buffer_size: usize = 16384;
 
 // ============= TLS Handshake Constants =============
 
 pub const tls_digest_len: usize = 32;
 pub const tls_digest_pos: usize = 11;
-pub const tls_digest_half_len: usize = 16;
 
 /// Time skew limits for anti-replay (seconds)
 pub const time_skew_min: i64 = -2 * 60;

--- a/src/protocol/middleproxy.zig
+++ b/src/protocol/middleproxy.zig
@@ -51,7 +51,8 @@ pub fn getAesKeyAndIv(
     secret: []const u8,
     clt_ipv6: ?*const [16]u8,
     srv_ipv6: ?*const [16]u8,
-) struct { [32]u8, [16]u8 } {
+) !struct { [32]u8, [16]u8 } {
+    if (secret.len > 392 or purpose.len > 392 - secret.len) return error.InvalidKeyDerivationInput;
     var s_buf: [512]u8 = undefined;
     var s_len: usize = 0;
 
@@ -219,6 +220,10 @@ pub const MiddleProxyContext = struct {
     }
 
     pub fn deinit(self: *MiddleProxyContext, allocator: std.mem.Allocator) void {
+        self.encryptor.wipe();
+        self.decryptor.wipe();
+        std.crypto.secureZero(u8, self.s2c_buf);
+        std.crypto.secureZero(u8, self.c2s_buf);
         allocator.free(self.s2c_buf);
         allocator.free(self.c2s_buf);
     }
@@ -281,6 +286,16 @@ pub const MiddleProxyContext = struct {
                 actual_payload_len -= payload_len % 4;
             }
 
+            // Real MTProto messages are never empty. Without this, an authenticated
+            // client streaming 0x00 bytes (or all-padding "secure" frames) turns each
+            // consumed input byte into a full 80-96 byte RPC_PROXY_REQ frame sent to
+            // Telegram's middle proxy -- a ~96x egress amplifier (audit G01-2). Drop
+            // the frame instead of encapsulating it, but still advance `pos` past it.
+            if (actual_payload_len == 0) {
+                pos += header_len + payload_len;
+                continue;
+            }
+
             const payload = self.c2s_buf[pos + header_len .. pos + header_len + actual_payload_len];
 
             // 3. Pass is_quickack to the encapsulator
@@ -339,7 +354,7 @@ pub const MiddleProxyContext = struct {
         out_len += 4;
         std.mem.writeInt(i32, out_buf[out_len..][0..4], self.seq_no, .little);
         out_len += 4;
-        self.seq_no += 1;
+        self.seq_no +%= 1;
 
         @memcpy(out_buf[out_len .. out_len + 4], &rpc_proxy_req);
         out_len += 4;
@@ -411,6 +426,19 @@ pub const MiddleProxyContext = struct {
     /// Takes raw AES-CBC bytes from DC, decrypts them block by block, parses MTProtoFrames,
     /// strips RPC_PROXY_ANS, and writes the inner payload into `out_buf`.
     pub fn decapsulateS2C(self: *MiddleProxyContext, dc_chunk: []const u8, out_buf: []u8) ![]u8 {
+        var consumed: usize = 0;
+        var written: usize = 0;
+        while (consumed < dc_chunk.len) {
+            const take = @min(dc_chunk.len - consumed, self.s2c_buf.len - self.s2c_len);
+            if (take == 0) return error.MiddleProxyBufferOverflow;
+            const output = try self.decapsulateS2CChunk(dc_chunk[consumed..][0..take], out_buf[written..]);
+            consumed += take;
+            written += output.len;
+        }
+        return out_buf[0..written];
+    }
+
+    fn decapsulateS2CChunk(self: *MiddleProxyContext, dc_chunk: []const u8, out_buf: []u8) ![]u8 {
         if (self.s2c_len + dc_chunk.len > self.s2c_buf.len) return error.MiddleProxyBufferOverflow;
         @memcpy(self.s2c_buf[self.s2c_len .. self.s2c_len + dc_chunk.len], dc_chunk);
         self.s2c_len += dc_chunk.len;
@@ -466,7 +494,7 @@ pub const MiddleProxyContext = struct {
 
             const frame_seq_no = std.mem.readInt(i32, self.s2c_buf[parse_pos + 4 ..][0..4], .little);
             if (frame_seq_no != self.read_seq_no) return error.BadMiddleProxySeqNo;
-            self.read_seq_no += 1;
+            self.read_seq_no +%= 1;
 
             // Payload is after Length (4) and SeqNo (4), and before CRC32 (4)
             const payload = self.s2c_buf[parse_pos + 8 .. frame_end - 4];
@@ -508,6 +536,7 @@ pub const MiddleProxyContext = struct {
 
                 switch (self.proto_tag) {
                     .abridged => {
+                        if (conn_data.len % 4 != 0) return error.InvalidPayloadLength;
                         const len_div_4: usize = (conn_data.len + pad_len) / 4;
                         if (len_div_4 < 127) {
                             header_buf[0] = @intCast(len_div_4);
@@ -710,7 +739,7 @@ test "decapsulate s2c skips noop padding words" {
     const key = [_]u8{0} ** 32;
     const iv = [_]u8{0} ** 16;
 
-    var ctx = try MiddleProxyContext.init(
+    var ctx = try MiddleProxyContext.initWithBuffer(
         allocator,
         crypto.AesCbc.init(&key, &iv),
         crypto.AesCbc.init(&key, &iv),
@@ -720,6 +749,7 @@ test "decapsulate s2c skips noop padding words" {
         ip4(.{ 91, 105, 192, 110 }, 443),
         .intermediate,
         null,
+        32,
     );
     defer ctx.deinit(allocator);
 
@@ -871,6 +901,52 @@ test "encapsulate c2s supports payloads larger than 64KiB" {
     try std.testing.expectEqualSlices(u8, &rpc_proxy_req, rpc_payload[0..4]);
 }
 
+test "encapsulate c2s drops zero-length abridged frames instead of amplifying them" {
+    const allocator = std.testing.allocator;
+
+    const key = [_]u8{0} ** 32;
+    const iv = [_]u8{0} ** 16;
+
+    var ctx = try MiddleProxyContext.init(
+        allocator,
+        crypto.AesCbc.init(&key, &iv),
+        crypto.AesCbc.init(&key, &iv),
+        [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 },
+        -2,
+        ip4(.{ 10, 20, 30, 40 }, 12345),
+        ip4(.{ 91, 105, 192, 110 }, 443),
+        .abridged,
+        null,
+    );
+    defer ctx.deinit(allocator);
+
+    // Three zero-length abridged frames (length byte 0x00, no payload) followed by
+    // one real 4-byte frame (length byte 0x01, then 4 payload bytes). Before the
+    // fix, each 0x00 byte alone produced an 80-byte RPC_PROXY_REQ frame on its own
+    // (a 96x amplifier with an ad_tag) -- see G01-2.
+    const client_data = [_]u8{ 0x00, 0x00, 0x00, 0x01, 0xde, 0xad, 0xbe, 0xef };
+    var out_buf: [512]u8 = undefined;
+
+    const written = try ctx.encapsulateC2S(client_data[0..], out_buf[0..]);
+
+    // Only the one real frame produced output: rpc_len = 56 + 4 (client_data),
+    // frame_total_len = rpc_len + 12 = 72, padded to a multiple of 16 -> 80 bytes.
+    try std.testing.expectEqual(@as(usize, 80), written.len);
+
+    // The empty frames advanced seq_no by zero: exactly one message was encapsulated.
+    try std.testing.expectEqual(@as(i32, -1), ctx.seq_no);
+
+    // All input bytes, including the dropped empty frames, were consumed.
+    try std.testing.expectEqual(@as(usize, 0), ctx.c2s_len);
+
+    var decryptor = crypto.AesCbc.init(&key, &iv);
+    var scratch: [80]u8 = undefined;
+    @memcpy(scratch[0..], written);
+    try decryptor.decryptInPlace(scratch[0..]);
+    const rpc_payload = scratch[8..68];
+    try std.testing.expectEqualSlices(u8, &rpc_proxy_req, rpc_payload[0..4]);
+}
+
 // ── getAesKeyAndIv known-answer tests ──────────────────────────────────────────
 //
 // Independent reference re-derivation of the middle-proxy AES key/iv, mirroring
@@ -938,7 +1014,7 @@ test "getAesKeyAndIv KAT: v4 with both IPs, CLIENT and SERVER" {
     const secret = [_]u8{0x07} ** 16;
 
     inline for (.{ "CLIENT", "SERVER" }) |purpose| {
-        const got = getAesKeyAndIv(&nonce_srv, &nonce_clt, &clt_ts, &srv_ip, &clt_port, purpose, &clt_ip, &srv_port, &secret, null, null);
+        const got = try getAesKeyAndIv(&nonce_srv, &nonce_clt, &clt_ts, &srv_ip, &clt_port, purpose, &clt_ip, &srv_port, &secret, null, null);
         const exp = refKeyIv(&nonce_srv, &nonce_clt, &clt_ts, &srv_ip, &clt_port, purpose, &clt_ip, &srv_port, &secret, null);
         try std.testing.expectEqualSlices(u8, &exp[0], &got[0]);
         try std.testing.expectEqualSlices(u8, &exp[1], &got[1]);
@@ -955,7 +1031,7 @@ test "getAesKeyAndIv KAT: v4 with NAT-translated client IP" {
     const srv_port = [_]u8{ 0xBB, 0x01 };
     const secret = [_]u8{0x5a} ** 16;
 
-    const got = getAesKeyAndIv(&nonce_srv, &nonce_clt, &clt_ts, &srv_ip, &clt_port, "CLIENT", &nat_clt_ip, &srv_port, &secret, null, null);
+    const got = try getAesKeyAndIv(&nonce_srv, &nonce_clt, &clt_ts, &srv_ip, &clt_port, "CLIENT", &nat_clt_ip, &srv_port, &secret, null, null);
     const exp = refKeyIv(&nonce_srv, &nonce_clt, &clt_ts, &srv_ip, &clt_port, "CLIENT", &nat_clt_ip, &srv_port, &secret, null);
     try std.testing.expectEqualSlices(u8, &exp[0], &got[0]);
     try std.testing.expectEqualSlices(u8, &exp[1], &got[1]);
@@ -973,7 +1049,7 @@ test "getAesKeyAndIv KAT: v6 with the IPv6 block" {
     const clt_v6 = [_]u8{0xab} ** 16;
     const srv_v6 = [_]u8{0xcd} ** 16;
 
-    const got = getAesKeyAndIv(&nonce_srv, &nonce_clt, &clt_ts, &srv_ip, &clt_port, "SERVER", &clt_ip, &srv_port, &secret, &clt_v6, &srv_v6);
+    const got = try getAesKeyAndIv(&nonce_srv, &nonce_clt, &clt_ts, &srv_ip, &clt_port, "SERVER", &clt_ip, &srv_port, &secret, &clt_v6, &srv_v6);
     const exp = refKeyIv(&nonce_srv, &nonce_clt, &clt_ts, &srv_ip, &clt_port, "SERVER", &clt_ip, &srv_port, &secret, .{ .clt = clt_v6, .srv = srv_v6 });
     try std.testing.expectEqualSlices(u8, &exp[0], &got[0]);
     try std.testing.expectEqualSlices(u8, &exp[1], &got[1]);

--- a/src/protocol/obfuscation.zig
+++ b/src/protocol/obfuscation.zig
@@ -51,19 +51,18 @@ pub const ObfuscationParams = struct {
 
             const decrypt_iv = std.mem.readInt(u128, dec_iv_bytes, .big);
 
-            // Decrypt the handshake to check proto tag
-            var decryptor = crypto.AesCtr.init(&decrypt_key, decrypt_iv);
+            // Only bytes 56..61 are inspected: they use the fourth counter block.
+            var decryptor = crypto.AesCtr.init(&decrypt_key, decrypt_iv +% 3);
             defer decryptor.wipe();
-            var decrypted: [constants.handshake_len]u8 = undefined;
-            @memcpy(&decrypted, handshake);
+            var decrypted: [16]u8 = handshake[48..64].*;
             decryptor.apply(&decrypted);
 
             // Check proto tag at offset 56
-            const tag_bytes: [4]u8 = decrypted[constants.proto_tag_pos..][0..4].*;
+            const tag_bytes: [4]u8 = decrypted[constants.proto_tag_pos - 48 ..][0..4].*;
             const proto_tag = constants.ProtoTag.fromBytes(tag_bytes) orelse continue;
 
             // Extract DC index at offset 60
-            const dc_idx = std.mem.readInt(i16, decrypted[constants.dc_idx_pos..][0..2], .little);
+            const dc_idx = std.mem.readInt(i16, decrypted[constants.dc_idx_pos - 48 ..][0..2], .little);
 
             // Derive encrypt key
             var enc_key_input: [constants.prekey_len + 16]u8 = undefined;

--- a/src/protocol/tls.zig
+++ b/src/protocol/tls.zig
@@ -15,8 +15,23 @@ fn realtimeSeconds() i64 {
     return @intCast(ts.sec);
 }
 
+fn timestampWithinWindow(timestamp: u32, now: i64) bool {
+    const diff = now -| @as(i64, timestamp);
+    return diff >= constants.time_skew_min and diff <= constants.time_skew_max;
+}
+
+test "timestamp window includes both 120-second boundaries" {
+    try std.testing.expect(timestampWithinWindow(1000, 880));
+    try std.testing.expect(timestampWithinWindow(1000, 1120));
+    try std.testing.expect(!timestampWithinWindow(1000, 879));
+    try std.testing.expect(!timestampWithinWindow(1000, 1121));
+    try std.testing.expect(!timestampWithinWindow(1000, 0));
+}
+
 /// Re-export for convenience
 pub const UserSecret = obfuscation.UserSecret;
+/// Bound authentication work; larger browser hellos are forwarded to the cover origin.
+pub const max_authenticated_hello_len = 4096;
 
 // ============= TLS Validation Result =============
 
@@ -40,13 +55,12 @@ pub const TlsValidation = struct {
 /// Validate a TLS ClientHello against user secrets.
 /// Returns validation result if a matching user is found.
 pub fn validateTlsHandshake(
-    allocator: std.mem.Allocator,
     handshake: []const u8,
     secrets: []const UserSecret,
     ignore_time_skew: bool,
     clock_offset_seconds: i64,
 ) !?TlsValidation {
-    _ = allocator;
+    if (handshake.len > max_authenticated_hello_len) return null;
 
     const min_len = constants.tls_digest_pos + constants.tls_digest_len + 1;
     if (handshake.len < min_len) return null;
@@ -58,15 +72,16 @@ pub fn validateTlsHandshake(
     const session_id_len_pos = constants.tls_digest_pos + constants.tls_digest_len;
     if (session_id_len_pos >= handshake.len) return null;
     const session_id_len: usize = handshake[session_id_len_pos];
-    if (session_id_len != 32) return null;
 
     const session_id_start = session_id_len_pos + 1;
-    if (handshake.len < session_id_start + session_id_len) return null;
+    const valid_session_id = session_id_len == 32 and handshake.len >= session_id_start + session_id_len;
 
     const HmacSha256 = std.crypto.auth.hmac.sha2.HmacSha256;
     const zero_digest = [_]u8{0} ** constants.tls_digest_len;
 
-    const now: i64 = if (!ignore_time_skew) realtimeSeconds() + clock_offset_seconds else 0;
+    const now: i64 = if (!ignore_time_skew) realtimeSeconds() +| clock_offset_seconds else 0;
+    var matched: ?TlsValidation = null;
+    var clock_skew = false;
 
     for (secrets) |entry| {
         var hmac = HmacSha256.init(&entry.secret);
@@ -78,6 +93,7 @@ pub fn validateTlsHandshake(
 
         // Constant-time comparison of first 28 bytes using stdlib
         if (!std.crypto.timing_safe.eql([28]u8, digest[0..28].*, computed[0..28].*)) continue;
+        if (!valid_session_id) continue;
 
         // Extract timestamp from last 4 bytes (XOR)
         const timestamp = std.mem.readInt(u32, &[4]u8{
@@ -88,13 +104,13 @@ pub fn validateTlsHandshake(
         }, .little);
 
         if (!ignore_time_skew) {
-            const time_diff = now - @as(i64, @intCast(timestamp));
-            if (time_diff < constants.time_skew_min or time_diff > constants.time_skew_max) {
+            if (!timestampWithinWindow(timestamp, now)) {
+                clock_skew = true;
                 continue;
             }
         }
 
-        return .{
+        matched = .{
             .user = entry.name,
             .session_id = handshake[session_id_start .. session_id_start + session_id_len],
             .digest = digest,
@@ -104,6 +120,8 @@ pub fn validateTlsHandshake(
         };
     }
 
+    if (matched != null) return matched;
+    if (clock_skew) return error.ClockSkew;
     return null;
 }
 
@@ -118,12 +136,13 @@ pub fn validateTlsHandshake(
 /// we use a comptime-built template that matches real Nginx/OpenSSL TLS 1.3 fingerprint:
 /// - Extensions in OpenSSL order: supported_versions THEN key_share
 /// - Fixed AppData size (consistent like a real certificate, not random)
-/// - Deterministic pseudo-random AppData body (high entropy, same every time)
+/// - Fresh random AppData body with the configured certificate-record size
 ///
-/// Only three fields are patched at runtime:
+/// Fields patched at runtime:
 /// - Server Random (offset 11..43): HMAC-SHA256 digest
 /// - Session ID (offset 44..76): echoed from ClientHello
 /// - X25519 key (offset 95..127): fresh random key
+/// - Cipher suite and fresh Application Data bytes
 ///
 /// The client (ConnectionSocket.cpp) validates the response by:
 /// - Checking for `\x16\x03\x03` prefix (ServerHello record)
@@ -152,6 +171,19 @@ pub fn buildServerHelloWithTemplate(
     session_id: []const u8,
     cipher: ?u16,
 ) ![]u8 {
+    const response = try allocator.alloc(u8, template.len);
+    errdefer allocator.free(response);
+    return buildServerHelloWithTemplateInto(response, template, secret, client_digest, session_id, cipher);
+}
+
+pub fn buildServerHelloWithTemplateInto(
+    out: []u8,
+    template: []const u8,
+    secret: []const u8,
+    client_digest: *const [constants.tls_digest_len]u8,
+    session_id: []const u8,
+    cipher: ?u16,
+) ![]u8 {
     // The ServerHello+CCS+AppData-header prefix is a fixed 138 bytes; only the trailing
     // fake-cert (AppData body) size varies. Accept any template whose length leaves room
     // for that prefix, so a profile-matched cert size (see buildServerHelloTemplateAlloc)
@@ -159,8 +191,8 @@ pub fn buildServerHelloWithTemplate(
     if (template.len < tmpl_appdata_offset) return error.BadServerHelloTemplate;
 
     // 1. Copy the pre-built Nginx template (random and session_id are zeroed in template)
-    const response = try allocator.alloc(u8, template.len);
-    errdefer allocator.free(response);
+    if (out.len < template.len) return error.OutOfSpace;
+    const response = out[0..template.len];
     @memcpy(response, template);
 
     // 1b. Echo a client-offered cipher suite. A real TLS server negotiates the
@@ -238,7 +270,7 @@ const pq_key_share_len: usize = 1120;
 ///   +2(group)+2(keylen)+1120(key) = 1215.
 const pq_server_hello_record_len: usize = 95 + pq_key_share_len;
 /// Full PQ response: ServerHello + CCS(6) + AppData(5 + cert payload).
-pub const pq_server_hello_len: usize = pq_server_hello_record_len + 6 + 5 + fake_cert_payload_len;
+const pq_server_hello_len: usize = pq_server_hello_record_len + 6 + 5 + fake_cert_payload_len;
 /// Offset of the 1120-byte PQ key_share inside the response.
 const pq_key_offset: usize = 95;
 /// Offset of the fake AppData body inside the PQ response.
@@ -248,6 +280,14 @@ const pq_appdata_offset: usize = pq_server_hello_record_len + 6 + 5;
 /// Return true when the ClientHello carries a key_share entry for X25519MLKEM768
 /// (named group 0x11ec). Mirrors the key_share walk in formatClientHelloFingerprint.
 pub fn clientOffersPqKeyShare(handshake: []const u8) bool {
+    return clientOffersKeyShare(handshake, pq_named_group, 1216);
+}
+
+pub fn clientOffersX25519KeyShare(handshake: []const u8) bool {
+    return clientOffersKeyShare(handshake, 0x001d, 32);
+}
+
+fn clientOffersKeyShare(handshake: []const u8, group: u16, expected_len: usize) bool {
     if (handshake.len < 43 or handshake[0] != constants.tls_record_handshake) return false;
     var pos: usize = 5;
     if (pos >= handshake.len or handshake[pos] != 0x01) return false; // ClientHello
@@ -267,20 +307,26 @@ pub fn clientOffersPqKeyShare(handshake: []const u8) bool {
     if (pos + 2 > handshake.len) return false;
     const ext_total = std.mem.readInt(u16, handshake[pos..][0..2], .big);
     pos += 2;
-    const ext_end = @min(pos + ext_total, handshake.len);
+    const ext_end = pos + ext_total;
+    if (ext_end > handshake.len) return false;
     while (pos + 4 <= ext_end) {
         const etype = std.mem.readInt(u16, handshake[pos..][0..2], .big);
         const elen = std.mem.readInt(u16, handshake[pos + 2 ..][0..2], .big);
         pos += 4;
         if (pos + elen > ext_end) break;
         if (etype == 0x0033) { // key_share: 2-byte client_shares list_len, then entries
+            if (elen < 2) return false;
             var kp: usize = pos + 2;
             const ks_end = pos + elen;
+            if (std.mem.readInt(u16, handshake[pos..][0..2], .big) != elen - 2) return false;
+            var found = false;
             while (kp + 4 <= ks_end) {
-                if (std.mem.readInt(u16, handshake[kp..][0..2], .big) == pq_named_group) return true;
-                kp += 4 + @as(usize, std.mem.readInt(u16, handshake[kp + 2 ..][0..2], .big));
+                const key_len = std.mem.readInt(u16, handshake[kp + 2 ..][0..2], .big);
+                if (kp + 4 + key_len > ks_end) return false;
+                if (std.mem.readInt(u16, handshake[kp..][0..2], .big) == group and key_len == expected_len) found = true;
+                kp += 4 + @as(usize, key_len);
             }
-            return false;
+            return found and kp == ks_end;
         }
         pos += elen;
     }
@@ -299,12 +345,26 @@ pub fn buildServerHelloPq(
     cipher: ?u16,
     cert_len: usize,
 ) ![]u8 {
+    if (cert_len > 0xFFFF) return error.CertTooLarge;
+    const response = try allocator.alloc(u8, pq_appdata_offset + cert_len);
+    errdefer allocator.free(response);
+    return buildServerHelloPqInto(response, secret, client_digest, session_id, cipher, cert_len);
+}
+
+pub fn buildServerHelloPqInto(
+    out: []u8,
+    secret: []const u8,
+    client_digest: *const [constants.tls_digest_len]u8,
+    session_id: []const u8,
+    cipher: ?u16,
+    cert_len: usize,
+) ![]u8 {
     if (session_id.len != 32) return error.BadSessionIdLength;
     if (cert_len > 0xFFFF) return error.CertTooLarge;
     // Match the fake-cert (AppData) record size used on the non-PQ path so a prober can't
     // tell PQ vs classical clients apart by cert-record length.
-    const r = try allocator.alloc(u8, pq_appdata_offset + cert_len);
-    errdefer allocator.free(r);
+    if (out.len < pq_appdata_offset + cert_len) return error.OutOfSpace;
+    const r = out[0 .. pq_appdata_offset + cert_len];
     @memset(r, 0);
 
     // ── Record 1: ServerHello with a 0x11ec key_share ──
@@ -384,7 +444,7 @@ pub fn buildServerHelloTemplateAlloc(allocator: std.mem.Allocator, cert_len: usi
 /// Walk a TLS record stream and return the payload length of the first Application Data
 /// (0x17) record, or null. Used to learn the mask origin's first encrypted-flight
 /// (certificate) record size so our fake cert record can match it instead of a fixed 2878.
-pub fn firstAppDataRecordLen(data: []const u8) ?usize {
+fn firstAppDataRecordLen(data: []const u8) ?usize {
     var pos: usize = 0;
     while (pos + 5 <= data.len) {
         const rtype = data[pos];
@@ -459,7 +519,7 @@ const nginx_template: [nginx_template_len]u8 = blk: {
     break :blk buildNginxTemplate(default_template_seed);
 };
 
-pub fn buildServerHelloTemplate(seed: ?u64) [nginx_template_len]u8 {
+fn buildServerHelloTemplate(seed: ?u64) [nginx_template_len]u8 {
     const actual_seed = seed orelse crypto.randomInt(u64);
     return buildNginxTemplate(actual_seed);
 }
@@ -985,7 +1045,7 @@ test "fuzz: TLS ClientHello parsers never panic on arbitrary input" {
             var fp_buf: [256]u8 = undefined;
             _ = formatClientHelloFingerprint(data, &fp_buf);
             const secrets = [_]UserSecret{.{ .name = "u", .secret = [_]u8{0x11} ** 16 }};
-            _ = validateTlsHandshake(std.testing.allocator, data, &secrets, true, 0) catch {};
+            _ = validateTlsHandshake(data, &secrets, true, 0) catch {};
         }
     }.one, .{});
 }
@@ -1045,7 +1105,7 @@ test "formatClientHelloFingerprint summarizes ciphers/groups/keyshare" {
 }
 
 test "clientOffersPqKeyShare detects a 0x11ec key_share entry" {
-    var ch: [160]u8 = undefined;
+    var ch: [1400]u8 = undefined;
     var n: usize = 0;
     const W = struct {
         fn b(buf: []u8, i: *usize, v: u8) void {
@@ -1082,19 +1142,30 @@ test "clientOffersPqKeyShare detects a 0x11ec key_share entry" {
     const ks_len_at = n;
     W.h(&ch, &n, 0);
     const ks_payload_start = n;
-    W.h(&ch, &n, 8); // client_shares list length
+    W.h(&ch, &n, 1260); // GREASE, x25519, then PQ
+    W.h(&ch, &n, 0x0a0a);
+    W.h(&ch, &n, 0);
+    W.h(&ch, &n, 0x001d);
+    W.h(&ch, &n, 32);
+    for (0..32) |_| W.b(&ch, &n, 0xDD);
+    const pq_group_at = n;
     W.h(&ch, &n, 0x11ec); // group
-    W.h(&ch, &n, 4); // key length
+    W.h(&ch, &n, 1216); // client X25519MLKEM768 key length
     var kk: usize = 0;
-    while (kk < 4) : (kk += 1) W.b(&ch, &n, 0xCC);
+    while (kk < 1216) : (kk += 1) W.b(&ch, &n, 0xCC);
     std.mem.writeInt(u16, ch[ks_len_at..][0..2], @intCast(n - ks_payload_start), .big);
     std.mem.writeInt(u16, ch[ext_total_at..][0..2], @intCast(n - ext_start), .big);
     std.mem.writeInt(u16, ch[hs_len_at..][0..2], @intCast(n - hs_body_start), .big);
     std.mem.writeInt(u16, ch[rec_len_at..][0..2], @intCast(n - 5), .big);
 
     try std.testing.expect(clientOffersPqKeyShare(ch[0..n]));
+    try std.testing.expect(clientOffersX25519KeyShare(ch[0..n]));
+    std.mem.writeInt(u16, ch[pq_group_at + 2 ..][0..2], 1217, .big);
+    try std.testing.expect(!clientOffersPqKeyShare(ch[0..n]));
+    try std.testing.expect(!clientOffersX25519KeyShare(ch[0..n]));
+    std.mem.writeInt(u16, ch[pq_group_at + 2 ..][0..2], 1216, .big);
     // Flip the offered group to x25519 -> no longer a PQ offer.
-    std.mem.writeInt(u16, ch[ks_payload_start + 2 ..][0..2], 0x001d, .big);
+    std.mem.writeInt(u16, ch[pq_group_at..][0..2], 0x001d, .big);
     try std.testing.expect(!clientOffersPqKeyShare(ch[0..n]));
     // Truncated input never panics.
     try std.testing.expect(!clientOffersPqKeyShare(ch[0..20]));
@@ -1218,7 +1289,6 @@ test "buildServerHelloTemplate depends on seed" {
 }
 
 test "validateTlsHandshake - valid handshake" {
-    const allocator = std.testing.allocator;
 
     // Create mock secrets
     var secrets = [_]UserSecret{
@@ -1254,23 +1324,54 @@ test "validateTlsHandshake - valid handshake" {
     handshake[constants.tls_digest_pos + 30] = computed_mac[30] ^ ts_bytes[2];
     handshake[constants.tls_digest_pos + 31] = computed_mac[31] ^ ts_bytes[3];
 
-    const result = try validateTlsHandshake(allocator, &handshake, &secrets, true, 0);
+    const result = try validateTlsHandshake(&handshake, &secrets, true, 0);
     try std.testing.expect(result != null);
     try std.testing.expectEqualStrings("bob", result.?.user);
     try std.testing.expectEqual(@as(u32, 0x12345678), result.?.timestamp);
 }
 
 test "validateTlsHandshake - invalid user" {
-    const allocator = std.testing.allocator;
     var secrets = [_]UserSecret{.{ .name = "alice", .secret = [_]u8{0x1A} ** 16 }};
     var handshake = [_]u8{0xAA} ** 64; // random junk
 
-    const result = try validateTlsHandshake(allocator, &handshake, &secrets, true, 0);
+    const result = try validateTlsHandshake(&handshake, &secrets, true, 0);
     try std.testing.expect(result == null);
 }
 
+test "TLS clock skew validation and correction use authenticated timestamps" {
+    const secrets = [_]UserSecret{.{ .name = "clock", .secret = [_]u8{1} ** 16 }};
+    var hello = [_]u8{0} ** 96;
+    hello[43] = 32;
+    const mac = crypto.sha256Hmac(&secrets[0].secret, &hello);
+    const now = realtimeSeconds();
+    var timestamp: [4]u8 = undefined;
+    std.mem.writeInt(u32, &timestamp, @intCast(now), .little);
+    @memcpy(hello[11..43], &mac);
+    for (0..4) |i| hello[39 + i] ^= timestamp[i];
+    try std.testing.expect((try validateTlsHandshake(&hello, &secrets, false, 0)) != null);
+    try std.testing.expectError(error.ClockSkew, validateTlsHandshake(&hello, &secrets, false, 300));
+    try std.testing.expectError(error.ClockSkew, validateTlsHandshake(&hello, &secrets, false, -300));
+    try std.testing.expect((try validateTlsHandshake(&hello, &secrets, true, 300)) != null);
+}
+
+test "PQ and classical server certificates use configured sizes" {
+    const alloc = std.testing.allocator;
+    const secret = [_]u8{1} ** 16;
+    const digest = [_]u8{2} ** 32;
+    const session = [_]u8{3} ** 32;
+    for ([_]usize{ 512, 1234, 4096, 8192 }) |size| {
+        const template = try buildServerHelloTemplateAlloc(alloc, size);
+        defer alloc.free(template);
+        const classic = try buildServerHelloWithTemplate(alloc, template, &secret, &digest, &session, null);
+        defer alloc.free(classic);
+        const pq = try buildServerHelloPq(alloc, &secret, &digest, &session, null, size);
+        defer alloc.free(pq);
+        try std.testing.expectEqual(@as(?usize, size), firstAppDataRecordLen(classic));
+        try std.testing.expectEqual(@as(?usize, size), firstAppDataRecordLen(pq));
+    }
+}
+
 test "validateTlsHandshake - rejects non-32 session id" {
-    const allocator = std.testing.allocator;
     var secrets = [_]UserSecret{.{ .name = "alice", .secret = [_]u8{0x1A} ** 16 }};
     var handshake = [_]u8{0x00} ** 80;
 
@@ -1289,7 +1390,7 @@ test "validateTlsHandshake - rejects non-32 session id" {
     handshake[constants.tls_digest_pos + 30] = computed_mac[30] ^ ts_bytes[2];
     handshake[constants.tls_digest_pos + 31] = computed_mac[31] ^ ts_bytes[3];
 
-    const result = try validateTlsHandshake(allocator, &handshake, &secrets, true, 0);
+    const result = try validateTlsHandshake(&handshake, &secrets, true, 0);
     try std.testing.expect(result == null);
 }
 
@@ -1301,8 +1402,6 @@ test "extractSni - malformed returns null" {
 }
 
 test "validateTlsHandshake returns canonical_hmac" {
-    const allocator = std.testing.allocator;
-
     var secrets = [_]UserSecret{.{ .name = "alice", .secret = [_]u8{0x1A} ** 16 }};
     var handshake = [_]u8{0x00} ** 96;
 
@@ -1321,7 +1420,7 @@ test "validateTlsHandshake returns canonical_hmac" {
     handshake[constants.tls_digest_pos + 30] = computed_mac[30] ^ ts_bytes[2];
     handshake[constants.tls_digest_pos + 31] = computed_mac[31] ^ ts_bytes[3];
 
-    const result = try validateTlsHandshake(allocator, &handshake, &secrets, true, 0);
+    const result = try validateTlsHandshake(&handshake, &secrets, true, 0);
     try std.testing.expect(result != null);
     try std.testing.expectEqualSlices(u8, &computed_mac, &result.?.canonical_hmac);
 }
@@ -1476,7 +1575,6 @@ test "extractSni - fuzz malformed input" {
 }
 
 test "validateTlsHandshake - fuzz random and replayed input" {
-    const allocator = std.testing.allocator;
     const secrets = [_]UserSecret{
         .{ .name = "alice", .secret = [_]u8{0x1A} ** 16 },
         .{ .name = "bob", .secret = [_]u8{0x2B} ** 16 },
@@ -1489,7 +1587,7 @@ test "validateTlsHandshake - fuzz random and replayed input" {
     for (0..3000) |_| {
         const len: usize = @as(usize, random.int(u16)) % random_buf.len;
         random.bytes(random_buf[0..len]);
-        const parsed = try validateTlsHandshake(allocator, random_buf[0..len], &secrets, true, 0);
+        const parsed = try validateTlsHandshake(random_buf[0..len], &secrets, true, 0);
         if (parsed) |v| {
             try std.testing.expect(v.session_id.len == 32);
             try std.testing.expect(v.user.len > 0);
@@ -1499,8 +1597,8 @@ test "validateTlsHandshake - fuzz random and replayed input" {
     // Replayed bytes produce identical canonical HMAC.
     var hello_buf: [512]u8 = undefined;
     const hello = try buildTlsAuthClientHello(&hello_buf, secrets[0].secret, "google.com");
-    const first = try validateTlsHandshake(allocator, hello, &secrets, true, 0);
-    const second = try validateTlsHandshake(allocator, hello, &secrets, true, 0);
+    const first = try validateTlsHandshake(hello, &secrets, true, 0);
+    const second = try validateTlsHandshake(hello, &secrets, true, 0);
     try std.testing.expect(first != null and second != null);
     try std.testing.expectEqualSlices(u8, &first.?.canonical_hmac, &second.?.canonical_hmac);
 }

--- a/src/proxy/child_process.zig
+++ b/src/proxy/child_process.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+/// Linux deployments use GNU coreutils (Debian/Ubuntu and the published image).
+/// Reset the signalfd owner's inherited mask in the child, never on a live
+/// event-loop thread. No shell interpolation; the original argv stays separate.
+pub fn run(allocator: std.mem.Allocator, io: std.Io, requested: std.process.RunOptions) !std.process.RunResult {
+    var options = requested;
+    if (options.timeout == .none) options.timeout = .{ .duration = .{ .raw = .fromSeconds(12), .clock = .awake } };
+    if (builtin.os.tag != .linux) return std.process.run(allocator, io, options);
+    const argv = try allocator.alloc([]const u8, options.argv.len + 2);
+    defer allocator.free(argv);
+    argv[0] = "/usr/bin/env";
+    argv[1] = "--default-signal=TERM,INT,HUP,USR1";
+    @memcpy(argv[2..], options.argv);
+    options.argv = argv;
+    return std.process.run(allocator, io, options);
+}
+
+test "child runner clears inherited signalfd signal mask" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    var mask = std.posix.sigemptyset();
+    std.posix.sigaddset(&mask, .TERM);
+    var old: std.posix.sigset_t = undefined;
+    std.posix.sigprocmask(std.posix.SIG.BLOCK, &mask, &old);
+    defer std.posix.sigprocmask(std.posix.SIG.SETMASK, &old, null);
+    var threaded: std.Io.Threaded = .init(std.testing.allocator, .{});
+    defer threaded.deinit();
+    const result = try run(std.testing.allocator, threaded.io(), .{ .argv = &.{ "/bin/sh", "-c", "kill -TERM $$; exit 99" } });
+    defer std.testing.allocator.free(result.stdout);
+    defer std.testing.allocator.free(result.stderr);
+    try std.testing.expect(result.term == .signal);
+    try std.testing.expectEqual(std.posix.SIG.TERM, result.term.signal);
+}

--- a/src/proxy/connection_phase.zig
+++ b/src/proxy/connection_phase.zig
@@ -27,7 +27,6 @@ pub const ConnectionPhase = enum {
     middle_proxy_handshake,
     relaying,
     mask_relaying,
-    closing,
 };
 
 pub fn hasFatalEpollHangup(events: u32) bool {

--- a/src/proxy/connection_pool.zig
+++ b/src/proxy/connection_pool.zig
@@ -61,7 +61,6 @@ pub fn ConnectionPool(comptime SlotType: type) type {
                     self.free_count += 1;
                     return null;
                 };
-                fresh.* = .{};
                 self.slots[idx] = fresh;
                 const hi = idx + 1;
                 if (hi > self.allocated_hi) self.allocated_hi = hi;

--- a/src/proxy/dc_nonce.zig
+++ b/src/proxy/dc_nonce.zig
@@ -18,9 +18,11 @@ pub fn send(
     };
 
     var tg_nonce = obfuscation.generateNonce();
+    defer std.crypto.secureZero(u8, &tg_nonce);
 
     if (slot.use_fast_mode) {
         var client_s2c_key_iv: [constants.key_len + constants.iv_len]u8 = undefined;
+        defer std.crypto.secureZero(u8, &client_s2c_key_iv);
         @memcpy(client_s2c_key_iv[0..constants.key_len], &params.encrypt_key);
         std.mem.writeInt(u128, client_s2c_key_iv[constants.key_len..][0..constants.iv_len], params.encrypt_iv, .big);
         obfuscation.prepareTgNonce(&tg_nonce, params.proto_tag, &client_s2c_key_iv);
@@ -32,22 +34,29 @@ pub fn send(
 
     const tg_enc_key_iv = tg_nonce[constants.skip_len..][0 .. constants.key_len + constants.iv_len];
     var tg_enc_key: [constants.key_len]u8 = tg_enc_key_iv[0..constants.key_len].*;
+    defer std.crypto.secureZero(u8, &tg_enc_key);
     var tg_enc_iv_bytes: [constants.iv_len]u8 = tg_enc_key_iv[constants.key_len..][0..constants.iv_len].*;
+    defer std.crypto.secureZero(u8, &tg_enc_iv_bytes);
     const tg_enc_iv = std.mem.readInt(u128, &tg_enc_iv_bytes, .big);
 
     var tg_dec_key_iv: [constants.key_len + constants.iv_len]u8 = undefined;
+    defer std.crypto.secureZero(u8, &tg_dec_key_iv);
     for (0..tg_enc_key_iv.len) |i| {
         tg_dec_key_iv[i] = tg_enc_key_iv[tg_enc_key_iv.len - 1 - i];
     }
     var tg_dec_key: [constants.key_len]u8 = tg_dec_key_iv[0..constants.key_len].*;
+    defer std.crypto.secureZero(u8, &tg_dec_key);
     const tg_dec_iv = std.mem.readInt(u128, tg_dec_key_iv[constants.key_len..][0..constants.iv_len], .big);
 
     var tg_encryptor = crypto.AesCtr.init(&tg_enc_key, tg_enc_iv);
+    defer tg_encryptor.wipe();
     var encrypted_nonce: [constants.handshake_len]u8 = undefined;
+    defer std.crypto.secureZero(u8, &encrypted_nonce);
     @memcpy(&encrypted_nonce, &tg_nonce);
     tg_encryptor.apply(&encrypted_nonce);
 
     var nonce_to_send: [constants.handshake_len]u8 = undefined;
+    defer std.crypto.secureZero(u8, &nonce_to_send);
     @memcpy(nonce_to_send[0..constants.proto_tag_pos], tg_nonce[0..constants.proto_tag_pos]);
     @memcpy(nonce_to_send[constants.proto_tag_pos..], encrypted_nonce[constants.proto_tag_pos..]);
 
@@ -57,40 +66,7 @@ pub fn send(
         return;
     }
 
-    // Promotion tag (optional), only for primary DC1..5.
-    if (loop.state.config.tag) |tag| {
-        const dc_abs = if (params.dc_idx > 0) @as(usize, @intCast(params.dc_idx)) else @as(usize, @abs(params.dc_idx));
-        if (dc_abs >= 1 and dc_abs <= constants.tg_datacenters_v4.len and dc_abs != 203) {
-            var promote_buf: [32]u8 = undefined;
-            var packet_len: usize = 0;
-
-            const rpc_id: u32 = 0xaeaf0c42;
-            var rpc_payload: [20]u8 = undefined;
-            std.mem.writeInt(u32, rpc_payload[0..4], rpc_id, .little);
-            @memcpy(rpc_payload[4..20], &tag);
-
-            switch (params.proto_tag) {
-                .abridged => {
-                    promote_buf[0] = 5;
-                    @memcpy(promote_buf[1..21], &rpc_payload);
-                    packet_len = 21;
-                },
-                .intermediate, .secure => {
-                    std.mem.writeInt(u32, promote_buf[0..4], 20, .little);
-                    @memcpy(promote_buf[4..24], &rpc_payload);
-                    packet_len = 24;
-                },
-            }
-
-            const tail = loop.state.allocator.alloc(u8, packet_len) catch {
-                close_slot(loop, slot, "alloc promotion tail failed");
-                return;
-            };
-            @memcpy(tail, promote_buf[0..packet_len]);
-            tg_encryptor.apply(tail);
-            slot.dc_initial_tail = tail;
-        }
-    }
+    // Promotion tags belong exclusively in MiddleProxy RPC_PROXY_REQ frames.
 
     slot.tg_encryptor = tg_encryptor;
     slot.tg_decryptor = crypto.AesCtr.init(&tg_dec_key, tg_dec_iv);

--- a/src/proxy/dns_cache.zig
+++ b/src/proxy/dns_cache.zig
@@ -1,0 +1,167 @@
+//! Owned background DNS refresh. Event loops only copy bounded snapshots.
+const std = @import("std");
+const builtin = @import("builtin");
+const net = @import("net_helpers.zig");
+
+pub const Cache = struct {
+    allocator: std.mem.Allocator,
+    entries: std.ArrayList(Entry) = .empty,
+    mutex: std.Io.Mutex = .init,
+    stopping: std.atomic.Value(bool) = .init(false),
+    thread: ?std.Thread = null,
+    const Entry = struct { host: []const u8, port: u16, addresses: net.AddressCandidates, literal: bool };
+    const Resolver = *const fn (std.mem.Allocator, []const u8, u16) anyerror!net.AddressList;
+
+    fn io() std.Io {
+        return std.Io.Threaded.global_single_threaded.io();
+    }
+
+    pub fn create(allocator: std.mem.Allocator) !*Cache {
+        const self = try allocator.create(Cache);
+        self.* = .{ .allocator = allocator };
+        return self;
+    }
+
+    /// Registration is startup-only; the worker never resizes the entries array.
+    pub fn add(self: *Cache, host: []const u8, port: u16, initial: net.AddressCandidates) !usize {
+        std.debug.assert(self.thread == null);
+        const owned = try self.allocator.dupe(u8, host);
+        errdefer self.allocator.free(owned);
+        const literal = if (net.Address.parse(host, port)) |_| true else |_| false;
+        try self.entries.append(self.allocator, .{ .host = owned, .port = port, .addresses = initial, .literal = literal });
+        return self.entries.items.len - 1;
+    }
+
+    pub fn start(self: *Cache) !void {
+        std.debug.assert(self.thread == null);
+        for (self.entries.items) |entry| {
+            if (!entry.literal) {
+                self.thread = try std.Thread.spawn(.{}, run, .{self});
+                return;
+            }
+        }
+    }
+
+    pub fn snapshot(self: *Cache, id: usize) net.AddressCandidates {
+        self.mutex.lockUncancelable(io());
+        defer self.mutex.unlock(io());
+        return self.entries.items[id].addresses;
+    }
+
+    pub fn destroy(self: *Cache) void {
+        self.stopping.store(true, .release);
+        if (self.thread) |thread| thread.join();
+        for (self.entries.items) |entry| self.allocator.free(entry.host);
+        self.entries.deinit(self.allocator);
+        self.allocator.destroy(self);
+    }
+
+    fn resolve(allocator: std.mem.Allocator, host: []const u8, port: u16) !net.AddressList {
+        // Production is Linux. NSS resolution in a deadline-bounded child also
+        // bounds shutdown even if the system resolver is wedged (five seconds).
+        return if (builtin.os.tag == .linux) net.lookupViaGetent(allocator, host, port) else net.getAddressList(allocator, host, port);
+    }
+
+    fn refresh(self: *Cache, resolver: Resolver) void {
+        for (self.entries.items, 0..) |entry, id| {
+            if (self.stopping.load(.acquire)) return;
+            if (entry.literal) continue;
+            const list = resolver(self.allocator, entry.host, entry.port) catch continue;
+            defer list.deinit();
+            if (list.addrs.len == 0) continue; // Keep the last good answer.
+            // Stable family preference matches startup resolution.
+            std.mem.sort(net.Address, list.addrs, {}, struct {
+                fn less(_: void, a: net.Address, b: net.Address) bool {
+                    return !net.isIpv6(a) and net.isIpv6(b);
+                }
+            }.less);
+            self.mutex.lockUncancelable(io());
+            self.entries.items[id].addresses = .init(list.addrs);
+            self.mutex.unlock(io());
+        }
+    }
+
+    fn run(self: *Cache) void {
+        while (!self.stopping.load(.acquire)) {
+            for (0..600) |_| {
+                if (self.stopping.load(.acquire)) return;
+                std.Io.sleep(io(), .fromMilliseconds(100), .awake) catch return;
+            }
+            self.refresh(resolve);
+        }
+    }
+};
+
+test "DNS refresh replaces snapshots, preserves last good answers, skips literals" {
+    const cache = try Cache.create(std.testing.allocator);
+    defer cache.destroy();
+    const original = net.AddressCandidates.init(&.{net.ip4(.{ 192, 0, 2, 1 }, 443)});
+    const id = try cache.add("example.test", 443, original);
+    const literal_id = try cache.add("127.0.0.1", 443, original);
+    const frozen = cache.snapshot(id);
+    const Fake = struct {
+        fn good(a: std.mem.Allocator, _: []const u8, port: u16) !net.AddressList {
+            const addresses = try a.alloc(net.Address, 2);
+            addresses[0] = net.ip6(@splat(1), port, 0, 0);
+            addresses[1] = net.ip4(.{ 192, 0, 2, 2 }, port);
+            return .{ .allocator = a, .addrs = addresses };
+        }
+        fn bad(_: std.mem.Allocator, _: []const u8, _: u16) !net.AddressList {
+            return error.ResolveFailed;
+        }
+        fn empty(a: std.mem.Allocator, _: []const u8, _: u16) !net.AddressList {
+            return .{ .allocator = a, .addrs = try a.alloc(net.Address, 0) };
+        }
+    };
+    cache.refresh(Fake.good);
+    const updated = cache.snapshot(id);
+    try std.testing.expectEqual(@as(u8, 2), updated.len);
+    try std.testing.expect(net.addressEql(updated.addresses[0], net.ip4(.{ 192, 0, 2, 2 }, 443)));
+    try std.testing.expect(net.addressEql(frozen.addresses[0], original.addresses[0]));
+    try std.testing.expect(net.addressEql(cache.snapshot(literal_id).addresses[0], original.addresses[0]));
+    cache.refresh(Fake.bad);
+    cache.refresh(Fake.empty);
+    try std.testing.expectEqual(@as(u8, 2), cache.snapshot(id).len);
+    cache.stopping.store(true, .release);
+    cache.refresh(Fake.good);
+}
+
+test "DNS worker joins on shutdown and literal-only caches need no worker" {
+    const cache = try Cache.create(std.testing.allocator);
+    _ = try cache.add("example.test", 443, .{});
+    try cache.start();
+    cache.destroy();
+    const literals = try Cache.create(std.testing.allocator);
+    defer literals.destroy();
+    _ = try literals.add("127.0.0.1", 443, .{});
+    try literals.start();
+    try std.testing.expect(literals.thread == null);
+}
+
+test "DNS snapshots remain coherent across concurrent readers and refresh" {
+    const cache = try Cache.create(std.testing.allocator);
+    defer cache.destroy();
+    const initial = net.AddressCandidates.init(&.{net.ip4(.{ 192, 0, 2, 1 }, 443)});
+    _ = try cache.add("example.test", 443, initial);
+    const Reader = struct {
+        fn run(c: *Cache) void {
+            for (0..1000) |_| {
+                const snapshot = c.snapshot(0);
+                std.debug.assert(snapshot.len == 1);
+                std.debug.assert(snapshot.addresses[0].getPort() == 443);
+                std.debug.assert(!net.isIpv6(snapshot.addresses[0]));
+            }
+        }
+        fn resolve(a: std.mem.Allocator, _: []const u8, port: u16) !net.AddressList {
+            const addresses = try a.alloc(net.Address, 1);
+            addresses[0] = net.ip4(.{ 192, 0, 2, 2 }, port);
+            return .{ .allocator = a, .addrs = addresses };
+        }
+    };
+    const first = try std.Thread.spawn(.{}, Reader.run, .{cache});
+    defer first.join();
+    const second = try std.Thread.spawn(.{}, Reader.run, .{cache});
+    defer second.join();
+    for (0..100) |_| cache.refresh(Reader.resolve);
+    try std.testing.expect(net.addressEql(cache.snapshot(0).addresses[0], net.ip4(.{ 192, 0, 2, 2 }, 443)));
+}

--- a/src/proxy/drs.zig
+++ b/src/proxy/drs.zig
@@ -30,9 +30,9 @@ pub const DynamicRecordSizer = struct {
     }
 
     pub fn recordSent(self: *DynamicRecordSizer, payload_len: usize) void {
-        if (!self.enabled) return;
-        self.records_sent += 1;
-        self.bytes_sent += @as(u64, @intCast(payload_len));
+        if (!self.enabled or self.current_size == full_size) return;
+        self.records_sent +|= 1;
+        self.bytes_sent +|= @as(u64, @intCast(payload_len));
         if (self.current_size == initial_size and
             (self.records_sent >= ramp_record_threshold or self.bytes_sent >= ramp_byte_threshold))
         {

--- a/src/proxy/endpoint_penalties.zig
+++ b/src/proxy/endpoint_penalties.zig
@@ -1,0 +1,61 @@
+const std = @import("std");
+const Address = std.Io.net.IpAddress;
+
+/// Small per-worker negative cache. Never removes the last route to a DC.
+pub const EndpointPenalties = struct {
+    entries: [64]?Entry = .{null} ** 64,
+    next: usize = 0,
+    const Entry = struct { addr: Address, until_ms: i64 };
+
+    pub fn failed(self: *EndpointPenalties, addr: Address, now: i64) void {
+        for (&self.entries) |*entry| {
+            if (entry.*) |old| if (old.addr.eql(&addr)) {
+                entry.* = .{ .addr = addr, .until_ms = now +| 60_000 };
+                return;
+            };
+        }
+        self.entries[self.next] = .{ .addr = addr, .until_ms = now +| 60_000 };
+        self.next = (self.next + 1) % self.entries.len;
+    }
+
+    pub fn succeeded(self: *EndpointPenalties, addr: Address) void {
+        for (&self.entries) |*entry| if (entry.*) |old| {
+            if (old.addr.eql(&addr)) entry.* = null;
+        };
+    }
+
+    fn blocked(self: *const EndpointPenalties, addr: Address, now: i64) bool {
+        for (self.entries) |entry| if (entry) |old| {
+            if (old.addr.eql(&addr) and old.until_ms > now) return true;
+        };
+        return false;
+    }
+
+    pub fn prioritize(self: *const EndpointPenalties, addresses: []Address, now: i64) void {
+        var insert: usize = 0;
+        for (0..addresses.len) |i| {
+            if (self.blocked(addresses[i], now)) continue;
+            const addr = addresses[i];
+            std.mem.copyBackwards(Address, addresses[insert + 1 .. i + 1], addresses[insert..i]);
+            addresses[insert] = addr;
+            insert += 1;
+        }
+    }
+};
+
+test "endpoint cooldown prefers healthy peers, expires, clears, retains last route" {
+    const a: Address = .{ .ip4 = .{ .bytes = .{ 192, 0, 2, 1 }, .port = 443 } };
+    const b: Address = .{ .ip4 = .{ .bytes = .{ 192, 0, 2, 2 }, .port = 443 } };
+    var cache: EndpointPenalties = .{};
+    cache.failed(a, 100);
+    var list = [_]Address{ a, b };
+    cache.prioritize(&list, 200);
+    try std.testing.expect(list[0].eql(&b));
+    try std.testing.expect(!cache.blocked(a, 60_100));
+    cache.succeeded(a);
+    try std.testing.expect(!cache.blocked(a, 200));
+    cache.failed(b, 200);
+    var sole = [_]Address{b};
+    cache.prioritize(&sole, 300);
+    try std.testing.expect(sole[0].eql(&b));
+}

--- a/src/proxy/handshake_flood_guard.zig
+++ b/src/proxy/handshake_flood_guard.zig
@@ -212,7 +212,8 @@ pub const HandshakeFloodGuard = struct {
                 }
 
                 var key = ClientKey{ .family = .ip6 };
-                @memcpy(&key.bytes, b);
+                // Group native IPv6 by /64, matching per-user network quotas.
+                @memcpy(key.bytes[0..8], b[0..8]);
                 break :blk key;
             },
         };

--- a/src/proxy/http_connect.zig
+++ b/src/proxy/http_connect.zig
@@ -81,25 +81,33 @@ pub const ParseResult = struct {
     header_end: usize, // offset past the final \r\n\r\n
 };
 
+test "CONNECT skips interim responses and accepts LF terminators" {
+    const input = "HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 200 OK\n\n";
+    const parsed = parseResponse(input).?;
+    try std.testing.expectEqual(@as(u16, 200), parsed.status);
+    try std.testing.expectEqual(input.len, parsed.header_end);
+    try std.testing.expectEqual(@as(u16, 0), parseResponse("garbage\r\n\r\n").?.status);
+}
+
 /// Parse an HTTP CONNECT response.
 /// Looks for `HTTP/1.x NNN` status line and `\r\n\r\n` terminator.
 /// Returns null if not enough data has been received yet.
 pub fn parseResponse(data: []const u8) ?ParseResult {
-    // Find the end of headers
-    const header_end = findHeaderEnd(data) orelse return null;
-
-    // Parse status line: "HTTP/1.x NNN ..."
-    const status = parseStatusCode(data) orelse return null;
-
-    return .{
-        .status = status,
-        .header_end = header_end,
-    };
+    var offset: usize = 0;
+    while (offset < data.len) {
+        const header_len = findHeaderEnd(data[offset..]) orelse return null;
+        const status = parseStatusCode(data[offset..]) orelse 0;
+        offset += header_len;
+        if (status >= 100 and status < 200 and status != 101) continue;
+        return .{ .status = status, .header_end = offset };
+    }
+    return null;
 }
 
 /// Check if we have received the complete header block.
 /// Returns the offset past `\r\n\r\n`, or null.
 fn findHeaderEnd(data: []const u8) ?usize {
+    const lf_end = if (std.mem.indexOf(u8, data, "\n\n")) |pos| pos + 2 else data.len + 1;
     if (data.len < 4) return null;
 
     var i: usize = 0;
@@ -107,10 +115,10 @@ fn findHeaderEnd(data: []const u8) ?usize {
         if (data[i] == '\r' and data[i + 1] == '\n' and
             data[i + 2] == '\r' and data[i + 3] == '\n')
         {
-            return i + 4;
+            return @min(i + 4, lf_end);
         }
     }
-    return null;
+    return if (lf_end <= data.len) lf_end else null;
 }
 
 /// Extract HTTP status code from the first line.
@@ -139,7 +147,7 @@ fn parseStatusCode(data: []const u8) ?u16 {
 
 /// Maximum response size we'll buffer before giving up.
 /// HTTP CONNECT responses are typically < 200 bytes.
-pub const max_response_size: usize = 4096;
+pub const max_response_size: usize = 16 * 1024;
 
 // ─── Internal Helpers ────────────────────────────────────────
 

--- a/src/proxy/http_fetch.zig
+++ b/src/proxy/http_fetch.zig
@@ -35,15 +35,8 @@ test "http fetch - curl config escaping backslash and double-quote" {
 }
 
 pub fn fetchUrlBytes(allocator: std.mem.Allocator, url: []const u8) ![]u8 {
-    return fetchUrlBytesStd(allocator, url) catch |err| {
-        // Zig's std resolver throws ResolvConfParseFailed on a /etc/resolv.conf whose
-        // last line lacks a trailing newline (SolusVM and several VPS images). curl
-        // resolves via NSS/getent, which tolerates it — retry there instead of failing
-        // the whole fetch (keeps the dependency-free std path for healthy hosts).
-        if (std.mem.eql(u8, @errorName(err), "ResolvConfParseFailed"))
-            return runCurlFetch(allocator, url, null);
-        return err;
-    };
+    // The std HTTP path has no deadline. curl bounds DNS, connect and body reads.
+    return runCurlFetch(allocator, url, null);
 }
 
 fn fetchUrlBytesStd(allocator: std.mem.Allocator, url: []const u8) ![]u8 {
@@ -206,8 +199,8 @@ fn writeCurlProxyConfig(
 
     // scheme/endpoint are interpolated unescaped into the proxy line; reject control bytes
     // so they can't break out of the value (same option-injection class as the creds).
-    for (scheme) |c| if (c < 0x20 or c == 0x7f) return error.CurlConfigWriteFailed;
-    for (endpoint) |c| if (c < 0x20 or c == 0x7f) return error.CurlConfigWriteFailed;
+    for (scheme) |c| if (c < 0x20 or c == 0x7f or c == '"' or c == '\\') return error.CurlConfigWriteFailed;
+    for (endpoint) |c| if (c < 0x20 or c == 0x7f or c == '"' or c == '\\') return error.CurlConfigWriteFailed;
 
     const header = std.fmt.bufPrint(content_buf, "proxy = \"{s}://{s}\"\nproxy-user = \"", .{ scheme, endpoint }) catch
         return error.CurlConfigTooLong;
@@ -311,7 +304,7 @@ pub fn fetchUrlBytesViaProxy(
     }
     try argv.append(allocator, url);
 
-    const result = std.process.run(allocator, io, .{
+    const result = @import("child_process").run(allocator, io, .{
         .argv = argv.items,
         .stdout_limit = std.Io.Limit.limited(1 * 1024 * 1024),
         .stderr_limit = std.Io.Limit.limited(1 * 1024 * 1024),
@@ -386,7 +379,7 @@ fn runCurlFetch(allocator: std.mem.Allocator, url: []const u8, interface: ?[]con
     var io_instance: std.Io.Threaded = .init(std.heap.page_allocator, .{});
     defer io_instance.deinit();
 
-    const result = std.process.run(allocator, io_instance.io(), .{
+    const result = @import("child_process").run(allocator, io_instance.io(), .{
         .argv = argv,
         .stdout_limit = std.Io.Limit.limited(1 * 1024 * 1024),
         .stderr_limit = std.Io.Limit.limited(1 * 1024 * 1024),

--- a/src/proxy/message_queue.zig
+++ b/src/proxy/message_queue.zig
@@ -2,7 +2,8 @@ const std = @import("std");
 const posix = std.posix;
 
 const msg_block_size: usize = 2048;
-const msg_free_cap_per_queue: usize = 4;
+// Retain one complete 32 KiB relay read to avoid churn under backpressure.
+const msg_free_cap_per_queue: usize = 16;
 
 const MsgBlock = struct {
     len: usize,
@@ -70,11 +71,6 @@ pub const MessageQueue = struct {
             self.total_len += take;
             off += take;
         }
-    }
-
-    pub fn appendOwned(self: *MessageQueue, owned: []u8) !void {
-        defer self.allocator.free(owned);
-        try self.appendCopy(owned);
     }
 
     pub fn prepareIovecs(self: *const MessageQueue, out: []posix.iovec_const) usize {

--- a/src/proxy/middle_proxy_fallback.zig
+++ b/src/proxy/middle_proxy_fallback.zig
@@ -21,6 +21,8 @@ pub fn fallbackToDirect(
     _ = loop.state.stats_mp_fallback.fetchAdd(1, .monotonic);
     slot.use_middle_proxy = false;
     slot.mp_step = .none;
+    if (slot.mp_enc) |*enc| enc.wipe();
+    if (slot.mp_dec) |*dec| dec.wipe();
     slot.mp_enc = null;
     slot.mp_dec = null;
 

--- a/src/proxy/middle_proxy_frames.zig
+++ b/src/proxy/middle_proxy_frames.zig
@@ -10,7 +10,6 @@ pub fn readReset(slot: anytype, encrypted: bool) void {
     slot.mp_frame_have = 0;
     slot.mp_frame_total_len = 0;
     slot.mp_frame_padded_len = 0;
-    slot.mp_frame_encrypted = encrypted;
     slot.mp_frame_first_decrypted = false;
     slot.mp_frame_need = if (encrypted) 16 else 4;
 }
@@ -30,13 +29,14 @@ pub fn writeFrame(
     comptime frame_buf_size: usize,
     comptime queue_upstream: fn (@TypeOf(slot), std.mem.Allocator, []const u8) anyerror!bool,
 ) !void {
+    if (payload.len % 4 != 0) return error.BadMiddleProxyFrameSize;
     var plain: [frame_buf_size]u8 = undefined;
     const total_len: usize = payload.len + 12;
     if (total_len > plain.len) return error.BadMiddleProxyFrameSize;
 
     std.mem.writeInt(u32, plain[0..4], @intCast(total_len), .little);
     std.mem.writeInt(i32, plain[4..8], slot.mp_write_seq_no, .little);
-    slot.mp_write_seq_no += 1;
+    slot.mp_write_seq_no +%= 1;
 
     @memcpy(plain[8 .. 8 + payload.len], payload);
     const checksum = middleproxy.crc32(plain[0 .. 8 + payload.len]);
@@ -212,7 +212,6 @@ const TestSlot = struct {
     mp_frame_have: usize = 0,
     mp_frame_total_len: usize = 0,
     mp_frame_padded_len: usize = 0,
-    mp_frame_encrypted: bool = false,
     mp_frame_first_decrypted: bool = false,
     mp_frame_need: usize = 0,
     mp_frame_buf: ?[]u8 = null,

--- a/src/proxy/middle_proxy_handshake.zig
+++ b/src/proxy/middle_proxy_handshake.zig
@@ -18,6 +18,77 @@ fn hasUpstreamPending(slot: anytype) bool {
     return !slot.upstream_queue.isEmpty();
 }
 
+test "nonce startup pins secret and advances only after pending write drains" {
+    const Step = enum { none, sending_rpc_nonce, waiting_rpc_nonce_response, sending_rpc_handshake, waiting_rpc_handshake_response };
+    const Queue = struct {
+        pending: bool = true,
+        pub fn isEmpty(self: @This()) bool {
+            return !self.pending;
+        }
+    };
+    const Slot = struct {
+        phase: enum { middle_proxy_handshake } = .middle_proxy_handshake,
+        mp_step: Step = .none,
+        mp_write_seq_no: i32 = 0,
+        mp_read_seq_no: i32 = 0,
+        mp_frame_have: usize = 0,
+        mp_frame_need: usize = 0,
+        mp_frame_total_len: usize = 0,
+        mp_frame_padded_len: usize = 0,
+        mp_frame_first_decrypted: bool = false,
+        mp_enc: ?u8 = null,
+        mp_dec: ?u8 = null,
+        mp_nonce: [16]u8 = undefined,
+        mp_timestamp: u32 = 0,
+        mp_secret: [256]u8 = undefined,
+        mp_secret_len: usize = 0,
+        upstream_queue: Queue = .{},
+    };
+    const Loop = struct {
+        state: struct {
+            clock_offset_seconds: i64 = 300,
+            middle_proxy_secret: [256]u8 = [_]u8{0x42} ** 256,
+            middle_proxy_secret_len: usize = 32,
+        } = .{},
+        message: [32]u8 = undefined,
+        failed_write: bool = false,
+        fallback_calls: usize = 0,
+        closed: bool = false,
+    };
+    const Cb = struct {
+        fn write(loop: *Loop, _: *Slot, payload: []const u8, _: bool) !void {
+            if (loop.failed_write) return error.ConnectionReset;
+            @memcpy(&loop.message, payload);
+        }
+        fn lock(_: *Loop) void {}
+        fn close(loop: *Loop, _: *Slot, _: []const u8) void {
+            loop.closed = true;
+        }
+        fn fallback(loop: *Loop, _: *Slot) bool {
+            loop.fallback_calls += 1;
+            return true;
+        }
+    };
+    var loop = Loop{};
+    var slot = Slot{};
+    begin(&loop, &slot, Cb.write, Cb.lock, Cb.lock, Cb.close, Cb.fallback);
+    try std.testing.expectEqual(Step.sending_rpc_nonce, slot.mp_step);
+    try std.testing.expectEqual(@as(usize, 32), slot.mp_secret_len);
+    @memset(&loop.state.middle_proxy_secret, 0x99);
+    try std.testing.expectEqual(@as(u8, 0x42), slot.mp_secret[0]);
+    try std.testing.expectEqualSlices(u8, &middleproxy.rpc_nonce_req, loop.message[0..4]);
+    const corrected = realtimeSeconds() + 300;
+    try std.testing.expect(@abs(@as(i64, slot.mp_timestamp) - corrected) <= 1);
+    slot.upstream_queue.pending = false;
+    onWritable(&slot);
+    try std.testing.expectEqual(Step.waiting_rpc_nonce_response, slot.mp_step);
+    try std.testing.expectEqual(@as(usize, 4), slot.mp_frame_need);
+    loop.failed_write = true;
+    begin(&loop, &slot, Cb.write, Cb.lock, Cb.lock, Cb.close, Cb.fallback);
+    try std.testing.expectEqual(@as(usize, 1), loop.fallback_calls);
+    try std.testing.expect(!loop.closed);
+}
+
 pub fn begin(
     loop: anytype,
     slot: anytype,
@@ -25,6 +96,7 @@ pub fn begin(
     comptime lock_shared: fn (@TypeOf(loop)) void,
     comptime unlock_shared: fn (@TypeOf(loop)) void,
     comptime close_slot: fn (@TypeOf(loop), @TypeOf(slot), []const u8) void,
+    comptime fallback_to_direct: fn (@TypeOf(loop), @TypeOf(slot)) bool,
 ) void {
     slot.phase = .middle_proxy_handshake;
     slot.mp_step = .sending_rpc_nonce;
@@ -36,7 +108,7 @@ pub fn begin(
     slot.mp_dec = null;
 
     crypto.randomBytes(&slot.mp_nonce);
-    const ts: u32 = @intCast(@mod(realtimeSeconds(), 4294967296));
+    const ts: u32 = @intCast(@mod(realtimeSeconds() +| loop.state.clock_offset_seconds, 4294967296));
     slot.mp_timestamp = ts;
 
     var crypto_ts: [4]u8 = undefined;
@@ -45,6 +117,8 @@ pub fn begin(
     var msg: [32]u8 = undefined;
     @memcpy(msg[0..4], &middleproxy.rpc_nonce_req);
     lock_shared(loop);
+    slot.mp_secret_len = loop.state.middle_proxy_secret_len;
+    @memcpy(slot.mp_secret[0..slot.mp_secret_len], loop.state.middle_proxy_secret[0..slot.mp_secret_len]);
     // Defensive copy: refresh rejects secrets shorter than 16 bytes, but
     // if that invariant is ever broken we must avoid a length-mismatched
     // memcpy panic when filling the 4-byte key selector field.
@@ -59,7 +133,7 @@ pub fn begin(
     @memcpy(msg[16..32], &slot.mp_nonce);
 
     write_frame(loop, slot, msg[0..], false) catch {
-        close_slot(loop, slot, "mp send nonce failed");
+        if (!fallback_to_direct(loop, slot)) close_slot(loop, slot, "mp send nonce failed");
         return;
     };
 
@@ -96,6 +170,8 @@ pub fn onReadable(
     comptime close_slot: fn (@TypeOf(loop), @TypeOf(slot), []const u8) void,
     comptime fallback_to_direct: fn (@TypeOf(loop), @TypeOf(slot)) bool,
 ) void {
+    _ = lock_shared;
+    _ = unlock_shared;
     switch (slot.mp_step) {
         .waiting_rpc_nonce_response => {
             // Nonce-stage failures get the same MP->direct fallback as the handshake stage:
@@ -116,16 +192,13 @@ pub fn onReadable(
                 return;
             }
 
-            lock_shared(loop);
-            const key_sel = loop.state.middle_proxy_secret[0..@min(@as(usize, 4), loop.state.middle_proxy_secret_len)];
-            const secret_slice = loop.state.middle_proxy_secret[0..loop.state.middle_proxy_secret_len];
+            const key_sel = slot.mp_secret[0..@min(@as(usize, 4), slot.mp_secret_len)];
+            const secret_slice = slot.mp_secret[0..slot.mp_secret_len];
             if (!std.mem.eql(u8, payload[4..8], key_sel)) {
-                unlock_shared(loop);
                 if (!fallback_to_direct(loop, slot)) close_slot(loop, slot, "mp key selector mismatch");
                 return;
             }
             if (!std.mem.eql(u8, payload[8..12], &middleproxy.rpc_crypto_aes)) {
-                unlock_shared(loop);
                 if (!fallback_to_direct(loop, slot)) close_slot(loop, slot, "mp crypto schema mismatch");
                 return;
             }
@@ -136,17 +209,14 @@ pub fn onReadable(
             std.mem.writeInt(u32, &ts_arr, slot.mp_timestamp, .little);
 
             const tg_addr = slot.current_upstream_addr orelse {
-                unlock_shared(loop);
                 if (!fallback_to_direct(loop, slot)) close_slot(loop, slot, "mp missing logical upstream addr");
                 return;
             };
 
             const local_addr = localSocketAddress(slot.upstream_fd) catch {
-                unlock_shared(loop);
                 if (!fallback_to_direct(loop, slot)) close_slot(loop, slot, "mp getsockname failed");
                 return;
             };
-            var middle_local_addr = local_addr;
 
             var tg_port: [2]u8 = undefined;
             var my_port: [2]u8 = undefined;
@@ -167,7 +237,6 @@ pub fn onReadable(
                     if (loop.state.middle_proxy_nat_ip4) |nat_ip| {
                         const my_ip_v4 = ipv4NetworkToHostBytes(nat_ip);
                         my_ip_v4_opt = my_ip_v4;
-                        middle_local_addr = ip4(nat_ip, local_port);
                     } else switch (local_addr) {
                         // No explicit NAT IP configured/detected: fall back to the source
                         // address getsockname() reports — the IP Telegram actually observes
@@ -213,7 +282,10 @@ pub fn onReadable(
                 secret_slice,
                 my_ip_v6_ptr,
                 tg_ip_v6_ptr,
-            );
+            ) catch {
+                if (!fallback_to_direct(loop, slot)) close_slot(loop, slot, "mp invalid key derivation input");
+                return;
+            };
 
             const dec_keys = middleproxy.getAesKeyAndIv(
                 &slot.mp_rpc_nonce_ans,
@@ -227,8 +299,10 @@ pub fn onReadable(
                 secret_slice,
                 my_ip_v6_ptr,
                 tg_ip_v6_ptr,
-            );
-            unlock_shared(loop);
+            ) catch {
+                if (!fallback_to_direct(loop, slot)) close_slot(loop, slot, "mp invalid key derivation input");
+                return;
+            };
 
             slot.mp_enc = crypto.AesCbc.init(&enc_keys[0], &enc_keys[1]);
             slot.mp_dec = crypto.AesCbc.init(&dec_keys[0], &dec_keys[1]);
@@ -289,8 +363,8 @@ pub fn onReadable(
 
             var middle_local_addr = local_addr;
             if (loop.state.middle_proxy_nat_ip4) |nat_ip| {
-                switch (local_addr) {
-                    .ip4 => |la4| middle_local_addr = ip4(nat_ip, la4.port),
+                switch (slot.current_upstream_addr orelse local_addr) {
+                    .ip4 => middle_local_addr = ip4(nat_ip, local_addr.getPort()),
                     .ip6 => {},
                 }
             }
@@ -317,6 +391,10 @@ pub fn onReadable(
             };
 
             slot.mp_step = .done;
+            if (slot.mp_frame_buf) |buf| {
+                loop.state.allocator.free(buf);
+                slot.mp_frame_buf = null;
+            }
             start_relay(loop, slot);
         },
         else => {},

--- a/src/proxy/middle_proxy_routing.zig
+++ b/src/proxy/middle_proxy_routing.zig
@@ -24,8 +24,6 @@ pub const MiddleProxySnapshot = struct {
     addrs_media_dc4_len: usize,
     addrs_203: [8]Address,
     addrs_203_len: usize,
-    secret: [256]u8,
-    secret_len: usize,
 
     /// Pick the single primary endpoint for (dc_abs, media?). Media-path
     /// traffic (client sent dc_idx<0) must go to the media MP fleet.
@@ -70,6 +68,7 @@ pub fn buildDcConnectPlan(
     user_name: []const u8,
 ) DcConnectPlan {
     var plan = DcConnectPlan{};
+    if (dc_abs != 203 and (dc_abs < 1 or dc_abs > constants.tg_datacenters_v4.len)) return plan;
     plan.is_media_path = (dc_idx < 0) or (dc_abs == 203);
 
     if (cfg.datacenter_override) |override| {
@@ -90,7 +89,7 @@ pub fn buildDcConnectPlan(
     const has_cdn_middle_proxy = cdn_dc and snapshot != null and snapshot.?.getForDc(dc_abs, true) != null;
 
     if (cfg.userBypassesMiddleProxy(user_name) and !has_cdn_middle_proxy) {
-        plan.candidates[0] = constants.getDcAddressV4(dc_abs);
+        plan.candidates[0] = constants.getDcAddressV4(dc_abs).?;
         plan.count = 1;
         plan.use_middle_proxy = false;
         plan.direct_fallback = null;
@@ -116,7 +115,7 @@ pub fn buildDcConnectPlan(
         cfg.use_middle_proxy and middle_addr != null;
 
     if (!plan.use_middle_proxy) {
-        plan.candidates[0] = constants.getDcAddressV4(dc_abs);
+        plan.candidates[0] = constants.getDcAddressV4(dc_abs).?;
         plan.count = 1;
         plan.direct_fallback = null;
         return plan;
@@ -151,7 +150,7 @@ pub fn buildDcConnectPlan(
         // Safety fallback: if cache has no middle-proxy endpoint for this DC,
         // avoid dropping valid users and go direct.
         plan.use_middle_proxy = false;
-        plan.candidates[0] = constants.getDcAddressV4(dc_abs);
+        plan.candidates[0] = constants.getDcAddressV4(dc_abs).?;
         plan.count = 1;
         plan.direct_fallback = null;
         return plan;
@@ -220,7 +219,7 @@ pub fn parseMiddleProxyAddressesForDc(
     return count;
 }
 
-pub fn parseMiddleProxyAddressForDc(config_text: []const u8, target_dc: i16) ?Address {
+fn parseMiddleProxyAddressForDc(config_text: []const u8, target_dc: i16) ?Address {
     var one: [1]Address = undefined;
     const sign: DcSignFilter = if (target_dc < 0) .negative_only else .positive_only;
     const n = parseMiddleProxyAddressesForDc(config_text, target_dc, sign, &one);
@@ -243,32 +242,8 @@ pub fn addressesEqual(a: []const Address, b: []const Address) bool {
     return true;
 }
 
-fn closeFd(fd: posix.fd_t) void {
-    while (true) {
-        switch (posix.errno(posix.system.close(fd))) {
-            .SUCCESS => return,
-            .INTR => continue,
-            else => return,
-        }
-    }
-}
-
-fn connectSockaddr(fd: posix.fd_t, addr: *const posix.sockaddr, addr_len: posix.socklen_t) !void {
-    while (true) switch (posix.errno(posix.system.connect(fd, addr, addr_len))) {
-        .SUCCESS => return,
-        .INTR => continue,
-        .ADDRNOTAVAIL => return error.AddressUnavailable,
-        .AFNOSUPPORT => return error.AddressFamilyUnsupported,
-        .AGAIN, .INPROGRESS => return error.WouldBlock,
-        .ALREADY => return error.ConnectionPending,
-        .CONNREFUSED => return error.ConnectionRefused,
-        .CONNRESET => return error.ConnectionResetByPeer,
-        .HOSTUNREACH => return error.HostUnreachable,
-        .NETUNREACH => return error.NetworkUnreachable,
-        .TIMEDOUT => return error.Timeout,
-        else => |err| return posix.unexpectedErrno(err),
-    };
-}
+const closeFd = @import("socket_utils.zig").closeFd;
+const connectSockaddr = @import("socket_utils.zig").connectSockaddr;
 
 fn isAddressReachable(address: Address, timeout_ms: i32) bool {
     const sock_flags = posix.SOCK.STREAM | posix.SOCK.CLOEXEC | posix.SOCK.NONBLOCK;
@@ -367,8 +342,6 @@ test "direct users bypass middle-proxy routing" {
         .addrs_media_dc4_len = 1,
         .addrs_203 = [_]Address{mp_dc203} ++ ([_]Address{mp_dc203} ** 7),
         .addrs_203_len = 1,
-        .secret = [_]u8{0} ** 256,
-        .secret_len = 16,
     };
 
     const regular_plan = buildDcConnectPlan(&cfg, 4, 4, &snapshot, "regular");
@@ -379,7 +352,7 @@ test "direct users bypass middle-proxy routing" {
     const admin_plan = buildDcConnectPlan(&cfg, 4, 4, &snapshot, "admin");
     try std.testing.expect(!admin_plan.use_middle_proxy);
     try std.testing.expect(admin_plan.direct_fallback == null);
-    try std.testing.expect(addressEql(admin_plan.candidates[0], constants.getDcAddressV4(4)));
+    try std.testing.expect(addressEql(admin_plan.candidates[0], constants.getDcAddressV4(4).?));
 
     const regular_media = buildDcConnectPlan(&cfg, 203, -203, &snapshot, "regular");
     try std.testing.expect(regular_media.use_middle_proxy);

--- a/src/proxy/net_helpers.zig
+++ b/src/proxy/net_helpers.zig
@@ -12,6 +12,23 @@ pub const AddressList = struct {
     }
 };
 
+/// Bounded DNS snapshot, copied for the lifetime of a connect attempt.
+pub const AddressCandidates = struct {
+    addresses: [16]Address = undefined,
+    len: u8 = 0,
+
+    pub fn init(addresses: []const Address) AddressCandidates {
+        var self: AddressCandidates = .{};
+        self.len = @intCast(@min(addresses.len, self.addresses.len));
+        @memcpy(self.addresses[0..self.len], addresses[0..self.len]);
+        return self;
+    }
+
+    pub fn slice(self: *const AddressCandidates) []const Address {
+        return self.addresses[0..self.len];
+    }
+};
+
 pub fn ip4(bytes: [4]u8, port: u16) Address {
     return .{ .ip4 = .{ .bytes = bytes, .port = port } };
 }
@@ -32,6 +49,44 @@ pub fn isIpv6(addr: Address) bool {
     };
 }
 
+/// Linux listener with explicit dual-stack and worker-sharing policy.
+pub fn listen(addr: Address, backlog: u31, reuse_port: bool) !std.Io.net.Server {
+    const posix = std.posix;
+    const family: u32 = if (isIpv6(addr)) posix.AF.INET6 else posix.AF.INET;
+    const rc = posix.system.socket(family, posix.SOCK.STREAM | posix.SOCK.CLOEXEC, posix.IPPROTO.TCP);
+    const fd: posix.fd_t = switch (posix.errno(rc)) {
+        .SUCCESS => @intCast(rc),
+        .AFNOSUPPORT => return error.AddressFamilyUnsupported,
+        else => |err| return posix.unexpectedErrno(err),
+    };
+    errdefer _ = posix.system.close(fd);
+    const on: c_int = 1;
+    const off: c_int = 0;
+    try posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.REUSEADDR, std.mem.asBytes(&on));
+    if (reuse_port) try posix.setsockopt(fd, posix.SOL.SOCKET, posix.SO.REUSEPORT, std.mem.asBytes(&on));
+    if (isIpv6(addr)) try posix.setsockopt(fd, posix.IPPROTO.IPV6, std.os.linux.IPV6.V6ONLY, std.mem.asBytes(&off));
+    const bind_rc = switch (addr) {
+        .ip4 => |a| blk: {
+            var sa = posix.sockaddr.in{ .family = posix.AF.INET, .port = std.mem.nativeToBig(u16, a.port), .addr = @bitCast(a.bytes), .zero = [_]u8{0} ** 8 };
+            break :blk posix.system.bind(fd, @ptrCast(&sa), @sizeOf(@TypeOf(sa)));
+        },
+        .ip6 => |a| blk: {
+            var sa = posix.sockaddr.in6{ .family = posix.AF.INET6, .port = std.mem.nativeToBig(u16, a.port), .flowinfo = a.flow, .addr = a.bytes, .scope_id = a.interface.index };
+            break :blk posix.system.bind(fd, @ptrCast(&sa), @sizeOf(@TypeOf(sa)));
+        },
+    };
+    switch (posix.errno(bind_rc)) {
+        .SUCCESS => {},
+        .ADDRINUSE => return error.AddressInUse,
+        else => |err| return posix.unexpectedErrno(err),
+    }
+    switch (posix.errno(posix.system.listen(fd, backlog))) {
+        .SUCCESS => {},
+        else => |err| return posix.unexpectedErrno(err),
+    }
+    return .{ .socket = .{ .handle = fd, .address = addr }, .options = {} };
+}
+
 pub fn addressEql(a: Address, b: Address) bool {
     return net.IpAddress.eql(&a, &b);
 }
@@ -49,9 +104,37 @@ pub fn getAddressList(allocator: std.mem.Allocator, host: []const u8, port: u16)
     // system NSS resolver via `getent`, which tolerates such files. Without this,
     // the proxy can resolve IP literals but no hostnames (mask_target, upstream
     // proxy host), so real-domain fronting silently breaks.
-    return lookupViaStd(allocator, host, port) catch
-        lookupViaGetent(allocator, host, port);
+    const resolved = lookupViaStd(allocator, host, port) catch |err| blk: {
+        if (err == error.ResolvConfParseFailed or err == error.DetectingNetworkConfigurationFailed)
+            break :blk try lookupViaGetent(allocator, host, port);
+        return err;
+    };
+    // Stable IPv4-first order across native DNS and NSS/getent. Preserve order
+    // within each family rather than depending on the resolver implementation.
+    preferIpv4(resolved.addrs);
+    return resolved;
 }
+
+fn preferIpv4(addresses: []Address) void {
+    std.mem.sort(Address, addresses, {}, struct {
+        fn less(_: void, a: Address, b: Address) bool {
+            return a == .ip4 and b == .ip6;
+        }
+    }.less);
+}
+
+const LookupProducer = struct {
+    host: net.HostName,
+    io: std.Io,
+    results: *std.Io.Queue(net.HostName.LookupResult),
+    port: u16,
+    failure: ?anyerror = null,
+    fn run(self: *LookupProducer) void {
+        self.host.lookup(self.io, self.results, .{ .port = self.port }) catch |err| {
+            self.failure = err;
+        };
+    }
+};
 
 fn lookupViaStd(allocator: std.mem.Allocator, host: []const u8, port: u16) !AddressList {
     const host_name = try net.HostName.init(host);
@@ -60,19 +143,37 @@ fn lookupViaStd(allocator: std.mem.Allocator, host: []const u8, port: u16) !Addr
     var results_buf: [32]net.HostName.LookupResult = undefined;
     var results: std.Io.Queue(net.HostName.LookupResult) = .init(&results_buf);
 
-    try host_name.lookup(io_ctx, &results, .{ .port = port });
+    var producer: LookupProducer = .{ .host = host_name, .io = io_ctx, .results = &results, .port = port };
+    const thread = try std.Thread.spawn(.{}, LookupProducer.run, .{&producer});
 
+    const drained = drainLookupResults(allocator, &results, io_ctx);
+    // Draining is complete even when allocation failed; joining cannot deadlock
+    // against a producer suspended on a full queue.
+    thread.join();
+    const addrs = try drained;
+    errdefer addrs.deinit();
+    if (producer.failure) |err| return err;
+    return addrs;
+}
+
+fn drainLookupResults(allocator: std.mem.Allocator, results: *std.Io.Queue(net.HostName.LookupResult), io_ctx: std.Io) !AddressList {
     var addrs: std.ArrayList(Address) = .empty;
     defer addrs.deinit(allocator);
+    var allocation_failed = false;
 
     while (results.getOneUncancelable(io_ctx)) |entry| {
         switch (entry) {
-            .address => |addr| try addrs.append(allocator, addr),
+            .address => |addr| if (!allocation_failed) {
+                addrs.append(allocator, addr) catch {
+                    allocation_failed = true;
+                };
+            },
             .canonical_name => {},
         }
     } else |err| switch (err) {
         error.Closed => {},
     }
+    if (allocation_failed) return error.OutOfMemory;
 
     if (addrs.items.len == 0) return error.NoAddressReturned;
     return .{
@@ -81,7 +182,7 @@ fn lookupViaStd(allocator: std.mem.Allocator, host: []const u8, port: u16) !Addr
     };
 }
 
-fn lookupViaGetent(allocator: std.mem.Allocator, host: []const u8, port: u16) !AddressList {
+pub fn lookupViaGetent(allocator: std.mem.Allocator, host: []const u8, port: u16) !AddressList {
     // Only resolve plain hostnames (no shell metacharacters); host comes from
     // config (mask_target / upstream proxy host), but stay defensive.
     for (host) |c| {
@@ -93,8 +194,9 @@ fn lookupViaGetent(allocator: std.mem.Allocator, host: []const u8, port: u16) !A
     var io_instance: std.Io.Threaded = .init(std.heap.page_allocator, .{});
     defer io_instance.deinit();
 
-    const result = std.process.run(allocator, io_instance.io(), .{
-        .argv = &.{ "getent", "ahosts", host },
+    const result = @import("child_process").run(allocator, io_instance.io(), .{
+        .argv = &.{ "getent", "ahosts", "--", host },
+        .timeout = .{ .duration = .{ .raw = .fromSeconds(5), .clock = .awake } },
         .stdout_limit = std.Io.Limit.limited(64 * 1024),
         .stderr_limit = std.Io.Limit.limited(4 * 1024),
     }) catch return error.ResolveFailed;
@@ -148,4 +250,51 @@ test "parseGetentAhosts dedupes ip/socktype lines" {
     const l2 = try parseGetentAhosts(std.testing.allocator, no_nl, 53);
     defer l2.deinit();
     try std.testing.expectEqual(@as(usize, 2), l2.addrs.len);
+}
+
+const SyntheticLookupProducer = struct {
+    fn run(results: *std.Io.Queue(net.HostName.LookupResult), io_ctx: std.Io) void {
+        defer results.close(io_ctx);
+        for (0..97) |i| results.putOneUncancelable(io_ctx, .{ .address = ip4(.{ 192, 0, 2, @intCast(i) }, 443) }) catch return;
+    }
+};
+
+test "DNS queue drains more answers than its fixed capacity" {
+    const io_ctx = std.Io.Threaded.global_single_threaded.io();
+    var storage: [32]net.HostName.LookupResult = undefined;
+    var queue: std.Io.Queue(net.HostName.LookupResult) = .init(&storage);
+    const producer = try std.Thread.spawn(.{}, SyntheticLookupProducer.run, .{ &queue, io_ctx });
+    const result = drainLookupResults(std.testing.allocator, &queue, io_ctx);
+    producer.join();
+    const list = try result;
+    defer list.deinit();
+    try std.testing.expectEqual(@as(usize, 97), list.addrs.len);
+    for (list.addrs, 0..) |addr, i| try std.testing.expect(addressEql(addr, ip4(.{ 192, 0, 2, @intCast(i) }, 443)));
+}
+
+test "DNS queue still drains its producer after allocation failure" {
+    const io_ctx = std.Io.Threaded.global_single_threaded.io();
+    var storage: [32]net.HostName.LookupResult = undefined;
+    var queue: std.Io.Queue(net.HostName.LookupResult) = .init(&storage);
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    const producer = try std.Thread.spawn(.{}, SyntheticLookupProducer.run, .{ &queue, io_ctx });
+    const result = drainLookupResults(failing.allocator(), &queue, io_ctx);
+    producer.join();
+    try std.testing.expectError(error.OutOfMemory, result);
+}
+
+test "DNS ordering is IPv4 first and stable within each family" {
+    const a = ip4(.{ 192, 0, 2, 1 }, 443);
+    const b = ip4(.{ 192, 0, 2, 2 }, 443);
+    const c = ip6(@splat(1), 443, 0, 0);
+    const d = ip6(@splat(2), 443, 0, 0);
+    var addresses = [_]Address{ c, a, d, b };
+    preferIpv4(&addresses);
+    for (addresses, [_]Address{ a, b, c, d }) |actual, expected| try std.testing.expect(addressEql(actual, expected));
+}
+
+test "startup address snapshots bound retained answers to sixteen" {
+    const addresses = [_]Address{ip4(.{ 192, 0, 2, 1 }, 443)} ** 97;
+    const candidates = AddressCandidates.init(&addresses);
+    try std.testing.expectEqual(@as(usize, 16), candidates.slice().len);
 }

--- a/src/proxy/network_detect.zig
+++ b/src/proxy/network_detect.zig
@@ -13,6 +13,7 @@ pub fn parseIpv4Literal(text: []const u8) ?[4]u8 {
     var i: usize = 0;
     while (parts.next()) |p| {
         if (i >= 4 or p.len == 0) return null;
+        for (p) |c| if (!std.ascii.isDigit(c)) return null;
         const n = std.fmt.parseInt(u16, p, 10) catch return null;
         if (n > 255) return null;
         out[i] = @intCast(n);
@@ -153,28 +154,13 @@ pub fn detectAwgEndpointIpv4(allocator: std.mem.Allocator) ?[4]u8 {
 
     for (paths) |path| {
         const io_ctx = std.Io.Threaded.global_single_threaded.io();
-        const content = std.Io.Dir.cwd().readFileAlloc(io_ctx, path, allocator, .limited(64 * 1024)) catch continue;
+        const content = std.Io.Dir.cwd().readFileAlloc(io_ctx, path, allocator, .limited(64 * 1024)) catch |err| {
+            if (err == error.AccessDenied) std.log.scoped(.proxy).warn("Cannot read tunnel endpoint config '{s}'; NAT detection will try remaining configs/public egress. Set middle_proxy_nat_ip explicitly if the endpoint differs", .{path});
+            continue;
+        };
         defer allocator.free(content);
 
         if (parseAwgEndpointIpv4FromConfig(allocator, content)) |ip| return ip;
-    }
-
-    return null;
-}
-
-pub fn detectPublicIpv4(allocator: std.mem.Allocator, comptime fetchBytes: anytype) ?[4]u8 {
-    const services = [_][]const u8{
-        "https://api.ipify.org",
-        "https://ifconfig.me",
-        "https://ipv4.icanhazip.com",
-    };
-
-    for (services) |url| {
-        const stdout = fetchBytes(allocator, url) catch continue;
-        const trimmed = std.mem.trim(u8, stdout, &[_]u8{ ' ', '\t', '\r', '\n' });
-        const parsed = parseIpv4Literal(trimmed);
-        allocator.free(stdout);
-        if (parsed) |ip| return ip;
     }
 
     return null;

--- a/src/proxy/proxy.zig
+++ b/src/proxy/proxy.zig
@@ -35,6 +35,7 @@ const http_fetch = @import("http_fetch.zig");
 const fd_limits = @import("fd_limits.zig");
 const connection_phase = @import("connection_phase.zig");
 const net_helpers = @import("net_helpers.zig");
+const dns_cache = @import("dns_cache.zig");
 const connection_pool_mod = @import("connection_pool.zig");
 const relay_steps = @import("relay_steps.zig");
 const middle_proxy_frames = @import("middle_proxy_frames.zig");
@@ -82,6 +83,41 @@ test {
 
 const log = std.log.scoped(.proxy);
 
+fn configValueEqual(comptime T: type, a: T, b: T) bool {
+    return switch (@typeInfo(T)) {
+        .optional => |o| if (a) |v| (if (b) |w| configValueEqual(o.child, v, w) else false) else b == null,
+        .pointer => |p| blk: {
+            if (p.size != .slice) break :blk a == b;
+            if (a.len != b.len) break :blk false;
+            for (a, b) |v, w| if (!configValueEqual(p.child, v, w)) break :blk false;
+            break :blk true;
+        },
+        .@"struct" => blk: {
+            if (@hasDecl(T, "iterator") and @hasDecl(T, "get") and @hasDecl(T, "count")) {
+                if (a.count() != b.count()) break :blk false;
+                var iter = a.iterator();
+                while (iter.next()) |entry| {
+                    const other = b.get(entry.key_ptr.*) orelse break :blk false;
+                    if (!configValueEqual(@TypeOf(other), entry.value_ptr.*, other)) break :blk false;
+                }
+            } else {
+                inline for (std.meta.fields(T)) |f| {
+                    if (!configValueEqual(f.type, @field(a, f.name), @field(b, f.name))) break :blk false;
+                }
+            }
+            break :blk true;
+        },
+        else => std.meta.eql(a, b),
+    };
+}
+
+fn isHotConfigField(comptime name: []const u8) bool {
+    for ([_][]const u8{ "users", "direct_users", "idle_timeout_sec", "handshake_timeout_sec", "graceful_shutdown_timeout_sec", "rate_limit_per_subnet", "handshake_flood_guard_enabled", "handshake_flood_guard_threshold", "handshake_flood_guard_window_sec", "handshake_flood_guard_block_sec", "log_level", "mask", "mask_port", "mask_target", "desync", "drs", "fast_mode", "max_connections" }) |hot| {
+        if (std.mem.eql(u8, name, hot)) return true;
+    }
+    return false;
+}
+
 const tls_header_len = 5;
 /// Upper bound on SO_REUSEPORT epoll worker threads ([server].workers / 0=auto).
 const max_workers = 256;
@@ -101,7 +137,6 @@ const accept_backoff_ns: i128 = @as(i128, accept_backoff_ms) * std.time.ns_per_m
 const accept_batch_limit: usize = 256;
 const stats_log_interval_s: i64 = 10;
 const stats_log_interval_ns: i128 = @as(i128, stats_log_interval_s) * std.time.ns_per_s;
-const timer_scan_budget: usize = 512;
 const middle_proxy_config_url = "https://core.telegram.org/getProxyConfig";
 const middle_proxy_secret_url = "https://core.telegram.org/getProxySecret";
 // Telegram rotates the middleproxy DC addresses / proxy secret well within a day
@@ -118,12 +153,11 @@ const middle_proxy_reactive_cooldown_ns: u64 = 60 * std.time.ns_per_s;
 const tunnel_socket_mark: u32 = 200;
 const tunnel_route_table: u32 = 200;
 const tunnel_pool_state_path = "/run/mtproto-proxy/tunnel-pool.state";
-const min_nofile_soft: usize = 65535;
 const client_hello_inline_size: usize = 512;
 const mp_handshake_frame_buf_size: usize = 2048;
-const read_buf_size: usize = 32 * 1024;
+const read_buf_size: usize = Config.relay_read_buffer_size;
 const max_pipelined_handshake_bytes: usize = 128 * 1024;
-const graceful_shutdown_check_ms: i32 = 100;
+const graceful_shutdown_check_ms: i32 = 25;
 
 const upstream_candidates_inline_cap: usize = 4;
 
@@ -173,7 +207,9 @@ fn formatFloodGuardTop(entries: []const HandshakeFloodGuard.TopEntry, buf: *[102
 
     for (entries) |entry| {
         var ip_buf: [64]u8 = undefined;
-        const ip = HandshakeFloodGuard.formatKey(entry.key, &ip_buf);
+        var redacted = entry.key;
+        if (redacted.family == .ip4) redacted.bytes[3] = 0 else @memset(redacted.bytes[8..], 0);
+        const ip = HandshakeFloodGuard.formatKey(redacted, &ip_buf);
         const blocked_for = if (entry.blocked_until_s > now_s) entry.blocked_until_s - now_s else 0;
 
         if (pos > 0 and pos < buf.len) {
@@ -206,17 +242,9 @@ fn optionalStringEql(a: ?[]const u8, b: ?[]const u8) bool {
     return b == null;
 }
 
-// Lock around the shared middle-proxy snapshot. Zig 0.16 has no std.Thread.Mutex
-// / std.Thread.RwLock, so this wraps std.Io.Mutex — a real cross-thread futex
-// mutex (atomic CAS fast path + futex park/wake via the Io) driven by the global
-// single-threaded Io (which disables only async task spawning, NOT mutual
-// exclusion). Cross-thread correctness matters because the middle-proxy updater
-// runs on its own thread AND, under the SO_REUSEPORT multi-worker model, N worker
-// threads read the snapshot concurrently. Readers serialize (no real RwLock
-// available), which is fine — the snapshot is read once per connection at routing
-// time, not on the per-byte relay path.
+// Shared snapshots use a real reader/writer lock: concurrent readers, exclusive updates.
 const CompatRwLock = struct {
-    mutex: std.Io.Mutex = .init,
+    mutex: std.Io.RwLock = .init,
 
     fn io() std.Io {
         return std.Io.Threaded.global_single_threaded.io();
@@ -231,11 +259,11 @@ const CompatRwLock = struct {
     }
 
     fn lockShared(self: *CompatRwLock) void {
-        self.mutex.lockUncancelable(io());
+        self.mutex.lockSharedUncancelable(io());
     }
 
     fn unlockShared(self: *CompatRwLock) void {
-        self.mutex.unlock(io());
+        self.mutex.unlockShared(io());
     }
 };
 
@@ -300,6 +328,93 @@ test "middle-proxy refresh selects proxy route for explicit socks5 and http upst
 
     cfg.upstream_mode = .tunnel;
     try std.testing.expectEqual(MiddleProxyFetchRoute.tunnel, middleProxyFetchRouteForConfig(&cfg));
+}
+
+/// Whether it is safe to trust trySelectReachableMiddleProxy's verdict.
+/// isAddressReachable opens a plain, unmarked, unproxied TCP socket, so it
+/// measures reachability on the host's DEFAULT route — on a tunnel/socks5/http
+/// upstream that (a) leaks a direct probe to Telegram MP IPs on exactly the
+/// network path the egress choice exists to hide this traffic from, and (b)
+/// can pick a candidate that is "reachable" on the wrong path but unreachable
+/// through the real egress. Only `.direct` (no configured egress to bypass)
+/// makes the probe meaningful.
+fn middleProxyProbeAllowed(cfg: *const Config) bool {
+    return middleProxyFetchRouteForConfig(cfg) == .direct;
+}
+
+test "middle-proxy reachability probe is skipped on any non-direct egress" {
+    var cfg = Config{
+        .users = std.StringHashMap([16]u8).init(std.testing.allocator),
+        .direct_users = std.StringHashMap(void).init(std.testing.allocator),
+    };
+    defer cfg.deinit(std.testing.allocator);
+
+    cfg.upstream_mode = .direct;
+    try std.testing.expect(middleProxyProbeAllowed(&cfg));
+
+    cfg.upstream_mode = .auto;
+    try std.testing.expect(middleProxyProbeAllowed(&cfg));
+
+    // Tunnel/socks5/http: a bare socket() probe would bypass the configured
+    // egress entirely, so it must not be trusted.
+    cfg.upstream_mode = .tunnel;
+    try std.testing.expect(!middleProxyProbeAllowed(&cfg));
+
+    cfg.upstream_mode = .socks5;
+    try std.testing.expect(!middleProxyProbeAllowed(&cfg));
+
+    cfg.upstream_mode = .http;
+    try std.testing.expect(!middleProxyProbeAllowed(&cfg));
+}
+
+/// Whether ANY connection this process serves could take a middle-proxy route,
+/// i.e. whether the background metadata updater thread is worth running at all.
+/// Same three-way predicate as the NAT-IP warning in ProxyState.init: regular
+/// traffic (use_middle_proxy), media/CDN traffic (force_media_middle_proxy,
+/// default true even with use_middle_proxy=false), and the ad-tag RPC (tag),
+/// which only takes effect over a middleproxy handshake.
+fn middleProxyUpdaterNeeded(cfg: *const Config) bool {
+    return cfg.use_middle_proxy or cfg.force_media_middle_proxy or cfg.tag != null;
+}
+
+/// Whether a specific connection's buildDcConnectPlan call should be handed a
+/// live middle-proxy snapshot. DC203 (CDN) has no direct address at all and
+/// always needs one; every other DC only needs one when regular MiddleProxy
+/// routing is on, or when force_media_middle_proxy could route ITS media path
+/// through MiddleProxy (buildDcConnectPlan itself gates that on dc_idx < 0, so
+/// handing a snapshot to a regular connection here is harmless — it's simply
+/// unused).
+fn middleProxySnapshotWanted(cfg: *const Config, dc_abs: usize) bool {
+    return cfg.use_middle_proxy or cfg.force_media_middle_proxy or dc_abs == 203;
+}
+
+test "middle-proxy updater runs whenever any MP route is reachable, not just use_middle_proxy" {
+    var cfg = Config{
+        .users = std.StringHashMap([16]u8).init(std.testing.allocator),
+        .direct_users = std.StringHashMap(void).init(std.testing.allocator),
+    };
+    defer cfg.deinit(std.testing.allocator);
+
+    // Shipped defaults: use_middle_proxy=false, force_media_middle_proxy=true.
+    // The updater must still run, or DC203/media snapshots never refresh.
+    cfg.use_middle_proxy = false;
+    cfg.force_media_middle_proxy = true;
+    try std.testing.expect(middleProxyUpdaterNeeded(&cfg));
+    try std.testing.expect(middleProxySnapshotWanted(&cfg, 1));
+    try std.testing.expect(middleProxySnapshotWanted(&cfg, 203));
+
+    // Everything off: no route can ever use MiddleProxy, so no updater and no
+    // snapshot for a regular DC — except CDN 203, which has no direct address.
+    cfg.force_media_middle_proxy = false;
+    cfg.tag = null;
+    try std.testing.expect(!middleProxyUpdaterNeeded(&cfg));
+    try std.testing.expect(!middleProxySnapshotWanted(&cfg, 1));
+    try std.testing.expect(middleProxySnapshotWanted(&cfg, 203));
+
+    // An ad-tag alone (no use_middle_proxy, no force_media) still needs the
+    // updater — the promotion RPC only takes effect over a MiddleProxy handshake.
+    cfg.tag = [_]u8{0} ** 16;
+    try std.testing.expect(middleProxyUpdaterNeeded(&cfg));
 }
 
 const DcConnectPlan = middle_proxy_routing.DcConnectPlan;
@@ -367,6 +482,7 @@ pub const MaskSafelistEntry = struct {
     domain: []const u8,
     /// Resolved address (port 443) of that domain's real server.
     addr: Address,
+    dns_id: usize,
 };
 
 /// Fetch a public-IP echo service through the SAME egress middle-proxy traffic uses, so
@@ -415,9 +531,11 @@ fn runSmallCommand(allocator: std.mem.Allocator, argv: []const []const u8) ?[]u8
     var io_instance: std.Io.Threaded = .init(std.heap.page_allocator, .{});
     defer io_instance.deinit();
 
-    const result = std.process.run(allocator, io_instance.io(), .{
+    const result = @import("child_process").run(allocator, io_instance.io(), .{
         .argv = argv,
-        .stdout_limit = std.Io.Limit.limited(512),
+        .expand_arg0 = .expand,
+        .timeout = .{ .duration = .{ .raw = .fromSeconds(10), .clock = .awake } },
+        .stdout_limit = std.Io.Limit.limited(32 * 1024),
         .stderr_limit = std.Io.Limit.limited(512),
     }) catch return null;
     defer allocator.free(result.stdout);
@@ -439,11 +557,20 @@ fn runSmallCommand(allocator: std.mem.Allocator, argv: []const []const u8) ?[]u8
 fn fetchClockOffsetSeconds(allocator: std.mem.Allocator, url: []const u8) ?i64 {
     // `-w %header{date}` prints ONLY the Date header value (tiny, always within the small
     // runSmallCommand stdout cap), unlike full `-I` headers where Date could be truncated.
-    const out = runSmallCommand(allocator, &.{ "curl", "-sS", "-o", "/dev/null", "--max-time", "8", "-w", "%header{date}", url }) orelse return null;
+    if (!std.mem.startsWith(u8, url, "https://")) return null;
+    const out = runSmallCommand(allocator, &.{ "curl", "-sSI", "--proto", "=https", "--proto-redir", "=https", "--max-time", "8", "--", url }) orelse return null;
     defer allocator.free(out);
     const http_epoch = http_fetch.parseHttpDate(out) orelse return null;
-    const off = http_epoch - realtimeSeconds();
-    return @max(@as(i64, -86400), @min(@as(i64, 86400), off));
+    return validatedClockOffset(http_epoch, realtimeSeconds());
+}
+
+fn validatedClockOffset(http_epoch: i64, local_epoch: i64) ?i64 {
+    const off = std.math.sub(i64, http_epoch, local_epoch) catch return null;
+    if (off < constants.time_skew_min or off > constants.time_skew_max) {
+        log.warn("clock_sync: refusing offset {d}s outside handshake skew window; fix the host clock", .{off});
+        return null;
+    }
+    return off;
 }
 
 fn detectActiveTunnelInterface(allocator: std.mem.Allocator) ?[]u8 {
@@ -469,6 +596,10 @@ fn readTunnelPoolStateValue(allocator: std.mem.Allocator, key: []const u8) ?[]u8
     ) catch return null;
     defer allocator.free(content);
 
+    return parseTunnelPoolStateValue(allocator, content, key);
+}
+
+fn parseTunnelPoolStateValue(allocator: std.mem.Allocator, content: []const u8, key: []const u8) ?[]u8 {
     var lines = std.mem.splitScalar(u8, content, '\n');
     while (lines.next()) |line| {
         const eq = std.mem.indexOfScalar(u8, line, '=') orelse continue;
@@ -480,6 +611,21 @@ fn readTunnelPoolStateValue(allocator: std.mem.Allocator, key: []const u8) ?[]u8
     }
 
     return null;
+}
+
+test "clock correction and tunnel state parsing are bounded" {
+    try std.testing.expectEqual(@as(?i64, 0), validatedClockOffset(1000, 1000));
+    try std.testing.expectEqual(@as(?i64, 42), validatedClockOffset(1042, 1000));
+    try std.testing.expect(validatedClockOffset(std.math.maxInt(i64), -1) == null);
+    try std.testing.expect(validatedClockOffset(100000, 0) == null);
+    const value = parseTunnelPoolStateValue(std.testing.allocator, "bad\nactive_old=wrong\n active = awg1 \r\n", "active").?;
+    defer std.testing.allocator.free(value);
+    try std.testing.expectEqualStrings("awg1", value);
+    try std.testing.expect(parseTunnelPoolStateValue(std.testing.allocator, "active=\n", "active") == null);
+    try std.testing.expect(parseTunnelPoolStateValue(std.testing.allocator, "other=x\n", "active") == null);
+    var state: ProxyState = undefined;
+    state.middle_proxy_updater_shutdown = .init(true);
+    try std.testing.expect(state.waitForUpdaterDelay(std.time.ns_per_hour));
 }
 
 fn tryFetchMiddleProxyViaInterface(
@@ -557,8 +703,8 @@ const ConnectionSlot = struct {
     validation_digest: [32]u8 = [_]u8{0} ** 32,
     validation_session_id: [32]u8 = [_]u8{0} ** 32,
     validation_session_id_len: u8 = 0,
-    validation_user: [32]u8 = [_]u8{0} ** 32,
-    validation_user_len: u8 = 0,
+    validation_user: []const u8 = "",
+    validation_user_len: usize = 0,
 
     server_hello: ?[]u8 = null,
     server_hello_off: usize = 0,
@@ -575,6 +721,8 @@ const ConnectionSlot = struct {
     tg_encryptor: ?crypto.AesCtr = null,
     tg_decryptor: ?crypto.AesCtr = null,
     middle_ctx: ?middleproxy.MiddleProxyContext = null,
+    mp_secret: [256]u8 = undefined,
+    mp_secret_len: usize = 0,
 
     dc_idx: i16 = 0,
     dc_abs: u16 = 0,
@@ -590,6 +738,10 @@ const ConnectionSlot = struct {
     direct_fallback_addr: ?Address = null,
     direct_fallback_used: bool = false,
     current_upstream_addr: ?Address = null,
+    proxy_candidate_index: u8 = 0,
+    mask_candidate_next: u8 = 0,
+    resolved_candidates: ?*net_helpers.AddressCandidates = null,
+    mask_dns_override: ?usize = null,
 
     // Pending initial bytes for direct DC path (promotion tag)
     dc_initial_tail: ?[]u8 = null,
@@ -666,13 +818,11 @@ const ConnectionSlot = struct {
     mp_frame_need: usize = 0,
     mp_frame_total_len: usize = 0,
     mp_frame_padded_len: usize = 0,
-    mp_frame_encrypted: bool = false,
     mp_frame_first_decrypted: bool = false,
 
     // Non-blocking proxy handshake state (SOCKS5 / HTTP CONNECT)
-    proxy_handshake_buf: [http_connect.max_response_size]u8 = undefined,
+    proxy_handshake_buf: ?*[http_connect.max_response_size]u8 = null,
     proxy_handshake_pos: u16 = 0,
-    proxy_handshake_len: u16 = 0,
     proxy_target_addr: ?Address = null,
 
     // Current epoll interests
@@ -688,6 +838,26 @@ const ConnectionSlot = struct {
     relay_half_closed: bool = false,
     client_detached: bool = false,
     upstream_detached: bool = false,
+    client_read_eof: bool = false,
+    upstream_read_eof: bool = false,
+    client_write_shutdown: bool = false,
+    upstream_write_shutdown: bool = false,
+
+    /// Record what we just armed on the client fd in epoll. The cache MUST describe the
+    /// live kernel registration: syncInterests only issues an EPOLL_CTL_MOD when the two
+    /// differ, so a cache that under-reports (the zeroed slot vs. the EPOLLIN armed at
+    /// accept) silently skips the *disarm* — the fd stays level-readable with bytes
+    /// nobody consumes in .connecting_upstream and the worker spins at 100% CPU.
+    fn noteClientRegistered(self: *ConnectionSlot, want_in: bool, want_out: bool) void {
+        self.client_interest_in = want_in;
+        self.client_interest_out = want_out;
+    }
+
+    /// Same invariant for the upstream fd (see noteClientRegistered).
+    fn noteUpstreamRegistered(self: *ConnectionSlot, want_in: bool, want_out: bool) void {
+        self.upstream_interest_in = want_in;
+        self.upstream_interest_out = want_out;
+    }
 
     fn hasClientPending(self: *const ConnectionSlot) bool {
         return !self.client_queue.isEmpty();
@@ -723,7 +893,17 @@ const ConnectionSlot = struct {
         };
     }
 
+    fn freezeResolvedCandidates(self: *ConnectionSlot, allocator: std.mem.Allocator, candidates: net_helpers.AddressCandidates) !void {
+        if (self.resolved_candidates == null) self.resolved_candidates = try allocator.create(net_helpers.AddressCandidates);
+        self.resolved_candidates.?.* = candidates;
+    }
+
     fn resetOwnedBuffers(self: *ConnectionSlot, allocator: std.mem.Allocator) void {
+        if (self.validation_user.len > 0) allocator.free(self.validation_user);
+        self.validation_user = "";
+        self.validation_user_len = 0;
+        if (self.proxy_handshake_buf) |buf| allocator.destroy(buf);
+        self.proxy_handshake_buf = null;
         self.client_queue.deinit();
         self.upstream_queue.deinit();
 
@@ -738,12 +918,21 @@ const ConnectionSlot = struct {
 
         if (self.mask_prebuffer) |buf| allocator.free(buf);
         self.mask_prebuffer = null;
+        if (self.resolved_candidates) |candidates| allocator.destroy(candidates);
+        self.resolved_candidates = null;
+        self.mask_dns_override = null;
 
         if (self.dc_initial_tail) |buf| allocator.free(buf);
         self.dc_initial_tail = null;
 
         if (self.middle_ctx) |*mp| mp.deinit(allocator);
         self.middle_ctx = null;
+        if (self.mp_enc) |*cipher| cipher.wipe();
+        if (self.mp_dec) |*cipher| cipher.wipe();
+        self.mp_enc = null;
+        self.mp_dec = null;
+        std.crypto.secureZero(u8, &self.mp_secret);
+        self.mp_secret_len = 0;
 
         if (self.upstream_candidates_heap) |buf| allocator.free(buf);
         self.upstream_candidates_heap = null;
@@ -752,6 +941,8 @@ const ConnectionSlot = struct {
         self.direct_fallback_addr = null;
         self.direct_fallback_used = false;
         self.current_upstream_addr = null;
+        self.proxy_candidate_index = 0;
+        self.mask_candidate_next = 0;
         self.dc_abs = 0;
         self.is_media_path = false;
         self.user_metrics = null;
@@ -812,6 +1003,126 @@ const ConnectionSlot = struct {
     }
 };
 
+/// The epoll interest pair each fd of a slot should hold in its current phase.
+const SlotInterests = struct {
+    client_in: bool,
+    client_out: bool,
+    upstream_in: bool,
+    upstream_out: bool,
+};
+
+/// Pure half of `syncInterests`: what the slot's phase asks for, independent of what
+/// the kernel currently holds. Split out so the cache-vs-wanted comparison — the thing
+/// that decides whether an EPOLL_CTL_MOD is issued at all — is unit-testable without
+/// an epoll fd.
+fn wantedInterests(slot: *const ConnectionSlot, now_ms: i64) SlotInterests {
+    var want = SlotInterests{
+        .client_in = false,
+        .client_out = slot.hasClientPending(),
+        .upstream_in = false,
+        .upstream_out = slot.hasUpstreamPending(),
+    };
+
+    switch (slot.phase) {
+        .reading_tls_header,
+        .reading_direct_obfuscated_handshake,
+        .reading_client_hello_body,
+        .reading_mtproto_tls_header,
+        .reading_mtproto_tls_body,
+        => {
+            want.client_in = slot.client_read_pause_until_ms == 0 or
+                now_ms >= slot.client_read_pause_until_ms;
+        },
+
+        .writing_server_hello_first,
+        .writing_server_hello_rest,
+        => {
+            want.client_out = true;
+        },
+
+        .desync_wait => {
+            // Wait for timer tick only; keeping EPOLLOUT enabled here can
+            // cause a busy loop because writable sockets trigger continuously.
+        },
+
+        .connecting_upstream => {
+            want.client_in = false;
+            want.upstream_out = true;
+        },
+
+        .proxy_socks5_greeting,
+        .proxy_socks5_auth,
+        .proxy_socks5_connect,
+        .proxy_http_connect,
+        => {
+            want.client_in = false;
+            want.upstream_out = true;
+        },
+
+        .proxy_socks5_greeting_resp,
+        .proxy_socks5_auth_resp,
+        .proxy_socks5_connect_resp,
+        .proxy_http_connect_resp,
+        => {
+            want.client_in = false;
+            want.upstream_in = true;
+        },
+
+        .writing_dc_nonce => {
+            want.client_in = false;
+            want.upstream_out = true;
+        },
+
+        .middle_proxy_handshake => {
+            want.upstream_out = want.upstream_out or
+                slot.mp_step == .sending_rpc_nonce or
+                slot.mp_step == .sending_rpc_handshake;
+            want.upstream_in = slot.mp_step == .waiting_rpc_nonce_response or
+                slot.mp_step == .waiting_rpc_handshake_response;
+        },
+
+        .relaying, .mask_relaying => {
+            want.client_in = !slot.client_read_eof and !slot.hasUpstreamPending();
+            want.upstream_in = !slot.upstream_read_eof and !slot.hasClientPending();
+        },
+
+        else => {},
+    }
+
+    return want;
+}
+
+test "epoll interest cache must be seeded at registration or the disarm is skipped" {
+    var slot: ConnectionSlot = .{};
+    slot.client_queue.allocator = std.testing.allocator;
+    slot.upstream_queue.allocator = std.testing.allocator;
+    defer slot.resetOwnedBuffers(std.testing.allocator);
+
+    // What acceptNewConnections registers with the kernel, recorded on the slot.
+    slot.client_fd = 3;
+    slot.noteClientRegistered(true, false);
+    try std.testing.expect(slot.client_interest_in);
+
+    // First client event ends in .connecting_upstream (a non-TLS byte under
+    // fake_tls_only → startMasking, or the trusted dd path). That phase wants the
+    // client fd disarmed; with an unseeded cache the pair would compare equal to the
+    // zeroed (false,false) and syncInterests would skip the EPOLL_CTL_MOD, leaving
+    // unread client bytes to spin the level-triggered loop at 100% CPU.
+    slot.phase = .connecting_upstream;
+    const want = wantedInterests(&slot, 0);
+    try std.testing.expect(!want.client_in);
+    try std.testing.expect(slot.client_interest_in != want.client_in);
+
+    // The upstream registration is seeded the same way: EPOLLOUT while the connect
+    // is in flight, which is exactly what .connecting_upstream wants — no redundant
+    // MOD on the first upstream event.
+    slot.upstream_fd = 4;
+    slot.noteUpstreamRegistered(false, true);
+    try std.testing.expect(!want.upstream_in and want.upstream_out);
+    try std.testing.expectEqual(slot.upstream_interest_in, want.upstream_in);
+    try std.testing.expectEqual(slot.upstream_interest_out, want.upstream_out);
+}
+
 pub const BenchCandidatePath = struct {
     slot: ConnectionSlot = .{},
 
@@ -832,6 +1143,18 @@ pub const BenchCandidatePath = struct {
 };
 
 const ConnectionPool = connection_pool_mod.ConnectionPool(ConnectionSlot);
+const EndpointPenalties = @import("endpoint_penalties.zig").EndpointPenalties;
+const WorkerHeartbeat = struct {
+    value: std.atomic.Value(i64) = .init(0),
+    tracked_fds: std.atomic.Value(u32) = .init(0),
+    padding: [52]u8 = undefined,
+    fn load(self: *const WorkerHeartbeat, comptime order: std.builtin.AtomicOrder) i64 {
+        return self.value.load(order);
+    }
+    fn store(self: *WorkerHeartbeat, value: i64, comptime order: std.builtin.AtomicOrder) void {
+        self.value.store(value, order);
+    }
+};
 
 const SignalController = struct {
     fd: posix.fd_t,
@@ -895,6 +1218,8 @@ pub const CloseReason = enum(u8) {
         if (has(reason, "replay")) return .replay_detected;
         if (has(reason, "budget")) return .handshake_budget;
         if (has(reason, "idle")) return .idle_timeout;
+        if (has(reason, "connect timeout") or has(reason, "wedge")) return .upstream_error;
+        if (has(reason, "half-close")) return .client_eof;
         if (has(reason, "timeout")) return .handshake_timeout;
         if (has(reason, "shutdown") or has(reason, "closing")) return .shutdown;
         if (has(reason, "bad ") or has(reason, "invalid") or has(reason, "unexpected") or has(reason, "alert")) return .bad_handshake;
@@ -961,17 +1286,14 @@ test "jitteredIdleTimeoutMs stays within bounds and respects the floor" {
     try std.testing.expect(jitteredIdleTimeoutMs(base_sec, 15, 1) != jitteredIdleTimeoutMs(base_sec, 15, 2));
 }
 
-/// Resolve a `host:port` string to a single address, or null when it is unusable.
-/// Used for the WEB relay's masking target; DNS is allowed so an operator may name a host.
-fn parseHostPort(allocator: std.mem.Allocator, spec: []const u8) ?Address {
+/// Parse a WEB masking `host:port` without resolving DNS.
+fn parseHostPort(spec: []const u8) ?struct { host: []const u8, port: u16 } {
     const colon = std.mem.lastIndexOfScalar(u8, spec, ':') orelse return null;
     const host = std.mem.trim(u8, spec[0..colon], "[] ");
     if (host.len == 0) return null;
     const port = std.fmt.parseInt(u16, spec[colon + 1 ..], 10) catch return null;
-    const list = getAddressList(allocator, host, port) catch return null;
-    defer list.deinit();
-    if (list.addrs.len == 0) return null;
-    return list.addrs[0];
+    if (port == 0) return null;
+    return .{ .host = host, .port = port };
 }
 
 pub const ProxyState = struct {
@@ -1264,6 +1586,7 @@ pub const ProxyState = struct {
     allocator: std.mem.Allocator,
     config_path: []const u8,
     config: Config,
+    metrics_config_mutex: CompatRwLock = .{},
     user_secrets: []const obfuscation.UserSecret,
     user_metrics_lock: CompatRwLock = .{},
     user_metrics: []*UserMetrics,
@@ -1278,6 +1601,11 @@ pub const ProxyState = struct {
     accept_paused: std.atomic.Value(bool),
     saturation_paused: std.atomic.Value(bool),
     mask_addr: ?Address,
+    mask_candidates: net_helpers.AddressCandidates = .{},
+    dns: *dns_cache.Cache,
+    mask_dns_id: ?usize = null,
+    web_dns_id: ?usize = null,
+    proxy_dns_id: ?usize = null,
     /// Opt-in SNI-following mask targets (config.mask_sni_safelist), resolved at boot.
     mask_safelist: []const MaskSafelistEntry,
     /// Peers allowed to speak the direct-obfuscated transport under `fake_tls_only`
@@ -1323,12 +1651,14 @@ pub const ProxyState = struct {
     /// the watchdog require EVERY active worker to be fresh, so a wedged non-owner
     /// SO_REUSEPORT shard is detected (not masked by worker 0 staying alive). 0 until
     /// a worker starts ticking.
-    worker_heartbeats: [max_workers]std.atomic.Value(i64),
+    worker_heartbeats: [max_workers]WorkerHeartbeat,
+    accepted_since_log: std.atomic.Value(u64) = .init(0),
+    closed_since_log: std.atomic.Value(u64) = .init(0),
     /// Anti-flood + per-subnet rate guards are SHARED across workers (behind
     /// guard_lock) so an IP/subnet spread across SO_REUSEPORT shards is still limited
     /// globally, not ~N×threshold. Touched only on the accept/handshake path.
-    subnet_limiter: SubnetRateLimit,
-    flood_guard: *HandshakeFloodGuard,
+    subnet_limiter: ?*SubnetRateLimit = null,
+    flood_guard: ?*HandshakeFloodGuard = null,
     guard_lock: CompatRwLock = .{},
     /// True once graceful shutdown/drain has begun — drives /readyz.
     shutting_down: std.atomic.Value(bool),
@@ -1371,11 +1701,17 @@ pub const ProxyState = struct {
     // consumes it to refresh ahead of the periodic timer (debounced by the cooldown).
     middle_proxy_refresh_requested: std.atomic.Value(bool),
     middle_proxy_updater_thread: ?std.Thread,
+    middle_proxy_spawn_retry_ms: i64 = 0,
     upstream: upstream_mod.Upstream,
     tunnel_info: tunnel_mod.Tunnel,
 
     pub fn init(allocator: std.mem.Allocator, cfg: Config, config_path: []const u8) !ProxyState {
         if (cfg.users.count() == 0) return error.NoUsersConfigured;
+        const dns = try dns_cache.Cache.create(allocator);
+        errdefer dns.destroy();
+        var mask_dns_id: ?usize = null;
+        var web_dns_id: ?usize = null;
+        var proxy_dns_id: ?usize = null;
 
         const user_secrets = try buildUserSecrets(allocator, &cfg);
         errdefer allocator.free(user_secrets);
@@ -1384,6 +1720,7 @@ pub const ProxyState = struct {
         errdefer freeUserMetricsSlice(allocator, user_metrics_owned);
 
         var resolved_addr: ?Address = null;
+        var mask_candidates: net_helpers.AddressCandidates = .{};
         if (cfg.mask) {
             const mask_target = cfg.effectiveMaskTarget();
             if (cfg.mask_target) |configured_target| {
@@ -1399,29 +1736,32 @@ pub const ProxyState = struct {
                 defer al.deinit();
                 if (al.addrs.len > 0) {
                     resolved_addr = al.addrs[0];
-                    log.info("Mask target '{s}:{d}' resolved at startup", .{ mask_target, cfg.mask_port });
+                    mask_candidates = .init(al.addrs);
+                    log.info("Mask target '{s}:{d}': retained {d} DNS addresses", .{ mask_target, cfg.mask_port, mask_candidates.len });
                 }
             }
+            mask_dns_id = try dns.add(mask_target, cfg.mask_port, mask_candidates);
         }
 
         // Resolve the opt-in SNI-following mask safelist (each domain → its own server,
-        // port 443). Failed resolutions are skipped, not fatal.
+        // port 443). Failed resolutions stay registered for background recovery.
         var mask_safelist_buf: std.ArrayListUnmanaged(MaskSafelistEntry) = .empty;
         errdefer mask_safelist_buf.deinit(allocator);
         if (cfg.mask and cfg.mask_sni_safelist.len > 0) {
             for (cfg.mask_sni_safelist) |domain| {
-                const sl = getAddressList(allocator, domain, 443) catch {
-                    log.warn("mask_sni_safelist: could not resolve '{s}', skipping", .{domain});
-                    continue;
+                const sl = getAddressList(allocator, domain, 443) catch blk: {
+                    log.warn("mask_sni_safelist: could not resolve '{s}', retrying in background", .{domain});
+                    break :blk null;
                 };
-                defer sl.deinit();
-                if (sl.addrs.len > 0) {
-                    mask_safelist_buf.append(allocator, .{ .domain = domain, .addr = sl.addrs[0] }) catch continue;
-                    log.info("mask_sni_safelist: fronting '{s}' enabled", .{domain});
-                }
+                defer if (sl) |list| list.deinit();
+                const candidates: net_helpers.AddressCandidates = if (sl) |list| .init(list.addrs) else .{};
+                const id = try dns.add(domain, 443, candidates);
+                try mask_safelist_buf.append(allocator, .{ .domain = domain, .addr = if (candidates.len > 0) candidates.addresses[0] else ip4(.{ 0, 0, 0, 0 }, 443), .dns_id = id });
+                log.info("mask_sni_safelist: fronting '{s}' enabled", .{domain});
             }
         }
-        const mask_safelist = mask_safelist_buf.toOwnedSlice(allocator) catch &.{};
+        const mask_safelist = try mask_safelist_buf.toOwnedSlice(allocator);
+        errdefer allocator.free(mask_safelist);
 
         // Peers allowed to bypass `fake_tls_only` with the direct-obfuscated transport.
         // Loopback is implied by [web].enabled; anything else must be named explicitly.
@@ -1436,8 +1776,18 @@ pub const ProxyState = struct {
         var web_mask_addr: ?Address = null;
         if (cfg.web.enabled and cfg.web.domain != null) {
             if (cfg.web.mask_backend) |spec| {
-                if (parseHostPort(allocator, spec)) |addr| {
-                    web_mask_addr = addr;
+                if (parseHostPort(spec)) |target| {
+                    const addresses = getAddressList(allocator, target.host, target.port) catch null;
+                    defer if (addresses) |list| list.deinit();
+                    const candidates: net_helpers.AddressCandidates = if (addresses) |list| .init(list.addrs) else .{};
+                    if (candidates.len > 0) {
+                        const addr = candidates.addresses[0];
+                        if (trusted_peers.isLoopback(addr) and addr.getPort() == cfg.port) return error.MaskBackendLoopsToProxy;
+                    }
+                    // The marker is never used for a connection: startMasking consumes
+                    // the cache snapshot, rejecting an empty snapshot until DNS recovers.
+                    web_mask_addr = if (candidates.len > 0) candidates.addresses[0] else ip4(.{ 0, 0, 0, 0 }, target.port);
+                    web_dns_id = try dns.add(target.host, target.port, candidates);
                     log.info("[web] masked connections for '{s}' are fronted with a PROXY header", .{cfg.web.domain.?});
                 } else {
                     log.warn("[web].mask_backend '{s}' is not a usable host:port; ignoring", .{spec});
@@ -1467,7 +1817,7 @@ pub const ProxyState = struct {
         // fake_cert_size is set (else the default ~2878). Falls back to the default size
         // if the configured value can't be built.
         const fake_cert_size: usize = if (cfg.fake_cert_size == 0)
-            tls.default_fake_cert_size
+            2400 + crypto.randomRange(usize, 1201)
         else
             std.math.clamp(@as(usize, cfg.fake_cert_size), tls.min_fake_cert_size, tls.max_fake_cert_size);
         const tls_template = tls.buildServerHelloTemplateAlloc(allocator, fake_cert_size) catch
@@ -1495,7 +1845,7 @@ pub const ProxyState = struct {
         const owned_config_path = try allocator.dupe(u8, config_path);
         errdefer allocator.free(owned_config_path);
 
-        return .{
+        var result: ProxyState = .{
             .allocator = allocator,
             .config_path = owned_config_path,
             .config = cfg,
@@ -1512,6 +1862,10 @@ pub const ProxyState = struct {
             .accept_paused = std.atomic.Value(bool).init(false),
             .saturation_paused = std.atomic.Value(bool).init(false),
             .mask_addr = resolved_addr,
+            .dns = dns,
+            .mask_dns_id = mask_dns_id,
+            .web_dns_id = web_dns_id,
+            .mask_candidates = mask_candidates,
             .mask_safelist = mask_safelist,
             .trusted = trusted,
             .web_only = cfg.web.onlyActive(),
@@ -1533,21 +1887,21 @@ pub const ProxyState = struct {
             .stats_web_only_masked = std.atomic.Value(u64).init(0),
             .middle_proxy_addrs_primary = constants.tg_middle_proxies_v4,
             .middle_proxy_addrs_media_primary = constants.tg_media_middle_proxies_v4,
-            .middle_proxy_addr_203 = constants.getDcAddressV4(203),
+            .middle_proxy_addr_203 = constants.getDcAddressV4(203).?,
             .middle_proxy_addrs_dc4 = [_]Address{constants.tg_middle_proxies_v4[3]} ++ ([_]Address{constants.tg_middle_proxies_v4[3]} ** 15),
             .middle_proxy_addrs_dc4_len = 1,
             .middle_proxy_addrs_media_dc4 = [_]Address{constants.tg_media_middle_proxies_v4[3]} ++ ([_]Address{constants.tg_media_middle_proxies_v4[3]} ** 15),
             .middle_proxy_addrs_media_dc4_len = 1,
-            .middle_proxy_addrs_203 = [_]Address{constants.getDcAddressV4(203)} ++ ([_]Address{constants.getDcAddressV4(203)} ** 7),
+            .middle_proxy_addrs_203 = [_]Address{constants.getDcAddressV4(203).?} ++ ([_]Address{constants.getDcAddressV4(203).?} ** 7),
             .middle_proxy_addrs_203_len = 1,
             .middle_proxy_secret = default_middle_proxy_secret,
             .middle_proxy_secret_len = middleproxy.proxy_secret.len,
             .middle_proxy_nat_ip4 = detected_nat_ip4,
             .middle_proxy_updater_shutdown = std.atomic.Value(bool).init(false),
             .middle_proxy_refresh_requested = std.atomic.Value(bool).init(false),
-            .worker_heartbeats = [_]std.atomic.Value(i64){std.atomic.Value(i64).init(0)} ** max_workers,
-            .subnet_limiter = SubnetRateLimit.init(),
-            .flood_guard = try HandshakeFloodGuard.create(allocator),
+            .worker_heartbeats = [_]WorkerHeartbeat{.{}} ** max_workers,
+            .subnet_limiter = null,
+            .flood_guard = null,
             .shutting_down = std.atomic.Value(bool).init(false),
             .middle_proxy_updater_thread = null,
             .upstream = upblk: {
@@ -1566,8 +1920,9 @@ pub const ProxyState = struct {
                                 defer proxy_list.deinit();
                                 if (proxy_list.addrs.len > 0) {
                                     log.info("Upstream mode: SOCKS5 via {s}:{d}", .{ host, cfg.upstream_proxy_port });
-                                    break :upblk upstream_mod.Upstream.initSocks5(
-                                        proxy_list.addrs[0],
+                                    proxy_dns_id = try dns.add(host, cfg.upstream_proxy_port, .init(proxy_list.addrs));
+                                    break :upblk upstream_mod.Upstream.initSocks5Candidates(
+                                        proxy_list.addrs,
                                         cfg.upstream_proxy_username,
                                         cfg.upstream_proxy_password,
                                     );
@@ -1591,8 +1946,9 @@ pub const ProxyState = struct {
                                 defer proxy_list.deinit();
                                 if (proxy_list.addrs.len > 0) {
                                     log.info("Upstream mode: HTTP CONNECT via {s}:{d}", .{ host, cfg.upstream_proxy_port });
-                                    break :upblk upstream_mod.Upstream.initHttpConnect(
-                                        proxy_list.addrs[0],
+                                    proxy_dns_id = try dns.add(host, cfg.upstream_proxy_port, .init(proxy_list.addrs));
+                                    break :upblk upstream_mod.Upstream.initHttpConnectCandidates(
+                                        proxy_list.addrs,
                                         cfg.upstream_proxy_username,
                                         cfg.upstream_proxy_password,
                                     );
@@ -1632,15 +1988,19 @@ pub const ProxyState = struct {
                 }
             },
         };
+        result.proxy_dns_id = proxy_dns_id;
+        return result;
     }
 
     pub fn deinit(self: *ProxyState) void {
+        self.dns.destroy();
         self.middle_proxy_updater_shutdown.store(true, .release);
         if (self.middle_proxy_updater_thread) |thread| {
             thread.join();
             self.middle_proxy_updater_thread = null;
         }
-        self.flood_guard.destroy(self.allocator);
+        if (self.flood_guard) |guard| guard.destroy(self.allocator);
+        if (self.subnet_limiter) |limiter| self.allocator.destroy(limiter);
         self.allocator.free(self.mask_safelist);
         if (self.trusted.extra.len > 0) self.allocator.free(self.trusted.extra);
         self.allocator.free(self.tls_server_hello_template);
@@ -1688,30 +2048,45 @@ pub const ProxyState = struct {
     // worker threads. Only on the accept/handshake path, so contention is bounded.
 
     fn floodIsBlocked(self: *ProxyState, addr: Address, cfg: HandshakeFloodGuard.Settings) bool {
+        if (!cfg.enabled) return false;
         self.guard_lock.lock();
         defer self.guard_lock.unlock();
-        return self.flood_guard.isBlocked(addr, cfg);
+        const guard = self.flood_guard orelse return false;
+        return guard.isBlocked(addr, cfg);
     }
 
     fn floodRecord(self: *ProxyState, addr: Address, event: HandshakeFloodGuard.Event, cfg: HandshakeFloodGuard.Settings) bool {
+        if (!cfg.enabled) return false;
         self.guard_lock.lock();
         defer self.guard_lock.unlock();
-        return self.flood_guard.record(addr, event, cfg);
+        if (self.flood_guard == null) self.flood_guard = HandshakeFloodGuard.create(self.allocator) catch return true;
+        return self.flood_guard.?.record(addr, event, cfg);
     }
 
     fn floodTop(self: *ProxyState, cfg: HandshakeFloodGuard.Settings, out: []HandshakeFloodGuard.TopEntry) usize {
+        if (!cfg.enabled) return 0;
         self.guard_lock.lock();
         defer self.guard_lock.unlock();
-        return self.flood_guard.top(cfg, out);
+        const guard = self.flood_guard orelse return 0;
+        return guard.top(cfg, out);
     }
 
     fn subnetCheck(self: *ProxyState, addr: Address, max_per_sec: u8) bool {
+        if (max_per_sec == 0) return true;
         self.guard_lock.lock();
         defer self.guard_lock.unlock();
-        return self.subnet_limiter.check(addr, max_per_sec);
+        if (self.subnet_limiter == null) {
+            const limiter = self.allocator.create(SubnetRateLimit) catch return false;
+            limiter.* = SubnetRateLimit.init();
+            self.subnet_limiter = limiter;
+        }
+        return self.subnet_limiter.?.check(addr, max_per_sec);
     }
 
     pub fn getMetricsSnapshot(self: *const ProxyState) MetricsSnapshot {
+        const config_mutex = @constCast(&self.metrics_config_mutex);
+        config_mutex.lock();
+        defer config_mutex.unlock();
         const now = realtimeSeconds();
         const accepted_total = self.connection_count.load(.monotonic);
         var close_reasons: [CloseReason.count]u64 = undefined;
@@ -1752,10 +2127,21 @@ pub const ProxyState = struct {
     }
 
     pub fn run(self: *ProxyState) !void {
+        log.info("Effective egress: {s}", .{self.tunnel_info.name()});
         if (builtin.os.tag != .linux) return error.UnsupportedOperatingSystem;
         const io_ctx = std.Io.Threaded.global_single_threaded.io();
         var signal_controller = try SignalController.init();
         defer signal_controller.deinit();
+        // Resolver inherits the blocked service-signal mask like all workers.
+        try self.dns.start();
+
+        // Resolve the worker count: 1 = classic single loop (default, unchanged),
+        // 0 = auto (one per CPU), clamped to [1, max_workers]. Published on the
+        // shared state so SIGHUP reload can refuse a racy live-reload under >1.
+        var worker_count: usize = self.config.workers;
+        if (worker_count == 0) worker_count = std.Thread.getCpuCount() catch 1;
+        worker_count = std.math.clamp(worker_count, 1, max_workers);
+        self.effective_workers = worker_count;
 
         var ipv6_ok = true;
         var server: net.Server = undefined;
@@ -1769,13 +2155,10 @@ pub const ProxyState = struct {
                 log.err("Invalid bind_address '{s}', cannot start", .{bind_str});
                 return error.InvalidBindAddress;
             };
-            ipv6_ok = isIpv6(parsed);
             listen_addr = parsed;
-            server = try parsed.listen(io_ctx, .{
-                .reuse_address = true,
-                .kernel_backlog = @intCast(self.config.backlog),
-            });
-            log.info("Listening on {s}:{d} (epoll)", .{ bind_str, self.config.port });
+            server = try net_helpers.listen(parsed, @intCast(self.config.backlog), worker_count > 1);
+            var listen_buf: [64]u8 = undefined;
+            log.info("Listening on {s} (epoll)", .{formatAddress(parsed, &listen_buf)});
         } else {
             // Default: try [::] (dual-stack), fall back to 0.0.0.0
             const address = ip6(
@@ -1785,19 +2168,13 @@ pub const ProxyState = struct {
                 0,
             );
             listen_addr = address;
-            server = address.listen(io_ctx, .{
-                .reuse_address = true,
-                .kernel_backlog = @intCast(self.config.backlog),
-            }) catch |err| blk: {
+            server = net_helpers.listen(address, @intCast(self.config.backlog), worker_count > 1) catch |err| blk: {
                 if (err == error.AddressFamilyUnsupported) {
                     ipv6_ok = false;
                     log.warn("IPv6 not available, falling back to IPv4 (0.0.0.0)", .{});
                     const address_v4 = ip4(.{ 0, 0, 0, 0 }, self.config.port);
                     listen_addr = address_v4;
-                    break :blk try address_v4.listen(io_ctx, .{
-                        .reuse_address = true,
-                        .kernel_backlog = @intCast(self.config.backlog),
-                    });
+                    break :blk try net_helpers.listen(address_v4, @intCast(self.config.backlog), worker_count > 1);
                 }
                 return err;
             };
@@ -1809,18 +2186,20 @@ pub const ProxyState = struct {
             }
         }
         defer server.deinit(io_ctx);
+        log.warn("Telegram DC routes require IPv4 egress; IPv6-only hosts need a configured SOCKS/HTTP or tunnel egress that reaches IPv4", .{});
 
         setNonBlocking(server.socket.handle);
 
-        // Resolve the worker count: 1 = classic single loop (default, unchanged),
-        // 0 = auto (one per CPU), clamped to [1, max_workers]. Published on the
-        // shared state so SIGHUP reload can refuse a racy live-reload under >1.
-        var worker_count: usize = self.config.workers;
-        if (worker_count == 0) worker_count = std.Thread.getCpuCount() catch 1;
-        worker_count = std.math.clamp(worker_count, 1, max_workers);
-        self.effective_workers = worker_count;
-
-        if (self.config.use_middle_proxy and self.config.datacenter_override == null) {
+        // Any of these three can route a connection through MiddleProxy (same
+        // predicate as the NAT-IP warning above): use_middle_proxy for regular
+        // traffic, force_media_middle_proxy (default true) for media/CDN even
+        // with use_middle_proxy=false, and tag for the ad-tag RPC that only
+        // takes effect over a middleproxy handshake. Gating the updater on
+        // use_middle_proxy alone left DC203's snapshot (always consulted for
+        // CDN media, see buildDcConnectPlan's dc_abs==203 case) frozen on the
+        // bundled constants for the life of the process under the shipped
+        // defaults, since Telegram rotates MP addresses within hours.
+        if (middleProxyUpdaterNeeded(&self.config) and self.config.datacenter_override == null) {
             // The INITIAL middle-proxy metadata refresh now runs inside the
             // updater thread (see middleProxyUpdaterMain), NOT synchronously
             // here, so a blocked/stalled core.telegram.org fetch on a censored
@@ -1833,9 +2212,7 @@ pub const ProxyState = struct {
                 self.middle_proxy_updater_thread = updater;
             } else |err| {
                 log.warn("Middle-proxy updater thread failed to start: {any}", .{err});
-                // No background thread: best-effort synchronous refresh so
-                // metadata is still populated (bounded by the OS connect timeout).
-                self.refreshMiddleProxyInfo() catch {};
+                self.middle_proxy_spawn_retry_ms = nowMs() + 10_000;
             }
         }
 
@@ -1859,11 +2236,16 @@ pub const ProxyState = struct {
         // but each worker adds its own listener + epoll fd — account for that 2×N
         // overhead so the RLIMIT warning is accurate under the multi-worker model.
         const effective_needed_fds = requiredFdsForConnections(self.config.max_connections) + 2 * worker_count;
-        checkNofileLimit(@max(effective_needed_fds, min_nofile_soft), self.config.max_connections);
+        checkNofileLimit(effective_needed_fds, self.config.max_connections);
 
-        if (self.config.metrics.enabled) {
-            try @import("../monitoring.zig").start(self);
-        }
+        const metrics: ?@import("../monitoring.zig").Handle = if (self.config.metrics.enabled)
+            @import("../monitoring.zig").start(self) catch |err| blk: {
+                log.warn("metrics endpoint unavailable: {any}", .{err});
+                break :blk null;
+            }
+        else
+            null;
+        defer if (metrics) |handle| handle.stop();
 
         if (worker_count <= 1) {
             // Classic single-threaded path — byte-for-byte the previous behavior.
@@ -1899,12 +2281,10 @@ pub const ProxyState = struct {
 
         var i: usize = 1;
         while (i < worker_count) : (i += 1) {
-            const extra = listen_addr.listen(io_ctx, .{
-                .reuse_address = true,
-                .kernel_backlog = @intCast(self.config.backlog),
-            }) catch |err| {
-                log.err("worker {d} listener failed ({any}); continuing with {d} workers", .{ i, err, i });
-                break;
+            const extra = net_helpers.listen(listen_addr, @intCast(self.config.backlog), worker_count > 1) catch |err| {
+                log.err("worker {d} listener failed: {any}", .{ i, err });
+                self.shutting_down.store(true, .release);
+                return err;
             };
             setNonBlocking(extra.socket.handle);
             // Spawn FIRST; only retain the listener (in extra_servers) once its
@@ -1915,7 +2295,8 @@ pub const ProxyState = struct {
                 log.err("worker {d} thread spawn failed ({any}); continuing with {d} workers", .{ i, err, extra_count });
                 var dead = extra;
                 dead.deinit(io_ctx); // remove the listenerless socket from the reuseport group
-                break;
+                self.shutting_down.store(true, .release);
+                return err;
             };
             extra_servers[extra_count] = extra;
             extra_count += 1;
@@ -1972,15 +2353,18 @@ pub const ProxyState = struct {
             .addrs_media_dc4_len = self.middle_proxy_addrs_media_dc4_len,
             .addrs_203 = self.middle_proxy_addrs_203,
             .addrs_203_len = self.middle_proxy_addrs_203_len,
-            .secret = self.middle_proxy_secret,
-            .secret_len = self.middle_proxy_secret_len,
         };
     }
 
-    /// Refresh helper. Tries the default route first; on any network-class
-    /// failure AND when the config selects tunnel upstream, retries via the
-    /// active tunnel route (`table 200`), pool state, then configured tunnel
-    /// candidates. This keeps the media MP cache warm after tunnel failover.
+    /// Refresh helper. When the config selects a configured egress (tunnel,
+    /// socks5, http), tries THAT route first — a host that chose non-direct
+    /// egress chose it to keep this exact traffic (fetching Telegram MP
+    /// metadata) off the local uplink, so trying direct first would emit the
+    /// SYNs the operator configured egress specifically to avoid, and on a
+    /// SYN-blackholing network could block the updater for the full kernel
+    /// connect timeout before ever trying the configured route. Falls back to
+    /// direct only when `allow_direct_fallback` allows it (fail-closed
+    /// otherwise, matching the socks5/http_connect branch below).
     fn fetchMiddleProxyAsset(self: *ProxyState, allocator: std.mem.Allocator, url: []const u8) ![]u8 {
         switch (middleProxyFetchRouteForConfig(&self.config)) {
             .socks5, .http_connect => {
@@ -1996,10 +2380,15 @@ pub const ProxyState = struct {
                 }
             },
             .tunnel => {
-                if (fetchUrlBytes(allocator, url)) |bytes| {
+                if (self.fetchMiddleProxyAssetViaTunnelPool(allocator, url, error.TunnelRouteUnavailable)) |bytes| {
                     return bytes;
-                } else |direct_err| {
-                    return self.fetchMiddleProxyAssetViaTunnelPool(allocator, url, direct_err);
+                } else |tunnel_err| {
+                    if (!self.config.allow_direct_fallback) return tunnel_err;
+                    log.warn("Middle-proxy asset {s} unavailable through the tunnel ({s}); trying direct fallback", .{
+                        url,
+                        @errorName(tunnel_err),
+                    });
+                    return fetchUrlBytes(allocator, url) catch tunnel_err;
                 }
             },
             .direct => return fetchUrlBytes(allocator, url),
@@ -2050,6 +2439,7 @@ pub const ProxyState = struct {
             }
         }
 
+        if (self.middle_proxy_updater_shutdown.load(.acquire)) return error.ShuttingDown;
         if (readTunnelPoolStateValue(allocator, "active")) |iface| {
             defer allocator.free(iface);
             if (tryFetchMiddleProxyViaInterface(allocator, url, iface, direct_err)) |bytes| {
@@ -2061,6 +2451,7 @@ pub const ProxyState = struct {
 
         var idx: usize = 0;
         while (self.config.tunnelCandidateAt(idx)) |iface| : (idx += 1) {
+            if (self.middle_proxy_updater_shutdown.load(.acquire)) return error.ShuttingDown;
             if (tryFetchMiddleProxyViaInterface(allocator, url, iface, direct_err)) |bytes| {
                 return bytes;
             } else |err| {
@@ -2075,9 +2466,9 @@ pub const ProxyState = struct {
         // The INITIAL refresh happens here (in this background thread) so it
         // never blocks the boot path. On a censored host it may fail (tunnel
         // handshake may not be up yet), so on failure run a short-cycle retry
-        // loop before falling back to the normal 24-hour cadence. This gets
+        // loop before falling back to the normal hourly cadence. This gets
         // media MP addresses into the cache within the first few minutes of
-        // uptime instead of the next day, all without delaying startup.
+        // uptime instead of the next hour, all without delaying startup.
         var initial_ok = false;
         if (self.refreshMiddleProxyInfo()) |_| {
             initial_ok = true;
@@ -2165,7 +2556,16 @@ pub const ProxyState = struct {
             std.mem.eql(u8, name, "NameServerFailure");
     }
 
+    fn selectReachableUntilShutdown(self: *ProxyState, candidates: []const Address, timeout: i32) ?Address {
+        for (candidates) |candidate| {
+            if (self.middle_proxy_updater_shutdown.load(.acquire)) return null;
+            if (trySelectReachableMiddleProxy(&.{candidate}, timeout)) |addr| return addr;
+        }
+        return null;
+    }
+
     fn refreshMiddleProxyInfo(self: *ProxyState) !void {
+        if (self.middle_proxy_updater_shutdown.load(.acquire)) return error.ShuttingDown;
         var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
         defer arena.deinit();
         const temp_alloc = arena.allocator();
@@ -2175,7 +2575,19 @@ pub const ProxyState = struct {
         // we transparently retry through the configured tunnel interface so
         // the runtime MP cache (including media endpoints) stays up to date.
         const cfg_bytes = self.fetchMiddleProxyAsset(temp_alloc, middle_proxy_config_url) catch |err| return err;
+        if (self.middle_proxy_updater_shutdown.load(.acquire)) return error.ShuttingDown;
         const next_secret = self.fetchMiddleProxyAsset(temp_alloc, middle_proxy_secret_url) catch |err| return err;
+
+        try self.mergeMiddleProxyAssets(cfg_bytes, next_secret, middleProxyProbeAllowed(&self.config));
+    }
+
+    /// Apply one fetched snapshot atomically. Kept separate from network fetches
+    /// so partial config responses and secret rotation can be tested directly.
+    fn mergeMiddleProxyAssets(self: *ProxyState, cfg_bytes: []const u8, next_secret: []const u8, probe_reachability: bool) !void {
+        // Reject the entire snapshot before probing or mutating cached routes.
+        if (next_secret.len < 16 or next_secret.len > self.middle_proxy_secret.len) {
+            return error.BadMiddleProxySecret;
+        }
 
         var next_primary: [5]?Address = [_]?Address{null} ** 5;
         var next_media_primary: [5]?Address = [_]?Address{null} ** 5;
@@ -2198,9 +2610,9 @@ pub const ProxyState = struct {
 
             next_primary[i] = if (count == 0)
                 null
-            else if (i == 3)
+            else if (i == 3 or !probe_reachability)
                 candidates[0]
-            else if (trySelectReachableMiddleProxy(candidates[0..count], 1200)) |reachable|
+            else if (self.selectReachableUntilShutdown(candidates[0..count], 1200)) |reachable|
                 reachable
             else
                 candidates[0];
@@ -2219,16 +2631,17 @@ pub const ProxyState = struct {
 
             next_media_primary[i] = if (media_count == 0)
                 null
-            else if (i == 3)
+            else if (i == 3 or !probe_reachability)
                 media_candidates[0]
-            else if (trySelectReachableMiddleProxy(media_candidates[0..media_count], 1200)) |reachable|
+            else if (self.selectReachableUntilShutdown(media_candidates[0..media_count], 1200)) |reachable|
                 reachable
             else
                 media_candidates[0];
         }
 
         var candidates_203: [8]Address = undefined;
-        const count_203 = parseMiddleProxyAddressesForDc(cfg_bytes, 203, .any, &candidates_203);
+        var count_203 = parseMiddleProxyAddressesForDc(cfg_bytes, 203, .negative_only, &candidates_203);
+        if (count_203 == 0) count_203 = parseMiddleProxyAddressesForDc(cfg_bytes, 203, .positive_only, &candidates_203);
         var next_203_candidates: [8]Address = undefined;
         var next_203_candidates_len: usize = 0;
         if (count_203 > 0) {
@@ -2237,10 +2650,6 @@ pub const ProxyState = struct {
             next_203_candidates_len = c203_n;
         }
         const next_addr_203 = if (count_203 == 0) null else candidates_203[0];
-
-        if (next_secret.len < 16 or next_secret.len > self.middle_proxy_secret.len) {
-            return error.BadMiddleProxySecret;
-        }
 
         self.middle_proxy_lock.lock();
         defer self.middle_proxy_lock.unlock();
@@ -2326,6 +2735,8 @@ const EventLoop = struct {
     /// 0..N-1; worker 0 owns the signalfd + systemd watchdog. Indexes the shared
     /// per-worker heartbeat slot.
     worker_id: usize,
+    traffic_c2s_pending: std.atomic.Value(u64) = .init(0),
+    traffic_s2c_pending: std.atomic.Value(u64) = .init(0),
     pool: ConnectionPool,
     accept_paused: bool,
     accept_resume_ns: i128,
@@ -2336,8 +2747,6 @@ const EventLoop = struct {
     last_watchdog_ms: i64 = 0,
     timer_scan_cursor: u32,
     stats_next_log_ns: i128,
-    accepted_since_log: u64,
-    closed_since_log: u64,
     // Snapshot of degradation counters for delta logging
     prev_dropped_cap: u64,
     prev_dropped_saturation: u64,
@@ -2348,7 +2757,10 @@ const EventLoop = struct {
     prev_mp_fallback: u64,
     prev_dropped_pool: u64,
     shared_read_buf: [read_buf_size]u8,
+    server_hello_scratch: [65535 + 2048]u8 = undefined,
     desync_wait_slots: std.ArrayListUnmanaged(u32),
+    desync_next_ns: i128 = 0,
+    endpoint_penalties: EndpointPenalties = .{},
     mp_c2s_scratch: ?[]u8,
     mp_s2c_scratch: ?[]u8,
     /// Fds whose slot was closed during the current epoll batch. closeSlot unmaps them
@@ -2376,8 +2788,6 @@ const EventLoop = struct {
             .shutdown_deadline_ns = 0,
             .timer_scan_cursor = 0,
             .stats_next_log_ns = nowNs() + stats_log_interval_ns,
-            .accepted_since_log = 0,
-            .closed_since_log = 0,
             .prev_dropped_cap = 0,
             .prev_dropped_saturation = 0,
             .prev_dropped_rate_limit = 0,
@@ -2402,6 +2812,7 @@ const EventLoop = struct {
     }
 
     fn deinit(self: *EventLoop) void {
+        defer self.flushTrafficCounters();
         for (self.pool.slots) |slot_opt| {
             if (slot_opt) |slot| {
                 if (slot.phase != .idle) {
@@ -2435,6 +2846,7 @@ const EventLoop = struct {
     }
 
     fn run(self: *EventLoop) !void {
+        defer self.flushTrafficCounters();
         var events: [256]linux.epoll_event = undefined;
         const timer_tick_ns: i128 = 5 * std.time.ns_per_ms;
         var next_timer_tick_ns: i128 = nowNs();
@@ -2445,6 +2857,7 @@ const EventLoop = struct {
             // calls — guarantees a freed fd number is never recycled within the batch that
             // still has queued events for it. See pending_close_fds.
             self.drainPendingCloses();
+            self.flushTrafficCounters();
 
             // Per-worker liveness heartbeat (this worker's slot), and pet the
             // systemd watchdog at half the configured interval — ONLY from the
@@ -2452,6 +2865,14 @@ const EventLoop = struct {
             // non-owner shard stops the watchdog and triggers a restart.
             const tick_ms = nowMs();
             self.state.worker_heartbeats[@min(self.worker_id, max_workers - 1)].store(tick_ms, .monotonic);
+            if (self.worker_id == 0 and !self.shutting_down and self.state.middle_proxy_updater_thread == null and self.state.middle_proxy_spawn_retry_ms != 0 and tick_ms >= self.state.middle_proxy_spawn_retry_ms) {
+                self.state.middle_proxy_spawn_retry_ms = tick_ms + 10_000;
+                if (std.Thread.spawn(.{}, ProxyState.middleProxyUpdaterMain, .{self.state})) |thread| {
+                    self.state.middle_proxy_updater_thread = thread;
+                    self.state.middle_proxy_spawn_retry_ms = 0;
+                } else |err| log.warn("Middle-proxy updater spawn retry failed: {any}", .{err});
+            }
+            self.state.worker_heartbeats[@min(self.worker_id, max_workers - 1)].tracked_fds.store(@intCast(self.pool.fd_to_slot.count()), .monotonic);
             if (self.signal_fd >= 0 and self.state.watchdog_usec > 0 and
                 tick_ms - self.last_watchdog_ms >= @as(i64, @intCast(self.state.watchdog_usec / 2000)) and
                 self.state.loopAlive(watchdog_stale_ms))
@@ -2537,7 +2958,7 @@ const EventLoop = struct {
                 self.onClientWritable(slot);
             }
             if (slot.phase == .idle) return;
-            if ((events & linux.EPOLL.IN) != 0) {
+            if ((events & (linux.EPOLL.IN | linux.EPOLL.RDHUP | linux.EPOLL.HUP)) != 0 and !slot.client_read_eof) {
                 self.onClientReadable(slot);
             }
         } else if (fd == slot.upstream_fd) {
@@ -2545,7 +2966,7 @@ const EventLoop = struct {
                 self.onUpstreamWritable(slot);
             }
             if (slot.phase == .idle) return;
-            if ((events & linux.EPOLL.IN) != 0) {
+            if ((events & (linux.EPOLL.IN | linux.EPOLL.RDHUP | linux.EPOLL.HUP)) != 0 and !slot.upstream_read_eof) {
                 self.onUpstreamReadable(slot);
             }
         }
@@ -2564,15 +2985,13 @@ const EventLoop = struct {
             // peer must not discard data already queued for the other peer. Detach the
             // hung-up fd from epoll and flush the surviving direction before tearing down;
             // a hard error (HUP/ERR) or an empty opposite queue still closes immediately.
-            const graceful = (events & (linux.EPOLL.HUP | linux.EPOLL.ERR)) == 0;
+            const graceful = (events & linux.EPOLL.ERR) == 0;
             const relaying = slot.phase == .relaying or slot.phase == .mask_relaying;
-            const opposite_pending = if (fd == slot.client_fd) slot.hasUpstreamPending() else slot.hasClientPending();
-            if (graceful and relaying and opposite_pending and !slot.relay_half_closed) {
-                self.beginRelayHalfClose(slot, fd);
+            const masking_connect = slot.phase == .connecting_upstream and slot.upstream_kind == .mask and fd == slot.client_fd;
+            if (!graceful or (!relaying and !masking_connect)) {
+                self.closeSlot(slot, "epoll hup/err");
                 return;
             }
-            self.closeSlot(slot, "epoll hup/err");
-            return;
         }
 
         if (slot.phase != .idle) {
@@ -2586,15 +3005,26 @@ const EventLoop = struct {
     fn acceptNewConnections(self: *EventLoop) !void {
         // Saturation hysteresis: if active > 90% of max, stop accepting entirely.
         // Resume only when active drops below 80% (checked in run() loop).
-        const active_now = self.state.active_connections.load(.monotonic);
+        var active_now = self.state.active_connections.load(.monotonic);
         const max = self.state.config.max_connections;
+        if (active_now >= (max * 8) / 10) {
+            // Reclaim silent unauthenticated sockets before pausing the listener.
+            // Existing authenticated users must not compete with idle probes.
+            for (self.pool.slots[0..self.pool.allocated_hi]) |candidate| {
+                const slot = candidate orelse continue;
+                if (slot.phase != .idle and slot.handshakeInProgress() and slot.first_byte_at_ms == 0) {
+                    self.closeSlot(slot, "silent connection capacity eviction");
+                    active_now = self.state.active_connections.load(.monotonic);
+                    if (active_now < (max * 8) / 10) break;
+                }
+            }
+        }
         if (active_now >= (max * 9) / 10) {
             // No connection is dropped here — the backlog is retained and served after the
             // 80% resume. Count only the transition INTO pause so the counter measures
             // saturation-pause events rather than every accept attempt while paused.
             if (!self.saturation_paused) {
-                self.pauseSaturation();
-                _ = self.state.stats_dropped_saturation.fetchAdd(1, .monotonic);
+                if (self.pauseSaturation()) _ = self.state.stats_dropped_saturation.fetchAdd(1, .monotonic);
             }
             return;
         }
@@ -2683,9 +3113,11 @@ const EventLoop = struct {
             };
 
             slot.active_reserved = true;
+            slot.client_queue.allocator = self.state.allocator;
+            slot.upstream_queue.allocator = self.state.allocator;
             slot.hs_counted = false;
-            slot.traffic_client_to_upstream_counter = &self.state.client_to_upstream_bytes_total;
-            slot.traffic_upstream_to_client_counter = &self.state.upstream_to_client_bytes_total;
+            slot.traffic_client_to_upstream_counter = &self.traffic_c2s_pending;
+            slot.traffic_upstream_to_client_counter = &self.traffic_s2c_pending;
             slot.user_metrics = null;
             slot.user_ip_key = null;
             slot.conn_id = self.state.connection_count.fetchAdd(1, .monotonic);
@@ -2708,12 +3140,12 @@ const EventLoop = struct {
             );
             slot.drs = DynamicRecordSizer.init(self.state.config.drs);
 
-            if (self.addFd(cfd, true, false)) |_| {
+            if (self.addClientFd(slot, cfd, true, false)) |_| {
                 self.pool.mapFd(cfd, slot.index) catch {
                     self.closeSlot(slot, "fd map failed");
                     continue;
                 };
-                self.accepted_since_log += 1;
+                _ = self.state.accepted_since_log.fetchAdd(1, .monotonic);
             } else |_| {
                 self.closeSlot(slot, "epoll add client failed");
                 continue;
@@ -2722,6 +3154,9 @@ const EventLoop = struct {
     }
 
     fn logPeriodicStats(self: *EventLoop, now_ns: i128) void {
+        if (self.worker_id != 0) return;
+        var tracked_fds: u64 = 0;
+        for (&self.state.worker_heartbeats) |*heartbeat| tracked_fds += heartbeat.tracked_fds.load(.monotonic);
         const active = self.state.active_connections.load(.monotonic);
         const hs = self.state.handshakes_inflight.load(.monotonic);
         const accepted_total = self.state.connection_count.load(.monotonic);
@@ -2778,9 +3213,9 @@ const EventLoop = struct {
             active,
             self.state.config.max_connections,
             hs,
-            self.accepted_since_log,
-            self.closed_since_log,
-            self.pool.fd_to_slot.count(),
+            self.state.accepted_since_log.swap(0, .monotonic),
+            self.state.closed_since_log.swap(0, .monotonic),
+            tracked_fds,
             accepted_total,
             self.accept_paused,
             self.saturation_paused,
@@ -2799,7 +3234,7 @@ const EventLoop = struct {
         // ME) is silently NOT applied for those connections. Surface it instead of letting it
         // pass unnoticed — the usual cause is a wrong/undetected egress NAT IP.
         if (d_mpf > 0 and (self.state.config.use_middle_proxy or self.state.config.tag != null)) {
-            log.warn("ad-tag likely inactive: {d} middle-proxy handshake(s) fell back to direct this interval — those connections carry no ad-tag/ME media. Check egress reachability and [server].middle_proxy_nat_ip.", .{d_mpf});
+            log.warn("middle-proxy degraded: {d} middle-proxy handshake(s) fell back to direct this interval — those connections lose middle-proxy media routing (direct promo tags remain). Check egress reachability and [server].middle_proxy_nat_ip.", .{d_mpf});
         }
 
         var top_entries: [5]HandshakeFloodGuard.TopEntry = undefined;
@@ -2813,12 +3248,16 @@ const EventLoop = struct {
             }
         }
 
-        self.accepted_since_log = 0;
-        self.closed_since_log = 0;
-
         while (self.stats_next_log_ns <= now_ns) {
             self.stats_next_log_ns += stats_log_interval_ns;
         }
+    }
+
+    fn flushTrafficCounters(self: *EventLoop) void {
+        const c2s = self.traffic_c2s_pending.swap(0, .monotonic);
+        const s2c = self.traffic_s2c_pending.swap(0, .monotonic);
+        if (c2s != 0) _ = self.state.client_to_upstream_bytes_total.fetchAdd(c2s, .monotonic);
+        if (s2c != 0) _ = self.state.upstream_to_client_bytes_total.fetchAdd(s2c, .monotonic);
     }
 
     fn pauseAccepting(self: *EventLoop, err: anyerror) void {
@@ -2854,12 +3293,13 @@ const EventLoop = struct {
         self.state.accept_paused.store(false, .monotonic);
     }
 
-    fn pauseSaturation(self: *EventLoop) void {
-        if (self.saturation_paused) return;
+    fn pauseSaturation(self: *EventLoop) bool {
+        if (self.saturation_paused) return true;
 
         self.modFd(self.listen_fd, false, false) catch |mod_err| {
             log.err("failed to pause accepts for saturation: {any}", .{mod_err});
-            return;
+            self.state.shutting_down.store(true, .release);
+            return false;
         };
 
         self.saturation_paused = true;
@@ -2872,6 +3312,7 @@ const EventLoop = struct {
                 "To handle more clients, increase max_connections or upgrade VPS RAM.",
             .{ active, max, @as(u32, 90), (max * 8) / 10, @as(u32, 80) },
         );
+        return true;
     }
 
     fn resumeSaturation(self: *EventLoop) void {
@@ -2992,6 +3433,7 @@ const EventLoop = struct {
     }
 
     fn reloadConfigFromDisk(self: *EventLoop) void {
+        @setEvalBranchQuota(100000);
         // With multiple SO_REUSEPORT workers, a live reload would swap and FREE
         // shared config string slices (tls_domain, mask_target, …) that the other
         // worker threads read on the handshake hot path — a torn-pointer /
@@ -3005,6 +3447,8 @@ const EventLoop = struct {
             return;
         };
         defer next.deinit(self.state.allocator);
+        self.state.metrics_config_mutex.lock();
+        defer self.state.metrics_config_mutex.unlock();
 
         if (next.users.count() == 0) {
             log.err("SIGHUP: reload rejected (no users configured)", .{});
@@ -3049,6 +3493,16 @@ const EventLoop = struct {
         if (next.web.onlyActive() != self.state.web_only) static_changes += 1;
         if (next.web.enabled != self.state.config.web.enabled) static_changes += 1;
         if (next.allow_direct_fallback != self.state.config.allow_direct_fallback) static_changes += 1;
+        // Every non-hot field, including nested sections and per-user limits,
+        // must report restart-required. New configuration fields are covered too.
+        inline for (std.meta.fields(Config)) |field| {
+            if (comptime !isHotConfigField(field.name)) {
+                if (!configValueEqual(field.type, @field(next, field.name), @field(self.state.config, field.name))) {
+                    static_changes += 1;
+                    log.warn("SIGHUP: {s} changed; restart required", .{field.name});
+                }
+            }
+        }
 
         if (next.idle_timeout_sec != self.state.config.idle_timeout_sec) {
             self.state.config.idle_timeout_sec = next.idle_timeout_sec;
@@ -3084,52 +3538,27 @@ const EventLoop = struct {
         }
         if (next.log_level != self.state.config.log_level) {
             self.state.config.log_level = next.log_level;
-            runtime_log.level = next.log_level;
+            runtime_log.level.store(next.log_level, .monotonic);
             applied += 1;
         }
         const tls_domain_changed = !std.mem.eql(u8, next.tls_domain, self.state.config.tls_domain);
         const mask_target_changed = !optionalStringEql(next.mask_target, self.state.config.mask_target);
-        if (next.mask != self.state.config.mask or next.mask_port != self.state.config.mask_port or tls_domain_changed or mask_target_changed) {
-            const resolved_mask_addr = self.resolveMaskAddress(&next);
-            if (next.mask) {
-                if (resolved_mask_addr) |addr| {
-                    self.state.mask_addr = addr;
-                } else {
-                    log.warn("SIGHUP: failed to resolve new mask target, keeping previous mask address", .{});
-                }
+        if (tls_domain_changed) {
+            static_changes += 1;
+            log.err("SIGHUP: tls_domain change requires restart and redistribution of every ee link; keeping current domain", .{});
+        }
+        if (!tls_domain_changed and (next.mask != self.state.config.mask or next.mask_port != self.state.config.mask_port or mask_target_changed)) {
+            const same_host = std.mem.eql(u8, next.effectiveMaskTarget(), self.state.config.effectiveMaskTarget());
+            if (!same_host or (next.mask and self.state.mask_addr == null)) {
+                static_changes += 1;
+                log.warn("SIGHUP: mask target change requires restart; DNS is never resolved on the event loop", .{});
             } else {
-                self.state.mask_addr = null;
+                if (self.state.mask_addr) |*addr| addr.setPort(next.mask_port);
+                for (self.state.mask_candidates.addresses[0..self.state.mask_candidates.len]) |*addr| addr.setPort(next.mask_port);
+                self.state.config.mask = next.mask;
+                self.state.config.mask_port = next.mask_port;
+                applied += 1;
             }
-            self.state.config.mask = next.mask;
-            self.state.config.mask_port = next.mask_port;
-            if (tls_domain_changed) {
-                if (self.state.allocator.dupe(u8, next.tls_domain)) |owned_tls_domain| {
-                    if (self.state.config.ownsTlsDomain()) {
-                        self.state.allocator.free(self.state.config.tls_domain);
-                    }
-                    self.state.config.tls_domain = owned_tls_domain;
-                } else |_| {
-                    log.warn("SIGHUP: failed to apply new tls_domain due to allocation error", .{});
-                }
-            }
-            if (mask_target_changed) {
-                if (next.mask_target) |target| {
-                    if (self.state.allocator.dupe(u8, target)) |owned_mask_target| {
-                        if (self.state.config.ownsMaskTarget()) {
-                            self.state.allocator.free(self.state.config.mask_target.?);
-                        }
-                        self.state.config.mask_target = owned_mask_target;
-                    } else |_| {
-                        log.warn("SIGHUP: failed to apply new mask_target due to allocation error", .{});
-                    }
-                } else {
-                    if (self.state.config.ownsMaskTarget()) {
-                        self.state.allocator.free(self.state.config.mask_target.?);
-                    }
-                    self.state.config.mask_target = null;
-                }
-            }
-            applied += 1;
         }
         if (next.desync != self.state.config.desync) {
             self.state.config.desync = next.desync;
@@ -3209,10 +3638,8 @@ const EventLoop = struct {
 
         // Relay half-close: upstream gracefully closed and we were draining its already-read
         // s2c data to a slow client. Once that queue empties, the connection is done.
-        if (slot.upstream_detached and !slot.hasClientPending()) {
-            self.closeSlot(slot, "relay drained after peer half-close");
-            return;
-        }
+        self.finishRelayHalfClose(slot);
+        if (slot.phase == .idle) return;
 
         switch (slot.phase) {
             .writing_server_hello_first => {
@@ -3300,10 +3727,8 @@ const EventLoop = struct {
 
                 // Relay half-close: client gracefully closed and we were draining its
                 // already-read c2s data to upstream. Once that queue empties, we're done.
-                if (slot.client_detached and !slot.hasUpstreamPending()) {
-                    self.closeSlot(slot, "relay drained after peer half-close");
-                    return;
-                }
+                self.finishRelayHalfClose(slot);
+                if (slot.phase == .idle) return;
 
                 if (slot.phase == .writing_dc_nonce and !slot.hasUpstreamPending()) {
                     self.onDcNonceWritable(slot);
@@ -3357,6 +3782,7 @@ const EventLoop = struct {
     fn enqueueDesyncWait(self: *EventLoop, slot: *ConnectionSlot) !void {
         if (slot.desync_wait_enqueued) return;
         try self.desync_wait_slots.append(self.state.allocator, slot.index);
+        if (self.desync_next_ns == 0 or slot.desync_deadline_ns < self.desync_next_ns) self.desync_next_ns = slot.desync_deadline_ns;
         slot.desync_wait_enqueued = true;
     }
 
@@ -3364,6 +3790,8 @@ const EventLoop = struct {
         if (self.desync_wait_slots.items.len == 0) return;
 
         const now_ns = nowNs();
+        if (now_ns < self.desync_next_ns) return;
+        self.desync_next_ns = 0;
         var write_idx: usize = 0;
         var read_idx: usize = 0;
 
@@ -3377,6 +3805,7 @@ const EventLoop = struct {
             }
 
             if (now_ns < slot.desync_deadline_ns) {
+                if (self.desync_next_ns == 0 or slot.desync_deadline_ns < self.desync_next_ns) self.desync_next_ns = slot.desync_deadline_ns;
                 self.desync_wait_slots.items[write_idx] = slot_idx;
                 write_idx += 1;
                 continue;
@@ -3441,7 +3870,7 @@ const EventLoop = struct {
     /// drain exactly its bytes (leaving the TLS ClientHello untouched in the socket buffer)
     /// so peer_addr reflects the real client behind a load balancer.
     fn tryConsumeProxyHeader(self: *EventLoop, slot: *ConnectionSlot) ProxyHeaderStep {
-        var peek: [256]u8 = undefined;
+        var peek: [4096]u8 = undefined;
         const msg_peek: u32 = 0x2; // MSG_PEEK (Linux)
         const rc = posix.system.recvfrom(slot.client_fd, &peek, peek.len, msg_peek, null, null);
         const n: usize = switch (posix.errno(rc)) {
@@ -3507,7 +3936,23 @@ const EventLoop = struct {
                     }
                     left -= got;
                 }
-                if (res.src) |real| slot.peer_addr = real;
+                if (res.src) |real| {
+                    slot.peer_addr = real;
+                    if (!slot.trusted_peer or !trusted_peers.isLoopback(real)) {
+                        const flood_cfg = floodGuardSettings(&self.state.config);
+                        if (self.state.floodIsBlocked(real, flood_cfg)) {
+                            _ = self.state.stats_dropped_flood_guard.fetchAdd(1, .monotonic);
+                            self.closeSlot(slot, "proxy client flood blocked");
+                            return .closed;
+                        }
+                        if (!self.state.subnetCheck(real, self.state.config.rate_limit_per_subnet)) {
+                            _ = self.state.stats_dropped_rate_limit.fetchAdd(1, .monotonic);
+                            _ = self.state.floodRecord(real, .rate_limit, flood_cfg);
+                            self.closeSlot(slot, "proxy client rate limited");
+                            return .closed;
+                        }
+                    }
+                }
                 slot.expect_proxy_header = false;
                 slot.proxy_header_optional = false;
                 slot.proxy_header_peeked = 0;
@@ -3549,7 +3994,7 @@ const EventLoop = struct {
                     // Feed the flood guard so a client that repeatedly burns the budget
                     // accrues a score (and the per-IP handshake_budget column is no longer
                     // dead telemetry). This is a client-driven, first-byte event.
-                    if (!slot.trusted_peer) {
+                    if (!slot.trusted_peer or !trusted_peers.isLoopback(slot.peer_addr)) {
                         _ = self.state.floodRecord(slot.peer_addr, .handshake_budget, floodGuardSettings(&self.state.config));
                     }
                     self.closeSlot(slot, "handshake budget exhausted");
@@ -3631,6 +4076,8 @@ const EventLoop = struct {
                 // masking cover for whatever was buffered instead of a bare
                 // silent close, so the response matches the masking target
                 // rather than fingerprinting the proxy.
+                slot.client_read_eof = true;
+                slot.relay_half_closed = true;
                 self.startMasking(slot, slot.handshake_buf[0..slot.handshake_pos]) catch {
                     self.closeSlot(slot, "client eof during direct obfuscated handshake");
                 };
@@ -3646,6 +4093,14 @@ const EventLoop = struct {
             };
             return;
         };
+
+        if (!slot.trusted_peer) {
+            const digest = crypto.sha256(slot.handshake_buf[8..56]);
+            if (self.state.replay_cache.checkAndInsert(&digest)) {
+                self.startMasking(slot, &slot.handshake_buf) catch self.closeSlot(slot, "dd replay masking failed");
+                return;
+            }
+        }
 
         self.finishParsedClientHandshake(slot, result);
     }
@@ -3706,12 +4161,14 @@ const EventLoop = struct {
         }
 
         const validation = tls.validateTlsHandshake(
-            self.state.allocator,
             client_hello,
             self.state.user_secrets,
             false,
             self.state.clock_offset_seconds,
-        ) catch null;
+        ) catch |err| blk: {
+            if (err == error.ClockSkew) log.warn("valid FakeTLS authentication rejected for clock skew; check host time synchronization", .{});
+            break :blk null;
+        };
 
         if (validation == null) {
             self.startMasking(slot, client_hello) catch {
@@ -3733,9 +4190,11 @@ const EventLoop = struct {
         slot.validation_digest = v.digest;
         slot.validation_session_id_len = @intCast(v.session_id.len);
         @memcpy(slot.validation_session_id[0..v.session_id.len], v.session_id);
-        const ulen = @min(v.user.len, slot.validation_user.len);
-        slot.validation_user_len = @intCast(ulen);
-        @memcpy(slot.validation_user[0..ulen], v.user[0..ulen]);
+        slot.validation_user = self.state.allocator.dupe(u8, v.user) catch {
+            self.closeSlot(slot, "username allocation failed");
+            return;
+        };
+        slot.validation_user_len = v.user.len;
 
         // Echo a client-offered cipher in the ServerHello (naturalistic, matches
         // how a real server negotiates) instead of a constant. Falls back to the
@@ -3762,6 +4221,10 @@ const EventLoop = struct {
         // A PQ-offering client (X25519MLKEM768 0x11ec) must be answered with a 0x11ec
         // key_share, else we emit a passive group-downgrade tell.
         const offers_pq = tls.clientOffersPqKeyShare(client_hello_bytes);
+        if (!offers_pq and !tls.clientOffersX25519KeyShare(client_hello_bytes)) {
+            self.startMasking(slot, client_hello_bytes) catch self.closeSlot(slot, "unsupported TLS key share");
+            return;
+        }
         if (fp_consumed) {
             var fp_buf: [256]u8 = undefined;
             if (tls.formatClientHelloFingerprint(client_hello_bytes, &fp_buf)) |fp| {
@@ -3774,6 +4237,21 @@ const EventLoop = struct {
 
         const echoed_cipher = tls.extractFirstTls13Cipher(client_hello_bytes);
         const session_id = slot.validation_session_id[0..slot.validation_session_id_len];
+        if (!self.state.config.desync) {
+            const response = (if (offers_pq)
+                tls.buildServerHelloPqInto(&self.server_hello_scratch, &slot.validation_secret, &slot.validation_digest, session_id, echoed_cipher, self.state.tls_server_hello_template.len - tls.server_hello_prefix_len)
+            else
+                tls.buildServerHelloWithTemplateInto(&self.server_hello_scratch, self.state.tls_server_hello_template, &slot.validation_secret, &slot.validation_digest, session_id, echoed_cipher)) catch {
+                self.closeSlot(slot, "build server hello failed");
+                return;
+            };
+            slot.phase = .writing_server_hello_rest;
+            _ = queueClient(slot, self.state.allocator, response) catch {
+                self.closeSlot(slot, "queue server hello failed");
+                return;
+            };
+            return;
+        }
         slot.server_hello = (if (offers_pq)
             tls.buildServerHelloPq(
                 self.state.allocator,
@@ -3935,6 +4413,13 @@ const EventLoop = struct {
     }
 
     fn finishParsedClientHandshake(self: *EventLoop, slot: *ConnectionSlot, result: anytype) void {
+        if (slot.validation_user.len == 0) {
+            slot.validation_user = self.state.allocator.dupe(u8, result.user) catch {
+                self.closeSlot(slot, "username allocation failed");
+                return;
+            };
+            slot.validation_user_len = result.user.len;
+        }
         slot.obf_params = result.params;
         slot.proto_tag = result.params.proto_tag;
         slot.dc_idx = result.params.dc_idx;
@@ -3951,12 +4436,18 @@ const EventLoop = struct {
             return;
         };
 
-        const snapshot = if (self.state.config.datacenter_override == null and (self.state.config.use_middle_proxy or dc_abs == 203))
+        // force_media_middle_proxy (default true) must see a snapshot for every
+        // media path (dc_idx < 0), not just DC203 — otherwise buildDcConnectPlan's
+        // `middle_addr != null` guard always fails for DC1..5 media under the
+        // shipped use_middle_proxy=false default, silently sending media direct
+        // and making the flag dead code for anything but CDN.
+        const snapshot = if (self.state.config.datacenter_override == null and middleProxySnapshotWanted(&self.state.config, dc_abs))
             self.state.getMiddleProxySnapshot()
         else
             null;
 
-        const plan = buildDcConnectPlan(&self.state.config, dc_abs, slot.dc_idx, if (snapshot) |*s| s else null, result.user);
+        var plan = buildDcConnectPlan(&self.state.config, dc_abs, slot.dc_idx, if (snapshot) |*s| s else null, result.user);
+        self.endpoint_penalties.prioritize(plan.candidates[0..plan.count], nowMs());
         if (plan.count == 0) {
             self.closeSlot(slot, "no upstream candidates");
             return;
@@ -4055,8 +4546,8 @@ const EventLoop = struct {
         slot.upstream_candidate_next = 1;
         slot.current_upstream_addr = candidates[0];
 
-        self.startConnectUpstream(slot, candidates[0], .dc) catch {
-            self.closeSlot(slot, "upstream connect start failed");
+        self.startConnectUpstream(slot, candidates[0], .dc) catch |err| {
+            if (!self.tryNextDcEndpoint(slot, err)) self.closeSlot(slot, "upstream connect start failed");
         };
     }
 
@@ -4066,6 +4557,20 @@ const EventLoop = struct {
     /// like nginx ssl_reject_handshake and closes, `drop` closes silently. Validation-failed /
     /// replay cases (SNI matched) keep masking — they're not handled here.
     fn handleInvalidSni(self: *EventLoop, slot: *ConnectionSlot, client_hello: []const u8, sni: ?[]const u8, reason: []const u8) void {
+        // The configured WEB domain is a legitimate carrier, not an unknown SNI.
+        if (sni) |name| {
+            if (self.state.web_mask_addr) |addr| {
+                if (self.state.config.web.domain) |domain| {
+                    if (std.ascii.eqlIgnoreCase(name, domain)) {
+                        slot.mask_addr_override = addr;
+                        slot.mask_dns_override = self.state.web_dns_id;
+                        slot.mask_send_proxy_header = true;
+                        self.startMasking(slot, client_hello) catch self.closeSlot(slot, reason);
+                        return;
+                    }
+                }
+            }
+        }
         _ = self.state.stats_unknown_sni.fetchAdd(1, .monotonic);
         switch (self.state.config.unknown_sni_action) {
             .mask => {
@@ -4080,6 +4585,7 @@ const EventLoop = struct {
                         if (self.state.config.web.domain) |domain| {
                             if (std.ascii.eqlIgnoreCase(s, domain)) {
                                 slot.mask_addr_override = web_addr;
+                                slot.mask_dns_override = self.state.web_dns_id;
                                 slot.mask_send_proxy_header = true;
                             }
                         }
@@ -4088,6 +4594,7 @@ const EventLoop = struct {
                         for (self.state.mask_safelist) |entry| {
                             if (std.ascii.eqlIgnoreCase(s, entry.domain)) {
                                 slot.mask_addr_override = entry.addr;
+                                slot.mask_dns_override = entry.dns_id;
                                 break;
                             }
                         }
@@ -4116,42 +4623,68 @@ const EventLoop = struct {
         if (!self.state.config.mask) return error.MaskingDisabled;
 
         // Consume a one-shot SNI-following override if set; otherwise the default target.
-        const addr = blk: {
+        const candidates = blk: {
             if (slot.mask_addr_override) |override| {
                 slot.mask_addr_override = null;
-                break :blk override;
+                const id = slot.mask_dns_override;
+                slot.mask_dns_override = null;
+                break :blk if (id) |value| self.state.dns.snapshot(value) else net_helpers.AddressCandidates.init(&.{override});
             }
-            break :blk self.state.mask_addr orelse return error.NoMaskAddress;
+            var current = if (self.state.mask_dns_id) |id| self.state.dns.snapshot(id) else self.state.mask_candidates;
+            for (current.addresses[0..current.len]) |*address| address.setPort(self.state.config.mask_port);
+            break :blk current;
         };
-        // A PROXY header, when the target expects one, must lead the stream — the
-        // terminator reads it before the ClientHello.
-        var header_buf: [64]u8 = undefined;
-        const header: []const u8 = if (slot.mask_send_proxy_header) blk: {
-            slot.mask_send_proxy_header = false;
-            break :blk proxy_protocol.buildV2(&header_buf, slot.peer_addr, addr);
-        } else "";
+        if (candidates.len == 0) return error.NoMaskAddress;
+        try slot.freezeResolvedCandidates(self.state.allocator, candidates);
+        slot.mask_candidate_next = 1;
+        var addr = candidates.addresses[0];
+        // Reject a cover target that routes back into this listener, including the
+        // public ingress address (not just the configured loopback address).
+        while (addr.getPort() == self.state.config.port) {
+            const local = try socket_utils.localSocketAddress(slot.client_fd);
+            if (!addressEql(addr, local) and !trusted_peers.isLoopback(addr)) break;
+            if (slot.mask_candidate_next >= candidates.len) return error.MaskBackendLoopsToProxy;
+            addr = candidates.addresses[slot.mask_candidate_next];
+            slot.mask_candidate_next += 1;
+        }
+        // Build any PROXY header only after a backend connects, so a DNS retry
+        // across address families uses the actual destination and header length.
+        slot.mask_prebuffer = try self.state.allocator.dupe(u8, buffered);
 
-        const pre = try self.state.allocator.alloc(u8, header.len + buffered.len);
-        if (header.len > 0) @memcpy(pre[0..header.len], header);
-        @memcpy(pre[header.len..], buffered);
-        slot.mask_prebuffer = pre;
-
-        try self.startConnectUpstream(slot, addr, .mask);
+        self.startConnectUpstream(slot, addr, .mask) catch |err| {
+            if (!self.tryNextResolvedEndpoint(slot, .mask, addr)) return err;
+        };
     }
 
     fn startConnectUpstream(self: *EventLoop, slot: *ConnectionSlot, addr: Address, kind: UpstreamKind) !void {
         const connect_result = if (kind == .mask) blk: {
-            const direct = upstream_mod.Upstream.initDirect();
+            const direct = if (self.state.config.upstream_mode == .tunnel) upstream_mod.Upstream.initDirectWithMark(tunnel_socket_mark) else upstream_mod.Upstream.initDirect();
             break :blk try direct.connect(addr);
-        } else try self.state.upstream.connect(addr);
+        } else blk: {
+            if (slot.resolved_candidates == null) {
+                if (self.state.proxy_dns_id) |id| {
+                    const candidates = self.state.dns.snapshot(id);
+                    if (candidates.len == 0) return error.NoProxyAddress;
+                    try slot.freezeResolvedCandidates(self.state.allocator, candidates);
+                }
+            }
+            while (true) {
+                const connector = if (slot.resolved_candidates) |candidates| self.state.upstream.withProxyAddress(candidates.addresses[slot.proxy_candidate_index]) else self.state.upstream.withProxyCandidate(slot.proxy_candidate_index);
+                break :blk connector.connect(addr) catch |err| {
+                    const count = if (slot.resolved_candidates) |candidates| candidates.len else self.state.upstream.proxyCandidateCount();
+                    if (slot.proxy_candidate_index + 1 >= count) return err;
+                    slot.proxy_candidate_index += 1;
+                    continue;
+                };
+            }
+        };
         const fd = connect_result.fd;
         errdefer closeFd(fd);
 
-        try self.addFd(fd, false, true);
+        try self.addUpstreamFd(slot, fd, false, true);
         errdefer _ = self.delFd(fd) catch {};
 
         try self.pool.mapFd(fd, slot.index);
-        errdefer self.pool.unmapFd(fd);
 
         slot.upstream_fd = fd;
         slot.upstream_kind = kind;
@@ -4166,13 +4699,6 @@ const EventLoop = struct {
             slot.proxy_target_addr = addr;
         }
 
-        errdefer {
-            slot.upstream_fd = -1;
-            slot.upstream_kind = .none;
-            slot.current_upstream_addr = null;
-            slot.proxy_target_addr = null;
-        }
-
         if (!connect_result.pending) {
             self.onUpstreamConnectComplete(slot);
         }
@@ -4181,7 +4707,10 @@ const EventLoop = struct {
     fn onUpstreamConnectComplete(self: *EventLoop, slot: *ConnectionSlot) void {
         if (checkSocketConnectError(slot.upstream_fd)) |_| {} else |err| {
             const failed_kind = slot.upstream_kind;
+            const failed_target = slot.current_upstream_addr;
             self.cleanupFailedUpstreamConnect(slot);
+
+            if (self.tryNextResolvedEndpoint(slot, failed_kind, failed_target)) return;
 
             if (failed_kind == .dc and self.tryNextDcEndpoint(slot, err)) {
                 return;
@@ -4199,8 +4728,18 @@ const EventLoop = struct {
 
         configureRelaySocket(slot.client_fd);
         configureRelaySocket(slot.upstream_fd);
+        if (slot.upstream_kind == .dc) if (slot.current_upstream_addr) |addr| self.endpoint_penalties.succeeded(addr);
 
         if (slot.upstream_kind == .mask) {
+            if (slot.mask_send_proxy_header) {
+                var header_buf: [64]u8 = undefined;
+                const header = proxy_protocol.buildV2(&header_buf, slot.peer_addr, slot.current_upstream_addr.?);
+                _ = queueUpstream(slot, self.state.allocator, header) catch {
+                    self.closeSlot(slot, "mask PROXY header failed");
+                    return;
+                };
+                slot.mask_send_proxy_header = false;
+            }
             if (slot.mask_prebuffer) |pre| {
                 if (queueUpstream(slot, self.state.allocator, pre)) |_| {
                     self.state.allocator.free(pre);
@@ -4214,6 +4753,7 @@ const EventLoop = struct {
             // Handshake complete (mask path) — release from handshake budget
             self.releaseHandshakeBudget(slot);
             slot.phase = .mask_relaying;
+            self.finishRelayHalfClose(slot);
             return;
         }
 
@@ -4297,15 +4837,45 @@ const EventLoop = struct {
             const fd = slot.upstream_fd;
             _ = self.delFd(fd) catch {};
             self.pool.unmapFd(fd);
-            closeFd(fd);
+            self.deferClose(fd);
             slot.upstream_fd = -1;
+            // The fd left epoll: keep the cache describing the kernel, so the next
+            // endpoint's registration starts from a truthful (false,false).
+            slot.noteUpstreamRegistered(false, false);
         }
         slot.upstream_kind = .none;
         slot.current_upstream_addr = null;
         slot.upstream_queue.clear();
     }
 
+    fn tryNextResolvedEndpoint(self: *EventLoop, slot: *ConnectionSlot, kind: UpstreamKind, target: ?Address) bool {
+        if (kind == .mask) {
+            const candidates = slot.resolved_candidates orelse return false;
+            while (slot.mask_candidate_next > 0 and slot.mask_candidate_next < candidates.len) {
+                const addr = candidates.addresses[slot.mask_candidate_next];
+                slot.mask_candidate_next += 1;
+                if (addr.getPort() == self.state.config.port) {
+                    const local = socket_utils.localSocketAddress(slot.client_fd) catch return false;
+                    if (addressEql(addr, local) or trusted_peers.isLoopback(addr)) continue;
+                }
+                self.startConnectUpstream(slot, addr, .mask) catch continue;
+                return true;
+            }
+            return false;
+        }
+        if (kind != .dc or self.state.upstream == .direct) return false;
+        const addr = target orelse return false;
+        const count = if (slot.resolved_candidates) |candidates| candidates.len else self.state.upstream.proxyCandidateCount();
+        if (slot.proxy_candidate_index + 1 >= count) return false;
+        slot.proxy_candidate_index += 1;
+        self.startConnectUpstream(slot, addr, kind) catch return false;
+        return true;
+    }
+
     fn tryNextDcEndpoint(self: *EventLoop, slot: *ConnectionSlot, err: anyerror) bool {
+        slot.proxy_candidate_index = 0;
+        const candidates = slot.upstreamCandidates();
+        if (candidates.len > 0) self.endpoint_penalties.failed(slot.current_upstream_addr orelse candidates[@min(slot.upstream_candidate_next -| 1, candidates.len - 1)], nowMs());
         return upstream_failover.tryNextDcEndpoint(
             self,
             slot,
@@ -4350,6 +4920,10 @@ const EventLoop = struct {
             null;
 
         const progress = relayClientToUpstreamStep(slot, self.state.allocator, mp_c2s_scratch, self.shared_read_buf[0..]) catch |err| {
+            if (err == error.EndOfStream) {
+                self.beginRelayHalfClose(slot, slot.client_fd);
+                return;
+            }
             if (slot.is_media_path) {
                 log.debug("[{d}] relay c2s error: dc_idx={d} err={any} c2s={d} s2c={d}", .{
                     slot.conn_id, slot.dc_idx, err, slot.c2s_bytes, slot.s2c_bytes,
@@ -4380,6 +4954,10 @@ const EventLoop = struct {
             null;
 
         const progress = relayUpstreamToClientStep(slot, self.state.allocator, mp_s2c_scratch, self.shared_read_buf[0..]) catch |err| {
+            if (err == error.EndOfStream) {
+                self.beginRelayHalfClose(slot, slot.upstream_fd);
+                return;
+            }
             if (slot.is_media_path) {
                 log.debug("[{d}] relay s2c error: dc_idx={d} err={any} c2s={d} s2c={d}", .{
                     slot.conn_id, slot.dc_idx, err, slot.c2s_bytes, slot.s2c_bytes,
@@ -4401,7 +4979,7 @@ const EventLoop = struct {
             return;
         };
         if (n == 0) {
-            self.closeSlot(slot, "direct obfuscated c2s eof");
+            self.beginRelayHalfClose(slot, slot.client_fd);
             return;
         }
 
@@ -4450,7 +5028,7 @@ const EventLoop = struct {
             return;
         };
         if (n == 0) {
-            self.closeSlot(slot, "direct obfuscated s2c eof");
+            self.beginRelayHalfClose(slot, slot.upstream_fd);
             return;
         }
 
@@ -4494,6 +5072,7 @@ const EventLoop = struct {
             self.shared_read_buf[0..],
             proxyHandshakeQueueUpstream,
             proxyHandshakeCloseSlot,
+            beginRelayHalfClose,
         );
     }
 
@@ -4504,6 +5083,7 @@ const EventLoop = struct {
             self.shared_read_buf[0..],
             relayQueueClient,
             proxyHandshakeCloseSlot,
+            beginRelayHalfClose,
         );
     }
 
@@ -4515,6 +5095,7 @@ const EventLoop = struct {
             mpLockMiddleProxyShared,
             mpUnlockMiddleProxyShared,
             mpHandshakeCloseSlot,
+            mpHandshakeFallbackToDirect,
         );
     }
 
@@ -4576,7 +5157,7 @@ const EventLoop = struct {
         var idx: usize = @intCast(self.timer_scan_cursor);
         if (idx >= hi) idx = 0;
 
-        const budget = @min(hi, timer_scan_budget);
+        const budget = hi; // Visit every deadline this tick; inactive slots are cheap pointer checks.
         var scanned: usize = 0;
         while (scanned < budget) : (scanned += 1) {
             const slot_opt = self.pool.slots[idx];
@@ -4586,11 +5167,6 @@ const EventLoop = struct {
             const slot = slot_opt orelse continue;
             if (slot.phase == .idle) continue;
 
-            if (slot.phase == .closing) {
-                self.closeSlot(slot, "closing phase");
-                continue;
-            }
-
             // Per-endpoint upstream connect deadline. Fires only while a connect() is still
             // in flight; lets failover advance to the next DC endpoint quickly instead of
             // burning the whole (global) handshake_timeout_sec on one black-holed endpoint.
@@ -4599,7 +5175,9 @@ const EventLoop = struct {
                 now_ms - slot.upstream_connect_started_ms > secondsToMs(self.state.config.dc_connect_timeout_sec))
             {
                 const failed_kind = slot.upstream_kind;
+                const failed_target = slot.current_upstream_addr;
                 self.cleanupFailedUpstreamConnect(slot);
+                if (self.tryNextResolvedEndpoint(slot, failed_kind, failed_target)) continue;
                 // Mirror onUpstreamConnectComplete's failure path: DC endpoints fail over to
                 // the next candidate; any other upstream kind (mask/proxy/middle) just closes.
                 if (failed_kind == .dc and self.tryNextDcEndpoint(slot, error.ConnectTimedOut)) continue;
@@ -4609,8 +5187,11 @@ const EventLoop = struct {
 
             if (slot.handshakeInProgress()) {
                 if (slot.first_byte_at_ms == 0) {
-                    if (now_ms - slot.created_at_ms > (if (slot.idle_timeout_ms > 0) slot.idle_timeout_ms else secondsToMs(self.state.config.idle_timeout_sec))) {
-                        self.closeSlot(slot, "idle pre-first-byte timeout");
+                    if (now_ms - slot.created_at_ms > jitteredIdleTimeoutMs(self.state.config.handshake_timeout_sec, self.state.config.idle_timeout_jitter_pct, slot.conn_id ^ @as(u64, @bitCast(slot.created_at_ms)))) {
+                        _ = self.state.stats_hs_timeout.fetchAdd(1, .monotonic);
+                        if (!slot.trusted_peer and !self.state.config.accept_proxy_protocol)
+                            _ = self.state.floodRecord(slot.peer_addr, .handshake_timeout, floodGuardSettings(&self.state.config));
+                        self.closeSlot(slot, "silent handshake timeout");
                         continue;
                     }
                 } else if (slot.phase == .reading_direct_obfuscated_handshake and
@@ -4627,14 +5208,14 @@ const EventLoop = struct {
                         self.closeSlot(slot, "dd handshake decision timeout");
                     };
                     continue;
-                } else if (now_ms - slot.first_byte_at_ms > secondsToMs(self.state.config.handshake_timeout_sec)) {
+                } else if (now_ms - slot.first_byte_at_ms > jitteredIdleTimeoutMs(self.state.config.handshake_timeout_sec, self.state.config.idle_timeout_jitter_pct, slot.conn_id ^ @as(u64, @bitCast(slot.created_at_ms)))) {
                     _ = self.state.stats_hs_timeout.fetchAdd(1, .monotonic);
                     // Only blame the client's IP when the stall is client-driven. An
                     // upstream-side timeout (DC unreachable, slow upstream proxy, stale
                     // middleproxy secret) is not the client's fault, and feeding it to the
                     // flood guard would block legit secret-holders behind a shared NAT
                     // during an upstream outage.
-                    if (isClientDrivenHandshakePhase(slot.phase) and !slot.mp_step.awaitingMiddleProxy() and !slot.trusted_peer) {
+                    if (isClientDrivenHandshakePhase(slot.phase) and !slot.mp_step.awaitingMiddleProxy() and (!slot.trusted_peer or !trusted_peers.isLoopback(slot.peer_addr))) {
                         _ = self.state.floodRecord(slot.peer_addr, .handshake_timeout, floodGuardSettings(&self.state.config));
                     }
                     // A timeout while still waiting on the middleproxy RPC handshake
@@ -4669,7 +5250,7 @@ const EventLoop = struct {
                     self.closeSlot(slot, "client silence wedge breaker");
                     continue;
                 }
-                if (slot.phase == .mask_relaying and self.state.config.mask_relay_max_secs > 0 and
+                if (slot.phase == .mask_relaying and !slot.mask_send_proxy_header and self.state.config.mask_relay_max_secs > 0 and
                     now_ms - slot.created_at_ms > secondsToMs(self.state.config.mask_relay_max_secs))
                 {
                     self.closeSlot(slot, "mask relay max duration");
@@ -4691,99 +5272,43 @@ const EventLoop = struct {
     }
 
     fn syncInterests(self: *EventLoop, slot: *ConnectionSlot) !void {
-        var want_client_in = false;
-        var want_client_out = slot.hasClientPending();
-        var want_upstream_in = false;
-        var want_upstream_out = slot.hasUpstreamPending();
-
-        switch (slot.phase) {
-            .reading_tls_header,
-            .reading_direct_obfuscated_handshake,
-            .reading_client_hello_body,
-            .reading_mtproto_tls_header,
-            .reading_mtproto_tls_body,
-            => {
-                want_client_in = slot.client_read_pause_until_ms == 0 or
-                    nowMs() >= slot.client_read_pause_until_ms;
-            },
-
-            .writing_server_hello_first,
-            .writing_server_hello_rest,
-            => {
-                want_client_out = true;
-            },
-
-            .desync_wait => {
-                // Wait for timer tick only; keeping EPOLLOUT enabled here can
-                // cause a busy loop because writable sockets trigger continuously.
-            },
-
-            .connecting_upstream => {
-                want_client_in = false;
-                want_upstream_out = true;
-            },
-
-            .proxy_socks5_greeting,
-            .proxy_socks5_auth,
-            .proxy_socks5_connect,
-            .proxy_http_connect,
-            => {
-                want_client_in = false;
-                want_upstream_out = true;
-            },
-
-            .proxy_socks5_greeting_resp,
-            .proxy_socks5_auth_resp,
-            .proxy_socks5_connect_resp,
-            .proxy_http_connect_resp,
-            => {
-                want_client_in = false;
-                want_upstream_in = true;
-            },
-
-            .writing_dc_nonce => {
-                want_client_in = false;
-                want_upstream_out = true;
-            },
-
-            .middle_proxy_handshake => {
-                want_upstream_out = want_upstream_out or
-                    slot.mp_step == .sending_rpc_nonce or
-                    slot.mp_step == .sending_rpc_handshake;
-                want_upstream_in = slot.mp_step == .waiting_rpc_nonce_response or
-                    slot.mp_step == .waiting_rpc_handshake_response;
-            },
-
-            .relaying, .mask_relaying => {
-                if (slot.relay_half_closed) {
-                    // One side gracefully closed; only drain the surviving direction's
-                    // queued data (want_*_out already reflects hasXPending). Don't read
-                    // from either peer — c2s has nowhere to go and the closed side is gone.
-                    want_client_in = false;
-                    want_upstream_in = false;
-                } else {
-                    want_client_in = !slot.hasUpstreamPending();
-                    want_upstream_in = !slot.hasClientPending();
-                }
-            },
-
-            else => {},
+        const want = wantedInterests(slot, nowMs());
+        const relaying = slot.phase == .relaying or slot.phase == .mask_relaying;
+        if (relaying and slot.client_fd != -1) {
+            if (!want.client_in and !want.client_out and !slot.client_detached) {
+                try self.delFd(slot.client_fd);
+                slot.client_detached = true;
+                slot.noteClientRegistered(false, false);
+            } else if ((want.client_in or want.client_out) and slot.client_detached) {
+                try self.addClientFd(slot, slot.client_fd, want.client_in, want.client_out);
+                slot.client_detached = false;
+            }
+        }
+        if (relaying and slot.upstream_fd != -1) {
+            if (!want.upstream_in and !want.upstream_out and !slot.upstream_detached) {
+                try self.delFd(slot.upstream_fd);
+                slot.upstream_detached = true;
+                slot.noteUpstreamRegistered(false, false);
+            } else if ((want.upstream_in or want.upstream_out) and slot.upstream_detached) {
+                try self.addUpstreamFd(slot, slot.upstream_fd, want.upstream_in, want.upstream_out);
+                slot.upstream_detached = false;
+            }
         }
 
         // A detached fd (relay half-close) has left epoll — never modFd it.
         if (slot.client_fd != -1 and !slot.client_detached) {
-            if (slot.client_interest_in != want_client_in or slot.client_interest_out != want_client_out) {
-                try self.modFd(slot.client_fd, want_client_in, want_client_out);
-                slot.client_interest_in = want_client_in;
-                slot.client_interest_out = want_client_out;
+            if (slot.client_interest_in != want.client_in or slot.client_interest_out != want.client_out) {
+                try self.modFd(slot.client_fd, want.client_in, want.client_out);
+                slot.client_interest_in = want.client_in;
+                slot.client_interest_out = want.client_out;
             }
         }
 
         if (slot.upstream_fd != -1 and !slot.upstream_detached) {
-            if (slot.upstream_interest_in != want_upstream_in or slot.upstream_interest_out != want_upstream_out) {
-                try self.modFd(slot.upstream_fd, want_upstream_in, want_upstream_out);
-                slot.upstream_interest_in = want_upstream_in;
-                slot.upstream_interest_out = want_upstream_out;
+            if (slot.upstream_interest_in != want.upstream_in or slot.upstream_interest_out != want.upstream_out) {
+                try self.modFd(slot.upstream_fd, want.upstream_in, want.upstream_out);
+                slot.upstream_interest_in = want.upstream_in;
+                slot.upstream_interest_out = want.upstream_out;
             }
         }
     }
@@ -4791,18 +5316,9 @@ const EventLoop = struct {
     fn ensureMpC2sScratch(self: *EventLoop) ![]u8 {
         if (self.mp_c2s_scratch) |buf| return buf;
 
-        // Worst-case RPC_PROXY_REQ expansion.
-        // The smallest consumable input is a single abridged header byte with
-        // len_val=0 → 0-byte payload → encrypted_len = 96 with ad_tag.
-        // A pathological client pipelining 1MB of such bytes would expand to
-        // ~96MB of encapsulated frames. Sizing the scratch buffer to match
-        // keeps encapsulateC2S overflow-free under adversarial load and
-        // prevents the spurious connection drops observed in production.
-        //
-        // One allocation per EventLoop (single-threaded), so the memory cost
-        // is bounded regardless of connection count.
-        const mp_max_expansion: usize = 96;
-        const capacity = self.state.config.middleProxyBufferBytes() * mp_max_expansion + 256;
+        // At most one prior buffered frame plus the current bounded read can
+        // complete here. Charge worst-case framing overhead per new input byte.
+        const capacity = self.state.config.middleProxyC2sScratchBytes();
         const buf = try self.state.allocator.alloc(u8, capacity);
         self.mp_c2s_scratch = buf;
         return buf;
@@ -4810,42 +5326,36 @@ const EventLoop = struct {
 
     fn ensureMpS2cScratch(self: *EventLoop) ![]u8 {
         if (self.mp_s2c_scratch) |buf| return buf;
-        const buf = try self.state.allocator.alloc(u8, self.state.config.middleProxyBufferBytes());
+        const buf = try self.state.allocator.alloc(u8, self.state.config.middleProxyBufferBytes() + read_buf_size + 16);
         self.mp_s2c_scratch = buf;
         return buf;
     }
 
-    /// Begin a relay half-close drain: the peer on `hung_fd` gracefully closed while data
-    /// was still queued for the other peer. Detach `hung_fd` from epoll (it stays open so
-    /// closeSlot still closes it) and let the surviving direction flush; the writable
-    /// handler closes the slot once its queue drains, with the relay idle timer as backstop.
+    /// EOF is only recorded after read() returns zero, never from RDHUP alone.
     fn beginRelayHalfClose(self: *EventLoop, slot: *ConnectionSlot, hung_fd: posix.fd_t) void {
-        _ = self.delFd(hung_fd) catch {};
-        if (hung_fd == slot.client_fd) {
-            slot.client_detached = true;
-            slot.client_interest_in = false;
-            slot.client_interest_out = false;
-        } else {
-            slot.upstream_detached = true;
-            slot.upstream_interest_in = false;
-            slot.upstream_interest_out = false;
-        }
+        if (hung_fd == slot.client_fd) slot.client_read_eof = true else slot.upstream_read_eof = true;
         slot.relay_half_closed = true;
-        slot.last_activity_ms = nowMs();
-        self.syncInterests(slot) catch {
-            self.closeSlot(slot, "half-close sync failed");
-            return;
-        };
-        // If the surviving direction had nothing buffered after all, close now.
-        if (slot.upstream_detached and !slot.hasClientPending()) {
-            self.closeSlot(slot, "relay drained after peer half-close");
-        } else if (slot.client_detached and !slot.hasUpstreamPending()) {
-            self.closeSlot(slot, "relay drained after peer half-close");
+        self.finishRelayHalfClose(slot);
+    }
+
+    fn finishRelayHalfClose(self: *EventLoop, slot: *ConnectionSlot) void {
+        if (!slot.relay_half_closed) return;
+        if (slot.client_read_eof and !slot.hasUpstreamPending() and !slot.upstream_write_shutdown) {
+            _ = linux.shutdown(slot.upstream_fd, linux.SHUT.WR);
+            slot.upstream_write_shutdown = true;
         }
+        if (slot.upstream_read_eof and !slot.hasClientPending() and !slot.client_write_shutdown) {
+            _ = linux.shutdown(slot.client_fd, linux.SHUT.WR);
+            slot.client_write_shutdown = true;
+        }
+        if (slot.client_read_eof and slot.upstream_read_eof and !slot.hasClientPending() and !slot.hasUpstreamPending())
+            self.closeSlot(slot, "relay drained after peer half-close");
     }
 
     fn closeSlot(self: *EventLoop, slot: *ConnectionSlot, reason: []const u8) void {
         if (slot.phase == .idle) return;
+        std.crypto.secureZero(u8, &slot.mp_secret);
+        slot.mp_secret_len = 0;
         // s2c counts payload handed to the client queue, so a large `qlen` here means we
         // decapsulated the bytes but never got them onto the socket.
         log.debug("[{d}] closing: user={s} dc_idx={d} media={} phase={s} reason={s} c2s={d} s2c={d} qlen={d} relay={}", .{
@@ -4898,7 +5408,7 @@ const EventLoop = struct {
             // RED errors + evasion signal: bucket the close reason once per slot.
             _ = self.state.close_reasons[@intFromEnum(CloseReason.classify(reason))].fetchAdd(1, .monotonic);
             slot.active_reserved = false;
-            self.closed_since_log += 1;
+            _ = self.state.closed_since_log.fetchAdd(1, .monotonic);
         }
         // Release the handshake-budget slot exactly once, keyed on hs_counted
         // (set at first byte). Pre-first-byte sessions were never counted, and
@@ -4916,9 +5426,25 @@ const EventLoop = struct {
         self.pool.release(slot);
     }
 
+    /// Register a slot's client fd and record the registration in one step. Slot fds must
+    /// go through this (never bare addFd): the interest cache is what syncInterests
+    /// compares against, so a registration it never saw makes a later disarm a no-op.
+    fn addClientFd(self: *EventLoop, slot: *ConnectionSlot, fd: posix.fd_t, want_in: bool, want_out: bool) !void {
+        try self.addFd(fd, want_in, want_out);
+        slot.noteClientRegistered(want_in, want_out);
+    }
+
+    /// Register a slot's upstream fd and record the registration (see addClientFd).
+    fn addUpstreamFd(self: *EventLoop, slot: *ConnectionSlot, fd: posix.fd_t, want_in: bool, want_out: bool) !void {
+        try self.addFd(fd, want_in, want_out);
+        slot.noteUpstreamRegistered(want_in, want_out);
+    }
+
+    /// Low-level epoll registration. Only for fds with no slot behind them (the
+    /// listener, the signalfd) — everything else uses addClientFd/addUpstreamFd.
     fn addFd(self: *EventLoop, fd: posix.fd_t, want_in: bool, want_out: bool) !void {
-        var events: u32 = linux.EPOLL.ERR | linux.EPOLL.HUP | linux.EPOLL.RDHUP;
-        if (want_in) events |= linux.EPOLL.IN;
+        var events: u32 = linux.EPOLL.ERR | linux.EPOLL.HUP;
+        if (want_in) events |= linux.EPOLL.IN | linux.EPOLL.RDHUP;
         if (want_out) events |= linux.EPOLL.OUT;
 
         var ev = linux.epoll_event{ .events = events, .data = .{ .fd = fd } };
@@ -4930,8 +5456,8 @@ const EventLoop = struct {
     }
 
     fn modFd(self: *EventLoop, fd: posix.fd_t, want_in: bool, want_out: bool) !void {
-        var events: u32 = linux.EPOLL.ERR | linux.EPOLL.HUP | linux.EPOLL.RDHUP;
-        if (want_in) events |= linux.EPOLL.IN;
+        var events: u32 = linux.EPOLL.ERR | linux.EPOLL.HUP;
+        if (want_in) events |= linux.EPOLL.IN | linux.EPOLL.RDHUP;
         if (want_out) events |= linux.EPOLL.OUT;
 
         var ev = linux.epoll_event{ .events = events, .data = .{ .fd = fd } };
@@ -4969,10 +5495,8 @@ const EventLoop = struct {
         }
 
         const prev = slot.pipelined_data.?;
-        const next = try self.state.allocator.alloc(u8, next_len);
-        @memcpy(next[0..prev.len], prev);
+        const next = try self.state.allocator.realloc(prev, next_len);
         @memcpy(next[prev.len..], extra);
-        self.state.allocator.free(prev);
         slot.pipelined_data = next;
     }
 };
@@ -4986,7 +5510,11 @@ fn relayUpstreamToClientStep(slot: *ConnectionSlot, allocator: std.mem.Allocator
 }
 
 fn queueTlsAppRecords(slot: *ConnectionSlot, allocator: std.mem.Allocator, payload: []u8) !void {
-    return relay_steps.queueTlsAppRecords(slot, allocator, payload, slotQueueClientPair);
+    return relay_steps.queueTlsAppRecords(slot, allocator, payload, slotQueueClientParts);
+}
+
+fn slotQueueClientParts(slot: *ConnectionSlot, _: std.mem.Allocator, parts: []const []const u8) !bool {
+    return queue_io.queueOrWriteParts(slot.client_fd, &slot.client_queue, parts, slot.traffic_upstream_to_client_counter orelse &noop_counter, if (slot.user_metrics) |entry| &entry.upstream_to_client_bytes_total else null);
 }
 
 /// Dummy counter for slots that don't yet have traffic counters attached
@@ -5012,17 +5540,6 @@ fn slotQueueClientPair(slot: *ConnectionSlot, allocator: std.mem.Allocator, firs
         &slot.client_queue,
         first,
         second,
-        slot.traffic_upstream_to_client_counter orelse &noop_counter,
-        if (slot.user_metrics) |entry| &entry.upstream_to_client_bytes_total else null,
-    );
-}
-
-fn slotQueueClientOwned(slot: *ConnectionSlot, allocator: std.mem.Allocator, owned: []u8) !bool {
-    _ = allocator;
-    return queue_io.queueOrWriteOwnedMsg(
-        slot.client_fd,
-        &slot.client_queue,
-        owned,
         slot.traffic_upstream_to_client_counter orelse &noop_counter,
         if (slot.user_metrics) |entry| &entry.upstream_to_client_bytes_total else null,
     );
@@ -5068,10 +5585,6 @@ fn queueClient(self: *ConnectionSlot, allocator: std.mem.Allocator, data: []cons
     return slotQueueClient(self, allocator, data);
 }
 
-fn queueClientOwned(self: *ConnectionSlot, allocator: std.mem.Allocator, data: []u8) !bool {
-    return slotQueueClientOwned(self, allocator, data);
-}
-
 fn queueUpstream(self: *ConnectionSlot, allocator: std.mem.Allocator, data: []const u8) !bool {
     return slotQueueUpstream(self, allocator, data);
 }
@@ -5093,6 +5606,10 @@ fn proxyHandshakeQueueUpstream(loop: *EventLoop, slot: *ConnectionSlot, data: []
 }
 
 fn proxyHandshakeCloseSlot(loop: *EventLoop, slot: *ConnectionSlot, reason: []const u8) void {
+    if (std.mem.eql(u8, reason, "socks5 connect rejected") or std.mem.eql(u8, reason, "http connect rejected")) {
+        loop.cleanupFailedUpstreamConnect(slot);
+        if (loop.tryNextDcEndpoint(slot, error.ConnectionRefused)) return;
+    }
     return loop.closeSlot(slot, reason);
 }
 
@@ -5153,42 +5670,401 @@ fn mpHandshakeFallbackToDirect(loop: *EventLoop, slot: *ConnectionSlot) bool {
     return loop.fallbackFromMiddleProxyToDirect(slot);
 }
 
+test "worker traffic counters batch global writes without losing bytes" {
+    var state: ProxyState = undefined;
+    state.client_to_upstream_bytes_total = .init(100);
+    state.upstream_to_client_bytes_total = .init(200);
+    var loop: EventLoop = undefined;
+    loop.state = &state;
+    loop.traffic_c2s_pending = .init(7);
+    loop.traffic_s2c_pending = .init(11);
+    loop.flushTrafficCounters();
+    loop.flushTrafficCounters();
+    try std.testing.expectEqual(@as(u64, 107), state.client_to_upstream_bytes_total.load(.monotonic));
+    try std.testing.expectEqual(@as(u64, 211), state.upstream_to_client_bytes_total.load(.monotonic));
+    try std.testing.expectEqual(@as(u64, 0), loop.traffic_c2s_pending.load(.monotonic));
+}
+
 test "handshakeInProgress - phases" {
     var slot: ConnectionSlot = undefined;
 
-    const hs_phases = [_]ConnectionPhase{
-        .reading_tls_header,
-        .reading_client_hello_body,
-        .writing_server_hello_first,
-        .desync_wait,
-        .writing_server_hello_rest,
-        .reading_mtproto_tls_header,
-        .reading_mtproto_tls_body,
-        .connecting_upstream,
-        .writing_dc_nonce,
-        .middle_proxy_handshake,
-    };
-    for (hs_phases) |phase| {
-        slot.phase = phase;
-        try std.testing.expect(slot.handshakeInProgress());
+    inline for (@typeInfo(ConnectionPhase).@"enum".fields) |field| {
+        slot.phase = @enumFromInt(field.value);
+        const expected = switch (slot.phase) {
+            .idle, .relaying, .mask_relaying => false,
+            else => true,
+        };
+        try std.testing.expectEqual(expected, slot.handshakeInProgress());
     }
+}
 
-    // Non-handshake phases
-    slot.phase = .idle;
-    try std.testing.expect(!slot.handshakeInProgress());
-    slot.phase = .relaying;
-    try std.testing.expect(!slot.handshakeInProgress());
-    slot.phase = .mask_relaying;
-    try std.testing.expect(!slot.handshakeInProgress());
-    slot.phase = .closing;
-    try std.testing.expect(!slot.handshakeInProgress());
+test "resolved retry exhaustion and overrides preserve masking prebuffer" {
+    const addr = ip4(.{ 192, 0, 2, 1 }, 443);
+    var state: ProxyState = undefined;
+    state.mask_candidates = .init(&.{addr});
+    state.upstream = upstream_mod.Upstream.initSocks5Candidates(&.{addr}, "user", "pass");
+    var loop: EventLoop = undefined;
+    loop.state = &state;
+    var pre = [_]u8{ 1, 2, 3 };
+    var slot = ConnectionSlot{ .mask_prebuffer = &pre, .mask_candidate_next = 0 };
+    try std.testing.expect(!loop.tryNextResolvedEndpoint(&slot, .mask, addr)); // An override never falls back to default.
+    slot.mask_candidate_next = 1;
+    try std.testing.expect(!loop.tryNextResolvedEndpoint(&slot, .mask, addr));
+    try std.testing.expect(!loop.tryNextResolvedEndpoint(&slot, .dc, addr));
+    try std.testing.expectEqualSlices(u8, &pre, slot.mask_prebuffer.?);
+    try std.testing.expectEqual(@as(u8, 0), slot.proxy_candidate_index);
+}
+
+test "connection DNS candidates are frozen copies and retain every override address" {
+    const allocator = std.testing.allocator;
+    var slot: ConnectionSlot = .{};
+    defer slot.resetOwnedBuffers(allocator);
+    const first = ip4(.{ 192, 0, 2, 1 }, 443);
+    const second = ip4(.{ 192, 0, 2, 2 }, 443);
+    var source = net_helpers.AddressCandidates.init(&.{ first, second });
+    try slot.freezeResolvedCandidates(allocator, source);
+    source = .init(&.{second});
+    try std.testing.expectEqual(@as(usize, 2), slot.resolved_candidates.?.len);
+    try std.testing.expect(addressEql(first, slot.resolved_candidates.?.addresses[0]));
+    try std.testing.expect(addressEql(second, slot.resolved_candidates.?.addresses[1]));
+    // A future connection receives the new snapshot; an in-flight retry does not.
+    var next: ConnectionSlot = .{};
+    defer next.resetOwnedBuffers(allocator);
+    try next.freezeResolvedCandidates(allocator, source);
+    try std.testing.expectEqual(@as(usize, 1), next.resolved_candidates.?.len);
+}
+
+test "relay FIN drains more than one read buffer and preserves reverse traffic" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    for ([_]bool{ false, true }) |from_upstream| {
+        var client: [2]i32 = undefined;
+        var upstream_pair: [2]i32 = undefined;
+        try std.testing.expectEqual(posix.E.SUCCESS, linux.errno(linux.socketpair(posix.AF.UNIX, posix.SOCK.STREAM | posix.SOCK.NONBLOCK, 0, &client)));
+        defer for (client) |fd| closeFd(fd);
+        try std.testing.expectEqual(posix.E.SUCCESS, linux.errno(linux.socketpair(posix.AF.UNIX, posix.SOCK.STREAM | posix.SOCK.NONBLOCK, 0, &upstream_pair)));
+        defer for (upstream_pair) |fd| closeFd(fd);
+        var state: ProxyState = undefined;
+        state.allocator = std.testing.allocator;
+        var loop: EventLoop = undefined;
+        loop.state = &state;
+        loop.epoll_fd = try epollCreate();
+        defer closeFd(loop.epoll_fd);
+        var slot = ConnectionSlot{ .phase = .mask_relaying, .client_fd = client[0], .upstream_fd = upstream_pair[0] };
+        slot.client_queue.allocator = std.testing.allocator;
+        slot.upstream_queue.allocator = std.testing.allocator;
+        defer slot.client_queue.deinit();
+        defer slot.upstream_queue.deinit();
+        try loop.addClientFd(&slot, slot.client_fd, true, false);
+        try loop.addUpstreamFd(&slot, slot.upstream_fd, true, false);
+        const sender = if (from_upstream) upstream_pair[1] else client[1];
+        const receiver = if (from_upstream) client[1] else upstream_pair[1];
+        const source_fd = if (from_upstream) slot.upstream_fd else slot.client_fd;
+        const reverse_fd = if (from_upstream) slot.client_fd else slot.upstream_fd;
+        const send_buffer: u32 = 4096;
+        try posix.setsockopt(reverse_fd, posix.SOL.SOCKET, linux.SO.SNDBUF, std.mem.asBytes(&send_buffer));
+        const payload = [_]u8{0x5a} ** (read_buf_size * 2 + 17);
+        try std.testing.expectEqual(payload.len, linux.write(sender, &payload, payload.len));
+        try std.testing.expectEqual(posix.E.SUCCESS, linux.errno(linux.shutdown(sender, linux.SHUT.WR)));
+        var received: usize = 0;
+        var buffer: [read_buf_size]u8 = undefined;
+        var reached_eof = false;
+        for (0..16) |_| {
+            loop.processSlotEvent(&slot, source_fd, linux.EPOLL.IN | linux.EPOLL.RDHUP);
+            loop.processSlotEvent(&slot, reverse_fd, linux.EPOLL.OUT);
+            while (true) {
+                const n = posix.read(receiver, &buffer) catch |err| switch (err) {
+                    error.WouldBlock => break,
+                    else => return err,
+                };
+                if (n == 0) {
+                    reached_eof = true;
+                    break;
+                }
+                try std.testing.expect(std.mem.allEqual(u8, buffer[0..n], 0x5a));
+                received += n;
+            }
+            if (reached_eof) break;
+        }
+        try std.testing.expectEqual(payload.len, received);
+        try std.testing.expect(reached_eof);
+        try std.testing.expectEqual(ConnectionPhase.mask_relaying, slot.phase);
+        try std.testing.expectEqual(@as(usize, 5), linux.write(receiver, "reply", 5));
+        loop.processSlotEvent(&slot, reverse_fd, linux.EPOLL.IN);
+        const reply_len = try posix.read(sender, &buffer);
+        try std.testing.expectEqualStrings("reply", buffer[0..reply_len]);
+    }
+}
+
+test "middle proxy response rejection falls back without starting relay" {
+    const Harness = struct {
+        state: *ProxyState,
+        payload: [32]u8 = @splat(0),
+        response_len: usize = 32,
+        fallbacks: usize = 0,
+        closed: bool = false,
+        started: bool = false,
+        fn read(self: *@This(), _: *ConnectionSlot, _: bool) !?[]const u8 {
+            return self.payload[0..self.response_len];
+        }
+        fn write(_: *@This(), _: *ConnectionSlot, _: []const u8, _: bool) !void {}
+        fn lock(_: *@This()) void {}
+        fn start(self: *@This(), _: *ConnectionSlot) void {
+            self.started = true;
+        }
+        fn close(self: *@This(), _: *ConnectionSlot, _: []const u8) void {
+            self.closed = true;
+        }
+        fn fallback(self: *@This(), _: *ConnectionSlot) bool {
+            self.fallbacks += 1;
+            return true;
+        }
+    };
+    var state: ProxyState = undefined;
+    var harness = Harness{ .state = &state };
+    var slot = ConnectionSlot{};
+    for ([_]MiddleProxyHandshakeStep{ .waiting_rpc_nonce_response, .waiting_rpc_handshake_response }) |step| {
+        for ([_]usize{ 0, 31, 32 }) |len| {
+            slot.mp_step = step;
+            harness.response_len = len;
+            middle_proxy_handshake.onReadable(&harness, &slot, Harness.read, Harness.write, Harness.lock, Harness.lock, Harness.start, Harness.close, Harness.fallback);
+        }
+    }
+    try std.testing.expectEqual(@as(usize, 6), harness.fallbacks);
+    try std.testing.expect(!harness.closed);
+    try std.testing.expect(!harness.started);
+    if (builtin.os.tag == .linux) {
+        // A SOCKS transport may be IPv6 while the logical MP endpoint is IPv4.
+        // The announced NAT address must follow the latter, not getsockname.
+        const fd_result = linux.socket(posix.AF.INET6, posix.SOCK.STREAM, 0);
+        try std.testing.expectEqual(posix.E.SUCCESS, linux.errno(fd_result));
+        const fd: i32 = @intCast(fd_result);
+        defer closeFd(fd);
+        state.allocator = std.testing.allocator;
+        state.config = .{ .users = std.StringHashMap([16]u8).init(std.testing.allocator), .direct_users = std.StringHashMap(void).init(std.testing.allocator) };
+        state.middle_proxy_nat_ip4 = .{ 203, 0, 113, 7 };
+        slot.upstream_fd = fd;
+        slot.current_upstream_addr = ip4(.{ 149, 154, 167, 50 }, 443);
+        slot.peer_addr = ip4(.{ 192, 0, 2, 8 }, 1234);
+        slot.mp_secret_len = 32;
+        @memset(slot.mp_secret[0..32], 0x42);
+        slot.mp_nonce = @splat(0x11);
+        slot.mp_timestamp = 0x12345678;
+        slot.mp_step = .waiting_rpc_nonce_response;
+        @memcpy(harness.payload[0..4], &middleproxy.rpc_nonce_req);
+        @memcpy(harness.payload[4..8], slot.mp_secret[0..4]);
+        @memcpy(harness.payload[8..12], &middleproxy.rpc_crypto_aes);
+        @memset(harness.payload[16..32], 0x22);
+        middle_proxy_handshake.onReadable(&harness, &slot, Harness.read, Harness.write, Harness.lock, Harness.lock, Harness.start, Harness.close, Harness.fallback);
+        try std.testing.expectEqual(MiddleProxyHandshakeStep.waiting_rpc_handshake_response, slot.mp_step);
+        try std.testing.expectEqual(@as(usize, 6), harness.fallbacks);
+        const expected_enc = try middleproxy.getAesKeyAndIv(&([_]u8{0x22} ** 16), &slot.mp_nonce, &.{ 0x78, 0x56, 0x34, 0x12 }, &.{ 50, 167, 154, 149 }, &.{ 0, 0 }, "CLIENT", &.{ 7, 113, 0, 203 }, &.{ 0xbb, 1 }, slot.mp_secret[0..32], null, null);
+        const expected_dec = try middleproxy.getAesKeyAndIv(&([_]u8{0x22} ** 16), &slot.mp_nonce, &.{ 0x78, 0x56, 0x34, 0x12 }, &.{ 50, 167, 154, 149 }, &.{ 0, 0 }, "SERVER", &.{ 7, 113, 0, 203 }, &.{ 0xbb, 1 }, slot.mp_secret[0..32], null, null);
+        try std.testing.expectEqualSlices(u8, &expected_enc[0], &slot.mp_enc.?.key);
+        try std.testing.expectEqualSlices(u8, &expected_enc[1], &slot.mp_enc.?.iv);
+        try std.testing.expectEqualSlices(u8, &expected_dec[0], &slot.mp_dec.?.key);
+        try std.testing.expectEqualSlices(u8, &expected_dec[1], &slot.mp_dec.?.iv);
+        @memcpy(harness.payload[0..4], &middleproxy.rpc_handshake);
+        @memcpy(harness.payload[20..32], "IPIPPRPDTIME");
+        middle_proxy_handshake.onReadable(&harness, &slot, Harness.read, Harness.write, Harness.lock, Harness.lock, Harness.start, Harness.close, Harness.fallback);
+        try std.testing.expect(harness.started);
+        try std.testing.expectEqual(MiddleProxyHandshakeStep.done, slot.mp_step);
+        defer slot.middle_ctx.?.deinit(std.testing.allocator);
+        try std.testing.expectEqualSlices(u8, &.{ 203, 0, 113, 7 }, slot.middle_ctx.?.our_ip_port[12..16]);
+    }
+}
+
+test "multicore handshake budget is bounded and released exactly once" {
+    var state: ProxyState = undefined;
+    state.config = .{ .users = std.StringHashMap([16]u8).init(std.testing.allocator), .direct_users = std.StringHashMap(void).init(std.testing.allocator) };
+    state.config.max_connections = 10;
+    state.handshakes_inflight = .init(0);
+    state.stats_dropped_hs_budget = .init(0);
+    var loop: EventLoop = undefined;
+    loop.state = &state;
+    var slots = [_]ConnectionSlot{.{}} ** 8;
+    const Worker = struct {
+        fn run(shared: *EventLoop, slot: *ConnectionSlot) void {
+            if (shared.reserveHandshakeBudget(slot)) {
+                std.debug.assert(shared.reserveHandshakeBudget(slot));
+            }
+        }
+    };
+    var threads: [8]std.Thread = undefined;
+    for (&threads, &slots) |*thread, *slot| thread.* = try std.Thread.spawn(.{}, Worker.run, .{ &loop, slot });
+    for (threads) |thread| thread.join();
+    try std.testing.expectEqual(@as(u64, 3), state.handshakes_inflight.load(.monotonic));
+    try std.testing.expectEqual(@as(u64, 5), state.stats_dropped_hs_budget.load(.monotonic));
+    for (&slots) |*slot| {
+        loop.releaseHandshakeBudget(slot);
+        loop.releaseHandshakeBudget(slot);
+    }
+    try std.testing.expectEqual(@as(u64, 0), state.handshakes_inflight.load(.monotonic));
+    // Refusal must happen before touching config_path or allocator.
+    state.effective_workers = 2;
+    loop.reloadConfigFromDisk();
+    try std.testing.expectEqual(@as(u32, 10), state.config.max_connections);
+}
+
+test "SOCKS response state machine authenticates and connects logical destination" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const Harness = struct {
+        state: *ProxyState,
+        closed: bool = false,
+        complete: bool = false,
+        message: [512]u8 = undefined,
+        message_len: usize = 0,
+        fn queue(self: *@This(), _: *ConnectionSlot, bytes: []const u8) !bool {
+            @memcpy(self.message[0..bytes.len], bytes);
+            self.message_len = bytes.len;
+            return true;
+        }
+        fn close(self: *@This(), _: *ConnectionSlot, _: []const u8) void {
+            self.closed = true;
+        }
+        fn done(self: *@This(), _: *ConnectionSlot) void {
+            self.complete = true;
+        }
+    };
+    var fds: [2]i32 = undefined;
+    try std.testing.expectEqual(posix.E.SUCCESS, linux.errno(linux.socketpair(posix.AF.UNIX, posix.SOCK.STREAM | posix.SOCK.NONBLOCK, 0, &fds)));
+    defer for (fds) |fd| closeFd(fd);
+    var state: ProxyState = undefined;
+    state.allocator = std.testing.allocator;
+    state.upstream = upstream_mod.Upstream.initSocks5(ip4(.{ 127, 0, 0, 1 }, 1080), "user", "pass");
+    var harness = Harness{ .state = &state };
+    var slot = ConnectionSlot{ .upstream_fd = fds[0], .proxy_target_addr = ip4(.{ 149, 154, 167, 50 }, 443) };
+    defer if (slot.proxy_handshake_buf) |buf| std.testing.allocator.destroy(buf);
+    proxy_upstream_handshake.startSocks5(&harness, &slot, Harness.queue, Harness.close);
+    try std.testing.expectEqual(ConnectionPhase.proxy_socks5_greeting_resp, slot.phase);
+    // Split the greeting across readable events; no premature phase advance.
+    try std.testing.expectEqual(@as(usize, 1), linux.write(fds[1], &.{5}, 1));
+    proxy_upstream_handshake.onSocks5Readable(&harness, &slot, Harness.queue, Harness.close, Harness.done);
+    try std.testing.expectEqual(ConnectionPhase.proxy_socks5_greeting_resp, slot.phase);
+    try std.testing.expectEqual(@as(usize, 1), linux.write(fds[1], &.{2}, 1));
+    proxy_upstream_handshake.onSocks5Readable(&harness, &slot, Harness.queue, Harness.close, Harness.done);
+    try std.testing.expectEqual(ConnectionPhase.proxy_socks5_auth_resp, slot.phase);
+    try std.testing.expectEqualSlices(u8, &.{ 1, 4, 'u', 's', 'e', 'r', 4, 'p', 'a', 's', 's' }, harness.message[0..harness.message_len]);
+    try std.testing.expectEqual(@as(usize, 2), linux.write(fds[1], &.{ 1, 0 }, 2));
+    proxy_upstream_handshake.onSocks5Readable(&harness, &slot, Harness.queue, Harness.close, Harness.done);
+    try std.testing.expectEqual(ConnectionPhase.proxy_socks5_connect_resp, slot.phase);
+    try std.testing.expectEqualSlices(u8, &.{ 149, 154, 167, 50 }, harness.message[4..8]);
+    try std.testing.expectEqual(@as(usize, 10), linux.write(fds[1], &.{ 5, 0, 0, 1, 127, 0, 0, 1, 0, 80 }, 10));
+    proxy_upstream_handshake.onSocks5Readable(&harness, &slot, Harness.queue, Harness.close, Harness.done);
+    try std.testing.expect(harness.complete);
+    try std.testing.expect(!harness.closed);
+    state.upstream = upstream_mod.Upstream.initHttpConnect(ip4(.{ 127, 0, 0, 1 }, 8080), "user", "pass");
+    harness.complete = false;
+    proxy_upstream_handshake.startHttpConnect(&harness, &slot, Harness.queue, Harness.close);
+    try std.testing.expectEqual(ConnectionPhase.proxy_http_connect_resp, slot.phase);
+    const prefix = "HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 200 OK\r\nX-Padding: ";
+    try std.testing.expectEqual(prefix.len, linux.write(fds[1], prefix, prefix.len));
+    proxy_upstream_handshake.onHttpConnectReadable(&harness, &slot, Harness.close, Harness.done);
+    try std.testing.expect(!harness.complete);
+    const padding = [_]u8{'x'} ** 5000;
+    try std.testing.expectEqual(padding.len, linux.write(fds[1], &padding, padding.len));
+    proxy_upstream_handshake.onHttpConnectReadable(&harness, &slot, Harness.close, Harness.done);
+    try std.testing.expect(!harness.complete);
+    try std.testing.expectEqual(@as(usize, 4), linux.write(fds[1], "\r\n\r\n", 4));
+    proxy_upstream_handshake.onHttpConnectReadable(&harness, &slot, Harness.close, Harness.done);
+    try std.testing.expect(harness.complete);
+    try std.testing.expect(!harness.closed);
+}
+
+test "middle proxy fetched snapshot merges partial routes and rotates secret atomically" {
+    const cfg = try Config.parse(std.testing.allocator, "[server]\nport=443\nmax_connections=32\nmiddle_proxy_nat_ip=\"192.0.2.1\"\n[censorship]\nmask=false\n[access.users]\nalice=\"00000000000000000000000000000001\"\n");
+    var state = try ProxyState.init(std.testing.allocator, cfg, "/tmp/mtproto-snapshot-test.toml");
+    defer state.deinit();
+    const before = state.getMiddleProxySnapshot();
+    const secret = [_]u8{0xa5} ** 32;
+    const partial =
+        "proxy_for 1 192.0.2.11:443;\n" ++
+        "proxy_for 4 192.0.2.41:443;\n" ++
+        "proxy_for 4 192.0.2.42:8443;\n" ++
+        "proxy_for -4 192.0.2.44:443;\n" ++
+        "proxy_for 203 192.0.2.203:443;\n" ++
+        "proxy_for -203 192.0.2.204:443;\n";
+    try state.mergeMiddleProxyAssets(partial, &secret, false);
+    const after = state.getMiddleProxySnapshot();
+    try std.testing.expect(addressEql(after.addrs_primary[0], try Address.parse("192.0.2.11", 443)));
+    for ([_]usize{ 1, 2, 4 }) |i| {
+        try std.testing.expect(addressEql(before.addrs_primary[i], after.addrs_primary[i]));
+    }
+    for ([_]usize{ 0, 1, 2, 4 }) |i| {
+        try std.testing.expect(addressEql(before.addrs_media_primary[i], after.addrs_media_primary[i]));
+    }
+    try std.testing.expectEqual(@as(usize, 2), after.addrs_dc4_len);
+    try std.testing.expect(addressEql(after.addrs_dc4[0], after.addrs_primary[3]));
+    try std.testing.expect(addressEql(after.addrs_dc4[1], try Address.parse("192.0.2.42", 8443)));
+    try std.testing.expectEqual(@as(usize, 1), after.addrs_media_dc4_len);
+    try std.testing.expect(addressEql(after.addrs_media_dc4[0], after.addrs_media_primary[3]));
+    try std.testing.expectEqual(@as(usize, 1), after.addrs_203_len);
+    try std.testing.expect(addressEql(after.addrs_203[0], try Address.parse("192.0.2.204", 443)));
+    try std.testing.expect(addressEql(after.addr_203, after.addrs_203[0]));
+    try std.testing.expectEqualSlices(u8, &secret, state.middle_proxy_secret[0..state.middle_proxy_secret_len]);
+
+    // Empty route data preserves the last good snapshot while a shorter secret
+    // replaces the old one and wipes its now-unused tail.
+    const shorter_secret = [_]u8{0x5a} ** 16;
+    try state.mergeMiddleProxyAssets("", &shorter_secret, false);
+    const retained = state.getMiddleProxySnapshot();
+    try std.testing.expect(addressesEqual(&after.addrs_primary, &retained.addrs_primary));
+    try std.testing.expect(addressesEqual(&after.addrs_media_primary, &retained.addrs_media_primary));
+    try std.testing.expect(addressesEqual(after.addrs_dc4[0..after.addrs_dc4_len], retained.addrs_dc4[0..retained.addrs_dc4_len]));
+    try std.testing.expect(addressesEqual(after.addrs_media_dc4[0..after.addrs_media_dc4_len], retained.addrs_media_dc4[0..retained.addrs_media_dc4_len]));
+    try std.testing.expect(addressesEqual(after.addrs_203[0..after.addrs_203_len], retained.addrs_203[0..retained.addrs_203_len]));
+    try std.testing.expect(addressEql(after.addr_203, retained.addr_203));
+    try std.testing.expectEqualSlices(u8, &shorter_secret, state.middle_proxy_secret[0..state.middle_proxy_secret_len]);
+    for (state.middle_proxy_secret[shorter_secret.len..]) |byte| try std.testing.expectEqual(@as(u8, 0), byte);
+
+    // Invalid secrets reject otherwise valid changed routes without a partial
+    // commit of endpoints or destruction of the previous usable secret.
+    const changed_routes = "proxy_for 1 192.0.2.99:443;\n";
+    const oversized = [_]u8{1} ** 257;
+    for ([_][]const u8{ "short", &oversized }) |bad_secret| {
+        try std.testing.expectError(error.BadMiddleProxySecret, state.mergeMiddleProxyAssets(changed_routes, bad_secret, false));
+        const rejected = state.getMiddleProxySnapshot();
+        try std.testing.expect(addressesEqual(&retained.addrs_primary, &rejected.addrs_primary));
+        try std.testing.expectEqualSlices(u8, &shorter_secret, state.middle_proxy_secret[0..state.middle_proxy_secret_len]);
+    }
+}
+
+test "disk reload applies hot settings without replacing startup capacity" {
+    const allocator = std.testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const path = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}/config.toml", .{tmp.sub_path});
+    const initial = "[server]\nport=443\nmax_connections=64\nmiddle_proxy_nat_ip=\"192.0.2.1\"\n[censorship]\nmask=false\n[access.users]\nalice=\"00000000000000000000000000000001\"\n";
+    const cfg = try Config.parse(allocator, initial);
+    var state = try ProxyState.init(allocator, cfg, path);
+    defer state.deinit();
+    state.effective_workers = 1;
+    var loop: EventLoop = undefined;
+    loop.state = &state;
+    loop.pool = try ConnectionPool.init(allocator, 64);
+    defer loop.pool.deinit();
+    const next = "[server]\nport=8443\nmax_connections=128\nidle_timeout_sec=123\nmiddle_proxy_nat_ip=\"192.0.2.1\"\n[censorship]\nmask=false\n[access.users]\nalice=\"00000000000000000000000000000002\"\n";
+    try tmp.dir.writeFile(io, .{ .sub_path = "config.toml", .data = next });
+    loop.reloadConfigFromDisk();
+    try std.testing.expectEqual(@as(u16, 443), state.config.port);
+    try std.testing.expectEqual(@as(u32, 64), state.config.max_connections);
+    try std.testing.expectEqual(@as(u32, 123), state.config.idle_timeout_sec);
+    try std.testing.expectEqual(@as(u8, 2), state.user_secrets[0].secret[15]);
+    try tmp.dir.writeFile(io, .{ .sub_path = "config.toml", .data = "[server]\nmax_connections=32\n[censorship]\nmask=false\n[access.users]\nalice=\"00000000000000000000000000000002\"\n" });
+    loop.reloadConfigFromDisk();
+    try std.testing.expectEqual(@as(u32, 32), state.config.max_connections);
+    try std.testing.expectEqual(@as(usize, 64), loop.pool.slots.len);
 }
 
 test "ProxyState access reload keeps active metrics safe" {
     const allocator = std.testing.allocator;
 
     const initial_cfg = try Config.parse(allocator,
+        \\[censorship]
+        \\mask = false
         \\[server]
+        \\middle_proxy_nat_ip = "192.0.2.1"
         \\port = 443
         \\
         \\[access.users]
@@ -5247,7 +6123,10 @@ test "ProxyState per-user unique-IP quota is allocated per config and survives r
     // `later` has a cap but no secret yet: it is added by the reload below, which
     // proves the quota comes from the STARTUP config rather than from the reloaded one.
     const initial_cfg = try Config.parse(allocator,
+        \\[censorship]
+        \\mask = false
         \\[server]
+        \\middle_proxy_nat_ip = "192.0.2.1"
         \\port = 443
         \\
         \\[access.users]
@@ -5306,9 +6185,11 @@ test "ProxyState per-user unique-IP quota is allocated per config and survives r
 fn reloadAccessUsersInThread(
     state: *ProxyState,
     next_cfg: *Config,
+    started: *std.atomic.Value(bool),
     done: *std.atomic.Value(bool),
     failed: *std.atomic.Value(bool),
 ) void {
+    started.store(true, .release);
     state.reloadAccessUsersForTest(next_cfg) catch {
         failed.store(true, .release);
     };
@@ -5319,7 +6200,10 @@ test "ProxyState access reload waits for metrics readers" {
     const allocator = std.testing.allocator;
 
     const initial_cfg = try Config.parse(allocator,
+        \\[censorship]
+        \\mask = false
         \\[server]
+        \\middle_proxy_nat_ip = "192.0.2.1"
         \\port = 443
         \\
         \\[access.users]
@@ -5340,10 +6224,12 @@ test "ProxyState access reload waits for metrics readers" {
 
     state.lockUserMetricsForReadForTest();
 
+    var started = std.atomic.Value(bool).init(false);
     var done = std.atomic.Value(bool).init(false);
     var failed = std.atomic.Value(bool).init(false);
-    const thread = try std.Thread.spawn(.{}, reloadAccessUsersInThread, .{ &state, &next_cfg, &done, &failed });
+    const thread = try std.Thread.spawn(.{}, reloadAccessUsersInThread, .{ &state, &next_cfg, &started, &done, &failed });
 
+    while (!started.load(.acquire)) std.atomic.spinLoopHint();
     sleepNs(20 * std.time.ns_per_ms);
     const completed_while_reader_locked = done.load(.acquire);
 

--- a/src/proxy/proxy_protocol.zig
+++ b/src/proxy/proxy_protocol.zig
@@ -67,6 +67,7 @@ fn parseV1(buf: []const u8) ParseResult {
     const src_port = std.fmt.parseInt(u16, src_port_s, 10) catch return .invalid;
 
     const addr = net.IpAddress.parse(src_ip, src_port) catch return .invalid;
+    if (std.mem.eql(u8, proto, "TCP4") != (addr == .ip4)) return .invalid;
     return .{ .ok = .{ .consumed = consumed, .src = addr } };
 }
 
@@ -76,6 +77,7 @@ fn parseV2(buf: []const u8) ParseResult {
     const ver_cmd = buf[12];
     if (ver_cmd >> 4 != 0x2) return .invalid; // version must be 2
     const cmd = ver_cmd & 0x0f; // 0=LOCAL, 1=PROXY
+    if (cmd > 1) return .invalid;
     const fam = buf[13];
     const addr_len = std.mem.readInt(u16, buf[14..16], .big);
     const total = 16 + @as(usize, addr_len);
@@ -97,7 +99,8 @@ fn parseV2(buf: []const u8) ParseResult {
             const port = std.mem.readInt(u16, ab[32..34], .big);
             return .{ .ok = .{ .consumed = total, .src = net_helpers.ip6(ip, port, 0, 0) } };
         },
-        else => return .{ .ok = .{ .consumed = total, .src = null } }, // unspec / unix: keep peer
+        0x00 => return .{ .ok = .{ .consumed = total, .src = null } },
+        else => return .invalid,
     }
 }
 

--- a/src/proxy/proxy_upstream_handshake.zig
+++ b/src/proxy/proxy_upstream_handshake.zig
@@ -19,7 +19,7 @@ fn sendSocks5Auth(
     const username = loop.state.upstream.proxyUsername() orelse "";
     const password = loop.state.upstream.proxyPassword() orelse "";
 
-    const msg = socks5.buildAuthRequest(&slot.proxy_handshake_buf, username, password);
+    const msg = socks5.buildAuthRequest(slot.proxy_handshake_buf.?, username, password);
     if (msg.len == 0) {
         close_slot(loop, slot, "socks5 auth request build failed");
         return;
@@ -49,7 +49,7 @@ fn sendSocks5Connect(
         return;
     };
 
-    const msg = socks5.buildConnectRequest(&slot.proxy_handshake_buf, target);
+    const msg = socks5.buildConnectRequest(slot.proxy_handshake_buf.?, target);
     if (msg.len == 0) {
         close_slot(loop, slot, "socks5 connect request build failed");
         return;
@@ -74,8 +74,15 @@ pub fn startSocks5(
     comptime queue_upstream: fn (@TypeOf(loop), @TypeOf(slot), []const u8) anyerror!bool,
     comptime close_slot: fn (@TypeOf(loop), @TypeOf(slot), []const u8) void,
 ) void {
+    if (slot.proxy_handshake_buf == null) {
+        slot.proxy_handshake_buf = loop.state.allocator.create([http_connect.max_response_size]u8) catch {
+            close_slot(loop, slot, "proxy handshake allocation failed");
+            return;
+        };
+    }
+
     const needs_auth = loop.state.upstream.socks5.needsAuth();
-    const msg = socks5.buildGreeting(&slot.proxy_handshake_buf, needs_auth);
+    const msg = socks5.buildGreeting(slot.proxy_handshake_buf.?, needs_auth);
     if (msg.len == 0) {
         close_slot(loop, slot, "socks5 greeting build failed");
         return;
@@ -103,7 +110,7 @@ pub fn onSocks5Readable(
 ) void {
     // Read into proxy_handshake_buf at current pos
     const pos: usize = slot.proxy_handshake_pos;
-    const space = slot.proxy_handshake_buf[pos..];
+    const space = slot.proxy_handshake_buf.?[pos..];
     if (space.len == 0) {
         close_slot(loop, slot, "socks5 response buffer overflow");
         return;
@@ -122,7 +129,7 @@ pub fn onSocks5Readable(
     }
 
     slot.proxy_handshake_pos += @intCast(n);
-    const have = slot.proxy_handshake_buf[0..slot.proxy_handshake_pos];
+    const have = slot.proxy_handshake_buf.?[0..slot.proxy_handshake_pos];
 
     switch (slot.phase) {
         .proxy_socks5_greeting_resp => {
@@ -147,6 +154,10 @@ pub fn onSocks5Readable(
                     sendSocks5Connect(loop, slot, queue_upstream, close_slot);
                 },
                 .username_password => {
+                    if (loop.state.upstream.proxyUsername() == null) {
+                        close_slot(loop, slot, "socks5 selected unoffered authentication method");
+                        return;
+                    }
                     sendSocks5Auth(loop, slot, queue_upstream, close_slot);
                 },
                 .no_acceptable => {
@@ -219,6 +230,13 @@ pub fn startHttpConnect(
     comptime queue_upstream: fn (@TypeOf(loop), @TypeOf(slot), []const u8) anyerror!bool,
     comptime close_slot: fn (@TypeOf(loop), @TypeOf(slot), []const u8) void,
 ) void {
+    if (slot.proxy_handshake_buf == null) {
+        slot.proxy_handshake_buf = loop.state.allocator.create([http_connect.max_response_size]u8) catch {
+            close_slot(loop, slot, "proxy handshake allocation failed");
+            return;
+        };
+    }
+
     const target = slot.proxy_target_addr orelse {
         close_slot(loop, slot, "http proxy no target addr");
         return;
@@ -228,7 +246,7 @@ pub fn startHttpConnect(
     const password = loop.state.upstream.proxyPassword();
 
     const msg = http_connect.buildConnectRequest(
-        &slot.proxy_handshake_buf,
+        slot.proxy_handshake_buf.?,
         target,
         username,
         password,
@@ -258,7 +276,7 @@ pub fn onHttpConnectReadable(
     comptime handshake_complete: fn (@TypeOf(loop), @TypeOf(slot)) void,
 ) void {
     const pos: usize = slot.proxy_handshake_pos;
-    const space = slot.proxy_handshake_buf[pos..];
+    const space = slot.proxy_handshake_buf.?[pos..];
     if (space.len == 0) {
         close_slot(loop, slot, "http connect response buffer overflow");
         return;
@@ -277,7 +295,7 @@ pub fn onHttpConnectReadable(
     }
 
     slot.proxy_handshake_pos += @intCast(n);
-    const have = slot.proxy_handshake_buf[0..slot.proxy_handshake_pos];
+    const have = slot.proxy_handshake_buf.?[0..slot.proxy_handshake_pos];
 
     const result = http_connect.parseResponse(have) orelse return; // need more
 

--- a/src/proxy/queue_io.zig
+++ b/src/proxy/queue_io.zig
@@ -58,6 +58,7 @@ pub fn queueOrWriteMsg(
             return err;
         };
 
+        if (n == 0) return error.ConnectionReset;
         noteTraffic(counter, n);
         noteTrafficOptional(user_counter, n);
         if (n == data.len) return true;
@@ -124,47 +125,32 @@ pub fn queueOrWriteMsgPair(
     return false;
 }
 
-pub fn queueOrWriteOwnedMsg(
-    fd: posix.fd_t,
-    queue: *MessageQueue,
-    owned: []u8,
-    counter: *std.atomic.Value(u64),
-    user_counter: ?*std.atomic.Value(u64),
-) !bool {
-    if (owned.len == 0) {
-        queue.allocator.free(owned);
-        return true;
-    }
-
+pub fn queueOrWriteParts(fd: posix.fd_t, queue: *MessageQueue, parts: []const []const u8, counter: *std.atomic.Value(u64), user_counter: ?*std.atomic.Value(u64)) !bool {
+    if (parts.len > max_scatter_parts) return error.TooManyParts;
+    var written: usize = 0;
     if (queue.isEmpty()) {
-        const n = writeFd(fd, owned) catch |err| {
-            if (err == error.WouldBlock) {
-                try queue.appendOwned(owned);
-                return false;
-            }
-            queue.allocator.free(owned);
-            return err;
-        };
-
-        noteTraffic(counter, n);
-        noteTrafficOptional(user_counter, n);
-        if (n == owned.len) {
-            queue.allocator.free(owned);
-            return true;
+        var iovecs: [max_scatter_parts]posix.iovec_const = undefined;
+        var total: usize = 0;
+        for (parts, 0..) |part, i| {
+            iovecs[i] = .{ .base = part.ptr, .len = part.len };
+            total += part.len;
         }
-
-        const remaining = owned[n..];
-        // Free `owned` on the appendCopy error path too — `try` here would leak it (every
-        // other exit frees it). Matches the OOM-safety of the sibling write helpers.
-        queue.appendCopy(remaining) catch |err| {
-            queue.allocator.free(owned);
-            return err;
+        if (total == 0) return true;
+        written = writevFd(fd, iovecs[0..parts.len]) catch |err| {
+            if (err != error.WouldBlock) return err;
+            for (parts) |part| try queue.appendCopy(part);
+            return false;
         };
-        queue.allocator.free(owned);
-        return false;
+        if (written == 0) return error.ConnectionReset;
+        noteTraffic(counter, written);
+        noteTrafficOptional(user_counter, written);
+        if (written == total) return true;
     }
-
-    try queue.appendOwned(owned);
+    for (parts) |part| {
+        const skip = @min(written, part.len);
+        written -= skip;
+        try queue.appendCopy(part[skip..]);
+    }
     return false;
 }
 

--- a/src/proxy/relay_steps.zig
+++ b/src/proxy/relay_steps.zig
@@ -11,6 +11,45 @@ pub const RelayProgress = enum {
     forwarded,
 };
 
+test "TLS relay chunk parser handles every TCP split across multiple records" {
+    const Cipher = struct {
+        fn apply(_: *@This(), _: []u8) void {}
+    };
+    const Mp = struct {
+        fn encapsulateC2S(_: *@This(), data: []u8, _: []u8) ![]u8 {
+            return data;
+        }
+    };
+    const Slot = struct {
+        relay_tls_hdr: [5]u8 = undefined,
+        relay_tls_hdr_pos: u8 = 0,
+        relay_tls_body_pos: u16 = 0,
+        relay_tls_body_len: u16 = 0,
+        relay_record_type: u8 = 0,
+        client_decryptor: ?Cipher = null,
+        tg_encryptor: ?Cipher = .{},
+        middle_ctx: ?Mp = null,
+        c2s_bytes: usize = 0,
+        output: [5]u8 = undefined,
+        count: usize = 0,
+        fn queue(self: *@This(), _: std.mem.Allocator, data: []const u8) !bool {
+            @memcpy(self.output[self.count..][0..data.len], data);
+            self.count += data.len;
+            return true;
+        }
+    };
+    const input = [_]u8{ 0x17, 3, 3, 0, 3, 'a', 'b', 'c', 0x14, 3, 3, 0, 1, 1, 0x17, 3, 3, 0, 2, 'd', 'e' };
+    for (1..input.len) |split| {
+        var data = input;
+        var slot = Slot{};
+        _ = try consumeClientTlsBytes(&slot, std.testing.allocator, null, data[0..split], Slot.queue);
+        _ = try consumeClientTlsBytes(&slot, std.testing.allocator, null, data[split..], Slot.queue);
+        try std.testing.expectEqualStrings("abcde", &slot.output);
+        try std.testing.expectEqual(@as(usize, 5), slot.c2s_bytes);
+        try std.testing.expectEqual(@as(u8, 0), slot.relay_tls_hdr_pos);
+    }
+}
+
 pub fn relayClientToUpstreamStep(
     slot: anytype,
     allocator: std.mem.Allocator,
@@ -18,88 +57,63 @@ pub fn relayClientToUpstreamStep(
     read_buf: []u8,
     comptime queue_upstream: fn (@TypeOf(slot), std.mem.Allocator, []const u8) anyerror!bool,
 ) !RelayProgress {
-    var consumed_any = false;
+    const n = posix.read(slot.client_fd, read_buf) catch |err| {
+        if (err == error.WouldBlock) return .none;
+        return err;
+    };
+    if (n == 0) return error.EndOfStream;
+    return consumeClientTlsBytes(slot, allocator, mp_c2s_scratch, read_buf[0..n], queue_upstream);
+}
 
-    while (true) {
+/// Consume an arbitrary TCP chunk, retaining only incomplete TLS header/body positions.
+fn consumeClientTlsBytes(
+    slot: anytype,
+    allocator: std.mem.Allocator,
+    mp_c2s_scratch: ?[]u8,
+    data: []u8,
+    comptime queue_upstream: fn (@TypeOf(slot), std.mem.Allocator, []const u8) anyerror!bool,
+) !RelayProgress {
+    var pos: usize = 0;
+    var forwarded = false;
+    while (pos < data.len) {
         if (slot.relay_tls_hdr_pos < 5) {
-            const n = posix.read(slot.client_fd, slot.relay_tls_hdr[slot.relay_tls_hdr_pos..]) catch |err| {
-                if (err == error.WouldBlock) return if (consumed_any) .partial else .none;
-                return err;
-            };
-            if (n == 0) return error.EndOfStream;
-            consumed_any = true;
-            slot.relay_tls_hdr_pos += @intCast(n);
-
-            if (slot.relay_tls_hdr_pos < 5) return .partial;
-
+            const take = @min(5 - @as(usize, slot.relay_tls_hdr_pos), data.len - pos);
+            @memcpy(slot.relay_tls_hdr[slot.relay_tls_hdr_pos..][0..take], data[pos..][0..take]);
+            slot.relay_tls_hdr_pos += @intCast(take);
+            pos += take;
+            if (slot.relay_tls_hdr_pos < 5) break;
             slot.relay_record_type = slot.relay_tls_hdr[0];
             slot.relay_tls_body_len = std.mem.readInt(u16, slot.relay_tls_hdr[3..5], .big);
             slot.relay_tls_body_pos = 0;
-
-            if (slot.relay_record_type == constants.tls_record_alert) return error.ConnectionReset;
             if (slot.relay_record_type != constants.tls_record_change_cipher and
-                slot.relay_record_type != constants.tls_record_application)
-            {
+                slot.relay_record_type != constants.tls_record_application) return error.ConnectionReset;
+            if (slot.relay_tls_body_len == 0 or slot.relay_tls_body_len > constants.max_tls_ciphertext_size)
                 return error.ConnectionReset;
-            }
-            if (slot.relay_tls_body_len == 0 or slot.relay_tls_body_len > constants.max_tls_ciphertext_size) {
-                return error.ConnectionReset;
-            }
         }
-
-        const remaining = slot.relay_tls_body_len - slot.relay_tls_body_pos;
-        if (remaining == 0) {
-            slot.relay_tls_hdr_pos = 0;
-            slot.relay_tls_body_pos = 0;
-            slot.relay_tls_body_len = 0;
-            if (consumed_any) return .partial;
-            continue;
+        const take = @min(@as(usize, slot.relay_tls_body_len - slot.relay_tls_body_pos), data.len - pos);
+        const payload = data[pos..][0..take];
+        if (take > 0 and slot.relay_record_type == constants.tls_record_application) {
+            if (slot.client_decryptor) |*dec| dec.apply(payload);
+            if (slot.middle_ctx) |*mp| {
+                const scratch = mp_c2s_scratch orelse return error.MissingMiddleProxyScratch;
+                const output = try mp.encapsulateC2S(payload, scratch);
+                if (output.len > 0) _ = try queue_upstream(slot, allocator, output);
+            } else if (slot.tg_encryptor) |*enc| {
+                enc.apply(payload);
+                _ = try queue_upstream(slot, allocator, payload);
+            } else return error.MissingUpstreamCipher;
+            slot.c2s_bytes += payload.len;
+            forwarded = true;
         }
-
-        const want = @min(@as(usize, remaining), read_buf.len);
-        const n = posix.read(slot.client_fd, read_buf[0..want]) catch |err| {
-            if (err == error.WouldBlock) return if (consumed_any) .partial else .none;
-            return err;
-        };
-        if (n == 0) return error.EndOfStream;
-
-        consumed_any = true;
-        slot.relay_tls_body_pos += @intCast(n);
-
-        if (slot.relay_record_type == constants.tls_record_change_cipher) {
-            if (slot.relay_tls_body_pos == slot.relay_tls_body_len) {
-                slot.relay_tls_hdr_pos = 0;
-                slot.relay_tls_body_pos = 0;
-                slot.relay_tls_body_len = 0;
-            }
-            return .partial;
-        }
-
-        const payload = read_buf[0..n];
-        if (slot.client_decryptor) |*dec| dec.apply(payload);
-
-        if (slot.middle_ctx) |*mp| {
-            const scratch = mp_c2s_scratch orelse return error.MissingMiddleProxyScratch;
-            const out_data = try mp.encapsulateC2S(payload, scratch);
-            if (out_data.len > 0) {
-                _ = try queue_upstream(slot, allocator, out_data);
-            }
-        } else if (slot.tg_encryptor) |*enc| {
-            enc.apply(payload);
-            _ = try queue_upstream(slot, allocator, payload);
-        }
-
-        slot.c2s_bytes += payload.len;
-
+        pos += take;
+        slot.relay_tls_body_pos += @intCast(take);
         if (slot.relay_tls_body_pos == slot.relay_tls_body_len) {
             slot.relay_tls_hdr_pos = 0;
             slot.relay_tls_body_pos = 0;
             slot.relay_tls_body_len = 0;
-            return .forwarded;
         }
-
-        return .partial;
     }
+    return if (forwarded) .forwarded else .partial;
 }
 
 pub fn relayUpstreamToClientStep(
@@ -141,23 +155,44 @@ pub fn queueTlsAppRecords(
     slot: anytype,
     allocator: std.mem.Allocator,
     payload: []u8,
-    comptime queue_client_pair: fn (@TypeOf(slot), std.mem.Allocator, []const u8, []const u8) anyerror!bool,
+    comptime queue_client_parts: fn (@TypeOf(slot), std.mem.Allocator, []const []const u8) anyerror!bool,
 ) !void {
     var off: usize = 0;
-    var header: [5]u8 = undefined;
+    var headers: [32][5]u8 = undefined;
+    var parts: [64][]const u8 = undefined;
+    var count: usize = 0;
 
     while (off < payload.len) {
-        const chunk_len = @min(payload.len - off, slot.drs.nextRecordSize());
+        // A genuine TLS 1.3 sender's on-wire application_data length is the
+        // plaintext chunk plus the 1-byte inner content type and 16-byte
+        // AEAD tag, so it can reach 16384+17=16401 but never lands on
+        // exactly 16384 (0x4000). We forward the MTProto payload with no
+        // such expansion, so letting chunk_len ride drs.nextRecordSize()'s
+        // ceiling unclamped put every bulk S2C record at precisely 0x4000 —
+        // a length no real TLS 1.3 stack ever emits, and a one-rule passive
+        // DPI record-length discriminator for this proxy. Stay one
+        // AEAD-tag-plus-content-type below the ceiling so the wire length
+        // can never hit that impossible constant.
+        const wire_cap = @min(payload.len - off, slot.drs.nextRecordSize());
+        const chunk_len = @min(wire_cap, constants.max_tls_plaintext_size - 17);
 
+        const header = &headers[count / 2];
         header[0] = constants.tls_record_application;
         header[1] = constants.tls_version[0];
         header[2] = constants.tls_version[1];
         std.mem.writeInt(u16, header[3..5], @intCast(chunk_len), .big);
 
-        _ = try queue_client_pair(slot, allocator, header[0..], payload[off .. off + chunk_len]);
+        parts[count] = header;
+        parts[count + 1] = payload[off .. off + chunk_len];
+        count += 2;
         slot.drs.recordSent(chunk_len);
         off += chunk_len;
+        if (count == parts.len) {
+            _ = try queue_client_parts(slot, allocator, &parts);
+            count = 0;
+        }
     }
+    if (count > 0) _ = try queue_client_parts(slot, allocator, parts[0..count]);
 }
 
 pub fn startRelay(
@@ -199,6 +234,9 @@ pub fn startRelay(
                 close_slot(loop, slot, "queue pipelined direct payload failed");
                 return;
             };
+        } else {
+            close_slot(loop, slot, "missing encryptor/middle_ctx");
+            return;
         }
 
         slot.c2s_bytes += buf.len;
@@ -213,6 +251,7 @@ pub fn relayRawClientToUpstream(
     read_buf: []u8,
     comptime queue_upstream: fn (@TypeOf(loop), @TypeOf(slot), []const u8) anyerror!bool,
     comptime close_slot: fn (@TypeOf(loop), @TypeOf(slot), []const u8) void,
+    comptime read_eof: fn (@TypeOf(loop), @TypeOf(slot), posix.fd_t) void,
 ) void {
     if (!slot.upstream_queue.isEmpty()) return;
 
@@ -222,7 +261,7 @@ pub fn relayRawClientToUpstream(
         return;
     };
     if (n == 0) {
-        close_slot(loop, slot, "mask relay c2s eof");
+        read_eof(loop, slot, slot.client_fd);
         return;
     }
 
@@ -239,6 +278,7 @@ pub fn relayRawUpstreamToClient(
     read_buf: []u8,
     comptime queue_client: fn (@TypeOf(loop), @TypeOf(slot), []const u8) anyerror!bool,
     comptime close_slot: fn (@TypeOf(loop), @TypeOf(slot), []const u8) void,
+    comptime read_eof: fn (@TypeOf(loop), @TypeOf(slot), posix.fd_t) void,
 ) void {
     if (!slot.client_queue.isEmpty()) return;
 
@@ -248,7 +288,7 @@ pub fn relayRawUpstreamToClient(
         return;
     };
     if (n == 0) {
-        close_slot(loop, slot, "mask relay s2c eof");
+        read_eof(loop, slot, slot.upstream_fd);
         return;
     }
 
@@ -257,4 +297,44 @@ pub fn relayRawUpstreamToClient(
         return;
     };
     slot.last_activity_ms = nowMs();
+}
+
+test "queueTlsAppRecords never emits the impossible 0x4000 TLS record length" {
+    // Regression (X03-4): a real TLS 1.3 bulk sender's application_data
+    // records top out at 16401 bytes and never at exactly 16384 (0x4000),
+    // since 16384 is the plaintext limit before the 1-byte content type and
+    // 16-byte AEAD tag are added. Before this fix chunk_len rode
+    // drs.nextRecordSize()'s ceiling of 16384 unclamped, so every full-size
+    // bulk S2C record hit 0x4000 exactly — a one-rule passive DPI tell.
+    const drs_mod = @import("drs.zig");
+
+    const FakeSlot = struct {
+        drs: drs_mod.DynamicRecordSizer,
+        lengths: [8]usize = undefined,
+        count: usize = 0,
+
+        fn queuePair(self: *@This(), allocator: std.mem.Allocator, parts: []const []const u8) !bool {
+            _ = allocator;
+            var i: usize = 0;
+            while (i < parts.len) : (i += 2) {
+                self.lengths[self.count] = std.mem.readInt(u16, parts[i][3..5], .big);
+                self.count += 1;
+            }
+            return true;
+        }
+    };
+
+    var slot = FakeSlot{ .drs = drs_mod.DynamicRecordSizer.init(false) };
+
+    const payload = try std.testing.allocator.alloc(u8, 40000);
+    defer std.testing.allocator.free(payload);
+    @memset(payload, 0xAB);
+
+    try queueTlsAppRecords(&slot, std.testing.allocator, payload, FakeSlot.queuePair);
+
+    try std.testing.expect(slot.count > 0);
+    for (slot.lengths[0..slot.count]) |len| {
+        try std.testing.expect(len != constants.max_tls_plaintext_size);
+        try std.testing.expect(len <= constants.max_tls_plaintext_size - 17);
+    }
 }

--- a/src/proxy/replay_cache.zig
+++ b/src/proxy/replay_cache.zig
@@ -2,6 +2,25 @@ const std = @import("std");
 const posix = std.posix;
 const crypto = @import("../crypto/crypto.zig");
 
+test "concurrent workers admit the same replay digest exactly once" {
+    const cache = try std.testing.allocator.create(ReplayCache);
+    defer std.testing.allocator.destroy(cache);
+    cache.* = ReplayCache.init();
+    var admitted = std.atomic.Value(u32).init(0);
+    const Worker = struct {
+        fn run(shared: *ReplayCache, count: *std.atomic.Value(u32)) void {
+            const digest = [_]u8{0x7b} ** 32;
+            for (0..1000) |_| {
+                if (!shared.checkAndInsert(&digest)) _ = count.fetchAdd(1, .monotonic);
+            }
+        }
+    };
+    var threads: [4]std.Thread = undefined;
+    for (&threads) |*thread| thread.* = try std.Thread.spawn(.{}, Worker.run, .{ cache, &admitted });
+    for (threads) |thread| thread.join();
+    try std.testing.expectEqual(@as(u32, 1), admitted.load(.monotonic));
+}
+
 fn nowSeconds() i64 {
     var ts: posix.timespec = undefined;
     const rc = posix.system.clock_gettime(.MONOTONIC, &ts);
@@ -12,7 +31,7 @@ fn nowSeconds() i64 {
 pub const ReplayCache = struct {
     const BUCKETS = 8192;
     const MAX_PROBES = 8;
-    const stale_after_s: i64 = 60 * 60;
+    const stale_after_s: i64 = 240;
 
     const Entry = struct {
         used: bool = false,
@@ -59,17 +78,18 @@ pub const ReplayCache = struct {
     /// Returns true if this digest was already seen (duplicate replay),
     /// false when inserted as a new digest.
     pub fn checkAndInsert(self: *ReplayCache, digest: *const [32]u8) bool {
+        return self.checkAndInsertAt(digest, nowSeconds());
+    }
+
+    fn checkAndInsertAt(self: *ReplayCache, digest: *const [32]u8, now_s: i64) bool {
         const io = lockIo();
         self.lock.lockUncancelable(io);
         defer self.lock.unlock(io);
 
         const key = digestKey(digest);
-        const now_s = nowSeconds();
         const start = self.indexFor(key);
 
         var first_stale_idx: ?usize = null;
-        var oldest_idx: usize = start;
-        var oldest_ts: i64 = std.math.maxInt(i64);
 
         var probe: usize = 0;
         while (probe < MAX_PROBES) : (probe += 1) {
@@ -89,13 +109,10 @@ pub const ReplayCache = struct {
             if (now_s - e.last_seen_s > stale_after_s and first_stale_idx == null) {
                 first_stale_idx = idx;
             }
-            if (e.last_seen_s < oldest_ts) {
-                oldest_ts = e.last_seen_s;
-                oldest_idx = idx;
-            }
         }
 
-        const victim_idx = first_stale_idx orelse oldest_idx;
+        // Saturation must reject the new handshake, never forget a live digest.
+        const victim_idx = first_stale_idx orelse return true;
         self.entries[victim_idx] = .{ .used = true, .key = key, .last_seen_s = now_s };
         return false;
     }
@@ -107,6 +124,20 @@ test "replay cache detects duplicate digest" {
 
     try std.testing.expect(!cache.checkAndInsert(&digest));
     try std.testing.expect(cache.checkAndInsert(&digest));
+}
+
+test "saturated replay probe window never evicts a live entry" {
+    var cache = ReplayCache.init();
+    const digest = [_]u8{0xab} ** 32;
+    const start = cache.indexFor(ReplayCache.digestKey(&digest));
+    for (0..ReplayCache.MAX_PROBES) |i| {
+        cache.entries[(start + i) & (ReplayCache.BUCKETS - 1)] = .{ .used = true, .key = i, .last_seen_s = nowSeconds() };
+    }
+    try std.testing.expect(cache.checkAndInsert(&digest));
+    try std.testing.expectEqual(@as(u64, 0), cache.entries[start].key);
+    const expired_now = nowSeconds() + 241;
+    try std.testing.expect(!cache.checkAndInsertAt(&digest, expired_now));
+    try std.testing.expect(cache.checkAndInsertAt(&digest, expired_now));
 }
 
 test "replay cache accepts distinct digests" {

--- a/src/proxy/sd_notify.zig
+++ b/src/proxy/sd_notify.zig
@@ -6,6 +6,20 @@
 const std = @import("std");
 const posix = std.posix;
 
+pub fn watchdogInterval(usec: ?[]const u8, owner_pid: ?[]const u8, current_pid: u32) u64 {
+    if (owner_pid) |text| {
+        const pid = std.fmt.parseInt(u32, text, 10) catch return 0;
+        if (pid != current_pid) return 0;
+    }
+    return std.fmt.parseInt(u64, usec orelse return 0, 10) catch 0;
+}
+
+test "watchdog interval honors the designated process" {
+    try std.testing.expectEqual(@as(u64, 1000), watchdogInterval("1000", "42", 42));
+    try std.testing.expectEqual(@as(u64, 0), watchdogInterval("1000", "43", 42));
+    try std.testing.expectEqual(@as(u64, 0), watchdogInterval("1000", "bad", 42));
+}
+
 /// Build an AF_UNIX address for `name`. `name` is either an absolute path or an
 /// abstract socket starting with '@' (encoded as a leading NUL byte). Returns
 /// the address plus its used length, or null if it doesn't fit.

--- a/src/proxy/socket_utils.zig
+++ b/src/proxy/socket_utils.zig
@@ -98,7 +98,7 @@ pub fn connectSockaddr(fd: posix.fd_t, addr: *const posix.sockaddr, addr_len: po
 pub fn checkSocketConnectError(fd: posix.fd_t) !void {
     var so_error: i32 = 0;
     var opt_len: linux.socklen_t = @sizeOf(i32);
-    const so_error_opt: u32 = 4; // SO_ERROR
+    const so_error_opt: u32 = linux.SO.ERROR;
     const rc = linux.getsockopt(fd, posix.SOL.SOCKET, so_error_opt, std.mem.asBytes(&so_error).ptr, &opt_len);
     if (linux.errno(rc) != .SUCCESS) return error.Unexpected;
     if (so_error == 0) return;
@@ -157,6 +157,7 @@ pub fn acceptClient(listen_fd: posix.fd_t) AcceptError!?AcceptResult {
             },
             .INTR => continue,
             .AGAIN => return null,
+            .NETDOWN, .PROTO, .NOPROTOOPT, .HOSTUNREACH, .OPNOTSUPP, .NETUNREACH, .NONET, .PERM => return null,
             .CONNABORTED => return error.ConnectionAborted,
             .CONNRESET => return error.ConnectionResetByPeer,
             .MFILE => return error.ProcessFdQuotaExceeded,

--- a/src/proxy/socks5.zig
+++ b/src/proxy/socks5.zig
@@ -70,7 +70,7 @@ pub fn buildGreeting(buf: []u8, use_auth: bool) []u8 {
 pub fn parseGreetingResponse(data: []const u8) ?Method {
     if (data.len < 2) return null;
     if (data[0] != version) return null;
-    return std.enums.fromInt(Method, data[1]) orelse .no_acceptable;
+    return std.enums.fromInt(Method, data[1]);
 }
 
 /// Minimum bytes needed for greeting response.

--- a/src/proxy/subnet_rate_limit.zig
+++ b/src/proxy/subnet_rate_limit.zig
@@ -21,7 +21,7 @@ pub const SubnetRateLimit = struct {
 
     pub const Entry = struct {
         used: bool = false,
-        subnet_key: u32 = 0,
+        subnet_key: u64 = 0,
         tokens: u8 = 0,
         last_refill_s: i64 = 0,
     };
@@ -35,7 +35,7 @@ pub const SubnetRateLimit = struct {
         };
     }
 
-    fn indexFor(self: *const SubnetRateLimit, key: u32) usize {
+    fn indexFor(self: *const SubnetRateLimit, key: u64) usize {
         var x = self.hash_seed ^ @as(u64, key);
         x +%= 0x9E3779B97F4A7C15;
         x ^= x >> 30;
@@ -46,7 +46,7 @@ pub const SubnetRateLimit = struct {
         return @as(usize, @intCast(x & (BUCKETS - 1)));
     }
 
-    pub fn findEntry(self: *SubnetRateLimit, key: u32) ?*Entry {
+    pub fn findEntry(self: *SubnetRateLimit, key: u64) ?*Entry {
         const start = self.indexFor(key);
         var probe: usize = 0;
         while (probe < MAX_PROBES) : (probe += 1) {
@@ -109,7 +109,7 @@ pub const SubnetRateLimit = struct {
         return true;
     }
 
-    pub fn subnetKey(addr: Address) u32 {
+    pub fn subnetKey(addr: Address) u64 {
         return switch (addr) {
             .ip4 => |ip4_addr| @as(u32, ip4_addr.bytes[0]) << 16 |
                 @as(u32, ip4_addr.bytes[1]) << 8 |
@@ -125,11 +125,13 @@ pub const SubnetRateLimit = struct {
                         @as(u32, ip6_bytes[14]);
                 }
 
-                break :blk @as(u32, ip6_bytes[0]) << 24 |
-                    @as(u32, ip6_bytes[1]) << 16 |
-                    @as(u32, ip6_bytes[2]) << 8 |
-                    @as(u32, ip6_bytes[3]) ^
-                    (@as(u32, ip6_bytes[4]) << 8 | @as(u32, ip6_bytes[5]));
+                // Preserve the full /48 identity and separate address families.
+                break :blk (@as(u64, 1) << 48) |
+                    (@as(u64, ip6_bytes[0]) << 40) |
+                    (@as(u64, ip6_bytes[1]) << 32) |
+                    (@as(u64, ip6_bytes[2]) << 24) |
+                    (@as(u64, ip6_bytes[3]) << 16) |
+                    (@as(u64, ip6_bytes[4]) << 8) | ip6_bytes[5];
             },
         };
     }
@@ -137,6 +139,13 @@ pub const SubnetRateLimit = struct {
 
 fn ip4(bytes: [4]u8, port: u16) Address {
     return .{ .ip4 = .{ .bytes = bytes, .port = port } };
+}
+
+test "IPv6 subnet identities preserve all 48 bits and family" {
+    const a = try Address.parse("2001:db8:1::1", 0);
+    const b = try Address.parse("2001:db9::1", 0);
+    try std.testing.expect(SubnetRateLimit.subnetKey(a) != SubnetRateLimit.subnetKey(b));
+    try std.testing.expect(SubnetRateLimit.subnetKey(try Address.parse("::1", 0)) != SubnetRateLimit.subnetKey(ip4(.{ 0, 0, 0, 1 }, 0)));
 }
 
 fn ip6(bytes: [16]u8, port: u16, flow: u32, scope_id: u32) Address {

--- a/src/proxy/trusted_peers.zig
+++ b/src/proxy/trusted_peers.zig
@@ -60,7 +60,7 @@ pub fn sameHost(a: Address, b: Address) bool {
             .ip6 => false,
         },
         .ip6 => |x| switch (nb) {
-            .ip6 => |y| std.mem.eql(u8, &x.bytes, &y.bytes),
+            .ip6 => |y| std.mem.eql(u8, &x.bytes, &y.bytes) and x.interface.index == y.interface.index,
             .ip4 => false,
         },
     };

--- a/src/proxy/upstream.zig
+++ b/src/proxy/upstream.zig
@@ -22,6 +22,7 @@ const net = std.Io.net;
 const posix = std.posix;
 const tunnel_mod = @import("../tunnel.zig");
 const Address = net.IpAddress;
+const AddressCandidates = @import("net_helpers.zig").AddressCandidates;
 
 pub const Tunnel = tunnel_mod.Tunnel;
 
@@ -35,6 +36,32 @@ fn socketFamily(addr: Address) posix.sa_family_t {
         .ip4 => posix.AF.INET,
         .ip6 => posix.AF.INET6,
     };
+}
+
+test "proxy endpoints and credentials remain separate from logical destination" {
+    const proxy_addr = Address{ .ip4 = .{ .bytes = .{ 192, 0, 2, 1 }, .port = 1080 } };
+    const socks = Upstream.initSocks5(proxy_addr, "user", "pass");
+    const http = Upstream.initHttpConnect(proxy_addr, "user", "pass");
+    for ([_]Upstream{ socks, http }) |up| {
+        try std.testing.expect(Address.eql(&proxy_addr, &up.proxyAddr().?));
+        try std.testing.expectEqualStrings("user", up.proxyUsername().?);
+        try std.testing.expectEqualStrings("pass", up.proxyPassword().?);
+    }
+    try std.testing.expect(Upstream.initDirect().proxyAddr() == null);
+}
+
+test "proxy DNS candidates preserve credentials and do not mutate shared selection" {
+    const first = Address{ .ip4 = .{ .bytes = .{ 192, 0, 2, 1 }, .port = 1080 } };
+    const second = Address{ .ip6 = .{ .bytes = @splat(1), .port = 1080 } };
+    const addresses = [_]Address{ first, second };
+    for ([_]Upstream{ Upstream.initSocks5Candidates(&addresses, "user", "pass"), Upstream.initHttpConnectCandidates(&addresses, "user", "pass") }) |up| {
+        try std.testing.expectEqual(@as(usize, 2), up.proxyCandidateCount());
+        const selected = up.withProxyCandidate(1);
+        try std.testing.expect(Address.eql(&second, &selected.proxyAddr().?));
+        try std.testing.expect(Address.eql(&first, &up.proxyAddr().?));
+        try std.testing.expectEqualStrings("user", selected.proxyUsername().?);
+        try std.testing.expectEqualStrings("pass", selected.proxyPassword().?);
+    }
 }
 
 fn toSocketAddr(addr: Address) SocketAddr {
@@ -80,30 +107,8 @@ fn createTcpSocket(family: posix.sa_family_t) !posix.fd_t {
     }
 }
 
-fn closeFd(fd: posix.fd_t) void {
-    while (true) switch (posix.errno(posix.system.close(fd))) {
-        .SUCCESS => return,
-        .INTR => continue,
-        else => return,
-    };
-}
-
-fn connectSockaddr(fd: posix.fd_t, addr: *const posix.sockaddr, addr_len: posix.socklen_t) !void {
-    while (true) switch (posix.errno(posix.system.connect(fd, addr, addr_len))) {
-        .SUCCESS => return,
-        .INTR => continue,
-        .ADDRNOTAVAIL => return error.AddressUnavailable,
-        .AFNOSUPPORT => return error.AddressFamilyUnsupported,
-        .AGAIN, .INPROGRESS => return error.WouldBlock,
-        .ALREADY => return error.ConnectionPending,
-        .CONNREFUSED => return error.ConnectionRefused,
-        .CONNRESET => return error.ConnectionResetByPeer,
-        .HOSTUNREACH => return error.HostUnreachable,
-        .NETUNREACH => return error.NetworkUnreachable,
-        .TIMEDOUT => return error.Timeout,
-        else => |err| return posix.unexpectedErrno(err),
-    };
-}
+const closeFd = @import("socket_utils.zig").closeFd;
+const connectSockaddr = @import("socket_utils.zig").connectSockaddr;
 
 /// What proxy-level handshake (if any) must be completed after TCP connect.
 pub const ProxyHandshake = enum {
@@ -163,6 +168,51 @@ pub const Upstream = union(Tag) {
             .username = username,
             .password = password,
         } };
+    }
+
+    pub fn initSocks5Candidates(addresses: []const Address, username: ?[]const u8, password: ?[]const u8) Upstream {
+        var self = initSocks5(addresses[0], username, password);
+        self.socks5.candidates = AddressCandidates.init(addresses);
+        return self;
+    }
+
+    pub fn initHttpConnectCandidates(addresses: []const Address, username: ?[]const u8, password: ?[]const u8) Upstream {
+        var self = initHttpConnect(addresses[0], username, password);
+        self.http_connect.candidates = AddressCandidates.init(addresses);
+        return self;
+    }
+
+    pub fn proxyCandidateCount(self: *const Upstream) usize {
+        return switch (self.*) {
+            .direct => 1,
+            .socks5 => |s| @max(1, s.candidates.len),
+            .http_connect => |h| @max(1, h.candidates.len),
+        };
+    }
+
+    pub fn withProxyAddress(self: *const Upstream, addr: Address) Upstream {
+        var selected = self.*;
+        switch (selected) {
+            .direct => {},
+            .socks5 => |*s| s.proxy_addr = addr,
+            .http_connect => |*h| h.proxy_addr = addr,
+        }
+        return selected;
+    }
+
+    pub fn withProxyCandidate(self: *const Upstream, index: usize) Upstream {
+        std.debug.assert(index < self.proxyCandidateCount());
+        var selected = self.*;
+        switch (selected) {
+            .direct => {},
+            .socks5 => |*s| if (s.candidates.len > 0) {
+                s.proxy_addr = s.candidates.addresses[index];
+            },
+            .http_connect => |*h| if (h.candidates.len > 0) {
+                h.proxy_addr = h.candidates.addresses[index];
+            },
+        }
+        return selected;
     }
 
     /// Create a non-blocking upstream socket.
@@ -230,19 +280,15 @@ pub const Direct = struct {
 
 pub const Socks5 = struct {
     proxy_addr: Address,
+    candidates: AddressCandidates = .{},
     username: ?[]const u8 = null,
     password: ?[]const u8 = null,
-    socket_mark: ?u32 = null,
 
     /// Connect to the SOCKS5 proxy server (not the target DC).
     /// Returns a result with `.proxy_handshake = .socks5`.
     pub fn connect(self: Socks5) !ConnectResult {
         const fd = try createTcpSocket(socketFamily(self.proxy_addr));
         errdefer closeFd(fd);
-
-        if (self.socket_mark) |mark| {
-            try applySocketMark(fd, mark);
-        }
 
         connectSocket(fd, self.proxy_addr) catch |err| switch (err) {
             error.WouldBlock, error.ConnectionPending => {
@@ -263,19 +309,15 @@ pub const Socks5 = struct {
 
 pub const HttpConnect = struct {
     proxy_addr: Address,
+    candidates: AddressCandidates = .{},
     username: ?[]const u8 = null,
     password: ?[]const u8 = null,
-    socket_mark: ?u32 = null,
 
     /// Connect to the HTTP proxy server (not the target DC).
     /// Returns a result with `.proxy_handshake = .http_connect`.
     pub fn connect(self: HttpConnect) !ConnectResult {
         const fd = try createTcpSocket(socketFamily(self.proxy_addr));
         errdefer closeFd(fd);
-
-        if (self.socket_mark) |mark| {
-            try applySocketMark(fd, mark);
-        }
 
         connectSocket(fd, self.proxy_addr) catch |err| switch (err) {
             error.WouldBlock, error.ConnectionPending => {
@@ -291,7 +333,14 @@ pub const HttpConnect = struct {
 fn applySocketMark(fd: posix.fd_t, mark: u32) !void {
     if (builtin.os.tag != .linux) return;
 
-    const so_mark: u32 = 36;
+    const so_mark: u32 = std.os.linux.SO.MARK;
     var mark_value: u32 = mark;
-    try posix.setsockopt(fd, posix.SOL.SOCKET, so_mark, std.mem.asBytes(&mark_value));
+    posix.setsockopt(fd, posix.SOL.SOCKET, so_mark, std.mem.asBytes(&mark_value)) catch |err| {
+        // Once per process: an outage must not flood journald per connection.
+        if (!mark_failure_reported.swap(true, .monotonic))
+            std.log.err("SO_MARK failed ({s}); tunnel egress requires CAP_NET_ADMIN (or CAP_NET_RAW on supported kernels). Check the service capability settings.", .{@errorName(err)});
+        return err;
+    };
 }
+
+var mark_failure_reported = std.atomic.Value(bool).init(false);

--- a/src/proxy/upstream_failover.zig
+++ b/src/proxy/upstream_failover.zig
@@ -2,11 +2,58 @@ const std = @import("std");
 
 const net_helpers = @import("net_helpers.zig");
 const socket_utils = @import("socket_utils.zig");
+const constants = @import("../protocol/constants.zig");
 
 const addressEql = net_helpers.addressEql;
 const formatAddress = socket_utils.formatAddress;
 
 const log = std.log.scoped(.proxy);
+
+test "candidate exhaustion falls back once and updates fast mode and metrics" {
+    const Address = std.Io.net.IpAddress;
+    const Slot = struct {
+        upstream_candidates_inline: [2]Address,
+        upstream_candidates_heap: ?[]Address = null,
+        upstream_candidate_count: usize = 2,
+        upstream_candidate_next: usize = 1,
+        current_upstream_addr: ?Address = null,
+        direct_fallback_addr: ?Address,
+        direct_fallback_used: bool = false,
+        use_middle_proxy: bool = true,
+        use_fast_mode: bool = false,
+        dc_abs: usize = 4,
+        is_media_path: bool = false,
+        conn_id: u64 = 1,
+    };
+    const Loop = struct {
+        state: struct {
+            stats_mp_fallback: std.atomic.Value(u64) = .init(0),
+            config: struct { fast_mode: bool = true } = .{},
+        } = .{},
+        starts: usize = 0,
+    };
+    const Cb = struct {
+        fn start(loop: *Loop, slot: *Slot, addr: Address) !void {
+            slot.current_upstream_addr = addr;
+            loop.starts += 1;
+        }
+        fn set(_: *Loop, slot: *Slot, addr: Address) !void {
+            slot.upstream_candidates_inline[0] = addr;
+            slot.upstream_candidate_count = 1;
+        }
+    };
+    const a = Address{ .ip4 = .{ .bytes = .{ 192, 0, 2, 1 }, .port = 443 } };
+    const b = Address{ .ip4 = .{ .bytes = .{ 192, 0, 2, 2 }, .port = 443 } };
+    var slot = Slot{ .upstream_candidates_inline = .{ a, b }, .direct_fallback_addr = a };
+    var loop = Loop{};
+    try std.testing.expect(tryNextDcEndpoint(&loop, &slot, error.Timeout, Cb.start, Cb.set));
+    try std.testing.expectEqual(@as(usize, 2), slot.upstream_candidate_next);
+    try std.testing.expect(tryNextDcEndpoint(&loop, &slot, error.Timeout, Cb.start, Cb.set));
+    try std.testing.expect(slot.direct_fallback_used and slot.use_fast_mode and !slot.use_middle_proxy);
+    try std.testing.expectEqual(@as(u64, 1), loop.state.stats_mp_fallback.load(.monotonic));
+    try std.testing.expect(!tryNextDcEndpoint(&loop, &slot, error.Timeout, Cb.start, Cb.set));
+    try std.testing.expectEqual(@as(usize, 2), loop.starts);
+}
 
 fn upstreamCandidates(slot: anytype) []const @TypeOf(slot.upstream_candidates_inline[0]) {
     const count: usize = slot.upstream_candidate_count;
@@ -21,9 +68,9 @@ pub fn tryNextDcEndpoint(
     comptime start_connect_upstream_dc: fn (@TypeOf(loop), @TypeOf(slot), @TypeOf(slot.current_upstream_addr.?)) anyerror!void,
     comptime set_single_upstream_candidate: fn (@TypeOf(loop), @TypeOf(slot), @TypeOf(slot.current_upstream_addr.?)) anyerror!void,
 ) bool {
-    const attempt_addr = slot.current_upstream_addr;
     const candidates = upstreamCandidates(slot);
     if (candidates.len == 0) return false;
+    const attempt_addr = slot.current_upstream_addr orelse candidates[@min(slot.upstream_candidate_next -| 1, candidates.len - 1)];
     const candidate_count = candidates.len;
 
     const next_u: usize = slot.upstream_candidate_next;
@@ -47,9 +94,9 @@ pub fn tryNextDcEndpoint(
             );
         };
 
-        if (attempt_addr) |addr| {
+        {
             var prev_buf: [64]u8 = undefined;
-            const prev_str = formatAddress(addr, &prev_buf);
+            const prev_str = formatAddress(attempt_addr, &prev_buf);
             log.warn("[{d}] dc connect failed ({any}), retry candidate {d}/{d} after {s}", .{
                 slot.conn_id,
                 err,
@@ -64,6 +111,9 @@ pub fn tryNextDcEndpoint(
     if (!slot.direct_fallback_used and slot.direct_fallback_addr != null and slot.use_middle_proxy) {
         slot.direct_fallback_used = true;
         slot.use_middle_proxy = false;
+        _ = loop.state.stats_mp_fallback.fetchAdd(1, .monotonic);
+        slot.use_fast_mode = loop.state.config.fast_mode and
+            (slot.dc_abs >= 1 and slot.dc_abs <= constants.tg_datacenters_v4.len);
         const fallback = slot.direct_fallback_addr.?;
         slot.upstream_candidate_next = 1;
 

--- a/src/proxy/user_ip_limit.zig
+++ b/src/proxy/user_ip_limit.zig
@@ -31,6 +31,34 @@ const std = @import("std");
 const net = std.Io.net;
 const Address = net.IpAddress;
 
+test "concurrent workers preserve quota references" {
+    var limit = try UserIpLimit.init(std.testing.allocator, 1);
+    defer limit.deinit(std.testing.allocator);
+    const key = [_]u8{1} ** 16;
+    try std.testing.expect(limit.acquire(key));
+    var failed = std.atomic.Value(bool).init(false);
+    const Worker = struct {
+        fn run(shared: *UserIpLimit, errors: *std.atomic.Value(bool)) void {
+            for (0..1000) |_| {
+                if (shared.acquire([_]u8{1} ** 16)) {
+                    shared.release([_]u8{1} ** 16);
+                } else errors.store(true, .monotonic);
+                if (shared.acquire([_]u8{2} ** 16)) {
+                    errors.store(true, .monotonic);
+                    shared.release([_]u8{2} ** 16);
+                }
+            }
+        }
+    };
+    var threads: [4]std.Thread = undefined;
+    for (&threads) |*thread| thread.* = try std.Thread.spawn(.{}, Worker.run, .{ &limit, &failed });
+    for (threads) |thread| thread.join();
+    try std.testing.expect(!failed.load(.monotonic));
+    try std.testing.expectEqual(@as(u32, 1), limit.activeCount());
+    limit.release(key);
+    try std.testing.expectEqual(@as(u32, 0), limit.activeCount());
+}
+
 pub const UserIpLimit = struct {
     /// Upper bound on a configured cap. The table is a linear scan and is allocated
     /// eagerly for every capped user, so this both bounds the memory a typo

--- a/src/runtime_log.zig
+++ b/src/runtime_log.zig
@@ -1,3 +1,15 @@
 const std = @import("std");
 
-pub var level: std.log.Level = .info;
+const AtomicLevel = struct {
+    value: std.atomic.Value(u8) = .init(@intFromEnum(std.log.Level.info)),
+
+    pub fn load(self: *const AtomicLevel, comptime order: std.builtin.AtomicOrder) std.log.Level {
+        return @enumFromInt(self.value.load(order));
+    }
+
+    pub fn store(self: *AtomicLevel, new_level: std.log.Level, comptime order: std.builtin.AtomicOrder) void {
+        self.value.store(@intFromEnum(new_level), order);
+    }
+};
+
+pub var level: AtomicLevel = .{};

--- a/src/tunnel.zig
+++ b/src/tunnel.zig
@@ -36,51 +36,6 @@ pub const Tunnel = struct {
             .http_connect => "HTTP CONNECT",
         };
     }
-
-    /// Whether this tunnel type requires running inside a network namespace.
-    pub fn requiresNetns(self: *const Tunnel) bool {
-        return switch (self.tag) {
-            .none => false,
-            .tunnel => false,
-            .socks5 => false,
-            .http_connect => false,
-        };
-    }
-
-    /// The network namespace name, if applicable.
-    pub fn netnsName(self: *const Tunnel) ?[]const u8 {
-        return switch (self.tag) {
-            .none => null,
-            .tunnel => null,
-            .socks5 => null,
-            .http_connect => null,
-        };
-    }
-
-    /// Parse a tunnel type string from configuration.
-    /// Returns `.none` for unrecognized values.
-    pub fn fromString(s: []const u8) Tag {
-        if (std.mem.eql(u8, s, "tunnel")) {
-            return .tunnel;
-        }
-        // Backward compat: specific VPN names map to generic .tunnel
-        if (std.mem.eql(u8, s, "amnezia_wg") or std.mem.eql(u8, s, "amneziawg")) {
-            return .tunnel;
-        }
-        if (std.mem.eql(u8, s, "wireguard") or std.mem.eql(u8, s, "wg")) {
-            return .tunnel;
-        }
-        if (std.mem.eql(u8, s, "socks5")) {
-            return .socks5;
-        }
-        if (std.mem.eql(u8, s, "http") or std.mem.eql(u8, s, "http_connect")) {
-            return .http_connect;
-        }
-        if (std.mem.eql(u8, s, "none") or std.mem.eql(u8, s, "direct")) {
-            return .none;
-        }
-        return .none;
-    }
 };
 
 // ============= Tests =============
@@ -97,46 +52,4 @@ test "tunnel - name returns human-readable string" {
 
     const http = Tunnel{ .tag = .http_connect };
     try std.testing.expectEqualStrings("HTTP CONNECT", http.name());
-}
-
-test "tunnel - requiresNetns" {
-    const direct = Tunnel{ .tag = .none };
-    try std.testing.expect(!direct.requiresNetns());
-
-    const vpn = Tunnel{ .tag = .tunnel };
-    try std.testing.expect(!vpn.requiresNetns());
-
-    const socks = Tunnel{ .tag = .socks5 };
-    try std.testing.expect(!socks.requiresNetns());
-
-    const http = Tunnel{ .tag = .http_connect };
-    try std.testing.expect(!http.requiresNetns());
-}
-
-test "tunnel - netnsName" {
-    const direct = Tunnel{ .tag = .none };
-    try std.testing.expect(direct.netnsName() == null);
-
-    const vpn = Tunnel{ .tag = .tunnel };
-    try std.testing.expect(vpn.netnsName() == null);
-
-    const socks = Tunnel{ .tag = .socks5 };
-    try std.testing.expect(socks.netnsName() == null);
-
-    const http = Tunnel{ .tag = .http_connect };
-    try std.testing.expect(http.netnsName() == null);
-}
-
-test "tunnel - fromString parsing" {
-    try std.testing.expectEqual(Tunnel.Tag.tunnel, Tunnel.fromString("tunnel"));
-    try std.testing.expectEqual(Tunnel.Tag.tunnel, Tunnel.fromString("amnezia_wg"));
-    try std.testing.expectEqual(Tunnel.Tag.tunnel, Tunnel.fromString("amneziawg"));
-    try std.testing.expectEqual(Tunnel.Tag.tunnel, Tunnel.fromString("wireguard"));
-    try std.testing.expectEqual(Tunnel.Tag.tunnel, Tunnel.fromString("wg"));
-    try std.testing.expectEqual(Tunnel.Tag.socks5, Tunnel.fromString("socks5"));
-    try std.testing.expectEqual(Tunnel.Tag.http_connect, Tunnel.fromString("http"));
-    try std.testing.expectEqual(Tunnel.Tag.http_connect, Tunnel.fromString("http_connect"));
-    try std.testing.expectEqual(Tunnel.Tag.none, Tunnel.fromString("none"));
-    try std.testing.expectEqual(Tunnel.Tag.none, Tunnel.fromString("direct"));
-    try std.testing.expectEqual(Tunnel.Tag.none, Tunnel.fromString("unknown_value"));
 }

--- a/src/web/capability.zig
+++ b/src/web/capability.zig
@@ -16,8 +16,8 @@
 //!
 //!  1. Because we know every configured user secret, we can recompute the capability
 //!     and learn *which user* is behind a bridge request without ever seeing the
-//!     MTProto stream. That gives per-user accounting and lets a disabled user be
-//!     refused at the HTTP layer.
+//!     MTProto stream. Disabled/expired-user enforcement remains in the authenticated
+//!     MTProto backend; capabilities are a startup snapshot, not live access policy.
 //!  2. A visitor who cannot present a capability derived from a real secret never sees
 //!     the bridge page at all — they get the ordinary cover site. An active prober
 //!     without a valid user secret cannot distinguish this host from a plain website.

--- a/src/web/frame.zig
+++ b/src/web/frame.zig
@@ -293,4 +293,7 @@ test "frame type classification matches tdesktop" {
 test "serialize rejects oversized payload and short buffers" {
     var small: [4]u8 = undefined;
     try std.testing.expectError(error.NoSpace, serialize(&small, .welcome, 0, ""));
+    const oversized = try std.testing.allocator.alloc(u8, max_payload + 1);
+    defer std.testing.allocator.free(oversized);
+    try std.testing.expectError(error.PayloadTooLarge, serialize(&small, .data, 1, oversized));
 }

--- a/src/web/http.zig
+++ b/src/web/http.zig
@@ -1,10 +1,9 @@
 //! Minimal HTTP/1.1 request parsing for the WEB proxy relay.
 //!
 //! The relay is a small public website: it serves a cover page, one bridge page, and a
-//! WebSocket upgrade. It never proxies HTTP, never reads a request body, and only ever
-//! answers `GET`/`HEAD`. That makes the safe subset tiny — and lets us reject the whole
-//! class of smuggling tricks (bodies, `Transfer-Encoding`, duplicate `Content-Length`)
-//! outright instead of implementing them correctly.
+//! WebSocket upgrade. It never proxies HTTP and only answers `GET`/`HEAD`. Body-bearing
+//! requests receive a response with Connection: close: their bodies cannot become a
+//! second request or a WebSocket stream. Ambiguous framing is always rejected.
 //!
 //! `src/monitoring.zig` already serves `/metrics` with prefix matching and a single
 //! 2 KiB read. That is fine for a loopback endpoint but cannot extract
@@ -44,6 +43,7 @@ pub const Request = struct {
     http_1_0: bool,
     headers_buf: [max_headers]Header,
     headers_len: usize,
+    has_body: bool = false,
 
     pub fn headers(self: *const Request) []const Header {
         return self.headers_buf[0..self.headers_len];
@@ -55,6 +55,22 @@ pub const Request = struct {
             if (std.ascii.eqlIgnoreCase(h.name, name)) return h.value;
         }
         return null;
+    }
+
+    /// **Last** header matching `name` (ASCII case-insensitive), or null.
+    ///
+    /// RFC 9110 §5.2 makes repeated field lines equivalent to one comma-joined value, in
+    /// order, so any rule that reads the right-most entry of a list has to read the last
+    /// line. A terminator that *appends* its own `X-Forwarded-For` line instead of
+    /// replacing ours (a CDN, or an operator's own front) would otherwise hand
+    /// `header()`'s first match — the line the client wrote — to `forwardedForClient`,
+    /// and a hostile client would pick the address Telegram is told.
+    pub fn lastHeader(self: *const Request, name: []const u8) ?[]const u8 {
+        var found: ?[]const u8 = null;
+        for (self.headers()) |h| {
+            if (std.ascii.eqlIgnoreCase(h.name, name)) found = h.value;
+        }
+        return found;
     }
 
     /// True when a comma-separated list header contains `token` (case-insensitive).
@@ -79,6 +95,7 @@ pub const Request = struct {
     /// keep-alive and HTTP/1.0 to close; the relay honours both so its cover site
     /// behaves like an ordinary server rather than a one-shot responder.
     pub fn keepAlive(self: *const Request) bool {
+        if (self.has_body) return false;
         if (self.headerHasToken("connection", "close")) return false;
         if (self.http_1_0) return self.headerHasToken("connection", "keep-alive");
         return true;
@@ -95,6 +112,7 @@ pub fn listHasToken(value: []const u8, token: []const u8) bool {
 
 pub fn pathOf(target: []const u8) []const u8 {
     const q = std.mem.indexOfScalar(u8, target, '?') orelse return target;
+    if (q == 0) return "/";
     return target[0..q];
 }
 
@@ -127,13 +145,20 @@ pub fn parse(buf: []const u8) ParseError!Request {
     const request_line = lines.next() orelse return error.Malformed;
     var parts = std.mem.splitScalar(u8, request_line, ' ');
     const method_text = parts.next() orelse return error.Malformed;
-    const target = parts.next() orelse return error.Malformed;
+    const raw_target = parts.next() orelse return error.Malformed;
+    var target = raw_target;
+    if (std.mem.startsWith(u8, target, "http://") or std.mem.startsWith(u8, target, "https://")) {
+        const scheme_len: usize = if (target[4] == ':') 7 else 8;
+        const authority_end = std.mem.indexOfAnyPos(u8, target, scheme_len, "/?") orelse target.len;
+        if (authority_end == scheme_len) return error.Malformed;
+        target = if (authority_end == target.len) "/" else target[authority_end..];
+    }
     const version = parts.next() orelse return error.Malformed;
     if (parts.next() != null) return error.Malformed;
     const http_1_0 = std.mem.eql(u8, version, "HTTP/1.0");
     if (!std.mem.eql(u8, version, "HTTP/1.1") and !http_1_0) return error.Malformed;
-    if (target.len == 0 or target[0] != '/') return error.Malformed;
-    for (target) |c| {
+    if (target.len == 0 or (target[0] != '/' and target[0] != '?')) return error.Malformed;
+    for (raw_target) |c| {
         if (c <= 0x20 or c == 0x7f) return error.Malformed;
     }
 
@@ -168,16 +193,15 @@ pub fn parse(buf: []const u8) ParseError!Request {
         for (value) |c| {
             if (c < 0x20 and c != '\t') return error.Malformed;
         }
-        // We serve no endpoint that takes a body, so no body may be framed. Refusing
-        // `Transfer-Encoding` outright and allowing only a single `Content-Length: 0`
-        // keeps the anti-smuggling property — there is nothing to consume, so nothing to
-        // desynchronise — while still answering the one request an ordinary static host
-        // would answer. Rejecting `Content-Length: 0` outright is a free discriminator:
-        // one header, no secret, and every real site returns 200 where we would 400.
-        if (std.ascii.eqlIgnoreCase(name, "transfer-encoding")) return error.Malformed;
+        if (std.ascii.eqlIgnoreCase(name, "transfer-encoding")) {
+            if (!std.ascii.eqlIgnoreCase(value, "chunked") or request.header("transfer-encoding") != null or request.header("content-length") != null) return error.Malformed;
+            request.has_body = true;
+        }
         if (std.ascii.eqlIgnoreCase(name, "content-length")) {
-            if (!std.mem.eql(u8, value, "0")) return error.Malformed;
-            if (request.header("content-length") != null) return error.Malformed;
+            if (value.len == 0 or request.header("content-length") != null or request.header("transfer-encoding") != null) return error.Malformed;
+            for (value) |c| if (!std.ascii.isDigit(c)) return error.Malformed;
+            const length = std.fmt.parseInt(u64, value, 10) catch return error.Malformed;
+            request.has_body = length != 0;
         }
         if (request.headers_len >= max_headers) return error.Malformed;
         request.headers_buf[request.headers_len] = .{ .name = name, .value = value };
@@ -189,7 +213,7 @@ pub fn parse(buf: []const u8) ParseError!Request {
 
 /// True when the request is a well-formed RFC 6455 upgrade handshake.
 pub fn isWebSocketUpgrade(req: *const Request) bool {
-    if (req.method != .get) return false;
+    if (req.method != .get or req.has_body) return false;
     if (!req.headerHasToken("upgrade", "websocket")) return false;
     if (!req.headerHasToken("connection", "upgrade")) return false;
     const version = req.header("sec-websocket-version") orelse return false;
@@ -209,6 +233,9 @@ pub fn isWebSocketUpgrade(req: *const Request) bool {
 /// and cannot be forged. With a terminator that overwrites rather than appends (which is
 /// what our own vhost does) the list has exactly one entry and the two readings agree.
 /// A single-value header such as `CF-Connecting-IP` also lands here unchanged.
+///
+/// Repeated header *lines* are one and the same list (RFC 9110 §5.2), so the value fed
+/// in here must come from `Request.lastHeader`, never `Request.header`.
 pub fn forwardedForClient(value: []const u8) ?[]const u8 {
     var it = std.mem.splitBackwardsScalar(u8, value, ',');
     const last = std.mem.trim(u8, it.next() orelse return null, " \t");
@@ -223,6 +250,14 @@ const sample_get =
     "User-Agent: test\r\n" ++
     "Accept: */*\r\n" ++
     "\r\n";
+
+test "absolute-form targets route as origin-form without accepting ambiguous framing" {
+    const req = try parse("GET https://example.com/path?bridge=abc HTTP/1.1\r\nHost: example.com\r\n\r\n");
+    try std.testing.expectEqualStrings("/path", req.path());
+    try std.testing.expectEqualStrings("abc", req.query("bridge").?);
+    try std.testing.expectError(error.Malformed, parse("GET / HTTP/1.1\r\nContent-Length: 1\r\nTransfer-Encoding: chunked\r\n\r\n"));
+    try std.testing.expectError(error.Malformed, parse("GET / HTTP/1.1\r\nTransfer-Encoding: chunked\r\nContent-Length: 1\r\n\r\n"));
+}
 
 test "parses a plain GET" {
     const req = try parse(sample_get);
@@ -280,11 +315,14 @@ test "a duplicated content-length is still refused" {
     try std.testing.expectError(error.Malformed, parse(dup));
 }
 
-test "bodies and folded headers are refused" {
+test "body requests force connection close and folded headers are refused" {
     const with_len = "GET / HTTP/1.1\r\nHost: h\r\nContent-Length: 3\r\n\r\nabc";
-    try std.testing.expectError(error.Malformed, parse(with_len));
+    const body = try parse(with_len);
+    try std.testing.expect(!body.keepAlive());
+    try std.testing.expect(!isWebSocketUpgrade(&body));
     const chunked = "GET / HTTP/1.1\r\nHost: h\r\nTransfer-Encoding: chunked\r\n\r\n";
-    try std.testing.expectError(error.Malformed, parse(chunked));
+    const chunks = try parse(chunked);
+    try std.testing.expect(!chunks.keepAlive());
     const folded = "GET / HTTP/1.1\r\nHost: h\r\n  continued\r\n\r\n";
     try std.testing.expectError(error.Malformed, parse(folded));
 }
@@ -292,7 +330,7 @@ test "bodies and folded headers are refused" {
 test "malformed request lines are refused" {
     try std.testing.expectError(error.Malformed, parse("GET /\r\n\r\n"));
     try std.testing.expectError(error.Malformed, parse("GET / HTTP/2.0\r\n\r\n"));
-    try std.testing.expectError(error.Malformed, parse("GET http://x/ HTTP/1.1\r\n\r\n"));
+    try std.testing.expectError(error.Malformed, parse("GET http:/// HTTP/1.1\r\n\r\n"));
     try std.testing.expectError(error.Malformed, parse("GET / HTTP/1.1 extra\r\n\r\n"));
     try std.testing.expectError(error.Malformed, parse("GET / HTTP/1.1\r\nBad Header: x\r\n\r\n"));
     try std.testing.expectError(error.Malformed, parse("GET / HTTP/1.1\r\nnovalue\r\n\r\n"));
@@ -328,6 +366,24 @@ test "forwarded-for takes the right-most entry, which the client cannot forge" {
     try std.testing.expectEqualStrings("2001:db8::1", forwardedForClient(" 2001:db8::1 ").?);
     try std.testing.expectEqual(@as(?[]const u8, null), forwardedForClient(""));
     try std.testing.expectEqual(@as(?[]const u8, null), forwardedForClient("1.2.3.4, "));
+
+    // Two header LINES are one comma-joined list, so the right-most entry lives on the
+    // last line. Reading the first one hands the address the client typed to the proxy
+    // — and from there to RPC_PROXY_REQ.remote_ip_port and the per-user IP quota.
+    const two_lines =
+        "GET / HTTP/1.1\r\n" ++
+        "Host: relay.example.com\r\n" ++
+        "X-Forwarded-For: 9.9.9.9\r\n" ++
+        "X-Forwarded-For: 203.0.113.7\r\n" ++
+        "\r\n";
+    const req = try parse(two_lines);
+    try std.testing.expectEqualStrings("9.9.9.9", req.header("x-forwarded-for").?);
+    try std.testing.expectEqualStrings("203.0.113.7", req.lastHeader("X-Forwarded-For").?);
+    try std.testing.expectEqualStrings("203.0.113.7", forwardedForClient(req.lastHeader("x-forwarded-for").?).?);
+    // One line still reads the same through both accessors.
+    const one_line = try parse("GET / HTTP/1.1\r\nHost: h\r\nX-Forwarded-For: 1.2.3.4, 10.0.0.1\r\n\r\n");
+    try std.testing.expectEqualStrings("10.0.0.1", forwardedForClient(one_line.lastHeader("x-forwarded-for").?).?);
+    try std.testing.expectEqual(@as(?[]const u8, null), one_line.lastHeader("cf-connecting-ip"));
 }
 
 test "token list matching is case-insensitive and comma aware" {

--- a/src/web/page.zig
+++ b/src/web/page.zig
@@ -9,6 +9,17 @@
 //! an inline script. An active prober without a valid secret sees a plain website, and
 //! a curious human who opens the bridge link sees the same plain website too.
 //!
+//! ## Why the cover page is generated, not a constant
+//!
+//! It used to be one comptime string, which meant every mtproto.zig relay on earth
+//! answered `GET /` with byte-identical HTML: one SHA-256 of the body — or one grep for
+//! "This host serves static content only." — turned the list of relay domains anybody
+//! can lift out of CT logs into a list of confirmed deployments, no secret and no
+//! behavioural probing needed. `renderCover` picks the wording, the palette, the type
+//! and the layout from a hash of the relay's own hostname instead, so there is no
+//! cross-deployment signature left to match. Its only input is the hostname the visitor
+//! already typed, so nothing about the operator or their users can reach the page.
+//!
 //! ## What the bridge script may use
 //!
 //! It runs inside `lib_webview`'s restricted profile, whose document-start lock script
@@ -36,32 +47,127 @@
 
 const std = @import("std");
 
-/// Visible markup, shared by both responses. Deliberately unremarkable: a domain that
-/// serves a small static placeholder is the least interesting thing on the internet.
-pub const cover_body =
-    \\<!doctype html>
-    \\<html lang="en"><head>
-    \\<meta charset="utf-8">
-    \\<meta name="viewport" content="width=device-width,initial-scale=1">
-    \\<meta name="robots" content="noindex,nofollow">
-    \\<title>Static Host</title>
-    \\<style>
-    \\:root{color-scheme:light dark}
-    \\body{margin:0;min-height:100vh;display:grid;place-items:center;
-    \\font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
-    \\background:#fbfbfc;color:#1c1e21}
-    \\main{width:min(32rem,calc(100% - 3rem));padding:2rem;text-align:center}
-    \\h1{margin:0 0 .5rem;font-size:1.25rem;font-weight:600;letter-spacing:-.01em}
-    \\p{margin:0;color:#6b7280;font-size:.9375rem}
-    \\@media (prefers-color-scheme:dark){body{background:#0f1115;color:#e7e9ee}p{color:#9aa1ad}}
-    \\</style>
-    \\</head><body>
-    \\<main><h1>Nothing to see here</h1><p>This host serves static content only.</p></main>
-    \\</body></html>
-;
+/// The closing tags every cover page ends with. `renderBridge` splits here to inject the
+/// bridge script, so a generated page that does not end exactly like this is rejected.
+const cover_tail = "\n</body></html>";
 
-/// Everything before the injected `<script>` block — `cover_body` minus its trailing tags.
-const cover_head = cover_body[0 .. cover_body.len - "\n</body></html>".len];
+/// One placeholder site's words. Deliberately unremarkable and interchangeable: a domain
+/// that serves a small static placeholder is the least interesting thing on the internet,
+/// and there are millions of these pages already.
+const CoverText = struct {
+    title: []const u8,
+    heading: []const u8,
+    body: []const u8,
+};
+
+const cover_texts = [_]CoverText{
+    .{ .title = "Welcome", .heading = "Welcome", .body = "This server is up and running. There is no content at this address yet." },
+    .{ .title = "Coming soon", .heading = "Coming soon", .body = "This site has not been published yet. Please check back later." },
+    .{ .title = "Placeholder", .heading = "Placeholder page", .body = "The site for this domain has not been set up." },
+    .{ .title = "Under construction", .heading = "Under construction", .body = "This page is still being worked on. Thanks for your patience." },
+    .{ .title = "Maintenance", .heading = "Down for maintenance", .body = "The site is temporarily offline while some changes are made." },
+    .{ .title = "New site", .heading = "It works!", .body = "The web server is installed and working. Replace this page with your own." },
+    .{ .title = "Parked domain", .heading = "Domain parked", .body = "No website has been configured for this address." },
+    .{ .title = "Index", .heading = "Nothing here yet", .body = "This address serves no content at the moment." },
+};
+
+const Palette = struct {
+    bg: []const u8,
+    fg: []const u8,
+    muted: []const u8,
+    dark_bg: []const u8,
+    dark_fg: []const u8,
+    dark_muted: []const u8,
+};
+
+const palettes = [_]Palette{
+    .{ .bg = "#fbfbfc", .fg = "#1c1e21", .muted = "#6b7280", .dark_bg = "#0f1115", .dark_fg = "#e7e9ee", .dark_muted = "#9aa1ad" },
+    .{ .bg = "#ffffff", .fg = "#222222", .muted = "#767676", .dark_bg = "#121212", .dark_fg = "#ededed", .dark_muted = "#a0a0a0" },
+    .{ .bg = "#f7f6f3", .fg = "#2b2a27", .muted = "#7a776f", .dark_bg = "#1a1917", .dark_fg = "#e8e6e1", .dark_muted = "#a5a29a" },
+    .{ .bg = "#f4f6f8", .fg = "#1f2933", .muted = "#69707d", .dark_bg = "#141a20", .dark_fg = "#e3e8ee", .dark_muted = "#95a0ad" },
+    .{ .bg = "#fdfdfb", .fg = "#33322e", .muted = "#77756d", .dark_bg = "#17171a", .dark_fg = "#eceaea", .dark_muted = "#9c9a9a" },
+    .{ .bg = "#f5f5f5", .fg = "#111111", .muted = "#666666", .dark_bg = "#101010", .dark_fg = "#f0f0f0", .dark_muted = "#909090" },
+};
+
+const font_stacks = [_][]const u8{
+    "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Helvetica,Arial,sans-serif",
+    "system-ui,-apple-system,\"Segoe UI\",Roboto,Arial,sans-serif",
+    "\"Helvetica Neue\",Helvetica,Arial,sans-serif",
+    "Georgia,\"Times New Roman\",Times,serif",
+};
+
+const line_heights = [_][]const u8{ "1.45", "1.5", "1.55", "1.6" };
+const heading_sizes = [_][]const u8{ "1.125rem", "1.25rem", "1.375rem", "1.5rem" };
+const paddings = [_][]const u8{ "1.5rem", "2rem", "2.5rem" };
+
+/// Domain separation for the page seed, so the digest can never collide with any other
+/// use of the hostname (the bridge capability HMACs the same string under a user secret).
+const cover_label = "mtproto.zig web cover page v1\n";
+
+/// Render this deployment's cover page.
+///
+/// Everything visible is selected from a hash of `domain`: the same host always gets the
+/// same page (so it looks like a site, not like something regenerating itself), and two
+/// hosts get different ones (so no single body hash or grep string identifies a relay).
+/// The domain itself never appears in the output — the page must say nothing the visitor
+/// did not already know.
+pub fn renderCover(allocator: std.mem.Allocator, domain: []const u8) ![]u8 {
+    var seed: [32]u8 = undefined;
+    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+    hasher.update(cover_label);
+    hasher.update(domain);
+    hasher.final(&seed);
+
+    const text = cover_texts[seed[0] % cover_texts.len];
+    const palette = palettes[seed[1] % palettes.len];
+    const font = font_stacks[seed[2] % font_stacks.len];
+    const base_px: u8 = 15 + seed[3] % 3;
+    const line_height = line_heights[seed[4] % line_heights.len];
+    const width_rem: u8 = 28 + seed[5] % 7;
+    const padding = paddings[seed[6] % paddings.len];
+    const heading_size = heading_sizes[seed[7] % heading_sizes.len];
+    // A placeholder is as often pinned to the top of the page as centred in it.
+    const layout = if (seed[8] & 1 == 0)
+        "min-height:100vh;display:grid;place-items:center;"
+    else
+        "padding:4rem 1rem;";
+    const align_rule = if (seed[9] & 1 == 0) "text-align:center" else "text-align:left";
+    const robots = if (seed[10] & 1 == 0) "<meta name=\"robots\" content=\"noindex,nofollow\">\n" else "";
+
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+    try out.print(allocator,
+        \\<!doctype html>
+        \\<html lang="en"><head>
+        \\<meta charset="utf-8">
+        \\<meta name="viewport" content="width=device-width,initial-scale=1">
+        \\{s}<title>{s}</title>
+        \\<style>
+        \\:root{{color-scheme:light dark}}
+        \\body{{margin:0;{s}
+        \\font:{d}px/{s} {s};
+        \\background:{s};color:{s}}}
+        \\main{{width:min({d}rem,calc(100% - 3rem));margin:0 auto;padding:{s};{s}}}
+        \\h1{{margin:0 0 .5rem;font-size:{s};font-weight:600;letter-spacing:-.01em}}
+        \\p{{margin:0;color:{s};font-size:.9375rem}}
+        \\@media (prefers-color-scheme:dark){{body{{background:{s};color:{s}}}p{{color:{s}}}}}
+        \\</style>
+        \\</head><body>
+        \\<main><h1>{s}</h1><p>{s}</p></main>
+        \\</body></html>
+    , .{
+        robots,          text.title,
+        layout,          base_px,
+        line_height,     font,
+        palette.bg,      palette.fg,
+        width_rem,       padding,
+        align_rule,      heading_size,
+        palette.muted,   palette.dark_bg,
+        palette.dark_fg, palette.dark_muted,
+        text.heading,    text.body,
+    });
+    return out.toOwnedSlice(allocator);
+}
 
 const script_head =
     \\
@@ -118,14 +224,14 @@ const script_body =
     \\function connect(){
     \\ if(dead||ws||!CAP)return;
     \\ status(attempts?"reconnecting":"connecting");
-    \\ var scheme=location.protocol==="http:"?"ws://":"wss://";
+    \\ var scheme="wss://";
     \\ var socket;
     \\ try{socket=new WebSocket(scheme+location.host+WS_PATH+"?b="+CAP)}catch(e){fail();return}
     \\ ws=socket;socket.binaryType="arraybuffer";
     \\ socket.onopen=function(){
     \\  if(ws!==socket)return;
     \\  wsReady=true;
-    \\  if(attempts){toRelay=preAdopt.concat(toRelay)}
+    \\  if(attempts){toRelay=preAdopt.slice()}
     \\  flushToRelay();status("connected");
     \\ };
     \\ socket.onmessage=function(ev){
@@ -190,7 +296,7 @@ const script_body =
     \\  if(!d||d.t!=="tproxy-init"||d.v!==1)return;
     \\  if(!ev.ports||!ev.ports.length)return;
     \\  var o=ev.origin||"";
-    \\  if(o.indexOf("http://127.0.0.1:")!==0&&o.indexOf("http://[::1]:")!==0)return;
+    \\  if(o.indexOf("http://127.0.0.1:")!==0)return;
     \\  useParentPort(ev.ports[0]);
     \\ }catch(e){}
     \\});
@@ -217,12 +323,18 @@ const script_body =
     \\</body></html>
 ;
 
-/// Render the bridge page with `ws_path` baked into its script.
+/// Render the bridge page: this deployment's own `cover` page with `ws_path` baked into
+/// the injected script. Serving a *different* visible page to a capability holder would
+/// undo the whole point of the cover, so the bridge is always built from it.
 ///
 /// The page is otherwise byte-identical for every user: the capability is read from
 /// `location.search` by the script rather than templated into the body, so the response
 /// carries no per-user bytes at all.
-pub fn renderBridge(allocator: std.mem.Allocator, ws_path: []const u8) ![]u8 {
+pub fn renderBridge(allocator: std.mem.Allocator, cover: []const u8, ws_path: []const u8) ![]u8 {
+    if (ws_path.len == 0 or ws_path[0] != '/' or std.mem.startsWith(u8, ws_path, "//") or std.mem.indexOfAny(u8, ws_path, "?#\\") != null) return error.InvalidWsPath;
+    if (!std.mem.endsWith(u8, cover, cover_tail)) return error.InvalidCoverPage;
+    const cover_head = cover[0 .. cover.len - cover_tail.len];
+
     var out: std.ArrayList(u8) = .empty;
     errdefer out.deinit(allocator);
     try out.appendSlice(allocator, cover_head);
@@ -230,6 +342,12 @@ pub fn renderBridge(allocator: std.mem.Allocator, ws_path: []const u8) ![]u8 {
     try appendJsString(allocator, &out, ws_path);
     try out.appendSlice(allocator, script_body);
     return out.toOwnedSlice(allocator);
+}
+
+test "bridge rejects non-origin websocket paths" {
+    for ([_][]const u8{ "", "socket", "//other.test/socket", "/socket?x=1", "/socket#fragment", "/a\\b" }) |path| {
+        try std.testing.expectError(error.InvalidWsPath, renderBridge(std.testing.allocator, "", path));
+    }
 }
 
 /// Append `value` as a double-quoted JavaScript string literal, escaping everything that
@@ -255,35 +373,79 @@ fn appendJsString(allocator: std.mem.Allocator, out: *std.ArrayList(u8), value: 
 
 // ── tests ─────────────────────────────────────────────────────────────────────
 
-test "cover head is the cover body without its closing tags" {
-    try std.testing.expect(std.mem.startsWith(u8, cover_body, cover_head));
-    try std.testing.expect(std.mem.endsWith(u8, cover_body, "</body></html>"));
-    try std.testing.expect(!std.mem.containsAtLeast(u8, cover_head, 1, "</body>"));
+test "the cover page differs between deployments and leaks nothing about them" {
+    const allocator = std.testing.allocator;
+    const one = try renderCover(allocator, "relay.example.com");
+    defer allocator.free(one);
+    const two = try renderCover(allocator, "other.example.org");
+    defer allocator.free(two);
+
+    // The whole point: no single body hash and no single grep string identifies a relay.
+    try std.testing.expect(!std.mem.eql(u8, one, two));
+    // The visitor already knows the hostname, but the page must not repeat it — nor
+    // anything else about the deployment.
+    try std.testing.expect(!std.mem.containsAtLeast(u8, one, 1, "relay.example.com"));
+    try std.testing.expect(!std.mem.containsAtLeast(u8, two, 1, "other.example.org"));
+    // Stable for a given host: a site whose text changed on every fetch would itself be
+    // the tell, and the relay renders this page once at startup anyway.
+    const again = try renderCover(allocator, "relay.example.com");
+    defer allocator.free(again);
+    try std.testing.expectEqualStrings(one, again);
+
+    for ([_][]const u8{ one, two }) |html| {
+        try std.testing.expect(std.mem.startsWith(u8, html, "<!doctype html>"));
+        try std.testing.expect(std.mem.endsWith(u8, html, cover_tail));
+        try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, html, "<main>"));
+        try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, html, "</body>"));
+        // Everything is inline: an external reference would be a request the cover page
+        // makes and a plain website's placeholder would not.
+        try std.testing.expect(!std.mem.containsAtLeast(u8, html, 1, "http://"));
+        try std.testing.expect(!std.mem.containsAtLeast(u8, html, 1, "https://"));
+    }
 }
 
-test "bridge page embeds the websocket path and closes its tags" {
-    const html = try renderBridge(std.testing.allocator, "/api/v1/socket");
-    defer std.testing.allocator.free(html);
+test "bridge page embeds the websocket path in this deployment's own cover page" {
+    const allocator = std.testing.allocator;
+    const cover = try renderCover(allocator, "relay.example.com");
+    defer allocator.free(cover);
+    const html = try renderBridge(allocator, cover, "/api/v1/socket");
+    defer allocator.free(html);
+
+    // A capability holder must see exactly what a prober sees, plus the script.
+    try std.testing.expect(std.mem.startsWith(u8, html, cover[0 .. cover.len - cover_tail.len]));
     try std.testing.expect(std.mem.containsAtLeast(u8, html, 1, "var WS_PATH=\"/api/v1/socket\";"));
     try std.testing.expect(std.mem.endsWith(u8, html, "</body></html>"));
     try std.testing.expect(std.mem.containsAtLeast(u8, html, 1, "tproxy-android-init"));
     try std.testing.expect(std.mem.containsAtLeast(u8, html, 1, "tproxy-init"));
+
+    // The script has to land inside the document, so a cover page that does not end in
+    // the closing tags is refused rather than silently appended to.
+    try std.testing.expectError(
+        error.InvalidCoverPage,
+        renderBridge(allocator, "<!doctype html><html></html>", "/s"),
+    );
 }
 
 test "the bridge page carries no per-user bytes" {
     // The capability must be read from location.search at runtime, never templated in.
-    const html = try renderBridge(std.testing.allocator, "/s");
-    defer std.testing.allocator.free(html);
+    const allocator = std.testing.allocator;
+    const cover = try renderCover(allocator, "relay.example.com");
+    defer allocator.free(cover);
+    const html = try renderBridge(allocator, cover, "/s");
+    defer allocator.free(html);
     try std.testing.expect(std.mem.containsAtLeast(u8, html, 1, "location.search"));
 }
 
 test "a path that could break out of the script literal is refused" {
+    const allocator = std.testing.allocator;
+    const cover = try renderCover(allocator, "relay.example.com");
+    defer allocator.free(cover);
     try std.testing.expectError(
         error.InvalidWebSocketPath,
-        renderBridge(std.testing.allocator, "/a\nb"),
+        renderBridge(allocator, cover, "/a\nb"),
     );
-    const escaped = try renderBridge(std.testing.allocator, "/a<b>c&d\"e");
-    defer std.testing.allocator.free(escaped);
+    const escaped = try renderBridge(allocator, cover, "/a<b>c&d\"e");
+    defer allocator.free(escaped);
     try std.testing.expect(!std.mem.containsAtLeast(u8, escaped, 1, "<b>"));
     try std.testing.expect(std.mem.containsAtLeast(u8, escaped, 1, "\\u003c"));
     try std.testing.expect(std.mem.containsAtLeast(u8, escaped, 1, "\\\""));

--- a/src/web/relay.zig
+++ b/src/web/relay.zig
@@ -41,6 +41,7 @@
 //! Protocol reference: tdesktop `docs/web-proxy-plan.md` §6–§8.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const posix = std.posix;
 const linux = std.os.linux;
 
@@ -48,6 +49,7 @@ const config = @import("../config.zig");
 const crypto = @import("../crypto/crypto.zig");
 const socket_utils = @import("../proxy/socket_utils.zig");
 const net_helpers = @import("../proxy/net_helpers.zig");
+const dns_cache = @import("../proxy/dns_cache.zig");
 const message_queue = @import("../proxy/message_queue.zig");
 const queue_io = @import("../proxy/queue_io.zig");
 
@@ -104,7 +106,7 @@ const carrier_queue_limit: usize = 8 * 1024 * 1024;
 /// Hard ceiling on one stream's queue towards the backend. The client's own credit
 /// already bounds this at the 4 MiB window; the backend is loopback, so anything near
 /// this means the proxy is wedged and the stream is better off dead.
-const backend_queue_limit: usize = 1024 * 1024;
+const backend_queue_limit: usize = frame.initial_stream_window + 256;
 
 /// Cap on an HTTP connection's response queue. Every response we emit is a few KiB.
 const http_queue_limit: usize = 256 * 1024;
@@ -215,6 +217,10 @@ fn buildCapabilities(
 const ConnKind = enum { http, websocket, backend };
 
 const Conn = struct {
+    accounted_bytes: usize = 0,
+    batch: std.ArrayList(u8) = .empty,
+    batch_pending: bool = false,
+    batch_frames: usize = 0,
     fd: posix.fd_t,
     kind: ConnKind,
     peer: Address,
@@ -233,6 +239,8 @@ const Conn = struct {
     session: ?*Session = null,
     stream: ?*Stream = null,
     connecting: bool = false,
+    backend_candidates: net_helpers.AddressCandidates = .{},
+    backend_next: usize = 0,
     /// Diagnostics for the one failure mode that matters here — bytes arriving from the
     /// proxy but never reaching the client. Comparing `rx_bytes` against the proxy's own
     /// `s2c=` for the same connection localises a stall to one side of the socket in a
@@ -271,12 +279,11 @@ const Session = struct {
     welcomed: bool = false,
     tearing_down: bool = false,
     streams: std.AutoHashMapUnmanaged(u32, *Stream) = .empty,
-    closed_ids: [closed_history]u32 = [_]u32{0} ** closed_history,
+    closed_ids: []u32 = &.{},
     closed_pos: usize = 0,
     last_rx_ms: i64 = 0,
     last_ping_ms: i64 = 0,
     ping_payload: [8]u8 = [_]u8{0} ** 8,
-    ping_outstanding: bool = false,
     needs_window_flush: bool = false,
     /// DATA frames and payload bytes pushed at the client. Their ratio is the average
     /// frame size, which is what decides how much work the client's JS thread does per
@@ -291,8 +298,9 @@ const Session = struct {
     streams_refused: u32 = 0,
 
     fn rememberClosed(self: *Session, id: u32) void {
+        if (self.closed_ids.len == 0) return;
         self.closed_ids[self.closed_pos] = id;
-        self.closed_pos = (self.closed_pos + 1) % closed_history;
+        self.closed_pos = (self.closed_pos + 1) % self.closed_ids.len;
     }
 
     fn recentlyClosed(self: *const Session, id: u32) bool {
@@ -303,13 +311,32 @@ const Session = struct {
     }
 };
 
+test "closed stream retention scales beyond the former 64-id cap" {
+    var ids: [256]u32 = [_]u32{0} ** 256;
+    var session = Session{ .conn = undefined, .user = "test", .client_addr = null, .closed_ids = &ids };
+    for (1..257) |id| session.rememberClosed(@intCast(id));
+    try std.testing.expect(session.recentlyClosed(1));
+    try std.testing.expect(session.recentlyClosed(256));
+    try std.testing.expect(!session.recentlyClosed(0));
+}
+
+test "backend queue accommodates a complete granted receive window" {
+    try std.testing.expect(backend_queue_limit >= frame.initial_stream_window + 52);
+    try std.testing.expect(ws.max_message >= frame.max_payload + frame.header_size);
+}
+
 // ── the relay ─────────────────────────────────────────────────────────────────
 
 pub const Relay = struct {
     allocator: std.mem.Allocator,
     opts: Options,
+    backend_dns: ?*dns_cache.Cache = null,
+    backend_dns_id: usize = 0,
     caps: []UserCapability,
     /// Pre-rendered responses; the bridge page carries no per-user bytes.
+    /// The cover page is generated per deployment (see `page.renderCover`), so it is
+    /// owned here rather than being a constant.
+    cover_page: []u8,
     bridge_page: []u8,
     bridge_headers: []u8,
     cover_headers: []u8,
@@ -325,6 +352,7 @@ pub const Relay = struct {
     /// Closed connections whose memory is released at the top of the next loop
     /// iteration, together with their fd. See `closeConn`.
     pending_free: std.ArrayList(*Conn) = .empty,
+    batch_fds: std.ArrayList(posix.fd_t) = .empty,
     /// Reused snapshot of connection fds, so timers can close connections without
     /// mutating the map they are walking.
     tick_scratch: std.ArrayList(posix.fd_t) = .empty,
@@ -334,10 +362,10 @@ pub const Relay = struct {
     http_count: u32 = 0,
 
     bytes_out: std.atomic.Value(u64) = .init(0),
-    /// Set by `tick` when the aggregate queued bytes exceed the budget. While set, no new
-    /// client credit is handed out and backends stop being drained, so the total can only
-    /// fall. Cheaper than accounting on every queue mutation, and a 50 ms lag is
-    /// irrelevant against a multi-megabyte budget.
+    buffered_bytes: usize = 0,
+    streams_refused: u64 = 0,
+    accepts_refused: u64 = 0,
+    /// Soft backpressure before the hard budget enforced at every buffer mutation.
     throttled: bool = false,
     stop: bool = false,
     read_buf: [read_buf_size]u8 = undefined,
@@ -346,7 +374,12 @@ pub const Relay = struct {
         const caps = try buildCapabilities(allocator, cfg, opts.domain);
         errdefer allocator.free(caps);
 
-        const bridge_page = try page.renderBridge(allocator, opts.ws_path);
+        const cover_page = try page.renderCover(allocator, opts.domain);
+        errdefer allocator.free(cover_page);
+
+        // The bridge page IS the cover page plus the script: a capability holder must be
+        // served the same visible site a prober gets, or the cover proves nothing.
+        const bridge_page = try page.renderBridge(allocator, cover_page, opts.ws_path);
         errdefer allocator.free(bridge_page);
 
         // The bridge response must be framable by tdesktop's loopback fallback page,
@@ -356,7 +389,7 @@ pub const Relay = struct {
         const bridge_headers = try std.fmt.allocPrint(allocator, "Content-Type: text/html; charset=utf-8\r\n" ++
             "Content-Security-Policy: default-src 'none'; script-src 'unsafe-inline'; " ++
             "style-src 'unsafe-inline'; connect-src 'self' wss://{s}; base-uri 'none'; " ++
-            "form-action 'none'; frame-ancestors http://127.0.0.1:* http://[::1]:*\r\n" ++
+            "form-action 'none'; frame-ancestors http://127.0.0.1:*\r\n" ++
             "Referrer-Policy: no-referrer\r\n" ++
             "X-Content-Type-Options: nosniff\r\n" ++
             "Cache-Control: no-store\r\n", .{opts.domain});
@@ -381,15 +414,30 @@ pub const Relay = struct {
         var mask = posix.sigemptyset();
         posix.sigaddset(&mask, .TERM);
         posix.sigaddset(&mask, .INT);
+        posix.sigaddset(&mask, .HUP);
         var old_sigmask: posix.sigset_t = undefined;
         posix.sigprocmask(posix.SIG.BLOCK, &mask, &old_sigmask);
         errdefer posix.sigprocmask(posix.SIG.SETMASK, &old_sigmask, null);
         const signal_fd = try posix.signalfd(-1, &mask, linux.SFD.CLOEXEC | linux.SFD.NONBLOCK);
+        errdefer closeFd(signal_fd);
+        const cache = try dns_cache.Cache.create(allocator);
+        errdefer cache.destroy();
+        const spec = cfg.web.backend;
+        const colon = if (spec) |s| std.mem.lastIndexOfScalar(u8, s, ':') orelse return error.InvalidBackend else 0;
+        const host = if (spec) |s| std.mem.trim(u8, s[0..colon], "[] ") else "127.0.0.1";
+        const port = if (spec) |s| try std.fmt.parseInt(u16, s[colon + 1 ..], 10) else cfg.port;
+        const addresses = try net_helpers.getAddressList(allocator, host, port);
+        defer addresses.deinit();
+        const dns_id = try cache.add(host, port, net_helpers.AddressCandidates.init(addresses.addrs));
+        try cache.start();
 
         return .{
             .allocator = allocator,
             .opts = opts,
+            .backend_dns = cache,
+            .backend_dns_id = dns_id,
             .caps = caps,
+            .cover_page = cover_page,
             .bridge_page = bridge_page,
             .bridge_headers = bridge_headers,
             .cover_headers = cover_headers,
@@ -402,6 +450,7 @@ pub const Relay = struct {
     }
 
     pub fn deinit(self: *Relay) void {
+        if (self.backend_dns) |cache| cache.destroy();
         var it = self.conns.valueIterator();
         while (it.next()) |conn_ptr| {
             const conn = conn_ptr.*;
@@ -412,6 +461,7 @@ pub const Relay = struct {
                     var streams = session.streams.valueIterator();
                     while (streams.next()) |stream_ptr| self.allocator.destroy(stream_ptr.*);
                     session.streams.deinit(self.allocator);
+                    self.allocator.free(session.closed_ids);
                     self.allocator.destroy(session);
                 }
             }
@@ -423,12 +473,14 @@ pub const Relay = struct {
         self.pending_close.deinit(self.allocator);
         for (self.pending_free.items) |conn| self.destroyConn(conn);
         self.pending_free.deinit(self.allocator);
+        self.batch_fds.deinit(self.allocator);
         self.tick_scratch.deinit(self.allocator);
         closeFd(self.signal_fd);
         posix.sigprocmask(posix.SIG.SETMASK, &self.old_sigmask, null);
         closeFd(self.listen_fd);
         closeFd(self.epoll_fd);
         self.allocator.free(self.caps);
+        self.allocator.free(self.cover_page);
         self.allocator.free(self.bridge_page);
         self.allocator.free(self.bridge_headers);
         self.allocator.free(self.cover_headers);
@@ -462,7 +514,13 @@ pub const Relay = struct {
             for (events[0..n]) |ev| {
                 const fd = ev.data.fd;
                 if (fd == self.signal_fd) {
-                    self.stop = true;
+                    var info: linux.signalfd_siginfo = undefined;
+                    const size = posix.read(fd, std.mem.asBytes(&info)) catch continue;
+                    if (size == @sizeOf(linux.signalfd_siginfo)) {
+                        if (info.signo == @intFromEnum(posix.SIG.HUP)) {
+                            log.info("SIGHUP received; relay configuration changes require a restart", .{});
+                        } else self.stop = true;
+                    }
                     continue;
                 }
                 if (fd == self.listen_fd) {
@@ -472,6 +530,7 @@ pub const Relay = struct {
                 const conn = self.conns.get(fd) orelse continue;
                 self.dispatch(conn, ev.events);
             }
+            self.flushBatches();
 
             const now = nowMs();
             if (now - last_tick_ms >= event_loop_wait_ms) {
@@ -516,9 +575,7 @@ pub const Relay = struct {
     /// numbers eagerly, and a number reused inside one event batch would misattribute a
     /// stale hangup to a fresh connection.
     fn deferClose(self: *Relay, fd: posix.fd_t) void {
-        self.pending_close.append(self.allocator, fd) catch {
-            closeFd(fd);
-        };
+        self.pending_close.appendAssumeCapacity(fd);
     }
 
     fn drainPendingCloses(self: *Relay) void {
@@ -559,6 +616,17 @@ pub const Relay = struct {
             // One HTTP connection per session plus slack for cover-site traffic.
             const http_cap = @min(@as(u64, self.opts.max_sessions) * 4 + 32, 4096);
             if (self.http_count >= http_cap) {
+                var oldest: ?*Conn = null;
+                var peers = self.conns.valueIterator();
+                while (peers.next()) |candidate| {
+                    const idle = candidate.*;
+                    if (idle.kind != .http or idle.in.items.len != 0 or !idle.out.isEmpty()) continue;
+                    if (oldest == null or idle.deadline_ms < oldest.?.deadline_ms) oldest = idle;
+                }
+                if (oldest) |idle| self.closeConn(idle, "idle HTTP connection evicted for capacity");
+            }
+            if (self.http_count >= http_cap) {
+                self.accepts_refused +|= 1;
                 closeFd(result.fd);
                 continue;
             }
@@ -574,6 +642,10 @@ pub const Relay = struct {
     }
 
     fn createConn(self: *Relay, fd: posix.fd_t, kind: ConnKind, peer: Address) !*Conn {
+        // Reserve teardown storage before publishing an fd into an event batch.
+        const capacity = self.conns.count() + self.pending_close.items.len + 1;
+        try self.pending_close.ensureTotalCapacity(self.allocator, capacity);
+        try self.pending_free.ensureTotalCapacity(self.allocator, capacity);
         const conn = try self.allocator.create(Conn);
         errdefer self.allocator.destroy(conn);
         conn.* = .{
@@ -589,10 +661,67 @@ pub const Relay = struct {
     }
 
     fn destroyConn(self: *Relay, conn: *Conn) void {
+        self.buffered_bytes -= conn.accounted_bytes;
         conn.out.deinit();
         conn.in.deinit(self.allocator);
         conn.msg.deinit(self.allocator);
+        conn.batch.deinit(self.allocator);
         self.allocator.destroy(conn);
+    }
+
+    fn accountConn(self: *Relay, conn: *Conn) void {
+        const current = conn.out.total_len + conn.in.items.len + conn.msg.items.len + conn.batch.items.len;
+        self.buffered_bytes = self.buffered_bytes - conn.accounted_bytes + current;
+        conn.accounted_bytes = current;
+    }
+
+    fn canBuffer(self: *const Relay, extra: usize) bool {
+        return extra <= self.opts.max_buffer_bytes -| self.buffered_bytes;
+    }
+
+    fn writePair(self: *Relay, conn: *Conn, first: []const u8, second: []const u8) !bool {
+        if (!self.canBuffer(first.len + second.len)) return error.BufferBudgetExceeded;
+        defer self.accountConn(conn);
+        // Until SO_ERROR confirms the connection, keep every byte available for retry.
+        if (conn.connecting) {
+            try conn.out.appendCopy(first);
+            try conn.out.appendCopy(second);
+            return false;
+        }
+        return queue_io.queueOrWriteMsgPair(conn.fd, &conn.out, first, second, &self.bytes_out, null);
+    }
+
+    fn appendInput(self: *Relay, conn: *Conn, data: []const u8, fragmented: bool) !void {
+        if (!self.canBuffer(data.len)) return error.BufferBudgetExceeded;
+        defer self.accountConn(conn);
+        const buffer = if (fragmented) &conn.msg else &conn.in;
+        try buffer.appendSlice(self.allocator, data);
+    }
+
+    fn flushBatch(self: *Relay, conn: *Conn) !void {
+        if (conn.batch.items.len == 0) return;
+        var header: [ws.max_server_header]u8 = undefined;
+        const framing = try ws.writeHeader(&header, true, .binary, conn.batch.items.len);
+        if (!self.canBuffer(framing.len)) return error.BufferBudgetExceeded;
+        // Transfer already-accounted batch bytes to the socket queue.
+        defer self.accountConn(conn);
+        errdefer {
+            conn.batch.clearRetainingCapacity();
+            conn.batch_frames = 0;
+        }
+        _ = try queue_io.queueOrWriteMsgPair(conn.fd, &conn.out, framing, conn.batch.items, &self.bytes_out, null);
+        conn.batch.clearRetainingCapacity();
+        conn.batch_frames = 0;
+        self.syncConn(conn);
+    }
+
+    fn flushBatches(self: *Relay) void {
+        for (self.batch_fds.items) |fd| {
+            const conn = self.conns.get(fd) orelse continue;
+            conn.batch_pending = false;
+            self.flushBatch(conn) catch self.closeConn(conn, "carrier batch write failed");
+        }
+        self.batch_fds.clearRetainingCapacity();
     }
 
     fn closeConn(self: *Relay, conn: *Conn, reason: []const u8) void {
@@ -636,7 +765,7 @@ pub const Relay = struct {
         // can try to notify the websocket), so every caller that still holds `conn` on
         // return would otherwise be reading freed memory. Freeing on the same schedule
         // as the fd keeps `alive(fd)` an honest liveness check for all of them.
-        self.pending_free.append(self.allocator, conn) catch self.destroyConn(conn);
+        self.pending_free.appendAssumeCapacity(conn);
     }
 
     /// Recompute epoll interest, writing it out only when it changed.
@@ -657,6 +786,7 @@ pub const Relay = struct {
                     if (conn.connecting) break :blk false;
                     if (self.throttled) break :blk false;
                     const s = stream orelse break :blk false;
+                    if (s.session.conn.close_after_flush) break :blk false;
                     if (s.send_window == 0) break :blk false;
                     break :blk s.session.conn.out.total_len < carrier_high_water;
                 };
@@ -682,6 +812,12 @@ pub const Relay = struct {
     fn dispatch(self: *Relay, conn: *Conn, events: u32) void {
         const fd = conn.fd;
         const fatal = (events & (linux.EPOLL.ERR | linux.EPOLL.HUP)) != 0;
+        // A failed/prematurely closed connect must not enter the read/flush path:
+        // doing so can discard the queued preamble before trying another address.
+        if (conn.connecting and (fatal or (events & linux.EPOLL.RDHUP) != 0)) {
+            if (!self.retryBackend(conn)) self.closeConn(conn, "backend connect failed");
+            return;
+        }
         if ((events & linux.EPOLL.OUT) != 0) {
             self.onWritable(conn);
             if (!self.alive(fd)) return;
@@ -698,10 +834,11 @@ pub const Relay = struct {
     }
 
     fn onWritable(self: *Relay, conn: *Conn) void {
+        defer self.accountConn(conn);
         if (conn.kind == .backend and conn.connecting) {
             socket_utils.checkSocketConnectError(conn.fd) catch |err| {
                 log.debug("backend connect failed: {any}", .{err});
-                self.closeConn(conn, "backend connect failed");
+                if (!self.retryBackend(conn)) self.closeConn(conn, "backend connect failed");
                 return;
             };
             conn.connecting = false;
@@ -758,18 +895,14 @@ pub const Relay = struct {
             self.closeConn(conn, "client closed");
             return;
         }
-        if (conn.in.items.len + n > http.max_head_bytes) {
-            self.respondStatus(conn, "431 Request Header Fields Too Large");
-            return;
-        }
-        conn.in.appendSlice(self.allocator, self.read_buf[0..n]) catch {
+        self.appendInput(conn, self.read_buf[0..n], false) catch {
             self.closeConn(conn, "out of memory");
             return;
         };
         const fd = conn.fd;
         while (http.headEnd(conn.in.items) != null) {
-            const request = http.parse(conn.in.items) catch {
-                self.respondStatus(conn, "400 Bad Request");
+            const request = http.parse(conn.in.items) catch |err| {
+                self.respondStatus(conn, if (err == error.HeadTooLarge) "431 Request Header Fields Too Large" else "400 Bad Request");
                 return;
             };
             // `request` borrows slices out of conn.in, so the head can only be dropped
@@ -779,6 +912,7 @@ pub const Relay = struct {
             self.serve(conn, &request);
             if (!self.alive(fd)) return;
             dropFront(&conn.in, consumed);
+            self.accountConn(conn);
             if (conn.kind != .http) {
                 // Upgraded. Anything pipelined behind the request head is already the
                 // WebSocket stream, and no further readiness event will announce it.
@@ -788,10 +922,20 @@ pub const Relay = struct {
             if (conn.close_after_flush) return;
             conn.deadline_ms = nowMs() + http_idle_timeout_ms;
         }
+        if (conn.in.items.len >= http.max_head_bytes) self.respondStatus(conn, "431 Request Header Fields Too Large");
     }
 
     fn serve(self: *Relay, conn: *Conn, request: *const http.Request) void {
         const keep = request.keepAlive();
+        if (std.mem.eql(u8, request.path(), "/metrics") and metricsRequestAllowed(conn.peer, request)) {
+            var metrics_buf: [2048]u8 = undefined;
+            const body = self.renderMetrics(&metrics_buf) catch {
+                self.respondStatus(conn, "500 Internal Server Error");
+                return;
+            };
+            self.respondPage(conn, "200 OK", "Content-Type: text/plain; version=0.0.4\r\nCache-Control: no-store\r\n", body, keep, request.method == .head);
+            return;
+        }
         if (request.method == .other) {
             self.respondStatus(conn, "405 Method Not Allowed");
             return;
@@ -807,7 +951,7 @@ pub const Relay = struct {
                 self.upgrade(conn, request, name);
             } else {
                 // No valid capability: behave exactly like any other unknown path.
-                self.respondPage(conn, "404 Not Found", self.notfound_headers, page.cover_body, keep, request.method == .head);
+                self.respondPage(conn, "404 Not Found", self.notfound_headers, self.cover_page, keep, request.method == .head);
             }
             return;
         }
@@ -816,11 +960,26 @@ pub const Relay = struct {
             if (user != null) {
                 self.respondPage(conn, "200 OK", self.bridge_headers, self.bridge_page, keep, request.method == .head);
             } else {
-                self.respondPage(conn, "200 OK", self.cover_headers, page.cover_body, keep, request.method == .head);
+                self.respondPage(conn, "200 OK", self.cover_headers, self.cover_page, keep, request.method == .head);
             }
             return;
         }
-        self.respondPage(conn, "404 Not Found", self.notfound_headers, page.cover_body, keep, request.method == .head);
+        self.respondPage(conn, "404 Not Found", self.notfound_headers, self.cover_page, keep, request.method == .head);
+    }
+
+    fn renderMetrics(self: *const Relay, buffer: []u8) ![]const u8 {
+        var streams: usize = 0;
+        var it = self.conns.valueIterator();
+        while (it.next()) |conn| {
+            if (conn.*.session) |session| streams += session.streams.count();
+        }
+        return std.fmt.bufPrint(buffer, "# TYPE mtproto_web_sessions gauge\nmtproto_web_sessions {d}\n" ++
+            "# TYPE mtproto_web_streams gauge\nmtproto_web_streams {d}\n" ++
+            "# TYPE mtproto_web_streams_refused_total counter\nmtproto_web_streams_refused_total {d}\n" ++
+            "# TYPE mtproto_web_accept_refused_total counter\nmtproto_web_accept_refused_total {d}\n" ++
+            "# TYPE mtproto_web_throttled gauge\nmtproto_web_throttled {d}\n" ++
+            "# TYPE mtproto_web_buffered_bytes gauge\nmtproto_web_buffered_bytes {d}\n" ++
+            "# TYPE mtproto_web_bytes_out_total counter\nmtproto_web_bytes_out_total {d}\n", .{ self.session_count, streams, self.streams_refused, self.accepts_refused, @intFromBool(self.throttled), self.buffered_bytes, self.bytes_out.load(.monotonic) });
     }
 
     /// Constant-time match of a presented capability against every configured user.
@@ -844,8 +1003,12 @@ pub const Relay = struct {
     ) void {
         var head_buf: [1024]u8 = undefined;
         var writer: std.Io.Writer = .fixed(&head_buf);
-        writer.print("HTTP/1.1 {s}\r\n{s}Content-Length: {d}\r\nConnection: {s}\r\n\r\n", .{
+        var date_buf: [40]u8 = undefined;
+        const seconds = std.Io.Clock.real.now(std.Io.Threaded.global_single_threaded.io()).toSeconds();
+        const date = httpDate(&date_buf, @intCast(@max(0, seconds))) catch "Thu, 01 Jan 1970 00:00:00 GMT";
+        writer.print("HTTP/1.1 {s}\r\nDate: {s}\r\nServer: nginx\r\n{s}Content-Length: {d}\r\nConnection: {s}\r\n\r\n", .{
             status,
+            date,
             headers,
             body.len,
             if (keep_alive) "keep-alive" else "close",
@@ -859,7 +1022,7 @@ pub const Relay = struct {
         }
         conn.close_after_flush = !keep_alive;
         const payload = if (head_only) "" else body;
-        const drained = queue_io.queueOrWriteMsgPair(conn.fd, &conn.out, writer.buffered(), payload, &self.bytes_out, null) catch {
+        const drained = self.writePair(conn, writer.buffered(), payload) catch {
             self.closeConn(conn, "response write failed");
             return;
         };
@@ -873,7 +1036,9 @@ pub const Relay = struct {
     }
 
     fn respondStatus(self: *Relay, conn: *Conn, status: []const u8) void {
-        self.respondPage(conn, status, self.notfound_headers, page.cover_body, false, false);
+        var body_buf: [512]u8 = undefined;
+        const body = std.fmt.bufPrint(&body_buf, "<!doctype html><html><head><title>{s}</title></head><body><h1>{s}</h1></body></html>\n", .{ status, status }) catch self.cover_page;
+        self.respondPage(conn, status, self.notfound_headers, body, false, false);
     }
 
     // ── WebSocket upgrade ─────────────────────────────────────────────────────
@@ -897,7 +1062,7 @@ pub const Relay = struct {
             const want = std.fmt.bufPrint(&expected, "https://{s}", .{self.opts.domain}) catch "";
             if (!std.mem.eql(u8, origin, want)) {
                 log.debug("rejecting websocket upgrade with unexpected origin", .{});
-                self.respondPage(conn, "404 Not Found", self.notfound_headers, page.cover_body, false, false);
+                self.respondPage(conn, "404 Not Found", self.notfound_headers, self.cover_page, false, false);
                 return;
             }
         }
@@ -923,6 +1088,12 @@ pub const Relay = struct {
             .last_rx_ms = nowMs(),
             .last_ping_ms = nowMs(),
         };
+        session.closed_ids = self.allocator.alloc(u32, @max(closed_history, self.opts.max_streams)) catch {
+            self.allocator.destroy(session);
+            self.closeConn(conn, "out of memory");
+            return;
+        };
+        @memset(session.closed_ids, 0);
 
         conn.kind = .websocket;
         conn.session = session;
@@ -930,7 +1101,7 @@ pub const Relay = struct {
         conn.deadline_ms = 0;
         self.session_count += 1;
 
-        _ = queue_io.queueOrWriteMsg(conn.fd, &conn.out, head, &self.bytes_out, null) catch {
+        _ = self.writePair(conn, head, "") catch {
             self.closeConn(conn, "upgrade write failed");
             return;
         };
@@ -949,17 +1120,21 @@ pub const Relay = struct {
     ///
     /// Behind a TLS terminator the socket peer is the terminator, so a forwarded-for
     /// header is the only source of the real client. Only its right-most entry is read,
-    /// because that is the one our own hop wrote and the one a client cannot forge.
+    /// because that is the one our own hop wrote and the one a client cannot forge —
+    /// and only the LAST such header line, because a terminator that appends a line
+    /// rather than replacing ours would otherwise leave the client's own line first.
     ///
     /// In `--mode mask` this legitimately resolves to loopback: the masking hop inside
     /// the proxy is a raw byte pipe that carries no client address, so nginx genuinely
     /// observes 127.0.0.1. That costs per-IP granularity for relayed users, which is why
     /// they are exempt from the per-IP guards rather than sharing one key with them.
     fn clientAddress(self: *Relay, conn: *Conn, request: *const http.Request) ?Address {
-        if (self.opts.trust_forwarded_for and self.opts.client_ip_header.len > 0) {
-            if (request.header(self.opts.client_ip_header)) |value| {
+        if (self.opts.trust_forwarded_for and self.opts.client_ip_header.len > 0 and trusted_peers.isLoopback(conn.peer)) {
+            if (request.lastHeader(self.opts.client_ip_header)) |value| {
                 if (http.forwardedForClient(value)) |text| {
-                    if (Address.parse(text, 0)) |addr| return addr else |_| {}
+                    if (Address.parse(text, 0)) |addr| {
+                        if (!trusted_peers.isLoopback(addr)) return addr;
+                    } else |_| {}
                 }
             }
         }
@@ -979,6 +1154,7 @@ pub const Relay = struct {
             self.allocator.destroy(stream);
         }
         session.streams.deinit(self.allocator);
+        self.allocator.free(session.closed_ids);
         self.session_count -|= 1;
         const avg_frame = if (session.data_frames > 0) session.data_bytes / session.data_frames else 0;
         log.info("web session closed for user {s} (peak {d}/{d} streams, {d} refused, {d} KiB in {d} frames, avg {d} B)", .{
@@ -1005,7 +1181,7 @@ pub const Relay = struct {
             self.closeConn(conn, "websocket closed by peer");
             return;
         }
-        conn.in.appendSlice(self.allocator, self.read_buf[0..n]) catch {
+        self.appendInput(conn, self.read_buf[0..n], false) catch {
             self.closeConn(conn, "out of memory");
             return;
         };
@@ -1014,33 +1190,42 @@ pub const Relay = struct {
     }
 
     /// Parse and dispatch every complete WebSocket frame buffered in `conn.in`.
+    ///
+    /// Frames are consumed with a cursor and the buffer is compacted **once**, when the
+    /// pass ends. `dropFront` memmoves the whole remainder, so compacting per frame made
+    /// this O(n²) in the size of one read: a peer packing a 64 KiB read with minimal
+    /// 6-byte frames (a masked zero-length PONG costs it nothing and is answered by
+    /// nothing) moved ~340 MiB per pass and pinned the relay's single thread, stalling
+    /// every other WEB session on the box.
     fn processWsBuffer(self: *Relay, conn: *Conn) void {
+        if (conn.close_after_flush) return;
         const fd = conn.fd;
+        var used: usize = 0;
+        // Only a still-mapped connection may be touched: a frame handler can close this
+        // one, and then `conn` is queued for release and its buffer is no longer ours.
+        defer if (self.alive(fd)) {
+            dropFront(&conn.in, used);
+            self.accountConn(conn);
+        };
         while (true) {
-            const parsed = ws.parseHeader(conn.in.items) catch {
-                self.failCarrier(conn, ws.close_protocol_error, "bad websocket frame");
+            const rest = conn.in.items[used..];
+            const parsed = ws.parseHeader(rest) catch |err| {
+                self.failCarrier(conn, if (err == error.TooBig) ws.close_message_too_big else ws.close_protocol_error, "bad websocket frame");
                 return;
             };
             const header = switch (parsed) {
-                .incomplete => {
-                    if (conn.in.items.len > ws.max_message + 32) {
-                        self.failCarrier(conn, ws.close_message_too_big, "websocket header never completed");
-                    }
-                    return;
-                },
+                .incomplete => return,
                 .header => |h| h,
             };
-            if (conn.in.items.len < header.totalLen()) {
-                if (conn.in.items.len > ws.max_message + 32) {
-                    self.failCarrier(conn, ws.close_message_too_big, "websocket frame too large");
-                }
+            if (rest.len < header.totalLen()) {
                 return;
             }
-            const payload = conn.in.items[header.header_len..header.totalLen()];
+            const payload = rest[header.header_len..header.totalLen()];
             ws.unmask(payload, header.mask, 0);
+            // Counted before dispatch: the handler may return through the `defer` above.
+            used += header.totalLen();
             self.handleWsFrame(conn, header, payload);
-            if (!self.alive(fd)) return;
-            dropFront(&conn.in, header.totalLen());
+            if (!self.alive(fd) or conn.close_after_flush) return;
         }
     }
 
@@ -1059,7 +1244,7 @@ pub const Relay = struct {
                 }
                 var head: [ws.max_server_header]u8 = undefined;
                 const framing = ws.writeHeader(&head, true, .pong, payload.len) catch return;
-                _ = queue_io.queueOrWriteMsgPair(conn.fd, &conn.out, framing, payload, &self.bytes_out, null) catch {
+                _ = self.writePair(conn, framing, payload) catch {
                     self.closeConn(conn, "pong write failed");
                     return;
                 };
@@ -1096,7 +1281,7 @@ pub const Relay = struct {
             self.failCarrier(conn, ws.close_message_too_big, "fragmented message too large");
             return;
         }
-        conn.msg.appendSlice(self.allocator, payload) catch {
+        self.appendInput(conn, payload, true) catch {
             self.closeConn(conn, "out of memory");
             return;
         };
@@ -1106,6 +1291,7 @@ pub const Relay = struct {
         self.handleCarrierMessage(conn, conn.msg.items);
         if (!self.alive(fd)) return;
         conn.msg.clearRetainingCapacity();
+        self.accountConn(conn);
     }
 
     /// One carrier message holds one or more complete relay frames — an empty message or
@@ -1163,12 +1349,11 @@ pub const Relay = struct {
                 },
                 .pong => {
                     if (f.payload.len > frame.max_ping_payload) return error.Protocol;
-                    // Only an exact echo clears the outstanding probe, but a stale PONG
-                    // is not a protocol violation — it is just late, and the frame having
-                    // arrived at all is the liveness signal that actually matters.
-                    if (std.mem.eql(u8, f.payload, &session.ping_payload)) {
-                        session.ping_outstanding = false;
-                    }
+                    // Any inbound frame updates last_rx_ms; a late PONG remains valid.
+                },
+                .ping => {
+                    if (f.payload.len > frame.max_ping_payload) return error.Protocol;
+                    try self.sendFrame(session, .pong, 0, f.payload);
                 },
                 .bye => self.byeAndClose(session),
                 else => return error.Protocol,
@@ -1216,6 +1401,41 @@ pub const Relay = struct {
 
     fn sendFrame(self: *Relay, session: *Session, kind: frame.FrameType, stream_id: u32, payload: []const u8) !void {
         const conn = session.conn;
+        if (conn.close_after_flush) return error.CarrierClosed;
+        if (kind != .welcome and kind != .bye) {
+            if (conn.batch.items.len + frame.header_size + payload.len > data_frame_size or conn.batch_frames >= frame.max_batch_frames) {
+                self.flushBatch(conn) catch {
+                    self.closeConn(conn, "carrier batch write failed");
+                    return error.CarrierClosed;
+                };
+            }
+            if (!self.canBuffer(frame.header_size + payload.len) or conn.out.total_len + conn.batch.items.len + frame.header_size + payload.len > carrier_queue_limit) {
+                self.closeConn(conn, "carrier buffer budget exceeded");
+                return error.CarrierClosed;
+            }
+            if (!conn.batch_pending) {
+                self.batch_fds.append(self.allocator, conn.fd) catch {
+                    self.closeConn(conn, "out of memory");
+                    return error.CarrierClosed;
+                };
+                conn.batch_pending = true;
+            }
+            var relay_header: [frame.header_size]u8 = undefined;
+            frame.writeHeader(&relay_header, kind, stream_id, @intCast(payload.len));
+            conn.batch.ensureUnusedCapacity(self.allocator, relay_header.len + payload.len) catch {
+                self.closeConn(conn, "out of memory");
+                return error.CarrierClosed;
+            };
+            conn.batch.appendSliceAssumeCapacity(&relay_header);
+            conn.batch.appendSliceAssumeCapacity(payload);
+            conn.batch_frames += 1;
+            self.accountConn(conn);
+            return;
+        }
+        self.flushBatch(conn) catch {
+            self.closeConn(conn, "carrier batch write failed");
+            return error.CarrierClosed;
+        };
         var head: [ws.max_server_header + frame.header_size]u8 = undefined;
         const total = frame.header_size + payload.len;
         const framing = ws.writeHeader(head[0..ws.max_server_header], true, .binary, total) catch return error.Protocol;
@@ -1227,7 +1447,7 @@ pub const Relay = struct {
             self.closeConn(conn, "carrier queue limit exceeded");
             return error.CarrierClosed;
         }
-        _ = queue_io.queueOrWriteMsgPair(conn.fd, &conn.out, prefix, payload, &self.bytes_out, null) catch {
+        _ = self.writePair(conn, prefix, payload) catch {
             self.closeConn(conn, "carrier write failed");
             return error.CarrierClosed;
         };
@@ -1245,9 +1465,13 @@ pub const Relay = struct {
     }
 
     fn failCarrier(self: *Relay, conn: *Conn, code: u16, reason: []const u8) void {
+        // Discard unsent logical frames before the terminal WebSocket CLOSE.
+        conn.batch.clearRetainingCapacity();
+        conn.batch_frames = 0;
+        self.accountConn(conn);
         var buf: [8]u8 = undefined;
         if (ws.closeFrame(&buf, code)) |close_frame| {
-            _ = queue_io.queueOrWriteMsg(conn.fd, &conn.out, close_frame, &self.bytes_out, null) catch {};
+            _ = self.writePair(conn, close_frame, "") catch {};
         } else |_| {}
         conn.close_after_flush = true;
         log.debug("carrier failing: {s}", .{reason});
@@ -1268,6 +1492,7 @@ pub const Relay = struct {
             // error would drop every other stream with it. It does mean the client sees
             // an unexplained failure, so make the cause visible here.
             session.streams_refused +|= 1;
+            self.streams_refused +|= 1;
             if (session.streams_refused == 1) {
                 log.warn("user {s}: refused a stream over the [web].max_streams cap of {d}; " ++
                     "the client will retry it as a failed connection. Raise max_streams if this repeats.", .{
@@ -1289,18 +1514,22 @@ pub const Relay = struct {
         const live: u32 = @intCast(session.streams.count());
         if (live > session.streams_high_water) session.streams_high_water = live;
 
-        const dialed_fd = self.dialBackend() catch |err| {
+        const candidates = if (self.backend_dns) |cache| cache.snapshot(self.backend_dns_id) else net_helpers.AddressCandidates.init(&.{self.opts.backend});
+        var next: usize = 0;
+        const dialed_fd = dialCandidate(candidates, &next) catch |err| {
             log.debug("backend dial failed: {any}", .{err});
             self.closeStream(stream, true);
             return;
         };
-        const conn = self.createConn(dialed_fd, .backend, self.opts.backend) catch {
+        const conn = self.createConn(dialed_fd, .backend, candidates.addresses[next - 1]) catch {
             closeFd(dialed_fd);
             self.closeStream(stream, true);
             return;
         };
         conn.stream = stream;
         conn.connecting = true;
+        conn.backend_candidates = candidates;
+        conn.backend_next = next;
         conn.deadline_ms = nowMs() + backend_connect_timeout_ms;
         stream.conn = conn;
 
@@ -1310,8 +1539,45 @@ pub const Relay = struct {
         self.syncConn(conn);
     }
 
-    fn dialBackend(self: *Relay) !posix.fd_t {
-        const family: u32 = if (net_helpers.isIpv6(self.opts.backend)) posix.AF.INET6 else posix.AF.INET;
+    fn dialCandidate(candidates: net_helpers.AddressCandidates, next: *usize) !posix.fd_t {
+        while (next.* < candidates.len) {
+            const address = candidates.addresses[next.*];
+            next.* += 1;
+            return dialBackend(address) catch continue;
+        }
+        return error.BackendAddressesExhausted;
+    }
+
+    fn retryBackend(self: *Relay, conn: *Conn) bool {
+        const fd = dialCandidate(conn.backend_candidates, &conn.backend_next) catch return false;
+        // Preserve the old fd until the event batch ends; preserve the connection's queue.
+        self.pending_close.ensureTotalCapacity(self.allocator, self.conns.count() + self.pending_close.items.len + 1) catch {
+            closeFd(fd);
+            return false;
+        };
+        self.conns.put(self.allocator, fd, conn) catch {
+            closeFd(fd);
+            return false;
+        };
+        self.addFd(fd, false, true) catch {
+            _ = self.conns.remove(fd);
+            closeFd(fd);
+            return false;
+        };
+        const old_fd = conn.fd;
+        self.delFd(old_fd);
+        _ = self.conns.remove(old_fd);
+        self.deferClose(old_fd);
+        conn.fd = fd;
+        conn.peer = conn.backend_candidates.addresses[conn.backend_next - 1];
+        conn.want_in = false;
+        conn.want_out = true;
+        conn.deadline_ms = nowMs() + backend_connect_timeout_ms;
+        return true;
+    }
+
+    fn dialBackend(address: Address) !posix.fd_t {
+        const family: u32 = if (net_helpers.isIpv6(address)) posix.AF.INET6 else posix.AF.INET;
         const flags = posix.SOCK.STREAM | posix.SOCK.NONBLOCK | posix.SOCK.CLOEXEC;
         const rc = posix.system.socket(family, flags, posix.IPPROTO.TCP);
         const fd: posix.fd_t = switch (posix.errno(rc)) {
@@ -1320,7 +1586,7 @@ pub const Relay = struct {
         };
         errdefer closeFd(fd);
         var storage: posix.sockaddr.storage = undefined;
-        const len = addressToSockaddr(self.opts.backend, &storage);
+        const len = addressToSockaddr(address, &storage);
         socket_utils.connectSockaddr(fd, @ptrCast(&storage), len) catch |err| {
             if (err != error.WouldBlock) return err;
         };
@@ -1335,7 +1601,7 @@ pub const Relay = struct {
         var buf: [64]u8 = undefined;
         const header = proxy_protocol.buildV2(&buf, session.client_addr, self.opts.backend);
         const before = conn.out.total_len;
-        _ = queue_io.queueOrWriteMsg(conn.fd, &conn.out, header, &self.bytes_out, null) catch {
+        _ = self.writePair(conn, header, "") catch {
             self.closeConn(conn, "proxy header write failed");
             return;
         };
@@ -1360,7 +1626,7 @@ pub const Relay = struct {
         }
         const fd = conn.fd;
         const before = conn.out.total_len;
-        _ = queue_io.queueOrWriteMsg(conn.fd, &conn.out, data, &self.bytes_out, null) catch {
+        _ = self.writePair(conn, data, "") catch {
             self.closeConn(conn, "backend write failed");
             return;
         };
@@ -1440,6 +1706,7 @@ pub const Relay = struct {
         if (conn.connecting) return;
         const session = stream.session;
         conn.rx_passes += 1;
+        if (session.conn.close_after_flush or self.throttled) return;
         conn.last_window = stream.send_window;
         while (true) {
             const budget = @min(@as(usize, stream.send_window), data_frame_size);
@@ -1512,11 +1779,11 @@ pub const Relay = struct {
         var queued: usize = 0;
         var it = self.conns.iterator();
         while (it.next()) |entry| {
-            queued += entry.value_ptr.*.out.total_len;
+            queued += entry.value_ptr.*.accounted_bytes;
             self.tick_scratch.append(self.allocator, entry.key_ptr.*) catch break;
         }
         const was_throttled = self.throttled;
-        self.throttled = queued > self.opts.max_buffer_bytes;
+        self.throttled = queued >= self.opts.max_buffer_bytes -| (2 * read_buf_size);
         if (self.throttled != was_throttled) {
             log.warn("relay {s} at {d} KiB queued (budget {d} KiB)", .{
                 if (self.throttled) "throttling" else "resuming",
@@ -1528,6 +1795,7 @@ pub const Relay = struct {
         for (self.tick_scratch.items) |fd| {
             const conn = self.conns.get(fd) orelse continue;
             if (conn.deadline_ms != 0 and now >= conn.deadline_ms) {
+                if (conn.connecting and self.retryBackend(conn)) continue;
                 self.closeConn(conn, "timed out");
                 continue;
             }
@@ -1566,7 +1834,6 @@ pub const Relay = struct {
             if (quiet_for >= ping_interval_ms and now - session.last_ping_ms >= ping_interval_ms) {
                 session.last_ping_ms = now;
                 crypto.randomBytes(&session.ping_payload);
-                session.ping_outstanding = true;
                 self.sendFrame(session, .ping, 0, &session.ping_payload) catch {};
             }
         }
@@ -1575,8 +1842,147 @@ pub const Relay = struct {
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
+fn httpDate(buffer: []u8, seconds: u64) ![]const u8 {
+    const epoch = std.time.epoch.EpochSeconds{ .secs = seconds };
+    const day = epoch.getEpochDay();
+    const year = day.calculateYearDay();
+    const month = year.calculateMonthDay();
+    const time = epoch.getDaySeconds();
+    const weekdays = [_][]const u8{ "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
+    const months = [_][]const u8{ "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
+    return std.fmt.bufPrint(buffer, "{s}, {d:0>2} {s} {d} {d:0>2}:{d:0>2}:{d:0>2} GMT", .{ weekdays[(day.day + 4) % 7], @as(u8, month.day_index) + 1, months[month.month.numeric() - 1], year.year, time.getHoursIntoDay(), time.getMinutesIntoHour(), time.getSecondsIntoMinute() });
+}
+
+test "HTTP Date uses IMF-fixdate in UTC" {
+    var buffer: [40]u8 = undefined;
+    try std.testing.expectEqualStrings("Thu, 01 Jan 1970 00:00:00 GMT", try httpDate(&buffer, 0));
+    try std.testing.expectEqualStrings("Sun, 06 Nov 1994 08:49:37 GMT", try httpDate(&buffer, 784111777));
+}
+
+/// Only a direct loopback scrape, never a request forwarded by the public terminator.
+fn metricsRequestAllowed(peer: Address, request: *const http.Request) bool {
+    if (!trusted_peers.isLoopback(peer) or (request.method != .get and request.method != .head)) return false;
+    if (request.header("x-forwarded-for") != null or request.header("forwarded") != null or request.header("origin") != null) return false;
+    const host = request.header("host") orelse return false;
+    return std.mem.eql(u8, host, "127.0.0.1") or std.mem.startsWith(u8, host, "127.0.0.1:") or std.mem.eql(u8, host, "[::1]") or std.mem.startsWith(u8, host, "[::1]:");
+}
+
+/// Test-only witness: `processWsBuffer` must compact once per read pass, never once per
+/// frame. Counting it is the only way a test can see the O(n²) memmove come back.
+var compactions_for_test: usize = 0;
+
+fn testRelay(allocator: std.mem.Allocator, limit: usize) Relay {
+    var options: Options = undefined;
+    options.max_buffer_bytes = limit;
+    return .{
+        .allocator = allocator,
+        .opts = options,
+        .caps = &.{},
+        .cover_page = "",
+        .bridge_page = "",
+        .bridge_headers = "",
+        .cover_headers = "",
+        .notfound_headers = "",
+        .epoll_fd = -1,
+        .listen_fd = -1,
+        .signal_fd = -1,
+        .old_sigmask = undefined,
+    };
+}
+
+test "aggregate budget includes input and fragment buffers and releases consumed bytes" {
+    const allocator = std.testing.allocator;
+    var relay = testRelay(allocator, 8);
+    var conn = Conn{ .fd = -1, .kind = .websocket, .peer = net_helpers.ip4(.{ 127, 0, 0, 1 }, 0), .out = .{ .allocator = allocator } };
+    defer conn.in.deinit(allocator);
+    defer conn.msg.deinit(allocator);
+    try relay.appendInput(&conn, "12345", false);
+    try relay.appendInput(&conn, "678", true);
+    try std.testing.expectEqual(@as(usize, 8), relay.buffered_bytes);
+    try std.testing.expectError(error.BufferBudgetExceeded, relay.appendInput(&conn, "9", false));
+    dropFront(&conn.in, 3);
+    relay.accountConn(&conn);
+    try relay.appendInput(&conn, "abc", true);
+    try std.testing.expectEqual(@as(usize, 8), relay.buffered_bytes);
+}
+
+test "production emitter batches exact DATA and WINDOW bytes and refuses condemned carriers" {
+    const allocator = std.testing.allocator;
+    var relay = testRelay(allocator, 1024);
+    defer relay.batch_fds.deinit(allocator);
+    var conn = Conn{ .fd = -1, .kind = .websocket, .peer = net_helpers.ip4(.{ 127, 0, 0, 1 }, 0), .out = .{ .allocator = allocator } };
+    defer conn.batch.deinit(allocator);
+    var session = Session{ .conn = &conn, .user = "test", .client_addr = null };
+    try relay.sendFrame(&session, .data, 7, "abc");
+    const grant = frame.windowPayload(4096);
+    try relay.sendFrame(&session, .window, 7, &grant);
+    try std.testing.expectEqualSlices(u8, &.{ 2, 0, 0, 7, 0, 0, 0, 3, 'a', 'b', 'c', 4, 0, 0, 7, 0, 0, 0, 4, 0, 0, 16, 0 }, conn.batch.items);
+    try std.testing.expectEqual(@as(usize, 2), conn.batch_frames);
+    try std.testing.expectEqual(@as(usize, 1), relay.batch_fds.items.len);
+    try std.testing.expectEqual(conn.batch.items.len, relay.buffered_bytes);
+    conn.close_after_flush = true;
+    try std.testing.expectError(error.CarrierClosed, relay.sendFrame(&session, .data, 7, "ignored"));
+    try std.testing.expectEqual(@as(usize, 2), conn.batch_frames);
+}
+
+test "backend credit excludes PROXY header debt and grants only drained client bytes" {
+    const allocator = std.testing.allocator;
+    var relay = testRelay(allocator, 1024);
+    var carrier = Conn{ .fd = -1, .kind = .websocket, .peer = net_helpers.ip4(.{ 127, 0, 0, 1 }, 0), .out = .{ .allocator = allocator } };
+    var session = Session{ .conn = &carrier, .user = "test", .client_addr = null };
+    var stream = Stream{ .id = 1, .session = &session, .recv_window = frame.initial_stream_window - 100, .grant_debt = 4 };
+    var backend = Conn{ .fd = -1, .kind = .backend, .peer = carrier.peer, .stream = &stream, .out = .{ .allocator = allocator } };
+    defer backend.out.deinit();
+    try backend.out.appendCopy("0123456789");
+    relay.creditDrainWith(&backend, 14);
+    try std.testing.expectEqual(@as(usize, 0), stream.grant_debt);
+    try std.testing.expectEqual(@as(u32, 0), stream.pending_grant);
+    relay.creditDrainWith(&backend, 110);
+    try std.testing.expectEqual(frame.initial_stream_window, stream.recv_window);
+    try std.testing.expectEqual(@as(u32, 100), stream.pending_grant);
+    try std.testing.expect(session.needs_window_flush);
+    relay.creditDrainWith(&backend, 10); // no new bytes drained
+    try std.testing.expectEqual(@as(u32, 100), stream.pending_grant);
+}
+
+test "metrics accepts direct loopback requests and rejects public or forwarded requests" {
+    const request = try http.parse("GET /metrics HTTP/1.1\r\nHost: 127.0.0.1:8081\r\n\r\n");
+    try std.testing.expect(metricsRequestAllowed(net_helpers.ip4(.{ 127, 0, 0, 1 }, 0), &request));
+    try std.testing.expect(!metricsRequestAllowed(net_helpers.ip4(.{ 203, 0, 113, 7 }, 0), &request));
+    const forwarded = try http.parse("GET /metrics HTTP/1.1\r\nHost: 127.0.0.1:8081\r\nX-Forwarded-For: 203.0.113.7\r\n\r\n");
+    try std.testing.expect(!metricsRequestAllowed(net_helpers.ip4(.{ 127, 0, 0, 1 }, 0), &forwarded));
+    var relay = testRelay(std.testing.allocator, 1024);
+    relay.session_count = 3;
+    relay.streams_refused = 7;
+    var buffer: [2048]u8 = undefined;
+    const metrics = try relay.renderMetrics(&buffer);
+    try std.testing.expect(std.mem.indexOf(u8, metrics, "mtproto_web_sessions 3\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, metrics, "mtproto_web_streams_refused_total 7\n") != null);
+}
+
+test "a queued websocket CLOSE stops the rest of the same read batch" {
+    const allocator = std.testing.allocator;
+    var relay = testRelay(allocator, 1024);
+    defer relay.conns.deinit(allocator);
+    var conn = Conn{ .fd = -1, .kind = .websocket, .peer = net_helpers.ip4(.{ 127, 0, 0, 1 }, 0), .out = .{ .allocator = allocator } };
+    conn.want_out = true; // epoll interest is already correct; no OS call in this unit test
+    defer conn.in.deinit(allocator);
+    defer conn.out.deinit();
+    try relay.conns.put(allocator, conn.fd, &conn);
+    try conn.out.appendCopy("x"); // prevent an inline write on the fake fd
+    const close = [_]u8{ 0x88, 0x80, 1, 2, 3, 4 };
+    try conn.in.appendSlice(allocator, &close);
+    try conn.in.appendSlice(allocator, &close);
+    relay.accountConn(&conn);
+    relay.processWsBuffer(&conn);
+    try std.testing.expect(conn.close_after_flush);
+    try std.testing.expectEqual(@as(usize, 5), conn.out.total_len);
+    try std.testing.expectEqualSlices(u8, &close, conn.in.items);
+}
+
 fn dropFront(list: *std.ArrayList(u8), n: usize) void {
     if (n == 0) return;
+    if (builtin.is_test) compactions_for_test += 1;
     std.debug.assert(n <= list.items.len);
     const rest = list.items.len - n;
     if (rest > 0) std.mem.copyForwards(u8, list.items[0..rest], list.items[n..]);
@@ -1584,9 +1990,14 @@ fn dropFront(list: *std.ArrayList(u8), n: usize) void {
 }
 
 fn listen(host: []const u8, port: u16) !posix.fd_t {
-    const io_ctx = std.Io.Threaded.global_single_threaded.io();
-    const addr = try Address.parse(host, port);
-    const server = try addr.listen(io_ctx, .{ .reuse_address = true, .kernel_backlog = 128 });
+    const addr = Address.parse(host, port) catch |err| {
+        log.err("[web].host must be an IP literal, got '{s}': {any}", .{ host, err });
+        return err;
+    };
+    const server = net_helpers.listen(addr, 128, false) catch |err| {
+        log.err("Cannot bind WEB relay to {s}:{d}: {any}; check [web].host/port and other listeners", .{ host, port, err });
+        return err;
+    };
     const fd = server.socket.handle;
     socket_utils.setNonBlocking(fd);
     return fd;
@@ -1619,6 +2030,68 @@ fn addressToSockaddr(addr: Address, storage: *posix.sockaddr.storage) posix.sock
 }
 
 // ── tests ─────────────────────────────────────────────────────────────────────
+
+test "backend retry freezes candidates and preserves queued bytes while retiring stale fd" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    const allocator = std.testing.allocator;
+    const listener = try net_helpers.listen(net_helpers.ip4(.{ 127, 0, 0, 1 }, 0), 8, false);
+    defer closeFd(listener.socket.handle);
+    const target = try socket_utils.localSocketAddress(listener.socket.handle);
+    var relay = Relay{
+        .allocator = allocator,
+        .opts = undefined,
+        .caps = undefined,
+        .cover_page = undefined,
+        .bridge_page = undefined,
+        .bridge_headers = undefined,
+        .cover_headers = undefined,
+        .notfound_headers = undefined,
+        .epoll_fd = try socket_utils.epollCreate(),
+        .listen_fd = -1,
+        .signal_fd = -1,
+        .old_sigmask = undefined,
+    };
+    relay.opts.max_buffer_bytes = 1024;
+    defer closeFd(relay.epoll_fd);
+    defer relay.conns.deinit(allocator);
+    defer relay.pending_close.deinit(allocator);
+    defer relay.pending_free.deinit(allocator);
+    defer relay.tick_scratch.deinit(allocator);
+    defer relay.drainPendingCloses();
+    const first = try Relay.dialBackend(target);
+    const conn = try relay.createConn(first, .backend, target);
+    defer {
+        closeFd(conn.fd);
+        relay.destroyConn(conn);
+    }
+    conn.connecting = true;
+    conn.backend_candidates = net_helpers.AddressCandidates.init(&.{ target, target, target, target });
+    conn.backend_next = 1;
+    try std.testing.expect(!try relay.writePair(conn, "PROXY", "payload"));
+    try std.testing.expectEqual(@as(usize, 12), conn.out.total_len);
+    relay.dispatch(conn, linux.EPOLL.ERR);
+    try std.testing.expect(!relay.alive(first));
+    try std.testing.expect(relay.alive(conn.fd));
+    try std.testing.expectEqual(@as(usize, 1), relay.pending_close.items.len);
+    try std.testing.expectEqual(@as(usize, 12), conn.out.total_len);
+    try std.testing.expectEqual(@as(u64, 0), relay.bytes_out.load(.monotonic));
+    const second = conn.fd;
+    relay.tick(conn.deadline_ms);
+    try std.testing.expect(!relay.alive(second));
+    try std.testing.expect(relay.alive(conn.fd));
+    try std.testing.expectEqual(@as(usize, 2), relay.pending_close.items.len);
+    try std.testing.expectEqual(@as(usize, 12), conn.out.total_len);
+    const third = conn.fd;
+    relay.dispatch(conn, linux.EPOLL.RDHUP);
+    try std.testing.expect(!relay.alive(third));
+    try std.testing.expect(relay.alive(conn.fd));
+    try std.testing.expectEqual(@as(usize, 3), relay.pending_close.items.len);
+    try std.testing.expectEqual(@as(usize, 12), conn.out.total_len);
+    // A stale event has no mapped connection, and exhausted candidates cannot loop.
+    try std.testing.expect(!relay.retryBackend(conn));
+    var empty_next: usize = 0;
+    try std.testing.expectError(error.BackendAddressesExhausted, Relay.dialCandidate(.{}, &empty_next));
+}
 
 test "proxy v2 header round-trips through the proxy's own parser" {
     var buf: [64]u8 = undefined;
@@ -1679,6 +2152,55 @@ test "an unknown client becomes a LOCAL header the proxy tolerates" {
         .ok => |res| try std.testing.expectEqual(@as(?Address, null), res.src),
         else => return error.TestUnexpectedResult,
     }
+}
+
+test "a burst of tiny websocket frames compacts the carrier buffer once, not once per frame" {
+    const allocator = std.testing.allocator;
+    // Only the fields this path touches are real: a pong is answered by nothing, so no
+    // socket, session or epoll fd is reached. `alive()` is the connection map alone.
+    var relay = Relay{
+        .allocator = allocator,
+        .opts = undefined,
+        .caps = undefined,
+        .cover_page = undefined,
+        .bridge_page = undefined,
+        .bridge_headers = undefined,
+        .cover_headers = undefined,
+        .notfound_headers = undefined,
+        .epoll_fd = -1,
+        .listen_fd = -1,
+        .signal_fd = -1,
+        .old_sigmask = undefined,
+    };
+    defer relay.conns.deinit(allocator);
+    var conn = Conn{
+        .fd = 7,
+        .kind = .websocket,
+        .peer = net_helpers.ip4(.{ 127, 0, 0, 1 }, 0),
+        .out = .{ .allocator = allocator },
+    };
+    defer conn.out.deinit();
+    defer conn.in.deinit(allocator);
+    try relay.conns.put(allocator, conn.fd, &conn);
+
+    // The cheapest frame a client can send: masked, zero-length, opcode PONG.
+    const tiny_pong = [_]u8{ 0x8a, 0x80, 1, 2, 3, 4 };
+    for (0..512) |_| try conn.in.appendSlice(allocator, &tiny_pong);
+
+    compactions_for_test = 0;
+    relay.processWsBuffer(&conn);
+    try std.testing.expectEqual(@as(usize, 0), conn.in.items.len);
+    // One memmove for the pass. Per-frame compaction moved the whole remainder every
+    // time, which is what let one peer burn a core with a few MB/s of pongs.
+    try std.testing.expectEqual(@as(usize, 1), compactions_for_test);
+
+    // The cursor must still leave a trailing partial frame in place for the next read.
+    try conn.in.appendSlice(allocator, &tiny_pong);
+    try conn.in.appendSlice(allocator, tiny_pong[0..2]);
+    compactions_for_test = 0;
+    relay.processWsBuffer(&conn);
+    try std.testing.expectEqualSlices(u8, tiny_pong[0..2], conn.in.items);
+    try std.testing.expectEqual(@as(usize, 1), compactions_for_test);
 }
 
 test "dropFront compacts a buffer" {

--- a/src/web/ws.zig
+++ b/src/web/ws.zig
@@ -23,10 +23,8 @@ pub const guid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 /// base64 of a 20-byte SHA-1 digest.
 pub const accept_len: usize = 28;
 
-/// Largest client frame we will buffer. tdesktop sends one relay frame per carrier
-/// message and never exceeds 64 KiB of DATA, so this leaves >2x headroom while keeping
-/// per-session memory bounded and predictable.
-pub const max_message: usize = 128 * 1024;
+/// Largest client frame/message includes one maximum-size relay frame.
+pub const max_message: usize = @import("frame.zig").max_payload + @import("frame.zig").header_size;
 
 pub const Opcode = enum(u4) {
     continuation = 0x0,
@@ -169,8 +167,15 @@ pub fn parseHeader(buf: []const u8) FrameError!Incoming {
 /// Unmask a payload in place. `offset` is the payload byte index the slice starts at,
 /// so a payload can be unmasked in several chunks.
 pub fn unmask(payload: []u8, mask: [4]u8, offset: usize) void {
-    for (payload, 0..) |*byte, i| {
-        byte.* ^= mask[(offset + i) % 4];
+    const rotated = [4]u8{ mask[offset & 3], mask[(offset +% 1) & 3], mask[(offset +% 2) & 3], mask[(offset +% 3) & 3] };
+    const key: @Vector(16, u8) = (rotated ** 4);
+    var used: usize = 0;
+    while (payload.len - used >= 16) : (used += 16) {
+        const block: @Vector(16, u8) = payload[used..][0..16].*;
+        payload[used..][0..16].* = block ^ key;
+    }
+    for (payload[used..], used..) |*byte, i| {
+        byte.* ^= mask[(offset +% i) & 3];
     }
 }
 

--- a/test/capacity_connections_probe.py
+++ b/test/capacity_connections_probe.py
@@ -14,6 +14,8 @@ Default profile paths are tuned for the benchmark host layout used in README:
 from __future__ import annotations
 
 import argparse
+import errno
+import functools
 import hashlib
 import hmac
 import json
@@ -216,6 +218,14 @@ def listener_pids(port: int) -> list[int]:
     return sorted(set(ids))
 
 
+def listener_backlog(port: int) -> int:
+    try:
+        output = subprocess.check_output(["ss", "-H", "-ltn", "sport", "=", f":{port}"], text=True)
+        return sum(int(line.split()[1]) for line in output.splitlines() if len(line.split()) >= 5)
+    except (OSError, subprocess.SubprocessError, ValueError) as error:
+        raise RuntimeError(f"cannot measure accept backlog: {error}") from error
+
+
 def established_count(port: int) -> int:
     est_state = "01"
     port_hex = f"{port:04X}"
@@ -245,7 +255,7 @@ def established_count(port: int) -> int:
                 total += 1
         return total
 
-    return count_in("/proc/net/tcp") + count_in("/proc/net/tcp6")
+    return max(0, count_in("/proc/net/tcp") + count_in("/proc/net/tcp6") - listener_backlog(port))
 
 
 def kill_tree(root_pid: Optional[int]) -> None:
@@ -341,20 +351,6 @@ def kill_profile_processes(
             pass
 
 
-def wait_for_listen(port: int, timeout_sec: float) -> bool:
-    deadline = time.time() + timeout_sec
-    while time.time() < deadline:
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.settimeout(0.05)
-        try:
-            if s.connect_ex(("127.0.0.1", port)) == 0:
-                return True
-        finally:
-            s.close()
-        time.sleep(0.02)
-    return False
-
-
 def wait_for_profile_listen(
     process: subprocess.Popen[object], port: int, timeout_sec: float
 ) -> tuple[bool, str]:
@@ -414,6 +410,7 @@ def build_tls_auth_client_hello(secret: bytes, hostname: str) -> bytes:
         + sni_ext_len
         + 4  # supported_versions ext header
         + supported_versions_ext_len
+        + 42
     )
 
     record_payload_len = 4 + body_len
@@ -455,7 +452,7 @@ def build_tls_auth_client_hello(secret: bytes, hostname: str) -> bytes:
     pos += 1
 
     packet[pos : pos + 2] = struct.pack(
-        ">H", 4 + sni_ext_len + 4 + supported_versions_ext_len
+        ">H", 4 + sni_ext_len + 4 + supported_versions_ext_len + 42
     )
     pos += 2
 
@@ -482,6 +479,9 @@ def build_tls_auth_client_hello(secret: bytes, hostname: str) -> bytes:
     pos += 1
     packet[pos : pos + 2] = b"\x03\x04"
     pos += 2
+    packet[pos:pos + 10] = bytes.fromhex("003300260024001d0020")
+    packet[pos + 10:pos + 42] = os.urandom(32)
+    pos += 42
 
     if pos != len(packet):
         raise RuntimeError("internal tls-auth packet builder length mismatch")
@@ -502,10 +502,12 @@ def build_tls_auth_client_hello(secret: bytes, hostname: str) -> bytes:
     return bytes(packet)
 
 
+@functools.lru_cache(maxsize=32)
 def build_realistic_client_hello(hostname: str) -> bytes:
     """Build a realistic TLS ClientHello with SNI using stdlib ssl."""
 
     client_sock, server_sock = socket.socketpair()
+    tls_client = None
     try:
         client_sock.setblocking(False)
         server_sock.setblocking(False)
@@ -542,6 +544,8 @@ def build_realistic_client_hello(hostname: str) -> bytes:
             raise RuntimeError("failed to synthesize TLS ClientHello")
         return payload
     finally:
+        if tls_client is not None:
+            tls_client.close()
         try:
             server_sock.close()
         except OSError:
@@ -573,7 +577,13 @@ def maybe_send_payload(
         payload = build_realistic_client_hello(tls_domain)
         try:
             s.sendall(payload)
-            return True
+            header = bytearray()
+            while len(header) < 5:
+                chunk = s.recv(5 - len(header))
+                if not chunk:
+                    return False
+                header.extend(chunk)
+            return header[0] == 0x16 and header[1] == 3 and 1 <= header[2] <= 3
         except OSError:
             return False
     if traffic_mode == "tls-auth-full":
@@ -648,6 +658,7 @@ def open_connections(
     traffic_mode: str,
     secret_bytes: Optional[bytes],
     tls_domain: str,
+    local_errors: Optional[dict[str, int]] = None,
 ) -> tuple[list[socket.socket], int, int, int]:
     sockets: list[socket.socket] = []
     failures = 0
@@ -657,9 +668,22 @@ def open_connections(
     deadline = time.time() + open_budget_sec
 
     while len(sockets) < target and time.time() < deadline:
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.settimeout(connect_timeout_sec)
-        rc = s.connect_ex(("127.0.0.1", port))
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        except OSError as error:
+            failures += 1
+            if local_errors is not None:
+                key = errno.errorcode.get(error.errno, str(error.errno))
+                local_errors[key] = local_errors.get(key, 0) + 1
+            break
+        try:
+            s.settimeout(connect_timeout_sec)
+            rc = s.connect_ex(("127.0.0.1", port))
+        except OSError as error:
+            rc = error.errno or errno.EIO
+        if rc in (errno.EADDRNOTAVAIL, errno.EADDRINUSE, errno.EMFILE, errno.ENFILE) and local_errors is not None:
+            key = errno.errorcode[rc]
+            local_errors[key] = local_errors.get(key, 0) + 1
         if rc == 0:
             connect_ok += 1
             if maybe_send_payload(s, traffic_mode, secret_bytes, tls_domain):
@@ -703,8 +727,11 @@ def tune_nofile(target: int) -> None:
     desired = max(desired, soft)
     try:
         resource.setrlimit(resource.RLIMIT_NOFILE, (desired, hard))
-    except (OSError, ValueError):
-        pass
+    except (OSError, ValueError) as error:
+        print(f"WARN: RLIMIT_NOFILE update failed: {error}")
+    effective = resource.getrlimit(resource.RLIMIT_NOFILE)[0]
+    if effective < target:
+        print(f"WARN: RLIMIT_NOFILE requested={target}, effective={effective}; client EMFILE may limit the sweep")
 
 
 def tune_nproc(target: int) -> None:
@@ -730,11 +757,10 @@ def maybe_apply_sysctl(args: argparse.Namespace) -> None:
     ]
     for cmd in cmds:
         try:
-            subprocess.run(
-                cmd, check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
-            )
-        except (OSError, FileNotFoundError):
-            pass
+            result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+            print(f"sysctl {cmd[-1]}: rc={result.returncode} {(result.stdout or result.stderr).strip()}")
+        except OSError as error:
+            print(f"WARN: sysctl failed: {error}")
 
 
 def run_profile(
@@ -744,12 +770,8 @@ def run_profile(
     kill_profile_processes(profile)
     cleanup_port(profile.port)
 
-    if profile.prep == "set_low_pid":
-        try:
-            Path("/proc/sys/kernel/ns_last_pid").write_text("50000")
-        except OSError:
-            pass
-    elif profile.prep == "mtproto_zig_autocap":
+    autocap: object = "not applied for this profile; use its configured cap"
+    if profile.prep == "mtproto_zig_autocap":
         # Keep max_connections comfortably above the highest probed level,
         # so the probe measures host/runtime limits rather than config cap.
         levels = profile.levels
@@ -772,8 +794,12 @@ def run_profile(
             )
             if replaced:
                 cfg_path.write_text(next_text)
-        except OSError:
-            pass
+                autocap = desired
+            else:
+                autocap = "autocap_failed: max_connections assignment not found"
+        except OSError as error:
+            autocap = f"autocap_failed: {error}"
+        print(f"autocap: {autocap}")
 
     safe = profile.name.replace(" ", "_").replace(".", "_")
     log_path = results_dir / f"capacity_{safe}.log"
@@ -781,118 +807,130 @@ def run_profile(
     with log_path.open("w") as log_file:
         process = subprocess.Popen(profile.command, stdout=log_file, stderr=log_file)
 
-    startup_wait_total = args.startup_timeout_sec
-    started, startup_state = wait_for_profile_listen(
-        process, profile.port, args.startup_timeout_sec
-    )
-    if (not started) and startup_state != "exited" and args.startup_grace_sec > 0:
-        startup_wait_total += args.startup_grace_sec
+    connections: list[socket.socket] = []
+    try:
+        startup_wait_total = args.startup_timeout_sec
         started, startup_state = wait_for_profile_listen(
-            process, profile.port, args.startup_grace_sec
+            process, profile.port, args.startup_timeout_sec
         )
+        if (not started) and startup_state != "exited" and args.startup_grace_sec > 0:
+            startup_wait_total += args.startup_grace_sec
+            started, startup_state = wait_for_profile_listen(
+                process, profile.port, args.startup_grace_sec
+            )
 
-    if not started:
-        rc = process.poll()
-        err = "startup_exited" if startup_state == "exited" else "startup_timeout"
-        if rc is None:
+        if not started:
+            rc = process.poll()
+            err = "startup_exited" if startup_state == "exited" else "startup_timeout"
+            if rc is None:
+                kill_tree(process.pid)
+                rc = -999
+            kill_profile_processes(profile, exclude={process.pid})
+            tail = read_log_tail(log_path)
+            return {
+                "name": profile.name,
+                "ok": False,
+                "error": err,
+                "rc": rc,
+                "startup_wait_sec": startup_wait_total,
+                "log_tail": tail,
+                "log": str(log_path),
+                "command": profile.command,
+            }
+
+        time.sleep(1.0)
+        root_pid = process.pid
+        base_rss = tree_rss_kb(root_pid)
+
+        levels = profile.levels
+        if args.levels:
+            levels = [int(x) for x in args.levels.split(",") if x.strip()]
+
+        level_results: list[dict[str, object]] = []
+        max_established = 0
+        max_stable_target = 0
+        secret_bytes = bytes.fromhex(profile.secret_hex) if profile.secret_hex else None
+
+        if args.traffic_mode in ("tls-auth", "tls-auth-full") and not secret_bytes:
+            kill_tree(root_pid)
             kill_tree(process.pid)
-            rc = -999
-        kill_profile_processes(profile, exclude={process.pid})
-        tail = read_log_tail(log_path)
-        return {
-            "name": profile.name,
-            "ok": False,
-            "error": err,
-            "rc": rc,
-            "startup_wait_sec": startup_wait_total,
-            "log_tail": tail,
-            "log": str(log_path),
-            "command": profile.command,
-        }
+            cleanup_port(profile.port)
+            return {
+                "name": profile.name,
+                "ok": False,
+                "error": "missing_profile_secret",
+                "log": str(log_path),
+                "command": profile.command,
+                "traffic_mode": args.traffic_mode,
+            }
 
-    time.sleep(1.0)
-    root_pid = listener_pid(profile.port) or process.pid
-    base_rss = tree_rss_kb(root_pid)
+        for level in levels:
+            local_errors: dict[str, int] = {}
+            connections, failures, connect_ok, payload_ok = open_connections(
+                profile.port,
+                level,
+                args.connect_timeout_sec,
+                args.open_budget_sec,
+                args.fail_streak_limit,
+                args.traffic_mode,
+                secret_bytes,
+                args.tls_domain,
+                local_errors,
+            )
+            time.sleep(args.hold_seconds)
 
-    levels = profile.levels
-    if args.levels:
-        levels = [int(x) for x in args.levels.split(",") if x.strip()]
+            established = established_count(profile.port)
+            rss_now = tree_rss_kb(root_pid)
+            if should_expect_established(args.traffic_mode):
+                stable = established >= int(level * args.stable_ratio)
+            else:
+                stable = payload_ok >= int(level * args.stable_ratio)
 
-    level_results: list[dict[str, object]] = []
-    max_established = 0
-    max_stable_target = 0
-    secret_bytes = bytes.fromhex(profile.secret_hex) if profile.secret_hex else None
+            if established > max_established:
+                max_established = established
+            if stable and level > max_stable_target:
+                max_stable_target = level
 
-    if args.traffic_mode in ("tls-auth", "tls-auth-full") and not secret_bytes:
+            level_results.append(
+                {
+                    "target": level,
+                    "connect_ok": connect_ok,
+                    "connected_client_side": len(connections),
+                    "payload_ok": payload_ok,
+                    "established_server_side": established,
+                    "failures": failures,
+                    "local_resource_errors": local_errors,
+                    "listen_backlog": listener_backlog(profile.port),
+                    "rss_kb": rss_now,
+                    "stable": stable,
+                }
+            )
+
+            close_connections(connections)
+            time.sleep(args.settle_seconds)
+
         kill_tree(root_pid)
         kill_tree(process.pid)
+        kill_profile_processes(profile, exclude={process.pid, root_pid})
         cleanup_port(profile.port)
+
         return {
             "name": profile.name,
-            "ok": False,
-            "error": "missing_profile_secret",
+            "ok": True,
+            "base_rss_kb": base_rss,
+            "measurement_root_pid": root_pid,
+            "autocap": autocap,
+            "max_established_observed": max_established,
+            "max_stable_target": max_stable_target,
+            "levels": level_results,
             "log": str(log_path),
             "command": profile.command,
             "traffic_mode": args.traffic_mode,
         }
-
-    for level in levels:
-        connections, failures, connect_ok, payload_ok = open_connections(
-            profile.port,
-            level,
-            args.connect_timeout_sec,
-            args.open_budget_sec,
-            args.fail_streak_limit,
-            args.traffic_mode,
-            secret_bytes,
-            args.tls_domain,
-        )
-        time.sleep(args.hold_seconds)
-
-        established = established_count(profile.port)
-        rss_now = tree_rss_kb(root_pid)
-        if should_expect_established(args.traffic_mode):
-            stable = established >= int(level * args.stable_ratio)
-        else:
-            stable = payload_ok >= int(level * args.stable_ratio)
-
-        if established > max_established:
-            max_established = established
-        if stable and level > max_stable_target:
-            max_stable_target = level
-
-        level_results.append(
-            {
-                "target": level,
-                "connect_ok": connect_ok,
-                "connected_client_side": len(connections),
-                "payload_ok": payload_ok,
-                "established_server_side": established,
-                "failures": failures,
-                "rss_kb": rss_now,
-                "stable": stable,
-            }
-        )
-
+    finally:
         close_connections(connections)
-        time.sleep(args.settle_seconds)
-
-    kill_tree(root_pid)
-    kill_tree(process.pid)
-    kill_profile_processes(profile, exclude={process.pid, root_pid})
-    cleanup_port(profile.port)
-
-    return {
-        "name": profile.name,
-        "ok": True,
-        "base_rss_kb": base_rss,
-        "max_established_observed": max_established,
-        "max_stable_target": max_stable_target,
-        "levels": level_results,
-        "log": str(log_path),
-        "command": profile.command,
-        "traffic_mode": args.traffic_mode,
-    }
+        kill_tree(process.pid)
+        process.wait()
 
 
 def select_profiles(all_profiles: list[Profile], selectors: list[str]) -> list[Profile]:
@@ -1001,10 +1039,27 @@ def main() -> int:
     maybe_apply_sysctl(args)
 
     all_results: list[dict[str, object]] = []
+    output_path = Path(args.output) if args.output else results_dir / (
+        f"capacity_connections_{selected[0].name.lower().replace(' ', '_').replace('.', '_')}.json"
+        if len(selected) == 1 else "capacity_connections.json"
+    )
+    try:
+        port_range = Path("/proc/sys/net/ipv4/ip_local_port_range").read_text().strip()
+    except OSError:
+        port_range = "unavailable"
+    try:
+        time_wait_count = len(subprocess.check_output(["ss", "-H", "-tan", "state", "time-wait"], text=True).splitlines())
+    except (OSError, subprocess.SubprocessError):
+        time_wait_count = None
     for profile in selected:
         print(f"=== {profile.name} ===", flush=True)
-        result = run_profile(profile, args, results_dir)
+        try:
+            result = run_profile(profile, args, results_dir)
+        except (OSError, RuntimeError, ValueError) as error:
+            result = {"name": profile.name, "ok": False, "error": str(error)}
+        result["client_environment"] = {"ip_local_port_range": port_range, "initial_time_wait_count": time_wait_count, "nofile": resource.getrlimit(resource.RLIMIT_NOFILE)[0]}
         all_results.append(result)
+        output_path.write_text(json.dumps(all_results, indent=2, ensure_ascii=False))
         print(json.dumps(result, ensure_ascii=False), flush=True)
 
     if args.output:
@@ -1017,7 +1072,7 @@ def main() -> int:
 
     output_path.write_text(json.dumps(all_results, indent=2, ensure_ascii=False))
     print(f"RESULT_FILE {output_path}")
-    return 0
+    return 0 if all(result.get("ok") for result in all_results) else 1
 
 
 if __name__ == "__main__":

--- a/test/connection_stability_check.py
+++ b/test/connection_stability_check.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import errno
 import os
+import resource
 import socket
 import subprocess
 import sys
@@ -83,8 +84,10 @@ def tcp_states(port: int) -> Dict[str, int]:
         state, local_addr, peer_addr = parts[0], parts[3], parts[4]
         # Exact port match, not substring: `:443` must not also count :4433/:44310 etc.
         # (unrelated services on a shared VPS), which would skew the CLOSE-WAIT assertions.
-        if port_of(local_addr) == want or port_of(peer_addr) == want:
+        if port_of(local_addr) == want:
             states[state] = states.get(state, 0) + 1
+        if port_of(peer_addr) == want:
+            states["client:" + state] = states.get("client:" + state, 0) + 1
 
     return states
 
@@ -105,24 +108,32 @@ def print_snapshot(label: str, pid: Optional[int], port: int) -> Dict[str, objec
 
 
 def has_stats(stats: ProcStats) -> bool:
-    return any(
+    return all(
         v is not None for v in (stats.rss_kb, stats.vms_kb, stats.threads, stats.fds)
     )
 
 
 def open_idle_connections(
-    host: str, port: int, count: int, timeout: float
+    host: str, port: int, count: int, timeout: float, budget: float = 30.0
 ) -> tuple[list[socket.socket], int]:
     conns: list[socket.socket] = []
     failed = 0
 
+    deadline = time.monotonic() + budget
+    consecutive_failures = 0
     for i in range(count):
+        if time.monotonic() >= deadline or consecutive_failures >= 32:
+            failed += count - i
+            break
         try:
-            s = socket.create_connection((host, port), timeout=timeout)
+            s = socket.create_connection((host, port), timeout=min(timeout, max(0.001, deadline - time.monotonic())))
             conns.append(s)
+            consecutive_failures = 0
         except OSError as err:
             failed += 1
-            if err.errno == errno.EMFILE:
+            consecutive_failures += 1
+            if err.errno in (errno.EMFILE, errno.ENFILE):
+                print("WARN: local file-descriptor limit reached (EMFILE/ENFILE)")
                 failed += count - i - 1
                 break
 
@@ -161,15 +172,17 @@ def run_churn(
                 idx += 1
 
             try:
-                s = socket.create_connection((host, port), timeout=timeout)
-                if payload:
-                    s.sendall(payload)
-                    s.settimeout(0.3)
-                    try:
-                        _ = s.recv(128)
-                    except OSError:
-                        pass
-                s.close()
+                with socket.create_connection((host, port), timeout=timeout) as s:
+                    if payload:
+                        s.sendall(payload() if callable(payload) else payload)
+                        response = bytearray()
+                        while len(response) < 3:
+                            chunk = s.recv(3 - len(response))
+                            if not chunk:
+                                raise OSError("closed before authenticated ServerHello")
+                            response.extend(chunk)
+                        if response != b"\x16\x03\x03":
+                            raise OSError("invalid ServerHello prefix")
                 with ok_fail_lock:
                     ok += 1
             except OSError:
@@ -196,6 +209,7 @@ def assert_threshold(
     failures: list[str],
 ) -> None:
     if value is None or baseline is None:
+        failures.append(f"{name}: requested process metric unavailable")
         return
     if value > baseline + delta_limit:
         failures.append(
@@ -218,6 +232,11 @@ def main() -> int:
     parser.add_argument("--idle-hold-seconds", type=int, default=30)
     parser.add_argument("--idle-settle-seconds", type=int, default=8)
     parser.add_argument("--connect-timeout", type=float, default=1.0)
+    parser.add_argument("--idle-open-budget", type=float, default=30.0)
+    parser.add_argument("--payload", choices=("none", "tls-auth"), default="none",
+                        help="none measures TCP load only; tls-auth verifies ServerHello without masking-site traffic")
+    parser.add_argument("--secret", help="32 hex characters for tls-auth churn")
+    parser.add_argument("--tls-domain", default="google.com")
 
     parser.add_argument("--churn-total", type=int, default=30000)
     parser.add_argument("--churn-concurrency", type=int, default=300)
@@ -228,6 +247,20 @@ def main() -> int:
     parser.add_argument("--close-wait-limit", type=int, default=128)
 
     args = parser.parse_args()
+    if args.idle_cycles < 1 or args.idle_open_budget <= 0 or args.connect_timeout <= 0 or args.churn_concurrency < 1:
+        parser.error("idle-cycles/concurrency must be >= 1 and budgets/timeouts positive")
+    payload = b""
+    if args.payload == "tls-auth":
+        from capacity_connections_probe import build_tls_auth_client_hello
+        try:
+            secret = bytes.fromhex(args.secret or "")
+            if len(secret) != 16:
+                raise ValueError("expected 16 bytes")
+        except ValueError:
+            parser.error("--payload tls-auth requires a 32-hex-character --secret")
+        payload = lambda: build_tls_auth_client_hello(secret, args.tls_domain)
+    else:
+        print("WARN: --payload none measures TCP load only, not MTProto correctness")
 
     if args.pid is not None and not os.path.exists(f"/proc/{args.pid}"):
         print(f"error: /proc/{args.pid} not found. pass a valid proxy PID")
@@ -245,6 +278,13 @@ def main() -> int:
     )
 
     baseline = print_snapshot("baseline", args.pid, args.port)
+    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    desired = args.idle_connections + args.churn_concurrency + 128
+    try:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (max(soft, min(desired, hard) if hard != resource.RLIM_INFINITY else desired), hard))
+    except (OSError, ValueError) as error:
+        print(f"WARN: cannot raise RLIMIT_NOFILE: {error}")
+    failures: list[str] = []
 
     idle_closes: list[Dict[str, object]] = []
     stats_skipped_cycles = 0
@@ -254,8 +294,11 @@ def main() -> int:
             args.port,
             args.idle_connections,
             args.connect_timeout,
+            args.idle_open_budget,
         )
         print(f"idle_open[{cycle}]: opened={len(conns)} failed={failed_open}")
+        if len(conns) < args.idle_connections * 0.95:
+            failures.append(f"idle cycle {cycle}: pressure target not reached ({len(conns)}/{args.idle_connections}); check local EMFILE and server availability")
         open_snap = print_snapshot(f"idle_open_{cycle}", args.pid, args.port)
         if args.pid is not None and not has_stats(open_snap["stats"]):  # type: ignore[arg-type]
             stats_skipped_cycles += 1
@@ -275,7 +318,6 @@ def main() -> int:
 
     after_idle_close = idle_closes[-1]
 
-    payload = b"GET / HTTP/1.1\r\nHost: test\r\n\r\n"
     ok, fail, elapsed = run_churn(
         args.host,
         args.port,
@@ -292,10 +334,12 @@ def main() -> int:
         stats_skipped_cycles += 1
 
     if args.pid is None:
-        print("PASS (load-only mode, no PID assertions)")
-        return 0
-
-    failures: list[str] = []
+        if ok < args.churn_total * 0.95:
+            failures.append(f"churn success ratio too low: {ok}/{args.churn_total}")
+        for failure in failures:
+            print(f"FAIL: {failure}")
+        print("WARN: no PID supplied; memory/FD recovery was not checked")
+        return 1 if failures else 0
 
     # Hard fail if the proxy died at any point: a crashed PID makes every /proc read return
     # None, so all threshold asserts early-return and the script would otherwise print PASS

--- a/test/e2e/run.py
+++ b/test/e2e/run.py
@@ -34,6 +34,7 @@ import threading
 import time
 import traceback
 import zlib
+import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Optional
@@ -42,6 +43,7 @@ from typing import Callable, Optional
 ROOT = Path(__file__).resolve().parents[2]
 PROXY_BIN = ROOT / "zig-out/bin/mtproto-proxy"
 ACTIVE_PROXY_BIN = PROXY_BIN
+ACTIVE_OBF_GEN = None
 OBF_GEN = ROOT / "src/e2e_obf_handshake_gen.zig"
 DEFAULT_SECRET_HEX = "00112233445566778899aabbccddeeff"
 DEFAULT_TLS_DOMAIN = "google.com"
@@ -53,6 +55,12 @@ DEFAULT_MP_KEY_SEL = bytes([0xC4, 0xF9, 0xFA, 0xCA])  # first 4 bytes of default
 TLS_RECORD_HANDSHAKE = 0x16
 TLS_RECORD_CHANGE_CIPHER = 0x14
 TLS_RECORD_APPLICATION = 0x17
+
+# The proxy writes its own 64-byte obfuscation nonce (constants.handshake_len) upstream the
+# instant the DC connect completes — before a single client byte is relayed. A fake DC
+# therefore counts 64 bytes on its own, which is why "tunnel_bytes > 0" proves nothing about
+# the C2S transform; only a count that clears the nonce does.
+DC_NONCE_BYTES = 64
 
 _HANDSHAKE_CACHE: dict[tuple[str, int, str], bytes] = {}
 
@@ -81,6 +89,23 @@ def wait_for_condition(predicate: Callable[[], bool], timeout_sec: float, interv
             return True
         time.sleep(interval_sec)
     return predicate()
+
+
+def assert_client_payload_relayed(server, payload_bytes: int, what: str, timeout_sec: float = 2.0) -> None:
+    """Assert the fake DC saw the client's payload, not just the proxy's own nonce.
+
+    Both relay directions are length-preserving on the direct path (relay_steps.zig
+    re-encrypts in place and queues the same slice), so the DC must end up with exactly
+    the 64-byte nonce plus every payload byte the client sent. Comparing against that
+    total is what makes the assertion fail when the C2S transform drops or mangles bytes;
+    the old `tunnel_bytes > 0` was already satisfied by the nonce.
+    """
+    expected = DC_NONCE_BYTES + payload_bytes
+    ok = wait_for_condition(lambda: server.tunnel_bytes >= expected, timeout_sec=timeout_sec)
+    assert ok, (
+        f"{what}: fake DC saw {server.tunnel_bytes} bytes, expected >= {expected} "
+        f"({DC_NONCE_BYTES}-byte DC nonce + {payload_bytes} relayed client bytes)"
+    )
 
 
 def recv_exact(sock: socket.socket, n: int) -> bytes:
@@ -130,6 +155,7 @@ def build_tls_auth_client_hello(secret: bytes, hostname: str) -> bytes:
         + sni_ext_len
         + 4
         + supported_versions_ext_len
+        + 42
     )
 
     record_payload_len = 4 + body_len
@@ -167,7 +193,7 @@ def build_tls_auth_client_hello(secret: bytes, hostname: str) -> bytes:
     packet[pos] = 0
     pos += 1
 
-    packet[pos : pos + 2] = struct.pack(">H", 4 + sni_ext_len + 4 + supported_versions_ext_len)
+    packet[pos : pos + 2] = struct.pack(">H", 4 + sni_ext_len + 4 + supported_versions_ext_len + 42)
     pos += 2
 
     packet[pos : pos + 2] = b"\x00\x00"
@@ -192,6 +218,10 @@ def build_tls_auth_client_hello(secret: bytes, hostname: str) -> bytes:
     packet[pos : pos + 2] = b"\x03\x04"
     pos += 2
 
+    packet[pos:pos + 10] = bytes.fromhex("003300260024001d0020")
+    packet[pos + 10:pos + 42] = os.urandom(32)
+    pos += 42
+
     if pos != len(packet):
         raise RuntimeError("tls-auth packet build mismatch")
 
@@ -215,8 +245,8 @@ def generate_obf_handshake(secret_hex: str, dc_idx: int, proto: str = "intermedi
     if key in _HANDSHAKE_CACHE:
         return _HANDSHAKE_CACHE[key]
 
-    cmd = ["zig", "run", str(OBF_GEN), "--", secret_hex, str(dc_idx), proto]
-    proc = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True, check=False)
+    cmd = ([str(ACTIVE_OBF_GEN)] if ACTIVE_OBF_GEN else ["zig", "run", str(OBF_GEN), "--"]) + [secret_hex, str(dc_idx), proto]
+    proc = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True, check=False, timeout=30)
     if proc.returncode != 0:
         raise RuntimeError(f"obf handshake generator failed:\n{proc.stderr}\n{proc.stdout}")
     raw = proc.stdout.strip()
@@ -228,24 +258,27 @@ def generate_obf_handshake(secret_hex: str, dc_idx: int, proto: str = "intermedi
 
 
 def read_proxy_records(sock: socket.socket, budget_sec: float = 0.7) -> bytes:
+    previous_timeout = sock.gettimeout()
     sock.setblocking(False)
     deadline = time.time() + budget_sec
     out = bytearray()
-    while time.time() < deadline:
-        timeout = max(0.0, deadline - time.time())
-        r, _, _ = select.select([sock], [], [], timeout)
-        if not r:
-            continue
-        try:
-            chunk = sock.recv(8192)
-        except BlockingIOError:
-            continue
-        if not chunk:
-            break
-        out.extend(chunk)
-        if len(out) >= 4096:
-            break
-    sock.setblocking(True)
+    try:
+        while time.time() < deadline:
+            timeout = max(0.0, deadline - time.time())
+            r, _, _ = select.select([sock], [], [], timeout)
+            if not r:
+                continue
+            try:
+                chunk = sock.recv(8192)
+            except BlockingIOError:
+                continue
+            if not chunk:
+                break
+            out.extend(chunk)
+            if len(out) >= 4096:
+                break
+    finally:
+        sock.settimeout(previous_timeout)
     return bytes(out)
 
 
@@ -285,6 +318,7 @@ def connect_from(source_ip: str, host: str, port: int, timeout_sec: float = 2.0)
 
 
 def wait_socket_closed(sock: socket.socket, timeout_sec: float = 2.0) -> bool:
+    previous_timeout = sock.gettimeout()
     deadline = time.time() + timeout_sec
     sock.setblocking(False)
     try:
@@ -302,7 +336,7 @@ def wait_socket_closed(sock: socket.socket, timeout_sec: float = 2.0) -> bool:
                 return True
         return False
     finally:
-        sock.setblocking(True)
+        sock.settimeout(previous_timeout)
 
 
 def assert_socket_closed_soon(sock: socket.socket, timeout_sec: float = 2.0) -> None:
@@ -317,6 +351,12 @@ class ProxyInstance:
     log_path: Path
     port: int
     workdir: Path
+    metrics_port: int
+
+    def scrape(self) -> dict[str, float]:
+        with urllib.request.urlopen(f"http://127.0.0.1:{self.metrics_port}/metrics", timeout=3) as response:
+            return {line.split()[0]: float(line.split()[1]) for line in response.read().decode().splitlines()
+                    if line and not line.startswith("#")}
 
     def stop(self) -> None:
         try:
@@ -345,6 +385,8 @@ def start_proxy(config_text: str, port: int) -> ProxyInstance:
 
     temp_dir = Path(tempfile.mkdtemp(prefix="mtproto-e2e-"))
     cfg_path = temp_dir / "config.toml"
+    metrics_port = free_port()
+    config_text += f'\n[metrics]\nenabled = true\nhost = "127.0.0.1"\nport = {metrics_port}\n'
     log_path = temp_dir / "proxy.log"
     cfg_path.write_text(config_text, encoding="utf-8")
 
@@ -357,7 +399,7 @@ def start_proxy(config_text: str, port: int) -> ProxyInstance:
     )
     log_file.close()
 
-    if not wait_for_listen("127.0.0.1", port, timeout_sec=8.0):
+    if not wait_for_listen("127.0.0.1", port, timeout_sec=8.0) or proc.poll() is not None:
         if proc.poll() is None:
             proc.terminate()
             try:
@@ -368,7 +410,7 @@ def start_proxy(config_text: str, port: int) -> ProxyInstance:
         shutil.rmtree(temp_dir, ignore_errors=True)  # don't leak the workdir on early failure
         raise RuntimeError(f"proxy failed to listen on port {port}\n{tail}")
 
-    return ProxyInstance(proc=proc, cfg_path=cfg_path, log_path=log_path, port=port, workdir=temp_dir)
+    return ProxyInstance(proc=proc, cfg_path=cfg_path, log_path=log_path, port=port, workdir=temp_dir, metrics_port=metrics_port)
 
 
 class FakeSocks5Server:
@@ -707,6 +749,7 @@ def base_config(
     lines.append("")
 
     lines.append("[server]")
+    lines.append('bind_address = "127.0.0.1"')
     lines.append(f"port = {port}")
     lines.append(f"max_connections = {max_connections}")
     lines.append(f"idle_timeout_sec = {idle_timeout_sec}")
@@ -781,9 +824,7 @@ def scenario_fake_telegram_dc_via_socks5() -> None:
             assert connected, "SOCKS5 CONNECT was not attempted in time"
             # Send one more record after connect to reduce scheduling flakiness in CI.
             c.sendall(build_tls_record(TLS_RECORD_APPLICATION, b"\x12" * 128))
-            forwarded = wait_for_condition(lambda: socks.tunnel_bytes > 0, timeout_sec=2.0)
-            assert forwarded, "no C2S bytes reached fake DC tunnel"
-        assert socks.tunnel_bytes > 0, "no C2S bytes reached fake DC tunnel"
+            assert_client_payload_relayed(socks, 64 + 128, "no C2S bytes reached fake DC tunnel")
         assert any(p == 443 for _, p in socks.connect_targets), f"no DC connect in {socks.connect_targets}"
     finally:
         proxy.stop()
@@ -814,9 +855,9 @@ def scenario_desync_relay_via_socks5() -> None:
                 lambda: len(socks.connect_targets) > 0, timeout_sec=2.0
             ), "SOCKS5 CONNECT not attempted with desync enabled"
             c.sendall(build_tls_record(TLS_RECORD_APPLICATION, b"\x12" * 128))
-            assert wait_for_condition(
-                lambda: socks.tunnel_bytes > 0, timeout_sec=2.0
-            ), "desync corrupted the relay — no C2S bytes reached the fake DC"
+            assert_client_payload_relayed(
+                socks, 64 + 128, "desync corrupted the relay — C2S bytes lost on the way to the fake DC"
+            )
     finally:
         proxy.stop()
         socks.stop()
@@ -841,8 +882,7 @@ def scenario_direct_secure_via_socks5() -> None:
             c.sendall(b"\x44" * 128)
             connected = wait_for_condition(lambda: len(socks.connect_targets) > 0, timeout_sec=2.0)
             assert connected, "SOCKS5 CONNECT was not attempted for direct secure transport"
-            forwarded = wait_for_condition(lambda: socks.tunnel_bytes > 0, timeout_sec=2.0)
-            assert forwarded, "direct secure transport did not reach fake DC tunnel"
+            assert_client_payload_relayed(socks, 128, "direct secure transport did not reach fake DC tunnel")
         assert any(p == 443 for _, p in socks.connect_targets), f"no DC connect in {socks.connect_targets}"
     finally:
         proxy.stop()
@@ -884,6 +924,7 @@ def scenario_socks5_upstream_failure() -> None:
     proxy_port = free_port()
     cfg = base_config(
         port=proxy_port,
+        use_middle_proxy=True,
         upstream_type="socks5",
         upstream_host="127.0.0.1",
         upstream_port=socks.port,
@@ -898,7 +939,7 @@ def scenario_socks5_upstream_failure() -> None:
             assert_socket_closed_soon(c, timeout_sec=2.0)
         finally:
             c.close()
-        assert len(socks.connect_targets) >= 1, "SOCKS5 CONNECT was not attempted"
+        assert len(set(socks.connect_targets)) >= 2, "SOCKS5 rejection did not advance endpoint/fallback"
     finally:
         proxy.stop()
         socks.stop()
@@ -923,9 +964,7 @@ def scenario_http_connect_success() -> None:
             connected = wait_for_condition(lambda: len(http.connect_targets) > 0, timeout_sec=2.0)
             assert connected, "HTTP CONNECT was not attempted in time"
             c.sendall(build_tls_record(TLS_RECORD_APPLICATION, b"\x34" * 128))
-            forwarded = wait_for_condition(lambda: http.tunnel_bytes > 0, timeout_sec=2.0)
-            assert forwarded, "no tunneled bytes through HTTP CONNECT"
-        assert http.tunnel_bytes > 0, "no tunneled bytes through HTTP CONNECT"
+            assert_client_payload_relayed(http, 64 + 128, "no tunneled client bytes through HTTP CONNECT")
         assert any(p == 443 for _, p in http.connect_targets), f"no DC connect in {http.connect_targets}"
     finally:
         proxy.stop()
@@ -938,6 +977,7 @@ def scenario_http_connect_failure() -> None:
     proxy_port = free_port()
     cfg = base_config(
         port=proxy_port,
+        use_middle_proxy=True,
         upstream_type="http",
         upstream_host="127.0.0.1",
         upstream_port=http.port,
@@ -951,7 +991,7 @@ def scenario_http_connect_failure() -> None:
             assert_socket_closed_soon(c, timeout_sec=2.0)
         finally:
             c.close()
-        assert len(http.connect_targets) >= 1, "HTTP CONNECT was not attempted"
+        assert len(set(http.connect_targets)) >= 2, "HTTP rejection did not advance endpoint/fallback"
     finally:
         proxy.stop()
         http.stop()
@@ -1072,11 +1112,13 @@ def scenario_web_only_still_serves_the_relay() -> None:
         with socket.create_connection(("127.0.0.1", proxy_port), timeout=2.0) as c:
             c.settimeout(2.0)
             perform_valid_client_handshake(c, DEFAULT_SECRET_HEX, DEFAULT_TLS_DOMAIN)
-            c.sendall(b"\x44" * 128)
+            # A FakeTLS session, so the payload has to be a real application record: bare
+            # bytes are an illegal record type and relay_steps.zig closes the connection
+            # instead of relaying them.
+            c.sendall(build_tls_record(TLS_RECORD_APPLICATION, b"\x44" * 128))
             connected = wait_for_condition(lambda: len(socks.connect_targets) > 0, timeout_sec=3.0)
             assert connected, "web-only masked the relay's own loopback handshake"
-            forwarded = wait_for_condition(lambda: socks.tunnel_bytes > 0, timeout_sec=2.0)
-            assert forwarded, "web-only relay handshake did not reach the fake DC tunnel"
+            assert_client_payload_relayed(socks, 128, "web-only relay handshake did not reach the fake DC tunnel")
         assert not mask.received_bytes(), (
             f"a trusted loopback peer was sent to the masking backend: {mask.received_bytes()!r}"
         )
@@ -1130,6 +1172,8 @@ def scenario_web_only_masks_a_direct_client() -> None:
         upstream_host="127.0.0.1",
         upstream_port=socks.port,
     )
+    # This trust-boundary scenario deliberately needs a non-loopback listener.
+    cfg = cfg.replace('bind_address = "127.0.0.1"', 'bind_address = "0.0.0.0"')
     proxy = start_proxy(cfg, proxy_port)
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as c:
@@ -1148,6 +1192,7 @@ def scenario_web_only_masks_a_direct_client() -> None:
         )
         relayed = wait_for_condition(lambda: len(socks.connect_targets) > 0, timeout_sec=1.5)
         assert not relayed, f"web-only still relayed a direct client upstream: {socks.connect_targets}"
+        assert proxy.scrape()["mtproto_web_only_masked_total"] >= 1
     finally:
         proxy.stop()
         mask.stop()
@@ -1182,9 +1227,12 @@ def scenario_web_only_ignored_without_web_enabled() -> None:
         with socket.create_connection(("127.0.0.1", proxy_port), timeout=2.0) as c:
             c.settimeout(2.0)
             perform_valid_client_handshake(c, DEFAULT_SECRET_HEX, DEFAULT_TLS_DOMAIN)
-            c.sendall(b"\x44" * 128)
+            # Application record, not bare bytes: an illegal record type would be torn down
+            # by relay_steps.zig, and the scenario would pass on the connect alone.
+            c.sendall(build_tls_record(TLS_RECORD_APPLICATION, b"\x44" * 128))
             connected = wait_for_condition(lambda: len(socks.connect_targets) > 0, timeout_sec=3.0)
             assert connected, "a stale [web].only masked traffic with the relay disabled"
+            assert_client_payload_relayed(socks, 128, "a stale [web].only broke the relay it should have ignored")
     finally:
         proxy.stop()
         mask.stop()
@@ -1275,6 +1323,7 @@ def scenario_replay_attack_rejected() -> None:
         # Settle, then assert the replay added NO second connect (the actual property).
         time.sleep(0.4)
         assert len(socks.connect_targets) == 1, f"replay should not create 2nd upstream connect: {socks.connect_targets}"
+        assert proxy.scrape()["mtproto_replay_hits_total"] >= 1
         c1.close()
     finally:
         proxy.stop()
@@ -1335,6 +1384,7 @@ def scenario_user_max_ips_distinct_client_networks() -> None:
         assert len(socks.connect_targets) == 3, (
             f"over-quota network was relayed upstream: {socks.connect_targets}"
         )
+        assert sum(v for k, v in proxy.scrape().items() if k.startswith("mtproto_user_ip_limit_refused_total{")) >= 1
     finally:
         for c in clients:
             try:
@@ -1367,6 +1417,53 @@ def scenario_slowloris_partial_clienthello() -> None:
             )
         finally:
             c.close()
+    finally:
+        proxy.stop()
+
+
+def scenario_silent_connections_do_not_starve_clients() -> None:
+    socks = FakeSocks5Server(mode="success")
+    socks.start()
+    port = free_port()
+    proxy = start_proxy(base_config(port=port, max_connections=64,
+        upstream_type="socks5", upstream_host="127.0.0.1", upstream_port=socks.port,
+        idle_timeout_sec=120, handshake_timeout_sec=5), port)
+    silent = []
+    try:
+        for _ in range(70):
+            silent.append(socket.create_connection(("127.0.0.1", port), timeout=2))
+        with socket.create_connection(("127.0.0.1", port), timeout=2) as client:
+            client.settimeout(2)
+            perform_valid_client_handshake(client, DEFAULT_SECRET_HEX, DEFAULT_TLS_DOMAIN)
+            client.sendall(build_tls_record(TLS_RECORD_APPLICATION, b"\x12" * 128))
+            assert_client_payload_relayed(socks, 128, "silent sockets starved authenticated client")
+        # Below saturation, a silent socket still uses the handshake deadline.
+        for client in silent:
+            client.close()
+        silent.clear()
+        with socket.create_connection(("127.0.0.1", port), timeout=2) as client:
+            assert wait_socket_closed(client, 8), "silent socket survived handshake deadline"
+    finally:
+        for client in silent:
+            client.close()
+        proxy.stop()
+        socks.stop()
+
+
+def scenario_long_username_expiry_and_reload_warning() -> None:
+    port = free_port()
+    username = "long_username_" + "x" * 80
+    cfg = base_config(port=port).replace("user1 =", username + " =")
+    cfg += f'\n[access.user_expirations]\n{username} = "2020-01-01"\n'
+    proxy = start_proxy(cfg, port)
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=2) as client:
+            client.settimeout(2)
+            perform_valid_client_handshake(client, DEFAULT_SECRET_HEX, DEFAULT_TLS_DOMAIN)
+            assert wait_socket_closed(client, 2), "expiry bypassed for long username"
+        proxy.cfg_path.write_text(cfg.replace("fake_tls_only = true", "fake_tls_only = false"))
+        proxy.proc.send_signal(signal.SIGHUP)
+        assert wait_for_condition(lambda: "fake_tls_only changed; restart required" in proxy.read_log_tail(), 2), proxy.read_log_tail()
     finally:
         proxy.stop()
 
@@ -1415,6 +1512,12 @@ def scenario_connection_churn_10k() -> None:
         elapsed = time.time() - start
         print(f"      churn: ok={ok} fail={fail} elapsed={elapsed:.2f}s")
         assert ok >= 9_500, f"too many churn failures: ok={ok} fail={fail}"
+        assert wait_for_condition(lambda: proxy.scrape()["mtproto_connections_active"] == 0, timeout_sec=8), "churn slots did not recover"
+        with urllib.request.urlopen(f"http://127.0.0.1:{proxy.metrics_port}/healthz", timeout=3) as response:
+            assert response.status == 200
+        with socket.create_connection(("127.0.0.1", proxy_port), timeout=2) as client:
+            client.sendall(build_tls_auth_client_hello(bytes.fromhex(DEFAULT_SECRET_HEX), DEFAULT_TLS_DOMAIN))
+            assert client.recv(3) == b"\x16\x03\x03", "authenticated handshake failed after churn"
     finally:
         proxy.stop()
 
@@ -1471,7 +1574,130 @@ def scenario_sigterm_during_active_relay() -> None:
         socks.stop()
 
 
+def scenario_proxy_header_split_tlv_quota() -> None:
+    socks = FakeSocks5Server(mode="success")
+    socks.start()
+    port = free_port()
+    cfg = base_config(port=port, web_enabled=True, upstream_type="socks5",
+                      upstream_host="127.0.0.1", upstream_port=socks.port)
+    cfg = cfg.replace("[server]", "[server]\naccept_proxy_protocol = true")
+    cfg += "\n[access.user_max_ips]\nuser1 = 1\n"
+    proxy = start_proxy(cfg, port)
+    clients = []
+    try:
+        for index, source in enumerate(("198.51.100.1", "203.0.113.1")):
+            client = socket.create_connection(("127.0.0.1", port), timeout=3)
+            clients.append(client)
+            address = socket.inet_aton(source) + socket.inet_aton("127.0.0.1") + struct.pack(">HH", 12345, port)
+            tlv = b"\xe0" + struct.pack(">H", 300) + b"x" * 300
+            header = b"\r\n\r\n\x00\r\nQUIT\n" + b"\x21\x11" + struct.pack(">H", len(address + tlv)) + address + tlv
+            client.sendall(header[:10])
+            time.sleep(0.04)
+            client.sendall(header[10:])
+            perform_valid_client_handshake(client, DEFAULT_SECRET_HEX, DEFAULT_TLS_DOMAIN)
+            if index == 0:
+                assert wait_for_condition(lambda: len(socks.connect_targets) == 1, 3), "split/TLV header did not reach upstream"
+            else:
+                assert_socket_closed_soon(client)
+        assert sum(v for k, v in proxy.scrape().items() if k.startswith("mtproto_user_ip_limit_refused_total{")) >= 1, "announced client address did not enforce quota"
+    finally:
+        for client in clients:
+            client.close()
+        proxy.stop()
+        socks.stop()
+
+
+def scenario_guard_admission_metrics() -> None:
+    for setting, metric in (
+        ("rate_limit_per_subnet = 1", "mtproto_drops_rate_limit_total"),
+        ("handshake_flood_guard_enabled = true\nhandshake_flood_guard_threshold = 1", "mtproto_drops_flood_guard_total"),
+    ):
+        port = free_port()
+        cfg = base_config(port=port, mask=False, handshake_timeout_sec=5).replace("[server]", "[server]\n" + setting)
+        proxy = start_proxy(cfg, port)
+        try:
+            if "flood" in metric:
+                # Invalid HTTP is masked, not a flood event. A deliberately incomplete
+                # TLS handshake exercises the documented timeout -> block path.
+                with socket.create_connection(("127.0.0.1", port), timeout=2) as stalled:
+                    stalled.sendall(b"\x16\x03")
+                    assert_socket_closed_soon(stalled, 8)
+            for _ in range(12):
+                with socket.create_connection(("127.0.0.1", port), timeout=2) as client:
+                    try:
+                        client.sendall(b"GET /invalid HTTP/1.0\r\n\r\n")
+                        client.recv(128)
+                    except (OSError, TimeoutError):
+                        pass
+            assert wait_for_condition(lambda: proxy.scrape()[metric] >= 1, 3), f"guard not wired to admission: {metric}"
+        finally:
+            proxy.stop()
+
+
+def scenario_explicit_relay_source() -> None:
+    source = _local_non_loopback_ipv4()
+    if source is None:
+        raise RuntimeError("explicit relay-source test needs a non-loopback IPv4")
+    for trusted in (False, True):
+        socks = FakeSocks5Server(mode="success")
+        socks.start()
+        port = free_port()
+        cfg = base_config(port=port, web_enabled=True, mask=False, upstream_type="socks5",
+                          upstream_host="127.0.0.1", upstream_port=socks.port)
+        if trusted:
+            cfg = cfg.replace("[web]", f'[web]\nrelay_sources = ["{source}"]')
+        proxy = start_proxy(cfg, port)
+        try:
+            with connect_from(source, "127.0.0.1", port) as client:
+                client.settimeout(3)
+                client.sendall(generate_obf_handshake(DEFAULT_SECRET_HEX, 1, "secure"))
+                if trusted:
+                    assert wait_for_condition(lambda: len(socks.connect_targets) == 1, 3), "listed relay rejected dd"
+                else:
+                    assert_socket_closed_soon(client)
+                    assert not socks.connect_targets, "unlisted non-loopback source bypassed FakeTLS gate"
+        finally:
+            proxy.stop()
+            socks.stop()
+
+
+def scenario_two_workers_traffic_health() -> None:
+    socks = FakeSocks5Server(mode="success")
+    socks.start()
+    port = free_port()
+    cfg = base_config(port=port, upstream_type="socks5", upstream_host="127.0.0.1", upstream_port=socks.port)
+    cfg = cfg.replace("[server]", "[server]\nworkers = 2")
+    proxy = start_proxy(cfg, port)
+    clients = []
+    try:
+        for _ in range(24):
+            client = socket.create_connection(("127.0.0.1", port), timeout=2)
+            clients.append(client)
+            perform_valid_client_handshake(client, DEFAULT_SECRET_HEX, DEFAULT_TLS_DOMAIN)
+            client.sendall(build_tls_record(TLS_RECORD_APPLICATION, b"\x55" * 128))
+        assert wait_for_condition(lambda: len(socks.connect_targets) == 24, 5)
+        assert wait_for_condition(lambda: socks.tunnel_bytes >= 24 * (DC_NONCE_BYTES + 128), 5), "two-worker traffic was lost"
+        assert proxy.scrape()["mtproto_connections_active"] >= 24
+        with urllib.request.urlopen(f"http://127.0.0.1:{proxy.metrics_port}/healthz", timeout=3) as response:
+            assert response.status == 200
+        # Linux exposes one SO_REUSEPORT socket per worker, not merely two threads.
+        with open("/proc/net/tcp") as table:
+            listeners = [line for line in table.readlines()[1:] if line.split()[1].endswith(f":{port:04X}") and line.split()[3] == "0A"]
+        assert len(listeners) == 2, f"expected two worker listeners, got {len(listeners)}"
+    finally:
+        for client in clients:
+            client.close()
+        proxy.stop()
+        socks.stop()
+
+
 SCENARIOS: dict[str, Callable[[], None]] = {
+    "guard_admission_metrics": scenario_guard_admission_metrics,
+    "explicit_relay_source": scenario_explicit_relay_source,
+    "two_workers_traffic_health": scenario_two_workers_traffic_health,
+    "proxy_header_split_tlv_quota": scenario_proxy_header_split_tlv_quota,
+    "silent_connections_do_not_starve_clients": scenario_silent_connections_do_not_starve_clients,
+    "long_username_expiry_and_reload_warning": scenario_long_username_expiry_and_reload_warning,
     "fake_telegram_dc_via_socks5": scenario_fake_telegram_dc_via_socks5,
     "desync_relay_via_socks5": scenario_desync_relay_via_socks5,
     "direct_secure_via_socks5": scenario_direct_secure_via_socks5,
@@ -1508,6 +1734,9 @@ def main() -> int:
         help="Run only selected scenario(s); repeatable",
     )
     parser.add_argument("--list", action="store_true", help="List available scenarios and exit")
+    parser.add_argument("--obf-gen", help="Precompiled handshake generator")
+    parser.add_argument("--scenario-timeout", type=int, default=90)
+    parser.add_argument("--fail-fast", action="store_true")
     args = parser.parse_args()
 
     if args.list:
@@ -1525,8 +1754,11 @@ def main() -> int:
         print(f"skip: e2e harness requires Linux runtime (current: {sys.platform})")
         return 0
 
-    global ACTIVE_PROXY_BIN
+    global ACTIVE_PROXY_BIN, ACTIVE_OBF_GEN
     ACTIVE_PROXY_BIN = Path(args.proxy_bin).resolve()
+    ACTIVE_OBF_GEN = Path(args.obf_gen).resolve() if args.obf_gen else None
+    if args.scenario_timeout < 1:
+        parser.error("--scenario-timeout must be positive")
 
     if not ACTIVE_PROXY_BIN.exists():
         print(f"error: missing binary {ACTIVE_PROXY_BIN}. Run `zig build` first.")
@@ -1538,12 +1770,25 @@ def main() -> int:
     print("")
 
     passed = 0
+    failures = []
+    def deadline(_signum, _frame):
+        raise TimeoutError("scenario deadline exceeded")
+    signal.signal(signal.SIGALRM, deadline)
     started = time.time()
     for name in selected:
         print(f"[RUN ] {name}")
         t0 = time.time()
         try:
-            SCENARIOS[name]()
+            signal.alarm(args.scenario_timeout)
+            for attempt in range(3):
+                try:
+                    SCENARIOS[name]()
+                    break
+                except (OSError, RuntimeError) as error:
+                    collision = "AddressInUse" in str(error) or "Address already in use" in str(error)
+                    if not collision or attempt == 2:
+                        raise
+                    print(f"[RETRY] {name}: port collision; selecting fresh ports")
             dt = time.time() - t0
             print(f"[PASS] {name} ({dt:.2f}s)")
             passed += 1
@@ -1551,12 +1796,18 @@ def main() -> int:
             dt = time.time() - t0
             print(f"[FAIL] {name} ({dt:.2f}s): {exc}")
             traceback.print_exc()
-            return 1
+            failures.append(name)
+            if args.fail_fast:
+                break
+        finally:
+            signal.alarm(0)
 
     total = time.time() - started
     print("")
     print(f"passed {passed}/{len(selected)} scenarios in {total:.2f}s")
-    return 0
+    if failures:
+        print("failed: " + ", ".join(failures))
+    return int(bool(failures))
 
 
 if __name__ == "__main__":

--- a/test/installer-e2e/Dockerfile
+++ b/test/installer-e2e/Dockerfile
@@ -14,6 +14,7 @@ RUN set -eux; \
         dbus \
         iproute2 \
         procps \
+        python3 \
         systemd \
         systemd-sysv; \
     apt-get clean; \

--- a/test/installer-e2e/run.sh
+++ b/test/installer-e2e/run.sh
@@ -409,7 +409,7 @@ echo "tunnel ownership: adopted config left unmarked, created configs marked"
 CONTAINER_SCRIPT
 }
 
-# Uninstall must remove every artifact AND do it without spewing expected-failure noise
+# Uninstall must remove owned artifacts AND do it without spewing expected-failure noise
 # (stop/disable of absent units, flushing an absent table 200, deleting an absent netns).
 verify_uninstall() {
   local container="$1"
@@ -418,6 +418,9 @@ verify_uninstall() {
 set -Eeuo pipefail
 
 # Exercise WEB provisioning before asserting that uninstall removes its artifacts.
+# Earlier setup fixtures restart the proxy repeatedly; isolate this scenario
+# from systemd's start-rate counter without changing the installed unit limits.
+systemctl reset-failed mtproto-proxy.service
 mtbuddy setup web --mode behind --domain relay.example.test --yes
 test -f /etc/systemd/system/mtproto-web-relay.service
 # Explicit sing-box cleanup fixtures: these test removal, not a provider connection.
@@ -425,6 +428,10 @@ mkdir -p /etc/mtproto-proxy
 printf '{}\n' > /etc/mtproto-proxy/singbox-egress.json
 printf '[Service]\nExecStart=/bin/true\n' > /etc/systemd/system/mtproto-singbox-egress.service
 systemctl daemon-reload
+shared_singbox_hash=""
+if [ -f /usr/local/bin/sing-box ]; then
+  shared_singbox_hash="$(sha256sum /usr/local/bin/sing-box)"
+fi
 out="$(mtbuddy uninstall --yes 2>&1)"
 printf '%s\n' "$out"
 
@@ -441,7 +448,6 @@ for f in \
   /etc/nginx/sites-available/mtproto-web \
   /etc/nginx/sites-enabled/mtproto-web \
   /usr/local/bin/setup_tunnel.sh \
-  /usr/local/bin/sing-box \
   /usr/local/bin/mtproto-singbox-route.sh \
   /etc/mtproto-proxy/singbox-egress.json \
   /usr/local/sbin/mtproto-tcpmss.sh \
@@ -450,6 +456,11 @@ for f in \
   /usr/local/bin/mtbuddy ; do
   if [ -e "$f" ]; then echo "FAIL: leftover $f"; fail=1; fi
 done
+
+# Shared dependencies can be used by other services and must remain untouched.
+if [ -n "$shared_singbox_hash" ] && ! printf '%s\n' "$shared_singbox_hash" | sha256sum --check --status; then
+  echo "FAIL: uninstall removed or changed shared sing-box"; fail=1
+fi
 
 # No mtproto unit files registered with systemd anymore.
 leftover_units="$(systemctl list-unit-files 2>/dev/null | grep -E "mtproto-(proxy|singbox|tunnel-pool|mask|web|tcpmss|syn-limit)" || true)"

--- a/test/installer-e2e/run.sh
+++ b/test/installer-e2e/run.sh
@@ -2,6 +2,8 @@
 set -Eeuo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+BUILD_DIR=""
 DOCKERFILE="$ROOT/test/installer-e2e/Dockerfile"
 LOG_DIR="${MTPROTO_INSTALLER_E2E_LOG_DIR:-$ROOT/test/installer-e2e/logs}"
 IMAGES="${MTPROTO_INSTALLER_E2E_IMAGES:-debian:11 debian:12 ubuntu:20.04 ubuntu:22.04 ubuntu:24.04}"
@@ -103,6 +105,11 @@ cleanup_containers() {
       docker rm -f "$container" >/dev/null 2>&1 || true
     fi
   done
+  if [[ -n "$BUILD_DIR" && -d "$BUILD_DIR" ]]; then
+    case "$BUILD_DIR" in
+      */mtproto-installer-build.*) rm -rf -- "$BUILD_DIR" ;;
+    esac
+  fi
 }
 
 trap cleanup_containers EXIT
@@ -148,6 +155,9 @@ verify_install_once() {
     test -f /opt/mtproto-proxy/config.toml
     test -x /opt/zapret/nfq/nfqws
     test -L /etc/nginx/sites-enabled/mtproto-masking
+    test -x /usr/local/sbin/mtproto-tcpmss.sh
+    systemctl is-enabled --quiet mtproto-tcpmss
+    iptables -t mangle -S OUTPUT | grep -- "! -o lo" | grep -- "--set-mss 88" >/dev/null
 
     for unit in mtproto-proxy nginx nfqws-mtproto mtproto-mask-health.timer; do
       systemctl is-active --quiet "$unit"
@@ -162,6 +172,14 @@ verify_install_once() {
     ss -lnt "( sport = :443 or sport = :8443 )" | grep "127.0.0.1:8443" >/dev/null
     curl -kfsS --resolve "wb.ru:8443:127.0.0.1" https://wb.ru:8443/ >/dev/null
   '
+  docker cp "$ROOT/test/capacity_connections_probe.py" "$container:/tmp/capacity_connections_probe.py"
+  run_in_container "$container" python3 -c '
+import socket, sys
+sys.path.insert(0, "/tmp")
+from capacity_connections_probe import maybe_send_payload
+with socket.create_connection(("127.0.0.1", int(sys.argv[1])), timeout=3) as peer:
+    assert maybe_send_payload(peer, "tls-auth-full", bytes.fromhex(sys.argv[3]), sys.argv[2]), "installed secret/SNI did not authenticate"
+' "$PORT" "$DOMAIN" "$SECRET"
 }
 
 install_fake_tunnel_tools() {
@@ -399,6 +417,14 @@ verify_uninstall() {
   run_script_in_container "$container" <<'CONTAINER_SCRIPT'
 set -Eeuo pipefail
 
+# Exercise WEB provisioning before asserting that uninstall removes its artifacts.
+mtbuddy setup web --mode behind --domain relay.example.test --yes
+test -f /etc/systemd/system/mtproto-web-relay.service
+# Explicit sing-box cleanup fixtures: these test removal, not a provider connection.
+mkdir -p /etc/mtproto-proxy
+printf '{}\n' > /etc/mtproto-proxy/singbox-egress.json
+printf '[Service]\nExecStart=/bin/true\n' > /etc/systemd/system/mtproto-singbox-egress.service
+systemctl daemon-reload
 out="$(mtbuddy uninstall --yes 2>&1)"
 printf '%s\n' "$out"
 
@@ -417,12 +443,16 @@ for f in \
   /usr/local/bin/setup_tunnel.sh \
   /usr/local/bin/sing-box \
   /usr/local/bin/mtproto-singbox-route.sh \
+  /etc/mtproto-proxy/singbox-egress.json \
+  /usr/local/sbin/mtproto-tcpmss.sh \
+  /usr/local/sbin/mtproto-syn-limit.sh \
+  /usr/local/bin/mtproto-mask-health.sh \
   /usr/local/bin/mtbuddy ; do
   if [ -e "$f" ]; then echo "FAIL: leftover $f"; fail=1; fi
 done
 
 # No mtproto unit files registered with systemd anymore.
-leftover_units="$(systemctl list-unit-files 2>/dev/null | grep -E "mtproto-(proxy|singbox|tunnel-pool|mask|web)" || true)"
+leftover_units="$(systemctl list-unit-files 2>/dev/null | grep -E "mtproto-(proxy|singbox|tunnel-pool|mask|web|tcpmss|syn-limit)" || true)"
 if [ -n "$leftover_units" ]; then
   echo "FAIL: mtproto unit files still registered:"; printf '%s\n' "$leftover_units"; fail=1
 fi
@@ -483,7 +513,7 @@ verify_update_preserves_config() {
     set -Eeuo pipefail
     cfg=/opt/mtproto-proxy/config.toml
     before_hash="$(sha256sum "$cfg" | cut -d" " -f1)"
-    mtbuddy update --version "'"$VERSION"'" --yes
+    mtbuddy update --version "'"$VERSION"'" --force
     after_hash="$(sha256sum "$cfg" | cut -d" " -f1)"
     if [ "$before_hash" != "$after_hash" ]; then
       echo "FAIL: config.toml changed across mtbuddy update ($before_hash -> $after_hash)"
@@ -514,6 +544,16 @@ fi
 test -x "$singbox"
 "$singbox" version | grep -F "sing-box" >/dev/null
 CONTAINER_SCRIPT
+}
+
+restore_proxy_under_test() {
+  local container="$1"
+  docker cp "$BUILD_DIR/bin/mtproto-proxy" "$container:/tmp/mtproto-proxy-under-test"
+  run_in_container "$container" bash -lc '
+    install -m 0755 /tmp/mtproto-proxy-under-test /opt/mtproto-proxy/mtproto-proxy
+    systemctl restart mtproto-proxy
+    systemctl is-active --quiet mtproto-proxy
+  '
 }
 
 run_case() {
@@ -549,7 +589,7 @@ run_case() {
   echo "::endgroup::"
 
   echo "::group::Install local mtbuddy ($base_image)"
-  docker cp "$ROOT/zig-out/bin/mtbuddy" "$container:/tmp/mtbuddy"
+  docker cp "$BUILD_DIR/bin/mtbuddy" "$container:/tmp/mtbuddy"
   run_in_container "$container" bash -lc '
     set -Eeuo pipefail
     install -m 0755 /tmp/mtbuddy /usr/local/bin/mtbuddy
@@ -571,6 +611,7 @@ run_case() {
   echo "::endgroup::"
 
   echo "::group::Verify install ($base_image)"
+  restore_proxy_under_test "$container"
   verify_install "$container" 2>&1 | tee "$LOG_DIR/$safe.verify.log"
   echo "::endgroup::"
 
@@ -587,6 +628,7 @@ run_case() {
 
   echo "::group::Update preserves config.toml + keeps service active ($base_image)"
   verify_update_preserves_config "$container" 2>&1 | tee "$LOG_DIR/$safe.update.log"
+  restore_proxy_under_test "$container"
   verify_install "$container" 2>&1 | tee "$LOG_DIR/$safe.verify-after-update.log"
   echo "::endgroup::"
 
@@ -596,7 +638,7 @@ run_case() {
   # `uninstall` could pass this whole suite without once being run. Put the local
   # binary back; the update step above has already proved the self-update path works.
   echo "::group::Restore the mtbuddy under test after the update ($base_image)"
-  docker cp "$ROOT/zig-out/bin/mtbuddy" "$container:/tmp/mtbuddy"
+  docker cp "$BUILD_DIR/bin/mtbuddy" "$container:/tmp/mtbuddy"
   run_in_container "$container" bash -lc '
     set -Eeuo pipefail
     install -m 0755 /tmp/mtbuddy /usr/local/bin/mtbuddy
@@ -606,6 +648,18 @@ run_case() {
   echo "::endgroup::"
 
   echo "::group::Setup tunnel with failing Telegram probe ($base_image)"
+  run_in_container "$container" bash -lc '
+    set -Eeuo pipefail
+    mtbuddy status
+    mtbuddy links
+    mtbuddy config validate
+    mtbuddy reload
+    mtbuddy setup syn-limit --preset soft
+    mtbuddy setup syn-limit --preset soft
+    test "$(iptables -S INPUT | grep -c -- "-j MTPROTO_SYNLIMIT")" = 1
+    iptables -S MTPROTO_SYNLIMIT | grep -- "--hashlimit-name mtproto_syn" >/dev/null
+    test -x /usr/local/sbin/mtproto-syn-limit.sh
+  '
   install_fake_tunnel_tools "$container"
   verify_tunnel_probe_failure_is_nonfatal "$container" 2>&1 | tee "$LOG_DIR/$safe.tunnel-probe-failure.log"
   echo "::endgroup::"
@@ -636,7 +690,8 @@ main() {
   echo "Docker architecture target: $target"
   echo "Installer release version under test: $VERSION"
 
-  zig build -Dtarget="$target" -Doptimize=ReleaseFast
+  BUILD_DIR="$(mktemp -d "${TMPDIR:-/tmp}/mtproto-installer-build.XXXXXX")"
+  zig build --prefix "$BUILD_DIR" -Dtarget="$target" -Doptimize=ReleaseFast
 
   local image
   for image in $IMAGES; do

--- a/test/test_probe_helpers.py
+++ b/test/test_probe_helpers.py
@@ -1,0 +1,38 @@
+"""Offline regressions for measurement harnesses (no target/network required)."""
+import errno
+import unittest
+from unittest.mock import patch, MagicMock
+
+import capacity_connections_probe as capacity
+import connection_stability_check as stability
+
+
+class ProbeHelpers(unittest.TestCase):
+    def test_incomplete_proc_stats_are_not_success(self):
+        self.assertFalse(stability.has_stats(stability.ProcStats(1, None, 1, 1)))
+
+    def test_fd_exhaustion_stops_idle_load(self):
+        with patch.object(stability.socket, "create_connection", side_effect=OSError(errno.EMFILE, "fds")) as connect:
+            sockets, failed = stability.open_idle_connections("localhost", 1, 10000, 1)
+        self.assertEqual(sockets, [])
+        self.assertEqual(connect.call_count, 1)
+        self.assertGreater(failed, 0)
+
+    def test_churn_gets_fresh_authenticated_payload(self):
+        sock = MagicMock()
+        sock.recv.return_value = b"\x16\x03\x03"
+        sock.__enter__.return_value = sock
+        factory = MagicMock(side_effect=[b"first", b"second"])
+        with patch.object(stability.socket, "create_connection", return_value=sock):
+            ok, fail, _ = stability.run_churn("localhost", 1, 2, 1, 1, factory)
+        self.assertEqual((ok, fail), (2, 0))
+        self.assertEqual(factory.call_count, 2)
+
+    def test_tls_template_is_cached(self):
+        capacity.build_realistic_client_hello.cache_clear()
+        first = capacity.build_realistic_client_hello("example.com")
+        self.assertIs(first, capacity.build_realistic_client_hello("example.com"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/web-bridge/harness.js
+++ b/test/web-bridge/harness.js
@@ -34,6 +34,9 @@ function frame(type, stream, payload) {
 }
 const HELLO = frame(0x10, 0, Buffer.from([1]));
 const WELCOME = frame(0x11, 0);
+if (HELLO.toString('hex') !== process.argv[3] || WELCOME.toString('hex') !== process.argv[4]) {
+  throw new Error('harness frame encoding differs from production frame.serialize');
+}
 
 /// A fresh page instance with a scripted browser around it.
 function boot(opts) {
@@ -41,12 +44,15 @@ function boot(opts) {
   const timers = [];
   const listeners = {};
   const toClient = [];
+  let initReceiverReady = false;
 
   class FakeWebSocket {
     constructor(url) {
+      if (opts.constructorThrows) throw new Error('WebSocket construction failed');
       this.url = url;
       this.readyState = 0;
       this.sent = [];
+      this.binaryType = 'blob';
       sockets.push(this);
     }
     send(b) {
@@ -62,13 +68,20 @@ function boot(opts) {
       if (this.onopen) this.onopen();
     }
     deliver(buf) {
-      if (this.onmessage) this.onmessage({ data: new Uint8Array(buf).buffer });
+      const data = this.binaryType === 'arraybuffer' ? new Uint8Array(buf).buffer : { blob: Buffer.from(buf) };
+      if (this.onmessage) this.onmessage({ data });
     }
   }
 
   const bridge = {
     _receiver: null,
-    postMessage(v) { toClient.push(v); },
+    postMessage(v) {
+      toClient.push(v);
+      if (typeof v === 'string' && JSON.parse(v).t === 'tproxy-android-init') {
+        initReceiverReady = typeof this._receiver === 'function';
+        if (opts.synchronousHello) this._receiver({ data: new Uint8Array(HELLO).buffer });
+      }
+    },
     get onmessage() { return this._receiver; },
     set onmessage(v) { this._receiver = v; },
   };
@@ -80,7 +93,7 @@ function boot(opts) {
     clearTimeout: () => {},
     addEventListener: (type, fn) => { (listeners[type] = listeners[type] || []).push(fn); },
     location: {
-      search: '?bridge=' + CAP,
+      search: opts.capability === null ? '' : '?bridge=' + CAP,
       hash: opts.native ? '#android=' + NONCE : '',
       host: 'relay.example.com',
       protocol: 'https:',
@@ -102,6 +115,8 @@ function boot(opts) {
     listeners,
     toClient,
     bridge,
+    initReceiverReady: () => initReceiverReady,
+    runNextTimer: () => { const timer = timers.shift(); if (!timer) throw new Error('no timer'); timer.fn(); },
     controls: () => toClient.filter(m => typeof m === 'string').map(JSON.parse),
     // `.map(Buffer.from)` would pass the index as a byteOffset — bind the arity.
     binaries: () => toClient.filter(m => m instanceof ArrayBuffer).map(m => Buffer.from(m)),
@@ -112,19 +127,18 @@ const cases = {};
 
 // The normal path: a hidden WebView with the injected bridge object.
 cases['native handshake'] = (t) => {
-  const p = boot({ native: true });
+  const p = boot({ native: true, synchronousHello: true });
 
   const init = p.controls()[0];
   t.eq(init && init.t, 'tproxy-android-init', 'first control message');
   t.eq(init.v, 1, 'init version');
   t.eq(init.nonce, NONCE, 'init nonce echoes the fragment');
-  t.ok(typeof p.bridge.onmessage === 'function', 'onmessage is live before init is sent');
+  t.ok(p.initReceiverReady(), 'onmessage was live at the instant init was sent');
 
   t.eq(p.sockets.length, 1, 'exactly one carrier socket');
   t.eq(p.sockets[0].url, 'wss://relay.example.com/api/v1/socket?b=' + CAP, 'same-origin carrier url');
 
   // HELLO arrives before the socket opens, so it has to be queued rather than dropped.
-  p.bridge.onmessage({ data: new Uint8Array(HELLO).buffer });
   t.eq(p.sockets[0].sent.length, 0, 'nothing sent before the socket opened');
   p.sockets[0].open();
   t.eq(p.sockets[0].sent.length, 1, 'HELLO flushed on open');
@@ -174,7 +188,7 @@ cases['iframe fallback'] = (t) => {
   const p = boot({ native: false });
   t.eq(p.sockets.length, 0, 'no carrier before tproxy-init');
 
-  const port = { onmessage: null, start() {}, posted: [], postMessage(v) { this.posted.push(v); } };
+  const port = { onmessage: null, start() {}, posted: [], postMessage(v, transfer = []) { this.posted.push(structuredClone(v, { transfer })); } };
   const post = (origin) => p.listeners.message.forEach(fn =>
     fn({ data: { t: 'tproxy-init', v: 1 }, origin, ports: [port] }));
 
@@ -205,15 +219,57 @@ cases['garbage never throws'] = (t) => {
   for (const junk of ['not json', '{"t":', null, undefined, 42, {}, new Uint8Array(0).buffer]) {
     p.bridge.onmessage({ data: junk });
   }
+  p.bridge.onmessage({ get data() { throw new Error('hostile getter'); } });
+  p.bridge.onmessage(null);
   t.ok(true, 'handler survived garbage');
 };
 
 // The page must not carry a capability of its own: it reads one from the URL, so the
 // served bytes are identical for every user.
 cases['no carrier without a capability'] = (t) => {
-  const p = boot({ native: true, });
-  t.ok(src.indexOf('location.search') >= 0, 'capability is read from the URL');
-  t.eq(p.sockets[0].url.indexOf(CAP) > 0, true, 'capability reached the carrier url');
+  const p = boot({ native: true, capability: null });
+  if (typeof p.bridge.onmessage === 'function') p.bridge.onmessage({ data: new Uint8Array(HELLO).buffer });
+  p.timers.forEach(timer => timer.fn());
+  t.eq(p.sockets.length, 0, 'no websocket can open without a capability');
+};
+
+cases['failure before first open replays exactly one HELLO'] = (t) => {
+  const p = boot({ native: true, synchronousHello: true });
+  p.sockets[0].close();
+  p.runNextTimer();
+  p.sockets[1].open();
+  t.eq(p.sockets[1].sent.length, 1, 'queued and replayed HELLO are deduplicated');
+  t.ok(p.sockets[1].sent[0].equals(HELLO), 'HELLO survives failed connect');
+};
+
+cases['retry limit gives up after two retries'] = (t) => {
+  const p = boot({ native: true });
+  for (let i = 0; i < 2; i++) { p.sockets[i].close(); p.runNextTimer(); }
+  p.sockets[2].close();
+  t.eq(p.sockets.length, 3, 'only two replacement sockets');
+  t.eq(p.timers.length, 0, 'no timer after retry exhaustion');
+  t.ok(p.controls().some(c => c.state === 'failed'), 'retry exhaustion reported');
+};
+
+cases['client close and constructor failure terminate cleanly'] = (t) => {
+  const p = boot({ native: true });
+  p.bridge.onmessage({ data: JSON.stringify({ t: 'close' }) });
+  t.eq(p.sockets[0].readyState, 3, 'client close shuts carrier');
+  t.eq(p.timers.length, 0, 'client close never reconnects');
+  const bad = boot({ native: true, constructorThrows: true });
+  t.eq(bad.sockets.length, 0, 'failed constructor published no socket');
+  t.ok(bad.controls().some(c => c.state === 'failed'), 'constructor failure reported');
+};
+
+cases['BYE bytes reach the adopted client before it closes'] = (t) => {
+  const p = boot({ native: true });
+  p.sockets[0].open();
+  p.sockets[0].deliver(WELCOME);
+  const bye = frame(0x1f, 0);
+  p.sockets[0].deliver(bye);
+  t.ok(p.binaries().at(-1).equals(bye), 'BYE delivered intact');
+  p.bridge.onmessage({ data: JSON.stringify({ t: 'close' }) });
+  t.eq(p.timers.length, 0, 'no reconnect after BYE/client close');
 };
 
 let failures = 0;

--- a/test/web-bridge/render.zig
+++ b/test/web-bridge/render.zig
@@ -1,0 +1,22 @@
+const std = @import("std");
+const page = @import("page");
+const frame = @import("frame");
+
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+    const cover = try page.renderCover(allocator, "relay.example.com");
+    defer allocator.free(cover);
+    const html = try page.renderBridge(allocator, cover, "/api/v1/socket");
+    defer allocator.free(html);
+    var frame_buf: [16]u8 = undefined;
+    const hello = try frame.serialize(&frame_buf, .hello, 0, &.{1});
+    const hello_hex = std.fmt.bytesToHex(hello[0..9].*, .lower);
+    const welcome = try frame.serialize(&frame_buf, .welcome, 0, "");
+    const welcome_hex = std.fmt.bytesToHex(welcome[0..8].*, .lower);
+    const stdout = std.Io.File.stdout();
+    try stdout.writeStreamingAll(init.io, &hello_hex);
+    try stdout.writeStreamingAll(init.io, "\n");
+    try stdout.writeStreamingAll(init.io, &welcome_hex);
+    try stdout.writeStreamingAll(init.io, "\n");
+    try stdout.writeStreamingAll(init.io, html);
+}

--- a/test/web-bridge/run.py
+++ b/test/web-bridge/run.py
@@ -10,11 +10,10 @@ fallback. Neither is exercised by `zig build test`.
 This script lifts the inline script out of page.zig exactly as the relay renders it and
 hands it to harness.js, which impersonates the client.
 
-Skips (exit 0) when node is unavailable, so a dev box without it still gets a green
-`zig build`; CI runs on ubuntu-latest, which ships node.
+Missing node or zig is an error; contract tests cannot silently pass without running.
 """
 
-import re
+import os
 import shutil
 import subprocess
 import sys
@@ -27,39 +26,33 @@ HARNESS = Path(__file__).resolve().parent / "harness.js"
 WS_PATH = "/api/v1/socket"
 
 
-def multiline_literal(source: str, name: str) -> str:
-    """Return the text of a `const <name> = \\\\...` Zig multiline string literal."""
-    match = re.search(r"const %s =\n((?:[ \t]*\\\\.*\n)+)" % re.escape(name), source)
-    if not match:
-        raise SystemExit(f"could not find the {name} literal in {PAGE}")
-    lines = []
-    for raw in match.group(1).splitlines():
-        stripped = raw.strip()
-        if stripped.startswith("\\\\"):
-            lines.append(stripped[2:])
-    return "\n".join(lines)
-
-
-def extract_script() -> str:
-    source = PAGE.read_text(encoding="utf-8")
-    # renderBridge() writes: script_head + <ws path as a JS string> + script_body
-    page = multiline_literal(source, "script_head") + f'"{WS_PATH}"' + multiline_literal(source, "script_body")
+def extract_script() -> tuple[str, str, str]:
+    zig = os.environ.get("ZIG") or shutil.which("zig")
+    if not zig:
+        raise SystemExit("web-bridge: zig is required")
+    rendered = subprocess.run([
+        zig, "run", "--dep", "page", "--dep", "frame",
+        "-Mroot=" + str(HARNESS.with_name("render.zig")),
+        "-Mpage=" + str(PAGE),
+        "-Mframe=" + str(PAGE.with_name("frame.zig")),
+    ], check=True, text=True, capture_output=True, cwd=REPO).stdout
+    hello, welcome, page = rendered.split("\n", 2)
     body = page.split("<script>", 1)
     if len(body) != 2:
         raise SystemExit("the bridge page no longer opens a <script> element")
     js = body[1].split("</script>", 1)[0]
     if "TelegramWebProxy" not in js or "tproxy-init" not in js:
         raise SystemExit("the extracted script is missing a client boundary")
-    return js
+    return js, hello, welcome
 
 
 def main() -> int:
     node = shutil.which("node")
     if node is None:
-        print("web-bridge: node not found, skipping the bridge-page contract tests")
-        return 0
+        print("web-bridge: node is required", file=sys.stderr)
+        return 1
 
-    js = extract_script()
+    js, hello, welcome = extract_script()
     print(f"web-bridge: checking {len(js)} bytes of bridge script")
     with tempfile.TemporaryDirectory() as tmp:
         path = Path(tmp) / "bridge.js"
@@ -70,7 +63,7 @@ def main() -> int:
             print(syntax.stderr.strip())
             return 1
 
-        result = subprocess.run([node, str(HARNESS), str(path)], text=True)
+        result = subprocess.run([node, str(HARNESS), str(path), hello, welcome], text=True)
         return result.returncode
 
 

--- a/test/web-e2e/live_check.py
+++ b/test/web-e2e/live_check.py
@@ -46,7 +46,7 @@ def fail(m): print("  FAIL " + m); sys.exit(1)
 def build_tls_auth_client_hello(secret: bytes, hostname: str) -> bytes:
     host = hostname.encode()
     sni_list_len = 1 + 2 + len(host); sni_ext_len = 2 + sni_list_len; sv_len = 3
-    body_len = 2+32+1+32+2+2+1+1+2+4+sni_ext_len+4+sv_len
+    body_len = 2+32+1+32+2+2+1+1+2+4+sni_ext_len+4+sv_len+42
     rec_len = 4 + body_len
     p = bytearray(5 + rec_len)
     p[0]=0x16; p[1]=3; p[2]=1; p[3:5]=struct.pack(">H", rec_len)
@@ -56,12 +56,14 @@ def build_tls_auth_client_hello(secret: bytes, hostname: str) -> bytes:
     p[pos]=0x20; pos+=1; p[pos:pos+32]=os.urandom(32); pos+=32
     p[pos:pos+2]=struct.pack(">H",2); pos+=2; p[pos:pos+2]=b"\x13\x01"; pos+=2
     p[pos]=1; pos+=1; p[pos]=0; pos+=1
-    p[pos:pos+2]=struct.pack(">H",4+sni_ext_len+4+sv_len); pos+=2
+    p[pos:pos+2]=struct.pack(">H",4+sni_ext_len+4+sv_len+42); pos+=2
     p[pos:pos+2]=b"\x00\x00"; pos+=2; p[pos:pos+2]=struct.pack(">H",sni_ext_len); pos+=2
     p[pos:pos+2]=struct.pack(">H",sni_list_len); pos+=2; p[pos]=0; pos+=1
     p[pos:pos+2]=struct.pack(">H",len(host)); pos+=2; p[pos:pos+len(host)]=host; pos+=len(host)
     p[pos:pos+2]=b"\x00\x2b"; pos+=2; p[pos:pos+2]=struct.pack(">H",sv_len); pos+=2
     p[pos]=2; pos+=1; p[pos:pos+2]=b"\x03\x04"; pos+=2
+    p[pos:pos+10]=bytes.fromhex("003300260024001d0020")
+    p[pos+10:pos+42]=os.urandom(32); pos+=42
     assert pos==len(p)
     mi=bytearray(p)
     for i in range(rnd, rnd+32): mi[i]=0
@@ -171,11 +173,13 @@ def baseline():
     o = Obf(secret, 2)
     s = socket.create_connection((HOST, PORT), timeout=8)
     s.sendall(o.first); msg, _ = req_pq_multi(); s.sendall(o.send(padded_frame(msg)))
-    s.settimeout(5); got = b""; reset = False
+    s.settimeout(5); got = b""; reset = False; closed = False
     try:
         while True:
             c = s.recv(4096)
-            if not c: break
+            if not c:
+                closed = True
+                break
             got += c
             if len(got) > 64: break
     except (socket.timeout, ConnectionResetError) as e:
@@ -186,6 +190,8 @@ def baseline():
         plain = o.recv(got)
         served = len(plain) >= 12 and struct.unpack("<I", plain[0:4])[0] + 4 <= len(plain) + 16 and b"\x63\x24\x16\x05" in plain
     if served: fail("dd handshake from the INTERNET was served — fake_tls_only gate is open!")
+    if not got and not reset and not closed:
+        fail("dd rejection is inconclusive: connection stayed open with no response")
     ok(f"dd from the internet is not served ({'RST' if reset else str(len(got))+' bytes back, not MTProto'})")
 
 def tls_records(buf: bytes):
@@ -234,6 +240,7 @@ def faketls_e2e(name: str, dc: int = 2):
     if len(plain) < 4: fail(f"FakeTLS {name}: no reply from Telegram")
     ln = struct.unpack("<I", plain[0:4])[0]; payload = plain[4:4+ln]
     check_server_padding(f"FakeTLS {name}", ln, payload)
+    payload = strip_padding(payload)
     ctor = struct.unpack("<I", payload[20:24])[0]; echoed = payload[24:40]
     if ctor != 0x05162463 or echoed != nonce: fail(f"FakeTLS {name}: unexpected reply ctor={ctor:#x}")
     ok(f"FakeTLS {name}: req_pq_multi -> res_pq from DC{dc} ({int((time.time()-t0)*1000)} ms)")
@@ -262,15 +269,33 @@ async def web():
     issuer = dict(x[0] for x in cert["issuer"])
     ok(f"TLS cert issuer: {issuer.get('organizationName')} / {issuer.get('commonName')}, CN={dict(x[0] for x in cert['subject']).get('commonName')}")
     if "200" not in st or b"TelegramWebProxy" in body: fail(f"cover page: {st}, bridge leaked={b'TelegramWebProxy' in body}")
+    cover_body = body
+    def normalized_headers(raw):
+        return sorted(line.lower().strip() for line in raw.split("\r\n")[1:]
+                      if line and not line.lower().startswith(("date:", "connection:")))
+    cover_headers = normalized_headers(head)
     ok(f"cover page: {st}, {len(body)} bytes, no bridge script")
 
     st, head, body, _ = https_get("/?bridge=" + "A" * 43)
     if "200" not in st or b"TelegramWebProxy" in body: fail("bad capability leaked the bridge page")
+    if body != cover_body or normalized_headers(head) != cover_headers:
+        fail("bad capability differs from the ordinary cover response")
     ok("bad capability -> same cover page")
+    unknown_status, unknown_headers, unknown_body, _ = https_get("/unknown-" + os.urandom(8).hex())
+    if "404" not in unknown_status or unknown_body != cover_body:
+        fail("unknown path must return 404 with the cover body")
 
     st, head, body, _ = https_get("/?bridge=" + cap)
     if "200" not in st or b"TelegramWebProxy" not in body or b"tproxy-init" not in body: fail(f"bridge page: {st}")
     csp = [l for l in head.split("\r\n") if l.lower().startswith("content-security-policy")]
+    if not csp or "frame-ancestors" not in csp[0] or "connect-src" not in csp[0]:
+        fail("bridge CSP is absent or missing frame-ancestors/connect-src")
+    if "cache-control: no-store" not in head.lower() or "x-frame-options:" in head.lower():
+        fail("bridge needs no-store and must allow the client's iframe")
+    for other_name, other_secret in list(USERS.items())[1:2]:
+        _, _, other_body, _ = https_get("/?bridge=" + capability(HOST, bytes.fromhex(other_secret)))
+        if other_body != body:
+            fail(f"bridge content varies by user ({name}, {other_name})")
     ok(f"bridge page for '{name}': {st}, {len(body)} bytes, CSP present={bool(csp)}")
 
     # WSS with a bad capability must look like any unknown path
@@ -278,6 +303,11 @@ async def web():
         async with websockets.connect(f"wss://{HOST}{WS_PATH}?b=" + "A"*43, origin=f"https://{HOST}", open_timeout=10, ssl=SSL_CTX) as w:
             fail("websocket upgraded with a bad capability")
     except websockets.exceptions.InvalidStatus as e:
+        if e.response.status_code != 404:
+            fail(f"bad capability returned {e.response.status_code}, expected 404")
+        rejected_headers = "HTTP/1.1 404 Not Found\r\n" + str(e.response.headers)
+        if bytes(e.response.body) != unknown_body or normalized_headers(rejected_headers) != normalized_headers(unknown_headers):
+            fail("bad websocket capability differs from an ordinary unknown-path response")
         ok(f"bad capability -> websocket refused with {e.response.status_code}")
 
     async with websockets.connect(f"wss://{HOST}{WS_PATH}?b={cap}", origin=f"https://{HOST}", open_timeout=10, max_size=2*1024*1024, ssl=SSL_CTX) as w:
@@ -306,6 +336,7 @@ async def web():
         ln = struct.unpack("<I", plain[0:4])[0]; payload = plain[4:4+ln]
         # unencrypted MTProto: auth_key_id(8) msg_id(8) len(4) body
         check_server_padding("WEB relay", ln, payload)
+        payload = strip_padding(payload)
         ctor = struct.unpack("<I", payload[20:24])[0]; echoed = payload[24:40]
         if ctor != 0x05162463 or echoed != nonce: fail(f"unexpected reply ctor={ctor:#x} nonce_match={echoed==nonce}")
         ok(f"req_pq_multi -> res_pq from Telegram DC2 via relay (RTT {int((time.time()-t0)*1000)} ms, {len(plain)} bytes), nonce echoed")
@@ -356,6 +387,7 @@ async def idle(seconds: int = 210):
             if len(plain) >= 4 and len(plain) >= 4 + struct.unpack("<I", plain[0:4])[0]: break
         ln = struct.unpack("<I", plain[0:4])[0]; payload = plain[4:4+ln]
         check_server_padding("WEB relay after idle", ln, payload)
+        payload = strip_padding(payload)
         if struct.unpack("<I", payload[20:24])[0] != 0x05162463 or payload[24:40] != nonce: fail("bad res_pq after idle")
         ok(f"after {seconds}s idle: req_pq -> res_pq (DC2, user {name}) in {int((time.time()-t1)*1000)} ms")
         await w.send(frame(0x03, 7))


### PR DESCRIPTION
Security and stability fixes for the proxy, WEB relay, dashboard and VPN setup, including AWG 3.1 import support and background DNS refresh.

Validation: 469 Linux unit tests, 25 E2E scenarios, and live direct/VPN FakeTLS and WEB checks.

No Markdown documentation or audit files are included in this branch. Local Markdown reports and workspace state are ignored. Existing public documentation is unchanged.