### PR TITLE
fix: verify bootstrap checksum against archive filename

### DIFF
--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -235,7 +235,7 @@ download_artifact() {
   fi
 
   step "Verifying checksum for $artifact"
-  awk -v artifact="$artifact" 'NF != 2 || ($2 != artifact && $2 != "*" artifact) { bad=1 } END { exit (bad || NR != 1) }' "$TMP/${sha_name}" \
+  awk -v artifact="$tar_name" 'NF != 2 || ($2 != artifact && $2 != "*" artifact) { bad=1 } END { exit (bad || NR != 1) }' "$TMP/${sha_name}" \
     || fail "Checksum filename mismatch for $artifact"
   if command -v sha256sum >/dev/null 2>&1; then
     (cd "$TMP" && sha256sum -c "${sha_name}" >/dev/null) || fail "Checksum verification failed: $artifact"


### PR DESCRIPTION
Fresh installations fail with "Checksum filename mismatch" because bootstrap compares the checksum filename with the binary name, while releases checksum the .tar.gz archive. Compare against the archive name so valid release checksums pass while retaining signature and checksum verification.

Validation: eight checksum scenarios passed, including valid archive names and rejection of incorrect names, multiple entries, empty files, and incorrect digests. bash -n and git diff --check passed.