### PR TITLE
feat: add user traffic history and fix WEB with bind_address

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
           # suite into a green skip that proves nothing. Import them here first so that
           # failure is loud and the pytest run below can only be a real result.
           /tmp/dashboard-venv/bin/python -c "import fastapi, httpx, psutil, uvicorn"
-          /tmp/dashboard-venv/bin/python -m pytest -q src/ctl/dashboard_assets/test_server.py
+          /tmp/dashboard-venv/bin/python -m pytest -q src/ctl/dashboard_assets/test_server.py src/ctl/dashboard_assets/test_traffic.py
 
   e2e:
     name: E2E Integration

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ PRODUCT_VISION.md
 
 # Dashboard authentication token generated at runtime.
 src/ctl/dashboard_assets/dashboard.token
+src/ctl/dashboard_assets/traffic.sqlite3*

--- a/src/config.zig
+++ b/src/config.zig
@@ -251,7 +251,7 @@ pub const Config = struct {
         host: ?[]const u8 = null,
         port: u16 = 8081,
         /// `host:port` of the stock MTProxy the relay dials on every OPEN.
-        /// Defaults to this proxy on loopback.
+        /// Defaults to this proxy's bind_address (loopback for wildcard listeners).
         backend: ?[]const u8 = null,
         /// `host:port` of a TLS terminator that accepts a PROXY-protocol header, used
         /// ONLY for masked connections whose SNI is `domain`.

--- a/src/ctl/dashboard.zig
+++ b/src/ctl/dashboard.zig
@@ -50,6 +50,7 @@ const PIP_INSTALL_ARGV = [_][]const u8{
 
 // Embed dashboard assets at comptime
 const server_py = @embedFile("dashboard_assets/server.py");
+const traffic_py = @embedFile("dashboard_assets/traffic.py");
 const index_html = @embedFile("dashboard_assets/static/index.html");
 const style_css = @embedFile("dashboard_assets/static/style.css");
 const app_js = @embedFile("dashboard_assets/static/app.js");
@@ -246,6 +247,7 @@ pub fn execute(ui: *Tui, allocator: std.mem.Allocator, opts: DashboardOpts) !voi
         return;
     };
     try sys.writeFile(INSTALL_DIR ++ "/proxy.service", @import("build_options").proxy_service);
+    try sys.writeFile(INSTALL_DIR ++ "/traffic.py", traffic_py);
     try sys.writeFile(INSTALL_DIR ++ "/static/index.html", index_html);
     try sys.writeFile(INSTALL_DIR ++ "/static/style.css", style_css);
     try sys.writeFile(INSTALL_DIR ++ "/static/app.js", app_js);

--- a/src/ctl/dashboard_assets/server.py
+++ b/src/ctl/dashboard_assets/server.py
@@ -19,6 +19,8 @@ import queue
 import subprocess
 import sys
 import shutil
+import urllib.request
+from traffic import TrafficHistory, parse_metrics
 from pathlib import Path
 from urllib.parse import quote, urlparse
 
@@ -171,8 +173,15 @@ def _proxy_version() -> str | None:
 
 @asynccontextmanager
 async def _lifespan(app):
-    yield
-    await asyncio.to_thread(stop_log_thread)
+    _traffic_stop.clear()
+    worker = threading.Thread(target=_traffic_loop, daemon=True)
+    worker.start()
+    try:
+        yield
+    finally:
+        _traffic_stop.set()
+        await asyncio.to_thread(worker.join, 8)
+        await asyncio.to_thread(stop_log_thread)
 
 
 app = FastAPI(lifespan=_lifespan)
@@ -1663,6 +1672,61 @@ def _masking_status() -> dict:
     return result
 
 
+_traffic_stop = threading.Event()
+_traffic_snapshot = {"available": False, "error": "collecting", "items": {}}
+
+
+def _traffic_sample():
+    global _traffic_snapshot
+    try:
+        path = _find_config_path()
+        if path is None or tomllib is None:
+            raise ValueError("config_unavailable")
+        cfg = tomllib.loads("\n".join(_strip_inline_comment(line) for line in path.read_text().splitlines()))
+        metrics = cfg.get("metrics", {})
+        if not metrics.get("enabled", False):
+            raise ValueError("metrics_disabled")
+        host = str(metrics.get("host") or "127.0.0.1")
+        if host in ("0.0.0.0", "::"):
+            host = "127.0.0.1" if host == "0.0.0.0" else "::1"
+        # Only IP literals from the local config, no credentials, redirects or env proxies.
+        ip = ipaddress.ip_address(host)
+        authority = f"[{ip}]" if ip.version == 6 else str(ip)
+        port = int(metrics.get("port", 9400))
+        if not 1 <= port <= 65535:
+            raise ValueError("metrics_unavailable")
+        class NoRedirect(urllib.request.HTTPRedirectHandler):
+            def redirect_request(self, *args, **kwargs):
+                return None
+        opener = urllib.request.build_opener(urllib.request.ProxyHandler({}), NoRedirect())
+        with opener.open(f"http://{authority}:{port}/metrics", timeout=3) as response:
+            raw = response.read(4 * 1024 * 1024 + 1)
+        if len(raw) > 4 * 1024 * 1024:
+            raise ValueError("metrics_unavailable")
+        process, counters = parse_metrics(raw.decode())
+        access = _load_proxy_runtime_config()
+        users = {**access.get("disabled_users", {}), **access.get("users", {})}
+        # Reusing a username with a different secret starts a new history.
+        identities = {name: hashlib.sha256((name + "\0" + str(secret).lower()).encode()).hexdigest() for name, secret in users.items()}
+        history = TrafficHistory(Path(__file__).parent / "traffic.sqlite3")
+        now = int(time.time())
+        history.record(now, process, {identities[name]: value for name, value in counters.items() if name in identities})
+        totals = {days: history.totals(now, days) for days in (7, 14, 30)}
+        starts = history.starts()
+        _traffic_snapshot = {"available": True, "updated_at": now, "items": {
+            name: {"started_at": starts.get(identity), "totals": {str(days): totals[days].get(identity, 0) for days in totals}}
+            for name, identity in identities.items()}}
+    except Exception as exc:
+        reason = str(exc) if str(exc) in ("metrics_disabled", "config_unavailable") else "metrics_unavailable"
+        _traffic_snapshot = {**_traffic_snapshot, "available": False, "error": reason}
+
+
+def _traffic_loop():
+    while not _traffic_stop.is_set():
+        _traffic_sample()
+        _traffic_stop.wait(30)
+
+
 _users_cache = {"ts": 0, "data": None}
 USERS_CACHE_TTL = 8  # seconds
 
@@ -2718,6 +2782,7 @@ def api_stats():
             "routing": _routing_status(),
             "masking": _masking_status(),
             "users": _users_status(),
+            "traffic": _traffic_snapshot,
         }
     )
 

