### PR TITLE
fix(dashboard): accept uv metadata and test the full installer lifecycle

### DIFF
--- a/src/ctl/dashboard.zig
+++ b/src/ctl/dashboard.zig
@@ -146,7 +146,27 @@ pub fn runInteractive(ui: *Tui, allocator: std.mem.Allocator) !void {
 fn uvExists(allocator: std.mem.Allocator) bool {
     const result = sys.exec(allocator, &.{ UV_BIN, "--version" }) catch return false;
     defer result.deinit();
-    return result.exit_code == 0 and std.mem.eql(u8, std.mem.trim(u8, result.stdout, " \r\n\t"), "uv " ++ UV_VERSION);
+    return result.exit_code == 0 and pinnedUvVersion(result.stdout);
+}
+
+fn pinnedUvVersion(output: []const u8) bool {
+    // uv appends optional platform/build metadata after the exact version.
+    var fields = std.mem.tokenizeAny(u8, output, " \r\n\t");
+    const name = fields.next() orelse return false;
+    const version = fields.next() orelse return false;
+    return std.mem.eql(u8, name, "uv") and std.mem.eql(u8, version, UV_VERSION);
+}
+
+test "dashboard accepts pinned uv with platform or build metadata" {
+    try std.testing.expect(pinnedUvVersion("uv " ++ UV_VERSION ++ "\n"));
+    try std.testing.expect(pinnedUvVersion("uv " ++ UV_VERSION ++ " (x86_64-unknown-linux-gnu)\n"));
+    try std.testing.expect(pinnedUvVersion("uv " ++ UV_VERSION ++ " (abc123 2026-09-01)\n"));
+}
+
+test "dashboard rejects other uv versions and malformed output" {
+    for ([_][]const u8{ "", "uv", "uvx " ++ UV_VERSION, "uv 0.0.1", "uv " ++ UV_VERSION ++ "0", "uv " ++ UV_VERSION ++ "-rc1" }) |output| {
+        try std.testing.expect(!pinnedUvVersion(output));
+    }
 }
 
 /// Install `uv` from GitHub releases (astral.sh is blocked in some regions).

--- a/src/ctl/dashboard.zig
+++ b/src/ctl/dashboard.zig
@@ -29,7 +29,7 @@ const SERVICE_NAME = "proxy-monitor";
 const SERVICE_FILE = "/etc/systemd/system/" ++ SERVICE_NAME ++ ".service";
 
 const VENV_CREATE_ARGV = [_][]const u8{
-    "env", UV_SUBPROCESS_PATH, UV_PYTHON_INSTALL_ENV, UV_BIN, "venv", STAGED_VENV_DIR, "--python", "python3",
+    "env", UV_SUBPROCESS_PATH, UV_PYTHON_INSTALL_ENV, UV_BIN, "venv", STAGED_VENV_DIR, "--python", ">=3.11",
 };
 
 const PIP_INSTALL_ARGV = [_][]const u8{
@@ -416,4 +416,6 @@ test "dashboard venv keeps uv-managed Python outside ProtectHome paths" {
     try std.testing.expectEqualStrings("UV_PYTHON_INSTALL_DIR=/opt/mtproto-proxy/monitor/.uv-python", argv[2]);
     try std.testing.expectEqualStrings(UV_BIN, argv[3]);
     try std.testing.expectEqualStrings(STAGED_VENV_DIR, argv[5]);
+    try std.testing.expectEqualStrings("--python", argv[6]);
+    try std.testing.expectEqualStrings(">=3.11", argv[7]);
 }

--- a/test/installer-e2e/dashboard.sh
+++ b/test/installer-e2e/dashboard.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Runs inside the disposable systemd container, using the mtbuddy under test.
+set -Eeuo pipefail
+
+check_dashboard() {
+  systemctl is-active --quiet mtproto-proxy
+  systemctl is-enabled --quiet proxy-monitor
+  /opt/mtproto-proxy/monitor/.venv/bin/python - <<'PY'
+import base64
+import json
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+base = "http://127.0.0.1:61208"
+for attempt in range(40):
+    try:
+        token = Path("/opt/mtproto-proxy/monitor/dashboard.token").read_text().strip()
+        auth = "Basic " + base64.b64encode(("test:" + token).encode()).decode()
+        try:
+            opener.open(base + "/api/stats", timeout=10)
+        except urllib.error.HTTPError as exc:
+            assert exc.code == 401, exc.code
+        else:
+            raise AssertionError("dashboard API does not require authentication")
+        def get(path):
+            request = urllib.request.Request(base + path, headers={"Authorization": auth})
+            with opener.open(request, timeout=10) as response:
+                assert response.status == 200
+                return response.read()
+        stats = json.loads(get("/api/stats"))
+        assert "users" in stats and "traffic" in stats
+        for path in ("/", "/app.js", "/style.css"):
+            assert len(get(path)) > 100
+        break
+    except (OSError, ValueError):
+        if attempt == 39:
+            raise
+        time.sleep(1)
+print("dashboard service, authenticated API and static assets: OK")
+PY
+  systemctl is-active --quiet proxy-monitor
+}
+
+if [[ "${1:-}" == check ]]; then
+  check_dashboard
+  exit
+fi
+
+config_before="$(sha256sum /opt/mtproto-proxy/config.toml | cut -d " " -f1)"
+test ! -e /opt/mtproto-proxy/monitor/bin/uv
+mtbuddy setup dashboard
+check_dashboard
+uv_before="$(stat -c '%i:%Y' /opt/mtproto-proxy/monitor/bin/uv)"
+token_before="$(sha256sum /opt/mtproto-proxy/monitor/dashboard.token | cut -d " " -f1)"
+
+# Exercise real SQLite persistence through the installed module, not a mock.
+/opt/mtproto-proxy/monitor/.venv/bin/python - <<'PY'
+import sys
+import time
+sys.path.insert(0, "/opt/mtproto-proxy/monitor")
+from traffic import TrafficHistory
+history = TrafficHistory("/opt/mtproto-proxy/monitor/traffic.sqlite3")
+now = int(time.time())
+history.record(now - 30, "installer-test", {"installer-test": (0, 0)})
+history.record(now, "installer-test", {"installer-test": (100, 50)})
+assert history.totals(now, 30)["installer-test"] == 150
+PY
+
+mtbuddy setup dashboard
+check_dashboard
+test "$(stat -c '%i:%Y' /opt/mtproto-proxy/monitor/bin/uv)" = "$uv_before"
+test "$(sha256sum /opt/mtproto-proxy/monitor/dashboard.token | cut -d " " -f1)" = "$token_before"
+/opt/mtproto-proxy/monitor/.venv/bin/python - <<'PY'
+import sqlite3
+with sqlite3.connect("/opt/mtproto-proxy/monitor/traffic.sqlite3") as db:
+    assert db.execute("SELECT SUM(bytes) FROM buckets WHERE identity = ?", ("installer-test",)).fetchone()[0] == 150
+PY
+
+mtbuddy setup dashboard --remove
+test ! -e /opt/mtproto-proxy/monitor
+test ! -e /etc/systemd/system/proxy-monitor.service
+if systemctl is-active --quiet proxy-monitor; then
+  echo "dashboard still running after removal" >&2
+  exit 1
+fi
+systemctl is-active --quiet mtproto-proxy
+mtbuddy setup dashboard
+check_dashboard
+test "$(sha256sum /opt/mtproto-proxy/config.toml | cut -d " " -f1)" = "$config_before"
+echo "dashboard fresh install, redeploy, removal and reinstall: OK"

--- a/test/installer-e2e/dashboard.sh
+++ b/test/installer-e2e/dashboard.sh
@@ -8,12 +8,15 @@ check_dashboard() {
   /opt/mtproto-proxy/monitor/.venv/bin/python - <<'PY'
 import base64
 import json
+import sys
 import time
+import tomllib
 import urllib.error
 import urllib.request
 from pathlib import Path
 
 opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+assert sys.version_info >= (3, 11)
 base = "http://127.0.0.1:61208"
 for attempt in range(40):
     try:

--- a/test/installer-e2e/run.sh
+++ b/test/installer-e2e/run.sh
@@ -633,6 +633,11 @@ run_case() {
   verify_install "$container" 2>&1 | tee "$LOG_DIR/$safe.verify-after-nfqws-rerun.log"
   echo "::endgroup::"
 
+  echo "::group::Dashboard install, redeploy, removal and reinstall ($base_image)"
+  docker cp "$ROOT/test/installer-e2e/dashboard.sh" "$container:/tmp/dashboard-e2e.sh"
+  run_in_container "$container" bash /tmp/dashboard-e2e.sh 2>&1 | tee "$LOG_DIR/$safe.dashboard.log"
+  echo "::endgroup::"
+
   if [[ "$VERIFY_TUNNEL_DEPS" != "0" ]]; then
     echo "::group::Install tunnel dependency set ($base_image)"
     verify_tunnel_dependency_installers "$container" 2>&1 | tee "$LOG_DIR/$safe.tunnel-deps.log"
@@ -643,6 +648,7 @@ run_case() {
   verify_update_preserves_config "$container" 2>&1 | tee "$LOG_DIR/$safe.update.log"
   restore_proxy_under_test "$container"
   verify_install "$container" 2>&1 | tee "$LOG_DIR/$safe.verify-after-update.log"
+  run_in_container "$container" bash /tmp/dashboard-e2e.sh check 2>&1 | tee "$LOG_DIR/$safe.dashboard-after-update.log"
   echo "::endgroup::"
 
   # `mtbuddy update` installs the RELEASED mtbuddy over /usr/local/bin/mtbuddy


### PR DESCRIPTION
## Fix
Accept the exact pinned uv version with optional platform/build metadata. Continue rejecting other versions, prefixes and prereleases; archive checksum verification is unchanged. Explicitly require Python >=3.11 for dashboard runtime compatibility and TOML support.

## Regression coverage
- Unit test reproduced #419 before the fix.
- Real dashboard lifecycle test also failed before the fix and passes after it in a disposable Ubuntu 24.04 systemd container.
- Installer E2E now covers fresh install, authenticated API/static assets, redeploy preserving token and SQLite history, removal/reinstall and dashboard health after update.
- Previous CI tested the Python API but never invoked setup dashboard.

## Verification
466 native Zig tests passed (8 Linux-only skips), 33 Python tests passed. New dashboard lifecycle passed on all five CI distributions. Full installer E2E passed on Debian 12 / Ubuntu 20.04 / 22.04 / 24.04; Debian 11 remains blocked later by external GnuPG package mirror 404s, the previously approved infrastructure exception. Proxy E2E is completing.

Closes #419