--- a/src/ctl/dashboard_assets/static/app.js
+++ b/src/ctl/dashboard_assets/static/app.js
@@ -698,6 +698,56 @@ function _users_cache_bust() {
   }
 }
 
+let trafficDays = 30;
+let trafficSnapshot = null;
+function renderTraffic(snapshot) {
+  trafficSnapshot = snapshot;
+  const ru = LANG === 'ru';
+  $('trafficHeading').textContent = (ru ? 'Трафик · ' : 'Traffic · ') + trafficDays + (ru ? ' дней' : ' days') + ' ↓ + ↑';
+  document.querySelectorAll('[data-traffic-days]').forEach(button => {
+    button.setAttribute('aria-pressed', String(Number(button.dataset.trafficDays) === trafficDays));
+    button.textContent = button.dataset.trafficDays + (ru ? 'д' : 'd');
+  });
+  const entries = snapshot?.items || {};
+  const starts = Object.values(entries).map(v => v.started_at).filter(v => Number.isFinite(v));
+  let note = ru ? 'Сбор истории…' : 'Collecting traffic history…';
+  if (snapshot?.available && starts.length) {
+    const since = new Date(Math.min(...starts) * 1000).toLocaleDateString(ru ? 'ru-RU' : 'en-GB');
+    note = (ru ? '↓ + ↑ · Сбор с ' : '↓ + ↑ · Collected since ') + since +
+      (ru ? ' · История сохраняется при перезапуске' : ' · History survives restarts');
+  } else if (snapshot?.error === 'metrics_disabled') {
+    note = ru ? 'Для сбора трафика включите enabled = true в [metrics] конфига прокси и перезапустите прокси. Метрики оставьте на localhost.' :
+      'To collect traffic, set enabled = true in [metrics] and restart the proxy. Keep metrics bound to localhost.';
+  } else if (snapshot && !snapshot.available && snapshot.error !== 'collecting') {
+    note = ru ? 'Метрики недоступны · История сохранена, значения временно не обновляются' :
+      'Metrics unavailable · History is saved; values are temporarily not updating';
+  }
+  $('trafficNote').textContent = note;
+  document.querySelectorAll('.user-traffic').forEach(cell => {
+    const entry = entries[cell.dataset.trafficUser];
+    const bytes = entry?.totals?.[String(trafficDays)];
+    cell.textContent = snapshot?.available && entry?.started_at != null && Number.isFinite(bytes) ?
+      formatTrafficBytes(bytes) : '—';
+    cell.title = ru ? 'Сумма скачанного и отправленного через прокси. Скользящий период, точность до минуты. Паузы сбора более 5 минут не учитываются.' :
+      'Downloaded + uploaded through the proxy. Rolling period, minute resolution. Collection gaps longer than 5 minutes are excluded.';
+    if (Number.isFinite(entry?.started_at)) {
+      cell.title += (ru ? ' Сбор с ' : ' Collected since ') + new Date(entry.started_at * 1000).toLocaleDateString(ru ? 'ru-RU' : 'en-GB') + '.';
+    }
+  });
+}
+function formatTrafficBytes(bytes) {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+  let value = Math.max(0, Number(bytes)), unit = 0;
+  while (value >= 1000 && unit < units.length - 1) { value /= 1000; unit++; }
+  return (unit ? value.toFixed(value >= 100 ? 1 : 2).replace(/\.?0+$/, '') : String(Math.round(value))) + ' ' + units[unit];
+}
+document.querySelectorAll('[data-traffic-days]').forEach(button => {
+  button.addEventListener('click', () => {
+    trafficDays = Number(button.dataset.trafficDays);
+    renderTraffic(trafficSnapshot);
+  });
+});
+
 function renderUsers(users, perUserActive, proxyStats) {
   const card = $('usersCard');
   if (!card) return;
@@ -771,6 +821,7 @@ function renderUsers(users, perUserActive, proxyStats) {
       '<div class="user-name">' + toggleSwitch + '<span class="user-name-text">' + displayName + '</span>' + sessionsBadge + '</div>' +
       '<div class="user-route">' + directToggle + '</div>' +
       '<div class="user-link" title="' + esc(tg || tme || (isEnabled ? 'link unavailable' : 'disabled')) + '">' + esc(preview) + '</div>' +
+      '<div class="user-traffic" data-traffic-user="' + userName + '">—</div>' +
       '<div class="user-actions">' +
       '<button class="ui-btn user-share" type="button" data-link="' + tmeData + '" data-name="' + userName + '" data-label="' + displayName + '"' + (tme && isEnabled ? '' : ' disabled') + ' title="Share via QR">' + ICON['qr-share'] + '</button>' +
       '<button class="ui-btn user-copy" type="button" data-link="' + tgData + '"' + (tg && isEnabled ? '' : ' disabled') + ' title="Copy tg:// link">tg://</button>' +
@@ -1469,6 +1520,7 @@ async function poll() {
   }
 
   renderUsers(d.users || null, (d.proxy || {}).per_user_active || {}, d.proxy || {});
+  renderTraffic(d.traffic || null);
 }
 
 function setDataBadge(state, text) {

--- a/src/ctl/dashboard_assets/static/index.html
+++ b/src/ctl/dashboard_assets/static/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>MTProto Proxy — Dashboard</title>
-  <link rel="stylesheet" href="/style.css?v=20260610-paper12">
+  <link rel="stylesheet" href="/style.css?v=20260905-traffic1">
 </head>
 <body>
 <div class="app is-loading">
@@ -222,9 +222,15 @@
       <div class="title" data-i18n="users.title">Users</div>
       <div class="masthead-rule"></div>
       <div class="users-meta" id="usersMeta">—</div>
+      <div class="traffic-period" role="group" aria-label="Traffic period">
+        <button type="button" data-traffic-days="7" aria-pressed="false">7d</button>
+        <button type="button" data-traffic-days="14" aria-pressed="false">14d</button>
+        <button type="button" data-traffic-days="30" aria-pressed="true">30d</button>
+      </div>
     </div>
 
     <div class="users-note" id="usersNote">—</div>
+    <div class="traffic-heading" id="trafficHeading">Traffic · 30 days ↓ + ↑</div>
 
     <!-- Add user form (hidden by default) -->
     <div class="add-user-form" id="addUserForm" style="display:none">
@@ -250,6 +256,7 @@
     <!-- Add-user action moved BELOW the list (Paper AddUser-wrap). #addUserBtn id preserved. -->
     <div class="add-user-wrap">
       <button class="ui-btn add-user-btn" id="addUserBtn" type="button"><!--ICON:plus--><span data-i18n="users.add">Add user</span></button>
+      <div class="traffic-note" id="trafficNote" role="status">Collecting traffic history…</div>
     </div>
   </div>
 
@@ -474,6 +481,6 @@
 </div>
 
 </div>
-<script src="/app.js?v=20260613-wsticket1"></script>
+<script src="/app.js?v=20260905-traffic1"></script>
 </body>
 </html>

--- a/src/ctl/dashboard_assets/static/style.css
+++ b/src/ctl/dashboard_assets/static/style.css
@@ -1759,7 +1759,18 @@ body::before, body::after { content: none; }
 
 /* ── Corrective: user-row has 4 grid children (.user-name holds the toggle),
    not 5 — the toggle is NOT a separate column. Name column must be wide. ── */
-.user-row { grid-template-columns: minmax(150px, 1.4fr) 104px minmax(0, 2fr) auto; }
+.user-row { grid-template-columns: minmax(150px, 1.4fr) 104px minmax(0, 2fr) 150px auto; }
+.traffic-period { display: flex; flex-shrink: 0; border: 1px solid var(--border); border-radius: 3px; }
+.traffic-period button { padding: 6px 10px; border: 0; background: transparent; color: var(--text-mid); font: 12px/16px 'JetBrains Mono', monospace; cursor: pointer; }
+.traffic-period button[aria-pressed="true"] { color: #ffae32; background: #ffae321a; }
+.traffic-period button:focus-visible { outline: 2px solid #ffae32; outline-offset: 2px; }
+.traffic-period button:active { transform: scale(.97); }
+.traffic-heading { margin-top: 14px; padding-right: 196px; text-align: right; color: var(--text-mid); font: 12px/16px 'JetBrains Mono', monospace; }
+.add-user-wrap { display: flex; justify-content: space-between; align-items: center; gap: 16px; flex-wrap: wrap; }
+.traffic-note { color: var(--text-mid); font: 12px/18px 'JetBrains Mono', monospace; margin: 8px 0; }
+.user-traffic { text-align: right; color: var(--text-hi); font: 14px/20px 'JetBrains Mono', monospace; font-variant-numeric: tabular-nums; }
+@media (max-width: 1000px) { .user-row { grid-template-columns: minmax(110px, 1fr) 80px minmax(0, 1fr) 110px auto; } .users-head { flex-wrap: wrap; } }
+@media (max-width: 680px) { .traffic-heading { padding-right: 0; text-align: left; } .user-traffic { text-align: left; } .user-traffic::before { content: '↓ + ↑ '; color: var(--text-mid); } }
 .user-name { display: flex; align-items: center; gap: 0; min-width: 0; }
 .user-name-text { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 @media (max-width: 680px) { .user-row { grid-template-columns: 1fr; } }

--- a/src/ctl/dashboard_assets/test_server.py
+++ b/src/ctl/dashboard_assets/test_server.py
@@ -62,6 +62,52 @@ def test_unauthenticated_api_rejected(client):
     assert client.get("/api/stats").status_code == 401
 
 
+@pytest.mark.parametrize("username", ["alice", "alice.phone"])
+def test_traffic_collector_reads_metrics_and_keeps_database(monkeypatch, tmp_path, username):
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+    import threading
+    from traffic import TrafficHistory
+    counts = [100, 200]
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            assert self.path == "/metrics"
+            body = ("mtproto_start_time_seconds 123\n"
+                    f'mtproto_user_client_to_upstream_bytes_total{{user="{username}"}} {counts[0]}\n'
+                    f'mtproto_user_upstream_to_client_bytes_total{{user="{username}"}} {counts[1]}\n').encode()
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(body)
+        def log_message(self, *args):
+            pass
+    http = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=http.serve_forever, daemon=True)
+    thread.start()
+    cfg = tmp_path / "config.toml"
+    cfg.write_text(f'[metrics]\nenabled = true\nport = {http.server_port}\n[access.users]\n{username} = "' + 'a' * 32 + '"\n')
+    monkeypatch.setattr(server, "_find_config_path", lambda: cfg)
+    monkeypatch.setattr(server, "TrafficHistory", lambda path: TrafficHistory(tmp_path / "history.db"))
+    monkeypatch.setattr(server, "_traffic_snapshot", {})
+    try:
+        server._traffic_sample()
+        assert server._traffic_snapshot["available"]
+        counts[:] = [150, 350]
+        server._traffic_sample()
+        assert server._traffic_snapshot["items"][username]["totals"]["30"] == 200
+        assert 'a' * 32 not in (tmp_path / "history.db").read_bytes().decode(errors="replace")
+        cfg.write_text(cfg.read_text().replace('a' * 32, 'A' * 32))
+        counts[:] = [160, 360]
+        server._traffic_sample()
+        assert server._traffic_snapshot["items"][username]["totals"]["30"] == 220
+        cfg.write_text('[metrics]\nenabled = false\n')
+        server._traffic_sample()
+        assert server._traffic_snapshot["error"] == "metrics_disabled"
+        assert server._traffic_snapshot["items"][username]["totals"]["30"] == 220
+    finally:
+        http.shutdown()
+        http.server_close()
+        thread.join()
+
+
 def test_authenticated_api_ok(client, monkeypatch):
     monkeypatch.setattr(server, "_unit_active", lambda unit: False)
     monkeypatch.setattr(server, "_unit_enabled", lambda unit: False)

--- a/src/ctl/dashboard_assets/test_traffic.py
+++ b/src/ctl/dashboard_assets/test_traffic.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from traffic import TrafficHistory, parse_metrics
+
+
+def test_history_survives_restart_and_counts_resets(tmp_path):
+    path = tmp_path / "traffic.sqlite3"
+    h = TrafficHistory(path)
+    h.record(100, "boot1", {"alice": (1000, 2000)})
+    h.record(160, "boot1", {"alice": (1100, 2300)})
+    h = TrafficHistory(path)
+    h.record(220, "boot1", {"alice": (1150, 2400)})
+    assert h.totals(220, 7)["alice"] == 550
+    h.record(280, "boot2", {"alice": (10, 20)})
+    assert h.totals(280, 7)["alice"] == 580
+    h.record(280, "boot2", {"alice": (10, 20)})
+    assert h.totals(280, 7)["alice"] == 580
+
+
+def test_windows_and_new_id_do_not_inherit_history(tmp_path):
+    h = TrafficHistory(tmp_path / "history.db")
+    h.record(0, "boot", {"old": (0, 0)})
+    h.record(60, "boot", {"old": (100, 0)})
+    h.record(10 * 86400, "boot", {"old": (900, 0), "new": (900, 0)})
+    h.record(10 * 86400 + 60, "boot", {"old": (950, 0), "new": (900, 0)})
+    assert h.totals(10 * 86400 + 60, 7)["old"] == 50
+    assert h.totals(10 * 86400 + 60, 14)["old"] == 150
+    assert h.totals(10 * 86400 + 60, 30).get("new", 0) == 0
+
+
+def test_clock_rollback_and_retention(tmp_path):
+    h = TrafficHistory(tmp_path / "history.db")
+    h.record(100, "boot", {"a": (100, 0)})
+    h.record(160, "boot", {"a": (120, 0)})
+    h.record(140, "boot", {"a": (120, 0)})
+    h.record(220, "boot", {"a": (125, 0)})
+    assert h.totals(220, 7)["a"] == 25
+    h.record(32 * 86400, "boot", {})
+    assert h.totals(32 * 86400, 30) == {}
+    assert h.starts() == {}
+
+
+def test_metrics_parser_requires_both_directions_and_process_id():
+    raw = '''mtproto_start_time_seconds 123
+mtproto_user_client_to_upstream_bytes_total{user="a\\\"b"} 10
+mtproto_user_upstream_to_client_bytes_total{user="a\\\"b"} 20
+'''
+    assert parse_metrics(raw) == ("123", {'a"b': (10, 20)})
+    import pytest
+    with pytest.raises(ValueError):
+        parse_metrics(raw.splitlines()[1])

--- a/src/ctl/dashboard_assets/traffic.py
+++ b/src/ctl/dashboard_assets/traffic.py
@@ -1,0 +1,77 @@
+"""Persistent minute buckets for user traffic; no secrets or proxy links on disk."""
+import json
+import re
+import sqlite3
+from contextlib import contextmanager
+
+DAY = 86400
+
+
+def parse_metrics(text):
+    start = re.search(r"^mtproto_start_time_seconds (\d+)$", text, re.M)
+    if not start:
+        raise ValueError("Missing proxy start time")
+    values = {}
+    pattern = r'^mtproto_user_(client_to_upstream|upstream_to_client)_bytes_total\{user=("(?:[^"\\]|\\.)*")\} (\d+)$'
+    for direction, label, value in re.findall(pattern, text, re.M):
+        name = json.loads(label)
+        values.setdefault(name, {})[direction] = int(value)
+    if any(len(v) != 2 for v in values.values()):
+        raise ValueError("Incomplete user counters")
+    return start[1], {k: (v["client_to_upstream"], v["upstream_to_client"]) for k, v in values.items()}
+
+
+class TrafficHistory:
+    def __init__(self, path):
+        self.path = str(path)
+        with self.connect() as db:
+            db.executescript('''
+                CREATE TABLE IF NOT EXISTS baseline (
+                    identity TEXT PRIMARY KEY, process TEXT NOT NULL,
+                    tx INTEGER NOT NULL, rx INTEGER NOT NULL, sampled INTEGER NOT NULL,
+                    started INTEGER NOT NULL);
+                CREATE TABLE IF NOT EXISTS buckets (
+                    identity TEXT NOT NULL, minute INTEGER NOT NULL, bytes INTEGER NOT NULL,
+                    PRIMARY KEY(identity, minute));
+            ''')
+
+    @contextmanager
+    def connect(self):
+        db = sqlite3.connect(self.path, timeout=5)
+        try:
+            with db:
+                yield db
+        finally:
+            db.close()
+
+    def record(self, now, process, counters):
+        now = int(now)
+        with self.connect() as db:
+            for identity, (tx, rx) in counters.items():
+                old = db.execute("SELECT process,tx,rx,sampled,started FROM baseline WHERE identity=?", (identity,)).fetchone()
+                if old and now < old[3]:
+                    continue  # clock moved backwards: do not count the same interval twice
+                delta = 0
+                # A long collection gap cannot be dated reliably. Do not assign
+                # days of missed traffic to the current minute/window.
+                if old and now - old[3] <= 300:
+                    delta = sum(v if process != old[0] or v < before else v - before
+                                for v, before in zip((tx, rx), old[1:3]))
+                if delta:
+                    db.execute("INSERT INTO buckets VALUES(?,?,?) ON CONFLICT(identity,minute) DO UPDATE SET bytes=bytes+excluded.bytes",
+                               (identity, now // 60 * 60, delta))
+                db.execute("INSERT OR REPLACE INTO baseline VALUES(?,?,?,?,?,?)",
+                           (identity, process, tx, rx, now, old[4] if old else now))
+            db.execute("DELETE FROM buckets WHERE minute < ?", (now - 30 * DAY - 60,))
+            db.execute("DELETE FROM baseline WHERE sampled < ?", (now - 31 * DAY,))
+
+    def totals(self, now, days):
+        if days not in (7, 14, 30):
+            raise ValueError("Unsupported traffic period")
+        with self.connect() as db:
+            return dict(db.execute("SELECT identity,SUM(bytes) FROM buckets WHERE minute >= ? AND minute <= ? GROUP BY identity",
+                                   (int(now) - days * DAY, int(now))))
+
+    def starts(self):
+        with self.connect() as db:
+            return dict(db.execute("SELECT identity,started FROM baseline"))

--- a/src/web/relay.zig
+++ b/src/web/relay.zig
@@ -164,10 +164,22 @@ pub const Options = struct {
     }
 };
 
-/// Parse `[web].backend` (`host:port`), defaulting to this proxy on loopback.
+/// A specific listener must be reached on its bound address; another service
+/// may own loopback on that port. Wildcard listeners still use loopback.
+fn defaultBackendHost(cfg: *const config.Config) ![]const u8 {
+    const host = cfg.bind_address orelse return "127.0.0.1";
+    const addr = try Address.parse(host, cfg.port);
+    switch (addr) {
+        .ip4 => |v4| if (std.mem.allEqual(u8, &v4.bytes, 0)) return "127.0.0.1",
+        .ip6 => |v6| if (std.mem.allEqual(u8, &v6.bytes, 0)) return "::1",
+    }
+    return host;
+}
+
+/// Parse `[web].backend` (`host:port`), defaulting to this proxy's listener.
 pub fn resolveBackend(allocator: std.mem.Allocator, cfg: *const config.Config) !Address {
     const spec = cfg.web.backend orelse {
-        return net_helpers.ip4(.{ 127, 0, 0, 1 }, cfg.port);
+        return Address.parse(try defaultBackendHost(cfg), cfg.port);
     };
     const colon = std.mem.lastIndexOfScalar(u8, spec, ':') orelse return error.InvalidBackend;
     const host = std.mem.trim(u8, spec[0..colon], "[] ");
@@ -332,6 +344,8 @@ pub const Relay = struct {
     opts: Options,
     backend_dns: ?*dns_cache.Cache = null,
     backend_dns_id: usize = 0,
+    /// Only the implicit backend is guaranteed to be this host's proxy.
+    local_backend: bool = false,
     caps: []UserCapability,
     /// Pre-rendered responses; the bridge page carries no per-user bytes.
     /// The cover page is generated per deployment (see `page.renderCover`), so it is
@@ -424,7 +438,7 @@ pub const Relay = struct {
         errdefer cache.destroy();
         const spec = cfg.web.backend;
         const colon = if (spec) |s| std.mem.lastIndexOfScalar(u8, s, ':') orelse return error.InvalidBackend else 0;
-        const host = if (spec) |s| std.mem.trim(u8, s[0..colon], "[] ") else "127.0.0.1";
+        const host = if (spec) |s| std.mem.trim(u8, s[0..colon], "[] ") else try defaultBackendHost(cfg);
         const port = if (spec) |s| try std.fmt.parseInt(u16, s[colon + 1 ..], 10) else cfg.port;
         const addresses = try net_helpers.getAddressList(allocator, host, port);
         defer addresses.deinit();
@@ -436,6 +450,7 @@ pub const Relay = struct {
             .opts = opts,
             .backend_dns = cache,
             .backend_dns_id = dns_id,
+            .local_backend = spec == null,
             .caps = caps,
             .cover_page = cover_page,
             .bridge_page = bridge_page,
@@ -1516,7 +1531,7 @@ pub const Relay = struct {
 
         const candidates = if (self.backend_dns) |cache| cache.snapshot(self.backend_dns_id) else net_helpers.AddressCandidates.init(&.{self.opts.backend});
         var next: usize = 0;
-        const dialed_fd = dialCandidate(candidates, &next) catch |err| {
+        const dialed_fd = self.dialCandidate(candidates, &next) catch |err| {
             log.debug("backend dial failed: {any}", .{err});
             self.closeStream(stream, true);
             return;
@@ -1539,17 +1554,17 @@ pub const Relay = struct {
         self.syncConn(conn);
     }
 
-    fn dialCandidate(candidates: net_helpers.AddressCandidates, next: *usize) !posix.fd_t {
+    fn dialCandidate(self: *Relay, candidates: net_helpers.AddressCandidates, next: *usize) !posix.fd_t {
         while (next.* < candidates.len) {
             const address = candidates.addresses[next.*];
             next.* += 1;
-            return dialBackend(address) catch continue;
+            return dialBackend(address, self.local_backend) catch continue;
         }
         return error.BackendAddressesExhausted;
     }
 
     fn retryBackend(self: *Relay, conn: *Conn) bool {
-        const fd = dialCandidate(conn.backend_candidates, &conn.backend_next) catch return false;
+        const fd = self.dialCandidate(conn.backend_candidates, &conn.backend_next) catch return false;
         // Preserve the old fd until the event batch ends; preserve the connection's queue.
         self.pending_close.ensureTotalCapacity(self.allocator, self.conns.count() + self.pending_close.items.len + 1) catch {
             closeFd(fd);
@@ -1576,7 +1591,7 @@ pub const Relay = struct {
         return true;
     }
 
-    fn dialBackend(address: Address) !posix.fd_t {
+    fn dialBackend(address: Address, local_backend: bool) !posix.fd_t {
         const family: u32 = if (net_helpers.isIpv6(address)) posix.AF.INET6 else posix.AF.INET;
         const flags = posix.SOCK.STREAM | posix.SOCK.NONBLOCK | posix.SOCK.CLOEXEC;
         const rc = posix.system.socket(family, flags, posix.IPPROTO.TCP);
@@ -1586,6 +1601,21 @@ pub const Relay = struct {
         };
         errdefer closeFd(fd);
         var storage: posix.sockaddr.storage = undefined;
+        if (local_backend) {
+            // Preserve the existing loopback-only trust boundary even when the
+            // proxy binds a specific public IP. Never do this for remote backends.
+            const source = switch (address) {
+                .ip4 => net_helpers.ip4(.{ 127, 0, 0, 1 }, 0),
+                .ip6 => |v6| try Address.parse(if (std.mem.allEqual(u8, v6.bytes[0..10], 0) and
+                    v6.bytes[10] == 0xff and v6.bytes[11] == 0xff)
+                    "::ffff:127.0.0.1"
+                else
+                    "::1", 0),
+            };
+            const source_len = addressToSockaddr(source, &storage);
+            if (posix.errno(posix.system.bind(fd, @ptrCast(&storage), source_len)) != .SUCCESS)
+                return error.BackendSourceBindFailed;
+        }
         const len = addressToSockaddr(address, &storage);
         socket_utils.connectSockaddr(fd, @ptrCast(&storage), len) catch |err| {
             if (err != error.WouldBlock) return err;
@@ -2031,6 +2061,46 @@ fn addressToSockaddr(addr: Address, storage: *posix.sockaddr.storage) posix.sock
 
 // ── tests ─────────────────────────────────────────────────────────────────────
 
+test "implicit local backend keeps a trusted loopback source on a specific IPv4 listener" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    // UDP connect selects a local interface without sending any packets.
+    const rc = posix.system.socket(posix.AF.INET, posix.SOCK.DGRAM | posix.SOCK.CLOEXEC, 0);
+    if (posix.errno(rc) != .SUCCESS) return error.SocketFailed;
+    const probe: posix.fd_t = @intCast(rc);
+    defer closeFd(probe);
+    var storage: posix.sockaddr.storage = undefined;
+    const len = addressToSockaddr(net_helpers.ip4(.{ 192, 0, 2, 1 }, 9), &storage);
+    try socket_utils.connectSockaddr(probe, @ptrCast(&storage), len);
+    var target = try socket_utils.localSocketAddress(probe);
+    target.ip4.port = 0;
+    try std.testing.expect(!trusted_peers.isLoopback(target));
+    const server = try net_helpers.listen(target, 8, false);
+    defer closeFd(server.socket.handle);
+    target = try socket_utils.localSocketAddress(server.socket.handle);
+    const fd = try Relay.dialBackend(target, true);
+    defer closeFd(fd);
+    const source = try socket_utils.localSocketAddress(fd);
+    try std.testing.expect(trusted_peers.isLoopback(source));
+    const peers = trusted_peers.TrustedPeers{ .enabled = true };
+    try std.testing.expect(peers.contains(source));
+    // Explicit remote backends must retain normal routing, not a loopback source.
+    const explicit = try Relay.dialBackend(target, false);
+    defer closeFd(explicit);
+    try std.testing.expect(!peers.contains(try socket_utils.localSocketAddress(explicit)));
+}
+
+test "local backend source binding supports IPv6 and IPv4-mapped listeners" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    for ([_][]const u8{ "::1", "::ffff:127.0.0.1" }) |host| {
+        const server = try net_helpers.listen(try Address.parse(host, 0), 8, false);
+        defer closeFd(server.socket.handle);
+        const target = try socket_utils.localSocketAddress(server.socket.handle);
+        const fd = try Relay.dialBackend(target, true);
+        defer closeFd(fd);
+        try std.testing.expect(trusted_peers.isLoopback(try socket_utils.localSocketAddress(fd)));
+    }
+}
+
 test "backend retry freezes candidates and preserves queued bytes while retiring stale fd" {
     if (builtin.os.tag != .linux) return error.SkipZigTest;
     const allocator = std.testing.allocator;
@@ -2058,7 +2128,7 @@ test "backend retry freezes candidates and preserves queued bytes while retiring
     defer relay.pending_free.deinit(allocator);
     defer relay.tick_scratch.deinit(allocator);
     defer relay.drainPendingCloses();
-    const first = try Relay.dialBackend(target);
+    const first = try Relay.dialBackend(target, false);
     const conn = try relay.createConn(first, .backend, target);
     defer {
         closeFd(conn.fd);
@@ -2090,7 +2160,7 @@ test "backend retry freezes candidates and preserves queued bytes while retiring
     // A stale event has no mapped connection, and exhausted candidates cannot loop.
     try std.testing.expect(!relay.retryBackend(conn));
     var empty_next: usize = 0;
-    try std.testing.expectError(error.BackendAddressesExhausted, Relay.dialCandidate(.{}, &empty_next));
+    try std.testing.expectError(error.BackendAddressesExhausted, relay.dialCandidate(.{}, &empty_next));
 }
 
 test "proxy v2 header round-trips through the proxy's own parser" {
@@ -2211,6 +2281,34 @@ test "dropFront compacts a buffer" {
     try std.testing.expectEqualStrings("cdef", list.items);
     dropFront(&list, 4);
     try std.testing.expectEqual(@as(usize, 0), list.items.len);
+}
+
+test "default backend follows the proxy bind address" {
+    var cfg = config.Config{
+        .users = std.StringHashMap([16]u8).init(std.testing.allocator),
+        .direct_users = std.StringHashMap(void).init(std.testing.allocator),
+        .port = 9443,
+    };
+    defer cfg.deinit(std.testing.allocator);
+    const cases = .{
+        .{ "192.0.2.7", "192.0.2.7" },
+        .{ "2001:db8::7", "2001:db8::7" },
+        .{ "0.0.0.0", "127.0.0.1" },
+        .{ "::", "::1" },
+    };
+    inline for (cases) |case| {
+        cfg.bind_address = try std.testing.allocator.dupe(u8, case[0]);
+        const addr = try resolveBackend(std.testing.allocator, &cfg);
+        try std.testing.expect(trusted_peers.sameHost(try Address.parse(case[1], 9443), addr));
+        try std.testing.expectEqual(@as(u16, 9443), addr.getPort());
+        std.testing.allocator.free(cfg.bind_address.?);
+        cfg.bind_address = null;
+    }
+    cfg.bind_address = try std.testing.allocator.dupe(u8, "192.0.2.7");
+    cfg.web.backend = try std.testing.allocator.dupe(u8, "127.0.0.1:8443");
+    const explicit = try resolveBackend(std.testing.allocator, &cfg);
+    try std.testing.expect(trusted_peers.isLoopback(explicit));
+    try std.testing.expectEqual(@as(u16, 8443), explicit.getPort());
 }
 
 test "backend spec parsing rejects nonsense" {

--- a/test/e2e/run.py
+++ b/test/e2e/run.py
@@ -18,6 +18,7 @@ Runs real proxy process + fake upstream/mask servers and validates critical flow
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
 import hmac
 import os
@@ -379,7 +380,7 @@ class ProxyInstance:
         return "\n".join(lines[-max_lines:])
 
 
-def start_proxy(config_text: str, port: int) -> ProxyInstance:
+def start_proxy(config_text: str, port: int, host: str = "127.0.0.1") -> ProxyInstance:
     if not ACTIVE_PROXY_BIN.exists():
         raise RuntimeError(f"proxy binary not found: {ACTIVE_PROXY_BIN}; run `zig build` first")
 
@@ -399,7 +400,7 @@ def start_proxy(config_text: str, port: int) -> ProxyInstance:
     )
     log_file.close()
 
-    if not wait_for_listen("127.0.0.1", port, timeout_sec=8.0) or proc.poll() is not None:
+    if not wait_for_listen(host, port, timeout_sec=8.0) or proc.poll() is not None:
         if proc.poll() is None:
             proc.terminate()
             try:
@@ -1634,6 +1635,68 @@ def scenario_guard_admission_metrics() -> None:
             proxy.stop()
 
 
+def scenario_web_specific_bind() -> None:
+    """Issue #407: real WEB relay reaches a specific listener, not another service
+    on loopback at the same port, without trusting ordinary non-loopback clients."""
+    host = _local_non_loopback_ipv4()
+    assert host, "WEB bind regression needs a non-loopback IPv4"
+    socks = FakeSocks5Server(mode="success")
+    socks.start()
+    port, relay_port = free_port(), free_port()
+    cfg = base_config(port=port, web_enabled=True, mask=False, upstream_type="socks5",
+                      upstream_host="127.0.0.1", upstream_port=socks.port,
+                      web_domain="relay.example.test")
+    cfg = cfg.replace('bind_address = "127.0.0.1"', f'bind_address = "{host}"')
+    cfg = cfg.replace("[web]", f"[web]\nport = {relay_port}")
+    proxy = start_proxy(cfg, port, host)
+    relay = None
+    try:
+        with socket.socket() as other:
+            other.bind(("127.0.0.1", port))
+            other.listen()
+            with open(proxy.workdir / "relay.log", "wb") as log:
+                relay = subprocess.Popen([str(ACTIVE_PROXY_BIN), "web-relay", str(proxy.cfg_path)],
+                                         stdout=log, stderr=subprocess.STDOUT)
+            assert wait_for_listen("127.0.0.1", relay_port, 8), "WEB relay did not start"
+            mac = hmac.new(b"\xdd" + bytes.fromhex(DEFAULT_SECRET_HEX),
+                           b"tdesktop-web-proxy-bridge-v1\nrelay.example.test", hashlib.sha256).digest()
+            cap = base64.urlsafe_b64encode(mac).decode().rstrip("=")
+            with socket.create_connection(("127.0.0.1", relay_port), timeout=3) as ws:
+                ws.sendall((f"GET /api/v1/socket?b={cap} HTTP/1.1\r\n"
+                            "Host: relay.example.test\r\nOrigin: https://relay.example.test\r\n"
+                            "Upgrade: websocket\r\nConnection: Upgrade\r\n"
+                            "Sec-WebSocket-Version: 13\r\n"
+                            "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n").encode())
+                assert b"101" in recv_until(ws, b"\r\n\r\n").split(b"\r\n")[0]
+
+                def send_frame(kind: int, stream: int, payload: bytes = b"") -> None:
+                    data = bytes([kind]) + stream.to_bytes(3, "big") + struct.pack(">I", len(payload)) + payload
+                    mask = b"\x12\x34\x56\x78"
+                    size = bytes([0x80 | len(data)]) if len(data) < 126 else b"\xfe" + struct.pack(">H", len(data))
+                    ws.sendall(b"\x82" + size + mask + bytes(b ^ mask[i % 4] for i, b in enumerate(data)))
+
+                send_frame(0x10, 0, b"\x01")
+                assert recv_exact(ws, 10) == b"\x82\x08\x11\x00\x00\x00\x00\x00\x00\x00", "no WEB WELCOME"
+                send_frame(0x01, 1)
+                send_frame(0x02, 1, generate_obf_handshake(DEFAULT_SECRET_HEX, 1, "secure") + b"\x55" * 128)
+                assert_client_payload_relayed(socks, 128, "WEB specific-bind stream did not reach DC", 5)
+            with connect_from(host, host, port) as direct:
+                direct.sendall(generate_obf_handshake(DEFAULT_SECRET_HEX, 1, "secure"))
+                assert_socket_closed_soon(direct)
+            assert len(socks.connect_targets) == 1, "non-loopback client bypassed the FakeTLS gate"
+            assert not select.select([other], [], [], 0)[0], "relay dialed the unrelated loopback service"
+    finally:
+        if relay is not None:
+            relay.terminate()
+            try:
+                relay.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                relay.kill()
+                relay.wait(timeout=3)
+        proxy.stop()
+        socks.stop()
+
+
 def scenario_explicit_relay_source() -> None:
     source = _local_non_loopback_ipv4()
     if source is None:
@@ -1708,6 +1771,7 @@ SCENARIOS: dict[str, Callable[[], None]] = {
     "middleproxy_fallback_to_direct": scenario_middleproxy_fallback_to_direct,
     "mask_fallback_local_nginx": scenario_mask_fallback_local_nginx,
     "mask_fallback_custom_target": scenario_mask_fallback_custom_target,
+    "web_specific_bind": scenario_web_specific_bind,
     "web_only_serves_relay": scenario_web_only_still_serves_the_relay,
     "web_only_masks_direct_client": scenario_web_only_masks_a_direct_client,
     "web_only_inert_without_web": scenario_web_only_ignored_without_web_enabled,

--- a/test/installer-e2e/Dockerfile
+++ b/test/installer-e2e/Dockerfile
@@ -7,6 +7,11 @@ ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 
 RUN set -eux; \
+    # The CDN returns 404 for some Bullseye security package URLs with encoded '+'.
+    # Use Debian's security endpoint; keep package signature verification enabled.
+    if [ -f /etc/apt/sources.list ]; then \
+        sed -i 's|http://deb.debian.org/debian-security|http://security.debian.org/debian-security|g' /etc/apt/sources.list; \
+    fi; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
         ca-certificates \

--- a/test/installer-e2e/Dockerfile
+++ b/test/installer-e2e/Dockerfile
@@ -7,11 +7,6 @@ ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 
 RUN set -eux; \
-    # The CDN returns 404 for some Bullseye security package URLs with encoded '+'.
-    # Use Debian's security endpoint; keep package signature verification enabled.
-    if [ -f /etc/apt/sources.list ]; then \
-        sed -i 's|http://deb.debian.org/debian-security|http://security.debian.org/debian-security|g' /etc/apt/sources.list; \
-    fi; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
         ca-certificates \


### PR DESCRIPTION
## Changes
- Add persistent per-user traffic totals for 7, 14 and 30 days, with collection dates and EN/RU UI. Updated the Paper design first.
- Fix the implicit WEB backend for a specific bind_address without expanding trusted peers.
- Add dashboard history tests and a WEB regression scenario with a competing localhost listener.

Traffic collection requires local metrics to be enabled; history starts when the updated dashboard begins collecting.

## Verification
- Native Zig tests and Linux release build passed.
- 33 dashboard tests passed; JS syntax and Zig formatting checked.
- Desktop and narrow-screen traffic controls checked in the browser.
- Installer Debian 11 is currently blocked by external package mirror 404s. A mirror-only workaround did not resolve this and was reverted. Remaining checks are rerunning.

Closes #406
Closes #407